### PR TITLE
feat(media): add Boombox sound manager to Media Hub

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,196 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+> **⚠️ Living document rule**: Any architectural decision, layout choice, or configuration choice made during development or setup sessions **must be recorded here** before the session ends. This file is the single source of truth for why things are the way they are.
+
+## Project Overview
+
+TeslaUSB transforms a Raspberry Pi into a smart USB drive for Tesla dashcam recordings. It presents two or three USB mass storage LUNs to the vehicle (TeslaCam, LightShow, optional Music) while running a Flask web dashboard with GPS mapping, telemetry HUD, cloud sync, and media management.
+
+Target hardware: **Raspberry Pi Zero 2 W** (512MB RAM). Every design decision — memory, CPU, no JS frameworks, no CDN calls — must account for this constraint.
+
+## Common Commands
+
+### Development (on the Pi)
+```bash
+# Run web app manually (after setup)
+cd /home/pi/TeslaUSB && python3 web_control.py
+
+# View web service logs
+sudo journalctl -u gadget_web.service -f
+
+# Restart web service after Python changes
+sudo systemctl restart gadget_web.service
+
+# Restart AP/WiFi service after config changes
+sudo systemctl restart wifi-monitor.service
+
+# Switch operating modes
+sudo ~/TeslaUSB/present_usb.sh   # Connect to Tesla (Present mode)
+sudo ~/TeslaUSB/edit_usb.sh      # Enable network sharing (Edit mode)
+```
+
+### Tests
+```bash
+# Run all tests
+pytest
+
+# Run a single test file
+pytest tests/test_mapping_service.py
+
+# Run a single test
+pytest tests/test_sei_parser.py::test_function_name
+```
+
+### Setup & Deployment
+```bash
+# Full install/re-deploy (after changing templates or scripts/)
+sudo ./setup_usb.sh
+```
+
+## Architecture
+
+### Configuration System
+- **Single source of truth**: `config.yaml` at repo root — all paths, credentials, and settings live here.
+- **Bash scripts** read config via `scripts/config.sh` (uses `yq` with a single optimized eval call).
+- **Python** reads config via `scripts/web/config.py` (uses PyYAML).
+- Never hardcode paths or values; always use these wrappers.
+- After editing `config.yaml`, restart `gadget_web.service` (web changes) or `wifi-monitor.service` (AP changes).
+
+### Template System
+- Source files in `scripts/` and `templates/` use placeholders: `__GADGET_DIR__`, `__MNT_DIR__`, `__TARGET_USER__`, `__IMG_NAME__`, `__SECRET_KEY__`.
+- Run `sudo ./setup_usb.sh` after changing any template to substitute and deploy. Never hardcode installed paths.
+
+### Operating Modes
+- **Present mode** (default on boot): USB gadget active, drives RO-mounted at `/mnt/gadget/part*-ro`, Samba off.
+- **Edit mode**: Gadget off, drives RW-mounted at `/mnt/gadget/part*`, Samba on.
+- Current mode stored in `state.txt`; `mode_service.current_mode()` falls back to detection.
+- **Boot priority**: USB gadget presentation to Tesla is #1. Never add blocking work before UDC bind in `present_usb.sh`. All post-boot tasks (cleanup, chime selection, indexing, cloud sync) run via `teslausb-deferred-tasks.service`.
+
+### Flask Web App (`scripts/web/`)
+- Entry point: `web_control.py` — creates Flask app, registers all blueprints.
+- **Blueprints** (`blueprints/`): one per feature area (mapping, videos, lock_chimes, light_shows, music, wraps, license_plates, media, analytics, cleanup, cloud_archive, api, fsck, captive_portal, mode_control).
+- **Services** (`services/`): all business logic — mount handling, file ops, chimes, thumbnails, Samba, mode detection, geo-indexing, cloud sync, etc.
+- **Helpers** (`helpers/`): config_updater, refresh_cloud_token, safe_mode.
+- Blueprints are always registered — routes redirect when their required `.img` file is missing (never unregistered at import time).
+
+### Feature Gating (Image-Gated UI)
+Nav items and routes are hidden/blocked when the required disk image doesn't exist:
+- `usb_cam.img` → analytics, videos, cleanup sub-pages
+- `usb_lightshow.img` → chimes, light shows, wraps, license_plates
+- `usb_music.img` + `MUSIC_ENABLED` → music
+
+`partition_service.get_feature_availability()` returns a dict of booleans; `utils.get_base_context()` merges them into every template context; `base.html` wraps nav links in `{% if <flag> %}` guards. Each gated blueprint has a `@bp.before_request` hook — AJAX requests get 503 JSON, normal requests redirect to Settings with a flash.
+
+**When adding a new gated feature**: add to `get_feature_availability()`, guard nav link in `base.html`, add `@bp.before_request` in the blueprint.
+
+### Mount / Gadget Safety Rules
+- All mount/umount commands must run in PID 1 mount namespace: `sudo nsenter --mount=/proc/1/ns/mnt ...`
+- Resolve paths via `partition_service.get_mount_path()` / `iter_all_partitions()` — never hardcode.
+- `partition_mount_service.quick_edit_part2` temporarily remounts part2 RW in present mode (uses `.quick_edit_part2.lock`, 120s stale). Always restore RO mount and LUN on all code paths including failures.
+- **quick_edit_part2 sequence**: Clear LUN1 backing → unmount RO → detach loops → create RW loop → mount RW → do work → sync → unmount → detach → create RO loop → remount RO → restore LUN1 backing.
+- USB gadget serves the `.img` file directly as the LUN backing file — not loop devices. Loop devices are for local mounting only.
+
+### Lock Chimes
+- Rules: WAV <1 MiB, 16-bit PCM, 44.1/48 kHz, mono/stereo. `lock_chime_service` validates, re-encodes via ffmpeg if needed.
+- After replacing `LockChime.wav`, MUST rebind USB gadget (`partition_mount_service.rebind_usb_gadget()`) to force Tesla cache invalidation.
+- Present-mode uploads use `quick_edit_part2`; keep operations short and atomic (temp + fsync + MD5).
+- Boot optimization: `select_random_chime.py` passes `skip_quick_edit=True` when part2 is already RW-mounted at boot.
+
+### Video & Mapping
+- **No standalone Videos page.** All video browsing is in the map page (`mapping.html`) via a slide-out panel.
+- GPS/telemetry indexed from dashcam SEI metadata by `mapping_service.py` into `geodata.db` (SQLite).
+- Indexing triggered on startup, inotify file detection, and WiFi connect.
+- **No thumbnail system** — it has been removed. Never add thumbnail generation.
+- `file_watcher_service.py` uses `watchdog` (inotify) with 5-minute polling fallback.
+
+### Cloud Sync
+- Queue-based (SQLite), one file at a time, `nice -n 19` + `ionice -c3` on rclone.
+- Priority: Tesla event.json folders → geolocated trips → other clips (opt-in).
+- Mark file as `synced` only AFTER rclone confirms upload + DB commit + fsync.
+
+### Task Coordinator
+- `task_coordinator.py` enforces exclusive lock: geo-indexer, video archiver, and cloud sync never run simultaneously (critical for 512MB RAM).
+
+### Offline Access Point & Captive Portal
+- AP runs on virtual interface `uap0` concurrent with WiFi client on `wlan0`.
+- Three force modes: `auto`, `force_on`, `force_off` — persisted in `config.yaml` and runtime file `/run/teslausb-ap/force.mode`.
+- Captive portal: Flask blueprint intercepts OS connectivity check URLs; dnsmasq spoofs all DNS to gateway IP. Port 80 is required — no iptables redirects.
+
+### Services & Timers (systemd)
+- `gadget_web.service` — Flask web UI
+- `present_usb_on_boot.service` — presents USB gadget at boot
+- `teslausb-deferred-tasks.service` — post-boot: cleanup, chime selection, indexing, cloud sync
+- `chime_scheduler.timer` — checks scheduled chime changes every 60s
+- `wifi-monitor.service` — manages AP/STA roaming
+- `watchdog.service` — hardware watchdog (15s timeout)
+
+## UI/UX Rules
+
+Full design system: [`docs/UI_UX_DESIGN_SYSTEM.md`](docs/UI_UX_DESIGN_SYSTEM.md)
+
+- **No emoji icons** — use Lucide SVG icons exclusively.
+- **CSS tokens only** — never hardcode hex values; use `--bg-primary`, `--accent-success`, etc.
+- **Dark and light mode**: both must work; test both. Use `[data-theme="dark"]` selectors.
+- **Mobile-first**: bottom tab bar (<1024px), sidebar rail (>=1024px). Test at 375px and 1024px+.
+- **Touch targets**: minimum 44x44px.
+- **No "Edit Mode" / "Present Mode" in UI** — user-facing concept is "Network File Sharing". Show a status dot.
+- **No external CDN calls** — fonts, icons, and all assets must be bundled locally.
+- **Progressive disclosure**: Layer 1 (glanceable), Layer 2 (one tap), Layer 3 (deliberate action).
+
+## Pitfalls
+
+- Skipping `nsenter` for mounts — mounts vanish after subprocess exit.
+- Wrong unbind/mount order when leaving present mode — causes busy unmounts.
+- Editing templates without rerunning `setup_usb.sh` — placeholders stay unexpanded.
+- Long `quick_edit` operations leaving LUN unbound on failure — always restore on all code paths.
+- Adding blocking work before UDC bind in `present_usb.sh` — delays Tesla USB detection.
+- Adding a new blueprint route without a `before_request` image guard when the feature requires a disk image.
+- Marking a cloud file as `synced` before rclone confirms the upload.
+- Running rclone without `nice`/`ionice` — starves the web server.
+- Generating video thumbnails (system removed — don't add it back).
+- Deleting or overwriting `*.img` files — `is_protected_file()` guard must always be respected.
+
+## Partition Layout & Content Decisions
+
+These decisions were made during the initial setup session (2026-04-29) and must not be changed without updating this file.
+
+### USB LUN layout
+
+| LUN | Image | Format | What goes here |
+|-----|-------|--------|----------------|
+| 0 | `usb_cam.img` | exFAT | TeslaCam dashcam + Sentry recordings (Tesla writes here automatically) |
+| 1 | `usb_lightshow.img` | FAT32 | **Light shows only** — `/LightShow/*.fseq` + paired audio. Also `/Chimes/`, `/Wrap/`, and `/LicensePlate/` managed by TeslaUSB web UI |
+| 2 | `usb_music.img` | FAT32 | Music files + **`/Media/` folder** for Tesla Boombox and other Tesla-native media features |
+
+### Content placement rules
+
+- **Light shows** (`.fseq` + `.mp3`/`.wav` pairs) → LUN 1 `/LightShow/`
+- **Lock chimes** → LUN 1 `/Chimes/` — managed by TeslaUSB web UI (upload, preview, scheduler)
+- **Wraps** (PNG files for Tesla Paint Shop) → LUN 1 `/Wrap/` — managed by TeslaUSB web UI
+- **License plates** (PNG images, 420x100px recommended) → LUN 1 `/LicensePlate/` — managed by TeslaUSB web UI (upload, download, delete; up to 10 images)
+- **Boombox sounds** → LUN 2 `/Media/` — Tesla reads this folder natively; managed by the **Boombox blueprint** (`blueprints/boombox.py`, `services/boombox_service.py`). Upload/delete/preview via the web UI (Media Hub → Boombox tab). MP3 only, max 1 MiB per file, max 20 files. Uses `quick_edit_part3` in present mode.
+- **Music** → LUN 2 root or subfolders — Tesla music player reads from here
+
+### Why Boombox lives on LUN 2 (Music), not LUN 1 (LightShow)
+
+Tesla reads Boombox sounds from a `/Media/` folder on any connected USB drive. Placing it on LUN 2 (Music) keeps LUN 1 (LightShow) clean — only light shows, chimes, and wraps that TeslaUSB actively manages. This avoids confusion between Tesla-native media features and TeslaUSB-managed features.
+
+**Do not** put Boombox sounds, raw chime files, or wrap PNGs directly on the LightShow partition outside of the folders TeslaUSB manages (`/Chimes/`, `/Wrap/`, `/LightShow/`, `/LicensePlate/`).
+
+### Partition sizes (initial setup)
+
+| Partition | Size | Rationale |
+|-----------|------|-----------|
+| TeslaCam | 150 GB | Maximise dashcam + sentry storage |
+| LightShow | 10 GB | 30+ shows, chimes, wraps, license plates — ample headroom |
+| Music | 20 GB | Boombox sounds + room to grow a music library |
+| SD reserve | 5 GB | Keep filesystem healthy |
+
+## Workspace Rules
+
+- **Never install packages or node_modules inside the git repo.** Test tooling (Playwright, npm packages) must live outside — use `../playwright-test/` or similar.
+- **Never create temporary test/debug/scratch files inside the repo.** Put them in a parent directory.
+- **The git working tree must stay clean.** After any task, `git status` should show only intentional changes.
+- **Python `__pycache__/`** is gitignored — never commit `.pyc` files.

--- a/scripts/web/blueprints/__init__.py
+++ b/scripts/web/blueprints/__init__.py
@@ -14,6 +14,7 @@ from .music import music_bp
 from .media import media_bp
 from .captive_portal import captive_portal_bp, catch_all_redirect
 from .cloud_archive import cloud_archive_bp
+from .boombox import boombox_bp
 
 __all__ = [
     'mode_control_bp',
@@ -31,4 +32,5 @@ __all__ = [
     'captive_portal_bp',
     'catch_all_redirect',
     'cloud_archive_bp',
+    'boombox_bp',
 ]

--- a/scripts/web/blueprints/boombox.py
+++ b/scripts/web/blueprints/boombox.py
@@ -1,0 +1,115 @@
+"""Blueprint for Boombox custom honk-sound management.
+
+Manages MP3 files in the /Media/ folder on the music partition (LUN 2).
+Tesla reads /Media/ for custom Boombox horn sounds. Files other than MP3
+are rejected at upload time; the filename becomes the selectable sound name
+in the Tesla UI.
+"""
+
+import os
+import logging
+from flask import (
+    Blueprint,
+    render_template,
+    request,
+    redirect,
+    url_for,
+    flash,
+    jsonify,
+    send_file,
+)
+
+from config import IMG_MUSIC_PATH, MUSIC_ENABLED
+from utils import get_base_context, format_file_size
+from services.boombox_service import (
+    list_boombox_files,
+    upload_boombox_file,
+    delete_boombox_file,
+    resolve_boombox_file_path,
+    BoomboxServiceError,
+    MAX_FILE_SIZE,
+    MAX_FILE_COUNT,
+)
+
+logger = logging.getLogger(__name__)
+
+boombox_bp = Blueprint("boombox", __name__, url_prefix="/boombox")
+
+
+@boombox_bp.before_request
+def _require_music_image():
+    if not MUSIC_ENABLED or not os.path.isfile(IMG_MUSIC_PATH):
+        if request.headers.get("X-Requested-With") == "XMLHttpRequest":
+            return jsonify({"error": "Feature unavailable"}), 503
+        flash("This feature is not available because the Music disk image has not been created.")
+        return redirect(url_for("mode_control.index"))
+
+
+@boombox_bp.route("/")
+def boombox_home():
+    ctx = get_base_context()
+    files, error, used_bytes, free_bytes = list_boombox_files()
+    return render_template(
+        "boombox.html",
+        page="media",
+        media_tab="boombox",
+        **ctx,
+        files=files,
+        error=error,
+        used_bytes=used_bytes,
+        free_bytes=free_bytes,
+        max_file_size=MAX_FILE_SIZE,
+        max_file_count=MAX_FILE_COUNT,
+        format_file_size=format_file_size,
+    )
+
+
+@boombox_bp.route("/upload", methods=["POST"])
+def upload_boombox():
+    is_ajax = request.headers.get("X-Requested-With") == "XMLHttpRequest"
+    file = request.files.get("boombox_file")
+
+    if not file or not file.filename:
+        if is_ajax:
+            return jsonify({"success": False, "error": "No file selected."}), 400
+        flash("No file selected.", "error")
+        return redirect(url_for("boombox.boombox_home"))
+
+    try:
+        ok, msg = upload_boombox_file(file)
+    except BoomboxServiceError as exc:
+        ok, msg = False, str(exc)
+
+    if is_ajax:
+        return jsonify({"success": ok, "message": msg}), (200 if ok else 400)
+
+    flash(msg, "success" if ok else "error")
+    return redirect(url_for("boombox.boombox_home"))
+
+
+@boombox_bp.route("/delete/<path:filename>", methods=["POST"])
+def delete_boombox(filename):
+    is_ajax = request.headers.get("X-Requested-With") == "XMLHttpRequest"
+
+    try:
+        ok, msg = delete_boombox_file(filename)
+    except BoomboxServiceError as exc:
+        ok, msg = False, str(exc)
+
+    if is_ajax:
+        return jsonify({"success": ok, "message": msg}), (200 if ok else 400)
+
+    flash(msg, "success" if ok else "error")
+    return redirect(url_for("boombox.boombox_home"))
+
+
+@boombox_bp.route("/play/<path:filename>")
+def play_boombox(filename):
+    """Stream a Boombox MP3 for in-browser preview."""
+    try:
+        file_path = resolve_boombox_file_path(filename)
+    except BoomboxServiceError as exc:
+        flash(str(exc), "error")
+        return redirect(url_for("boombox.boombox_home"))
+
+    return send_file(file_path, mimetype="audio/mpeg")

--- a/scripts/web/blueprints/media.py
+++ b/scripts/web/blueprints/media.py
@@ -18,3 +18,4 @@ def media_home():
         return redirect(url_for('music.music_home'))
     # Fallback to lock_chimes even if not available (it will show the error message)
     return redirect(url_for('lock_chimes.lock_chimes'))
+

--- a/scripts/web/services/boombox_service.py
+++ b/scripts/web/services/boombox_service.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""Boombox custom honk-sound management helpers.
+
+Manages MP3 files in the /Media/ folder on the music partition (LUN 2).
+Tesla reads this folder for custom Boombox horn sounds.
+
+Constraints:
+- Folder: /Media/ at the root of usb_music.img (part3)
+- Format: MP3 only
+- Max file size: 1 MiB
+- Max file count: 20
+"""
+
+import os
+import re
+import logging
+from typing import List, Tuple
+
+from config import MNT_DIR
+from services.partition_service import get_mount_path
+from services.samba_service import close_samba_share
+from services.mode_service import current_mode
+from services.partition_mount_service import quick_edit_part3
+
+logger = logging.getLogger(__name__)
+
+BOOMBOX_FOLDER = "Media"
+ALLOWED_EXT = ".mp3"
+MAX_FILE_SIZE = 1 * 1024 * 1024  # 1 MiB
+MAX_FILE_COUNT = 20
+
+
+class BoomboxServiceError(Exception):
+    """Raised for user-facing Boombox service errors."""
+
+
+def _sanitize_filename(name: str) -> str:
+    """Strip directory components and disallowed characters from a filename."""
+    base = os.path.basename(name or "")
+    base = re.sub(r'[\x00-\x1f\x7f/\\:]', '', base).strip()
+    base = re.sub(r'\s+', ' ', base)
+    return base
+
+
+def _ensure_mount() -> Tuple[str, str]:
+    """Return the music partition mount path, or an empty string and error message."""
+    mount_path = get_mount_path("part3")
+    if not mount_path:
+        return "", "Music drive not mounted. Switch to Edit mode and try again."
+    if not os.path.ismount(mount_path):
+        return "", "Music drive is unavailable."
+    return mount_path, ""
+
+
+def _media_dir(mount_path: str) -> str:
+    """Return the /Media/ directory path within the given mount, creating it if needed."""
+    media_dir = os.path.join(mount_path, BOOMBOX_FOLDER)
+    os.makedirs(media_dir, exist_ok=True)
+    return media_dir
+
+
+def _validate_filename(name: str) -> str:
+    """Sanitize and validate an uploaded filename; raise BoomboxServiceError on failure."""
+    safe = _sanitize_filename(name)
+    if not safe:
+        raise BoomboxServiceError("Invalid filename.")
+    ext = os.path.splitext(safe)[1].lower()
+    if ext != ALLOWED_EXT:
+        raise BoomboxServiceError("Only MP3 files are accepted.")
+    return safe
+
+
+def _safe_file_path(media_dir: str, filename: str) -> str:
+    """Return an absolute path within media_dir for filename, rejecting traversal attempts."""
+    target = os.path.normpath(os.path.join(media_dir, filename))
+    if os.path.commonpath([media_dir, target]) != os.path.abspath(media_dir):
+        raise BoomboxServiceError("Invalid file path.")
+    return target
+
+
+def list_boombox_files(mount_path: str = "") -> Tuple[List[dict], str, int, int]:
+    """Return (files, error, used_bytes, free_bytes) for the /Media/ folder.
+
+    Each file entry: {name, size, size_str}.
+    If mount_path is empty the current mode mount is resolved automatically.
+    """
+    if not mount_path:
+        mount_path, err = _ensure_mount()
+        if err:
+            return [], err, 0, 0
+
+    media_dir = _media_dir(mount_path)
+
+    try:
+        stat = os.statvfs(mount_path)
+        free_bytes = stat.f_bavail * stat.f_frsize
+        total_bytes = stat.f_blocks * stat.f_frsize
+        used_bytes = total_bytes - free_bytes
+    except OSError:
+        free_bytes = 0
+        used_bytes = 0
+
+    files = []
+    try:
+        for entry in os.scandir(media_dir):
+            if not entry.is_file():
+                continue
+            if os.path.splitext(entry.name)[1].lower() != ALLOWED_EXT:
+                continue
+            size = entry.stat().st_size
+            files.append({"name": entry.name, "size": size})
+    except OSError as exc:
+        logger.warning("Could not read Media directory: %s", exc)
+        return [], "Unable to read Media directory.", used_bytes, free_bytes
+
+    files.sort(key=lambda f: f["name"].lower())
+    return files, "", used_bytes, free_bytes
+
+
+def upload_boombox_file(file_storage) -> Tuple[bool, str]:
+    """Upload an MP3 file to /Media/ on the music partition.
+
+    Mode-aware: uses quick_edit_part3 in present mode.
+    """
+    filename = _validate_filename(file_storage.filename)
+
+    file_storage.stream.seek(0, os.SEEK_END)
+    incoming_size = file_storage.stream.tell()
+    file_storage.stream.seek(0)
+
+    if incoming_size > MAX_FILE_SIZE:
+        return False, f"File too large (max {MAX_FILE_SIZE // (1024 * 1024)} MiB)."
+
+    file_bytes = file_storage.read()
+
+    def _do_upload(mount_path: str) -> Tuple[bool, str]:
+        media_dir = _media_dir(mount_path)
+
+        existing = [
+            e.name for e in os.scandir(media_dir)
+            if e.is_file() and os.path.splitext(e.name)[1].lower() == ALLOWED_EXT
+        ]
+        if len(existing) >= MAX_FILE_COUNT:
+            return False, f"Maximum of {MAX_FILE_COUNT} files reached. Delete one first."
+
+        free_bytes = os.statvfs(mount_path).f_bavail * os.statvfs(mount_path).f_frsize
+        if free_bytes <= incoming_size + (2 * 1024 * 1024):
+            return False, "Not enough free space on Music drive."
+
+        final_path = _safe_file_path(media_dir, filename)
+        tmp_path = final_path + ".tmp"
+
+        try:
+            with open(tmp_path, "wb") as fh:
+                fh.write(file_bytes)
+                fh.flush()
+                os.fsync(fh.fileno())
+
+            os.replace(tmp_path, final_path)
+
+            fd = os.open(media_dir, os.O_DIRECTORY)
+            try:
+                os.fsync(fd)
+            finally:
+                os.close(fd)
+        except OSError as exc:
+            logger.error("Failed to write Boombox file: %s", exc)
+            try:
+                os.remove(tmp_path)
+            except OSError:
+                pass
+            return False, "Failed to save file."
+
+        try:
+            close_samba_share("part3")
+        except Exception:
+            pass
+
+        return True, f"Uploaded {filename}."
+
+    mode = current_mode()
+    if mode == "present":
+        def _quick_callback():
+            rw_mount = os.path.join(MNT_DIR, "part3")
+            return _do_upload(rw_mount)
+
+        return quick_edit_part3(_quick_callback, timeout=30)
+
+    mount_path, err = _ensure_mount()
+    if err:
+        return False, err
+    return _do_upload(mount_path)
+
+
+def delete_boombox_file(filename: str) -> Tuple[bool, str]:
+    """Delete a single MP3 from /Media/ on the music partition.
+
+    Mode-aware: uses quick_edit_part3 in present mode.
+    """
+    safe_name = _validate_filename(filename)
+
+    def _do_delete(mount_path: str) -> Tuple[bool, str]:
+        media_dir = _media_dir(mount_path)
+        file_path = _safe_file_path(media_dir, safe_name)
+
+        if not os.path.isfile(file_path):
+            return False, f"{safe_name} not found."
+
+        try:
+            os.remove(file_path)
+            fd = os.open(media_dir, os.O_DIRECTORY)
+            try:
+                os.fsync(fd)
+            finally:
+                os.close(fd)
+        except OSError as exc:
+            logger.error("Failed to delete Boombox file: %s", exc)
+            return False, "Failed to delete file."
+
+        try:
+            close_samba_share("part3")
+        except Exception:
+            pass
+
+        return True, f"Deleted {safe_name}."
+
+    mode = current_mode()
+    if mode == "present":
+        def _quick_callback():
+            rw_mount = os.path.join(MNT_DIR, "part3")
+            return _do_delete(rw_mount)
+
+        return quick_edit_part3(_quick_callback, timeout=30)
+
+    mount_path, err = _ensure_mount()
+    if err:
+        return False, err
+    return _do_delete(mount_path)
+
+
+def resolve_boombox_file_path(filename: str) -> str:
+    """Return the absolute filesystem path for a Boombox MP3 file.
+
+    Raises BoomboxServiceError if the drive is not mounted or the file is absent.
+    """
+    safe_name = _validate_filename(filename)
+    mount_path, err = _ensure_mount()
+    if err:
+        raise BoomboxServiceError(err)
+    media_dir = _media_dir(mount_path)
+    file_path = _safe_file_path(media_dir, safe_name)
+    if not os.path.isfile(file_path):
+        raise BoomboxServiceError("File not found.")
+    return file_path

--- a/scripts/web/services/partition_service.py
+++ b/scripts/web/services/partition_service.py
@@ -51,6 +51,7 @@ def get_feature_availability():
         'shows_available': lightshow_exists,
         'wraps_available': lightshow_exists,
         'music_available': music_exists,
+        'boombox_available': music_exists,
         'cloud_archive_available': CLOUD_ARCHIVE_ENABLED,
         'cloud_provider_connected': CLOUD_ARCHIVE_ENABLED and bool(CLOUD_ARCHIVE_PROVIDER)
                                     and os.path.isfile(CLOUD_PROVIDER_CREDS_PATH),

--- a/scripts/web/static/icons/lucide-sprite.svg
+++ b/scripts/web/static/icons/lucide-sprite.svg
@@ -180,4 +180,9 @@
   <symbol id="icon-battery" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
     <rect width="16" height="10" x="2" y="7" rx="2" ry="2"/><line x1="22" x2="22" y1="11" y2="13"/>
   </symbol>
+  <symbol id="icon-volume-2" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"/>
+    <path d="M19.07 4.93a10 10 0 0 1 0 14.14"/>
+    <path d="M15.54 8.46a5 5 0 0 1 0 7.07"/>
+  </symbol>
 </svg>

--- a/scripts/web/templates/boombox.html
+++ b/scripts/web/templates/boombox.html
@@ -1,0 +1,303 @@
+{% extends "base.html" %}
+{% block head %}
+<style>
+    .boombox-panel {
+        background: var(--bg-container);
+        border: 1px solid var(--border-color);
+        border-radius: 8px;
+        padding: 20px;
+        box-shadow: 0 2px 10px var(--shadow);
+        transition: background-color 0.3s ease, box-shadow 0.3s ease, border-color 0.3s ease;
+    }
+
+    .boombox-upload-zone {
+        border: 2px dashed var(--border-input);
+        border-radius: 8px;
+        padding: 30px;
+        text-align: center;
+        background: var(--form-input-bg);
+        cursor: pointer;
+        transition: border-color 0.2s, background 0.2s;
+        margin-bottom: 20px;
+    }
+
+    .boombox-upload-zone.drag-over {
+        border-color: var(--accent-primary);
+        background: var(--bg-hover);
+    }
+
+    .boombox-upload-zone p {
+        margin: 6px 0;
+        color: var(--text-secondary);
+        font-size: 13px;
+    }
+
+    .boombox-upload-zone .zone-title {
+        font-size: 15px;
+        font-weight: 600;
+        color: var(--text-primary);
+        margin-bottom: 4px;
+    }
+
+    /* File list */
+    .boombox-file-row {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        padding: 10px 0;
+        border-bottom: 1px solid var(--border-color);
+    }
+
+    .boombox-file-row:last-child {
+        border-bottom: none;
+    }
+
+    .boombox-file-name {
+        flex: 1;
+        font-size: 14px;
+        color: var(--text-primary);
+        word-break: break-all;
+    }
+
+    .boombox-file-size {
+        font-size: 12px;
+        color: var(--text-secondary);
+        white-space: nowrap;
+    }
+
+    .boombox-file-actions {
+        display: flex;
+        gap: 8px;
+        flex-shrink: 0;
+    }
+
+    /* Mobile cards */
+    @media (max-width: 600px) {
+        .boombox-file-row {
+            flex-wrap: wrap;
+        }
+
+        .boombox-file-actions {
+            width: 100%;
+            justify-content: flex-end;
+        }
+    }
+
+    /* Storage bar */
+    .storage-bar {
+        height: 8px;
+        background: var(--border-color);
+        border-radius: 4px;
+        overflow: hidden;
+        margin: 8px 0 4px;
+    }
+
+    .storage-bar-fill {
+        height: 100%;
+        background: var(--accent-primary);
+        border-radius: 4px;
+        transition: width 0.3s;
+    }
+
+    /* Upload progress */
+    #uploadProgress {
+        display: none;
+        margin-bottom: 16px;
+    }
+
+    #uploadProgressBar {
+        height: 6px;
+        background: var(--accent-primary);
+        border-radius: 3px;
+        width: 0%;
+        transition: width 0.2s;
+    }
+</style>
+{% endblock %}
+
+{% block content %}
+<div class="container">
+    {% include 'media_hub_nav.html' %}
+
+    <h2>Boombox Sounds</h2>
+
+    <div class="info-box" style="margin-bottom: 20px;">
+        <p><strong>Tesla Boombox requirements:</strong></p>
+        <ul style="margin: 8px 0 0 20px; padding: 0; font-size: 13px; color: var(--text-secondary);">
+            <li><strong>Format:</strong> MP3 only</li>
+            <li><strong>Size:</strong> Max {{ (max_file_size / 1024 / 1024)|round(0)|int }} MiB per file</li>
+            <li><strong>Count:</strong> Up to {{ max_file_count }} files (currently {{ files|length }}/{{ max_file_count }})</li>
+            <li><strong>Filename:</strong> Becomes the sound name shown in the Tesla UI</li>
+        </ul>
+        <p style="margin-top: 10px; font-size: 13px; color: var(--text-secondary);">
+            Select a custom sound in your Tesla via <strong>Toybox &rarr; Boombox</strong>.
+        </p>
+    </div>
+
+    {% if error %}
+    <div class="error-box" style="margin-bottom: 20px;">
+        <p>{{ error }}</p>
+    </div>
+    {% endif %}
+
+    <div class="boombox-panel">
+        <!-- Storage summary -->
+        {% if used_bytes is defined %}
+        <div style="margin-bottom: 16px;">
+            <div style="display: flex; justify-content: space-between; font-size: 12px; color: var(--text-secondary);">
+                <span>Used: {{ format_file_size(used_bytes) }}</span>
+                <span>Free: {{ format_file_size(free_bytes) }}</span>
+            </div>
+            {% set total = used_bytes + free_bytes %}
+            {% if total > 0 %}
+            <div class="storage-bar">
+                <div class="storage-bar-fill" style="width: {{ [(used_bytes / total * 100)|round(1), 100]|min }}%;"></div>
+            </div>
+            {% endif %}
+        </div>
+        {% endif %}
+
+        <!-- Upload zone -->
+        {% if files|length < max_file_count %}
+        <div class="boombox-upload-zone" id="uploadZone" role="region" aria-label="Upload Boombox sound">
+            <p class="zone-title">Upload MP3 file</p>
+            <p>Drag &amp; drop here, or click to browse</p>
+            <p>MP3 only &bull; max {{ (max_file_size / 1024 / 1024)|round(0)|int }} MiB</p>
+            <input type="file" id="boomboxFileInput" accept=".mp3,audio/mpeg" style="display:none;" aria-label="Select MP3 file">
+        </div>
+
+        <!-- Upload progress -->
+        <div id="uploadProgress" aria-live="polite" aria-label="Upload progress">
+            <div style="background: var(--border-color); border-radius: 3px; overflow: hidden; margin-bottom: 6px;">
+                <div id="uploadProgressBar"></div>
+            </div>
+            <p id="uploadStatus" style="font-size: 12px; color: var(--text-secondary); margin: 0;"></p>
+        </div>
+        {% else %}
+        <div class="info-box" style="margin-bottom: 16px;">
+            <p>Maximum of {{ max_file_count }} files reached. Delete a file before uploading another.</p>
+        </div>
+        {% endif %}
+
+        <!-- File list -->
+        {% if files %}
+        <div id="fileList" aria-label="Boombox sound files">
+            {% for f in files %}
+            <div class="boombox-file-row" id="row-{{ loop.index }}">
+                <span class="boombox-file-name">{{ f.name }}</span>
+                <span class="boombox-file-size">{{ format_file_size(f.size) }}</span>
+                <div class="boombox-file-actions">
+                    <audio controls preload="none"
+                           src="{{ url_for('boombox.play_boombox', filename=f.name) }}"
+                           style="height: 32px; max-width: 140px;"
+                           aria-label="Preview {{ f.name }}"></audio>
+                    <form method="post"
+                          action="{{ url_for('boombox.delete_boombox', filename=f.name) }}"
+                          style="margin: 0;"
+                          onsubmit="return confirm('Delete {{ f.name }}?');">
+                        <button type="submit" class="action-btn danger"
+                                aria-label="Delete {{ f.name }}">
+                            <svg class="nav-icon" aria-hidden="true">
+                                <use href="{{ url_for('static', filename='icons/lucide-sprite.svg') }}#icon-trash-2"></use>
+                            </svg>
+                        </button>
+                    </form>
+                </div>
+            </div>
+            {% endfor %}
+        </div>
+        {% else %}
+        <p style="color: var(--text-secondary); font-size: 14px; margin: 0;">
+            No Boombox sounds uploaded yet. Add MP3 files above.
+        </p>
+        {% endif %}
+    </div>
+</div>
+
+<script>
+(function () {
+    const zone = document.getElementById('uploadZone');
+    const input = document.getElementById('boomboxFileInput');
+    const progress = document.getElementById('uploadProgress');
+    const bar = document.getElementById('uploadProgressBar');
+    const status = document.getElementById('uploadStatus');
+    const MAX_SIZE = {{ max_file_size }};
+
+    if (!zone || !input) return;
+
+    zone.addEventListener('click', () => input.click());
+
+    zone.addEventListener('dragover', (e) => {
+        e.preventDefault();
+        zone.classList.add('drag-over');
+    });
+
+    zone.addEventListener('dragleave', () => zone.classList.remove('drag-over'));
+
+    zone.addEventListener('drop', (e) => {
+        e.preventDefault();
+        zone.classList.remove('drag-over');
+        const file = e.dataTransfer.files[0];
+        if (file) uploadFile(file);
+    });
+
+    input.addEventListener('change', () => {
+        const file = input.files[0];
+        if (file) uploadFile(file);
+        input.value = '';
+    });
+
+    function uploadFile(file) {
+        if (!file.name.toLowerCase().endsWith('.mp3')) {
+            showStatus('Only MP3 files are accepted.', false);
+            return;
+        }
+        if (file.size > MAX_SIZE) {
+            showStatus('File is too large (max {{ (max_file_size / 1024 / 1024)|round(0)|int }} MiB).', false);
+            return;
+        }
+
+        const formData = new FormData();
+        formData.append('boombox_file', file);
+
+        progress.style.display = 'block';
+        bar.style.width = '0%';
+        showStatus('Uploading…', true);
+
+        const xhr = new XMLHttpRequest();
+        xhr.open('POST', '{{ url_for("boombox.upload_boombox") }}');
+        xhr.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
+
+        xhr.upload.addEventListener('progress', (e) => {
+            if (e.lengthComputable) {
+                bar.style.width = Math.round(e.loaded / e.total * 100) + '%';
+            }
+        });
+
+        xhr.addEventListener('load', () => {
+            try {
+                const resp = JSON.parse(xhr.responseText);
+                if (resp.success) {
+                    bar.style.width = '100%';
+                    showStatus(resp.message, true);
+                    setTimeout(() => window.location.reload(), 800);
+                } else {
+                    showStatus(resp.error || resp.message || 'Upload failed.', false);
+                }
+            } catch {
+                showStatus('Unexpected response from server.', false);
+            }
+        });
+
+        xhr.addEventListener('error', () => showStatus('Network error during upload.', false));
+
+        xhr.send(formData);
+    }
+
+    function showStatus(msg, ok) {
+        status.textContent = msg;
+        status.style.color = ok ? 'var(--accent-success)' : 'var(--accent-error)';
+    }
+}());
+</script>
+{% endblock %}

--- a/scripts/web/templates/media_hub_nav.html
+++ b/scripts/web/templates/media_hub_nav.html
@@ -12,6 +12,12 @@
     Music
   </a>
   {% endif %}
+  {% if boombox_available %}
+  <a href="{{ url_for('boombox.boombox_home') }}" class="media-pill {% if media_tab == 'boombox' %}active{% endif %}">
+    <svg class="nav-icon" aria-hidden="true"><use href="{{ url_for('static', filename='icons/lucide-sprite.svg') }}#icon-volume-2"></use></svg>
+    Boombox
+  </a>
+  {% endif %}
   {% if shows_available %}
   <a href="{{ url_for('light_shows.light_shows') }}" class="media-pill {% if media_tab == 'shows' %}active{% endif %}">
     <svg class="nav-icon" aria-hidden="true"><use href="{{ url_for('static', filename='icons/lucide-sprite.svg') }}#icon-sparkles"></use></svg>

--- a/scripts/web/web_control.py
+++ b/scripts/web/web_control.py
@@ -51,6 +51,7 @@ from blueprints import (
     captive_portal_bp,
     catch_all_redirect,
     cloud_archive_bp,
+    boombox_bp,
 )
 
 app.register_blueprint(mapping_bp)
@@ -59,6 +60,7 @@ app.register_blueprint(videos_bp)
 app.register_blueprint(lock_chimes_bp)
 app.register_blueprint(light_shows_bp)
 app.register_blueprint(music_bp)
+app.register_blueprint(boombox_bp)
 app.register_blueprint(wraps_bp)
 app.register_blueprint(media_bp)
 app.register_blueprint(analytics_bp)

--- a/tests/test_boombox_service.py
+++ b/tests/test_boombox_service.py
@@ -1,0 +1,259 @@
+"""Tests for boombox_service — upload validation, delete, and list."""
+
+import io
+import os
+import pytest
+from unittest.mock import patch, MagicMock
+
+# boombox_service is imported via scripts/web path added in conftest.py
+from services.boombox_service import (
+    _sanitize_filename,
+    _validate_filename,
+    _safe_file_path,
+    BoomboxServiceError,
+    MAX_FILE_SIZE,
+    MAX_FILE_COUNT,
+)
+
+
+# ---------------------------------------------------------------------------
+# _sanitize_filename
+# ---------------------------------------------------------------------------
+
+class TestSanitizeFilename:
+    def test_strips_directory_components(self):
+        assert _sanitize_filename("../../etc/passwd.mp3") == "passwd.mp3"
+
+    def test_strips_null_bytes(self):
+        assert _sanitize_filename("sound\x00.mp3") == "sound.mp3"
+
+    def test_collapses_whitespace(self):
+        assert _sanitize_filename("my  song.mp3") == "my song.mp3"
+
+    def test_empty_string(self):
+        assert _sanitize_filename("") == ""
+
+    def test_strips_backslash(self):
+        # On Unix, backslash is not a path separator, so basename keeps the whole
+        # string; the regex then removes the backslash character itself.
+        assert _sanitize_filename("folder\\file.mp3") == "folderfile.mp3"
+
+
+# ---------------------------------------------------------------------------
+# _validate_filename
+# ---------------------------------------------------------------------------
+
+class TestValidateFilename:
+    def test_accepts_mp3(self):
+        assert _validate_filename("honk.mp3") == "honk.mp3"
+
+    def test_accepts_mp3_uppercase(self):
+        assert _validate_filename("HONK.MP3") == "HONK.MP3"
+
+    def test_rejects_wav(self):
+        with pytest.raises(BoomboxServiceError, match="Only MP3"):
+            _validate_filename("honk.wav")
+
+    def test_rejects_flac(self):
+        with pytest.raises(BoomboxServiceError, match="Only MP3"):
+            _validate_filename("honk.flac")
+
+    def test_rejects_empty(self):
+        with pytest.raises(BoomboxServiceError, match="Invalid filename"):
+            _validate_filename("")
+
+    def test_rejects_traversal(self):
+        """Traversal characters are stripped, leaving a valid name."""
+        result = _validate_filename("../../../evil.mp3")
+        assert result == "evil.mp3"
+
+    def test_rejects_no_ext(self):
+        with pytest.raises(BoomboxServiceError, match="Only MP3"):
+            _validate_filename("noextension")
+
+
+# ---------------------------------------------------------------------------
+# _safe_file_path
+# ---------------------------------------------------------------------------
+
+class TestSafeFilePath:
+    def test_returns_path_within_media_dir(self, tmp_path):
+        media_dir = str(tmp_path)
+        result = _safe_file_path(media_dir, "honk.mp3")
+        assert result == os.path.join(media_dir, "honk.mp3")
+
+    def test_rejects_traversal(self, tmp_path):
+        media_dir = str(tmp_path)
+        with pytest.raises(BoomboxServiceError, match="Invalid file path"):
+            _safe_file_path(media_dir, "../outside.mp3")
+
+
+# ---------------------------------------------------------------------------
+# upload_boombox_file — size limit
+# ---------------------------------------------------------------------------
+
+class FakeFileStorage:
+    """Minimal werkzeug FileStorage substitute for tests."""
+
+    def __init__(self, filename: str, content: bytes):
+        self.filename = filename
+        self.stream = io.BytesIO(content)
+
+    def read(self) -> bytes:
+        return self.stream.getvalue()
+
+
+class TestUploadSizeLimit:
+    def test_rejects_oversized_file(self):
+        oversized = b"x" * (MAX_FILE_SIZE + 1)
+        fs = FakeFileStorage("big.mp3", oversized)
+        with patch("services.boombox_service.current_mode", return_value="edit"), \
+             patch("services.boombox_service._ensure_mount",
+                   return_value=("/fake/mount", "")):
+            ok, msg = __import__(
+                "services.boombox_service", fromlist=["upload_boombox_file"]
+            ).upload_boombox_file(fs)
+            assert not ok
+            assert "too large" in msg.lower()
+
+    def test_rejects_wrong_extension(self):
+        fs = FakeFileStorage("sound.wav", b"RIFF")
+        with pytest.raises(BoomboxServiceError, match="Only MP3"):
+            from services.boombox_service import upload_boombox_file
+            upload_boombox_file(fs)
+
+
+# ---------------------------------------------------------------------------
+# upload_boombox_file — file count limit
+# ---------------------------------------------------------------------------
+
+class TestUploadCountLimit:
+    def test_rejects_when_full(self, tmp_path):
+        """Upload is rejected when MAX_FILE_COUNT files already exist."""
+        media_dir = tmp_path / "Media"
+        media_dir.mkdir()
+        # Create MAX_FILE_COUNT dummy MP3 files
+        for i in range(MAX_FILE_COUNT):
+            (media_dir / f"sound{i}.mp3").write_bytes(b"ID3")
+
+        fs = FakeFileStorage("new.mp3", b"ID3")
+
+        def fake_ensure_mount():
+            return str(tmp_path), ""
+
+        def fake_media_dir(mount_path):
+            return str(media_dir)
+
+        with patch("services.boombox_service.current_mode", return_value="edit"), \
+             patch("services.boombox_service._ensure_mount", fake_ensure_mount), \
+             patch("services.boombox_service._media_dir", fake_media_dir):
+            from services.boombox_service import upload_boombox_file
+            ok, msg = upload_boombox_file(fs)
+            assert not ok
+            assert "Maximum" in msg
+
+
+# ---------------------------------------------------------------------------
+# delete_boombox_file — safety checks
+# ---------------------------------------------------------------------------
+
+class TestDeleteBoomboxFile:
+    def test_rejects_nonexistent_file(self, tmp_path):
+        media_dir = tmp_path / "Media"
+        media_dir.mkdir()
+
+        def fake_ensure_mount():
+            return str(tmp_path), ""
+
+        def fake_media_dir(mount_path):
+            return str(media_dir)
+
+        with patch("services.boombox_service.current_mode", return_value="edit"), \
+             patch("services.boombox_service._ensure_mount", fake_ensure_mount), \
+             patch("services.boombox_service._media_dir", fake_media_dir):
+            from services.boombox_service import delete_boombox_file
+            ok, msg = delete_boombox_file("ghost.mp3")
+            assert not ok
+            assert "not found" in msg.lower()
+
+    def test_rejects_wrong_extension(self, tmp_path):
+        with pytest.raises(BoomboxServiceError, match="Only MP3"):
+            from services.boombox_service import delete_boombox_file
+            delete_boombox_file("photo.png")
+
+    def test_deletes_existing_file(self, tmp_path):
+        media_dir = tmp_path / "Media"
+        media_dir.mkdir()
+        (media_dir / "honk.mp3").write_bytes(b"ID3")
+
+        def fake_ensure_mount():
+            return str(tmp_path), ""
+
+        def fake_media_dir(mount_path):
+            return str(media_dir)
+
+        with patch("services.boombox_service.current_mode", return_value="edit"), \
+             patch("services.boombox_service._ensure_mount", fake_ensure_mount), \
+             patch("services.boombox_service._media_dir", fake_media_dir), \
+             patch("services.boombox_service.close_samba_share"):
+            from services.boombox_service import delete_boombox_file
+            ok, msg = delete_boombox_file("honk.mp3")
+            assert ok
+            assert "honk.mp3" in msg
+            assert not (media_dir / "honk.mp3").exists()
+
+
+# ---------------------------------------------------------------------------
+# list_boombox_files
+# ---------------------------------------------------------------------------
+
+class TestListBoomboxFiles:
+    def test_lists_only_mp3_files(self, tmp_path):
+        media_dir = tmp_path / "Media"
+        media_dir.mkdir()
+        (media_dir / "a.mp3").write_bytes(b"ID3")
+        (media_dir / "b.wav").write_bytes(b"RIFF")
+        (media_dir / "c.mp3").write_bytes(b"ID3x")
+
+        def fake_ensure_mount():
+            return str(tmp_path), ""
+
+        def fake_media_dir(mount_path):
+            return str(media_dir)
+
+        with patch("services.boombox_service._ensure_mount", fake_ensure_mount), \
+             patch("services.boombox_service._media_dir", fake_media_dir):
+            from services.boombox_service import list_boombox_files
+            files, error, _, _ = list_boombox_files()
+            names = [f["name"] for f in files]
+            assert "a.mp3" in names
+            assert "c.mp3" in names
+            assert "b.wav" not in names
+            assert error == ""
+
+    def test_returns_sorted_names(self, tmp_path):
+        media_dir = tmp_path / "Media"
+        media_dir.mkdir()
+        for name in ["zebra.mp3", "apple.mp3", "mango.mp3"]:
+            (media_dir / name).write_bytes(b"ID3")
+
+        def fake_ensure_mount():
+            return str(tmp_path), ""
+
+        def fake_media_dir(mount_path):
+            return str(media_dir)
+
+        with patch("services.boombox_service._ensure_mount", fake_ensure_mount), \
+             patch("services.boombox_service._media_dir", fake_media_dir):
+            from services.boombox_service import list_boombox_files
+            files, _, _, _ = list_boombox_files()
+            names = [f["name"] for f in files]
+            assert names == sorted(names, key=str.lower)
+
+    def test_returns_error_when_mount_missing(self):
+        with patch("services.boombox_service._ensure_mount",
+                   return_value=("", "Music drive not mounted.")):
+            from services.boombox_service import list_boombox_files
+            files, error, _, _ = list_boombox_files()
+            assert files == []
+            assert "not mounted" in error


### PR DESCRIPTION
Add a new 'Boombox' tab to the Media Hub that lets users upload, preview, and delete custom MP3 honk sounds for Tesla's Boombox feature.

Tesla reads /Media/ on any connected USB drive for custom horn sounds. The filename becomes the selectable sound name in the Tesla UI.

Changes:
- New boombox_service.py: list/upload/delete/resolve for /Media/ on LUN 2 (music partition). MP3-only, max 1 MiB per file, max 20 files. Uses quick_edit_part3 in present mode (atomic temp-file + fsync write).
- New boombox.py blueprint: GET /boombox/ list, POST /boombox/upload, POST /boombox/delete/<name>, GET /boombox/play/<name>. Gated on music image availability (MUSIC_ENABLED + IMG_MUSIC_PATH).
- New boombox.html template: upload zone with drag-and-drop, inline audio preview, delete with confirmation. Follows design-system tokens.
- partition_service: add boombox_available flag (same condition as music_available).
- media_hub_nav.html: add Boombox pill tab gated on boombox_available, icon-volume-2.
- lucide-sprite.svg: add icon-volume-2 (speaker + waves).
- web_control.py + blueprints/__init__.py: register boombox_bp.
- CLAUDE.md: update Boombox entry to reflect new web UI.
- tests/test_boombox_service.py: 23 unit tests covering filename sanitization, size limit, count limit, delete safety, and list output.