### PR TITLE
feat: show total clip count in All Clips tab

### DIFF
--- a/scripts/web/blueprints/videos.py
+++ b/scripts/web/blueprints/videos.py
@@ -126,6 +126,7 @@ def file_browser():
         'events': compact_events,
         'has_next': (page_num * per_page) < total_events,
         'next_page': page_num + 1,
+        'total_count': total_events,
         'folder_structure': folder_structure
     })
 

--- a/scripts/web/templates/mapping.html
+++ b/scripts/web/templates/mapping.html
@@ -1920,6 +1920,14 @@ async function loadVideoList(append) {
             return;
         }
 
+        // Show summary count on first page load
+        if (!append && data.total_count) {
+            const summary = document.createElement('div');
+            summary.className = 'st-summary';
+            summary.innerHTML = '<strong>' + data.total_count + ' Clip' + (data.total_count !== 1 ? 's' : '') + '</strong>';
+            list.appendChild(summary);
+        }
+
         data.events.forEach(function(ev) {
             const card = document.createElement('div');
             card.className = 'vp-clip';


### PR DESCRIPTION
Adds a summary count (e.g. '61 Clips') at the top of the All Clips list, matching the Events and Trips tabs.