### PR TITLE
feat(map): persist selected day and view in the URL

### DIFF
--- a/scripts/web/templates/mapping.html
+++ b/scripts/web/templates/mapping.html
@@ -864,6 +864,74 @@ function formatLocalTime(isoStr) {
     } catch(e) { return 'Invalid Date'; }
 }
 
+// --- URL state (issue #57) ---
+//
+// Persist the selected day / view-mode in the query string so refresh,
+// share, bookmark, and browser back/forward all work. State on the page
+// (``currentDate`` / ``showingAllTime``) is the source of truth for
+// rendering; the URL is a serialized projection of that state.
+//
+// pushState vs replaceState policy:
+//   - Rapid cycling (chevrons + keyboard arrows) uses ``replaceState``
+//     so back/forward history doesn't flood with one entry per arrow.
+//   - Deliberate cross-day jumps (trip-panel taps, disambig pick,
+//     polyline click in All-time, event-marker "Go to this day", and
+//     the "All time" button itself) use ``pushState`` so the user can
+//     back out of an intentional navigation.
+//   - The popstate handler restores state from the URL with
+//     ``skipHistory: true`` so the restoration does not itself modify
+//     the history stack.
+function readUrlState() {
+    try {
+        const params = new URLSearchParams(window.location.search);
+        const view = params.get('view');
+        if (view === 'all-time') return { view: 'all-time' };
+        const date = params.get('date');
+        if (date && /^\d{4}-\d{2}-\d{2}$/.test(date)) {
+            // Reject syntactically-valid but impossible dates (e.g.
+            // 2026-13-99). Round-tripping through Date catches both
+            // out-of-range months/days and Feb-29 in non-leap years.
+            const parts = date.split('-');
+            const y = parseInt(parts[0], 10);
+            const m = parseInt(parts[1], 10);
+            const d = parseInt(parts[2], 10);
+            const dt = new Date(y, m - 1, d);
+            if (!isNaN(dt.getTime()) &&
+                dt.getFullYear() === y &&
+                dt.getMonth() === m - 1 &&
+                dt.getDate() === d) {
+                return { date };
+            }
+        }
+    } catch (e) { /* malformed URL — fall through to default */ }
+    return null;
+}
+
+function writeUrlState(state, options) {
+    const opts = options || {};
+    if (opts.skipHistory) return;
+    try {
+        const params = new URLSearchParams();
+        if (state && state.view === 'all-time') {
+            params.set('view', 'all-time');
+        } else if (state && state.date && /^\d{4}-\d{2}-\d{2}$/.test(state.date)) {
+            params.set('date', state.date);
+        }
+        const qs = params.toString();
+        const url = qs ? (window.location.pathname + '?' + qs)
+                       : window.location.pathname;
+        const stateObj = {
+            view: (state && state.view === 'all-time') ? 'all-time' : 'day',
+            date: (state && state.date) || null,
+        };
+        if (opts.pushHistory) {
+            window.history.pushState(stateObj, '', url);
+        } else {
+            window.history.replaceState(stateObj, '', url);
+        }
+    } catch (e) { /* history API unavailable (e.g. sandboxed iframe) */ }
+}
+
 // Fix Leaflet marker icon path for vendored setup
 L.Icon.Default.imagePath = '{{ url_for("static", filename="vendor/leaflet/images/") }}';
 
@@ -1234,7 +1302,7 @@ function showDisambigPopup(latlng, candidates) {
             const date = trip && trip.date;
             closeDisambigPopup();
             if (date && /^\d{4}-\d{2}-\d{2}$/.test(date)) {
-                loadDay(date);
+                loadDay(date, { pushHistory: true });
             }
             return;
         }
@@ -1432,13 +1500,20 @@ async function loadDays() {
     }
 }
 
-async function loadDay(date) {
+async function loadDay(date, options) {
     // Render all trips and events for ``date`` in a single pass.
     // Increments dayLoadSeq so any in-flight earlier loadDay() call
     // discards its results when it returns — this prevents the
     // indexer-refresh poll from overwriting a day the user just
     // navigated to with stale data from the previous day.
+    //
+    // ``options.pushHistory`` (default false) — when true the URL
+    // change goes onto the browser back stack; callers triggered by
+    // rapid cycling pass nothing to keep history clean.
+    // ``options.skipHistory`` (default false) — true only when the
+    // popstate handler is restoring state from the URL.
     if (!date) return;
+    const opts = options || {};
     closeDisambigPopup();
     // Drop the All time trip cache: leaving All time means the
     // disambiguation search must source from currentDayData.trips,
@@ -1447,6 +1522,10 @@ async function loadDay(date) {
     allTimeTrips = [];
     showingAllTime = false;
     currentDate = date;
+    writeUrlState({ date: date }, {
+        pushHistory: !!opts.pushHistory,
+        skipHistory: !!opts.skipHistory,
+    });
     const seq = ++dayLoadSeq;
 
     renderDayCard();  // immediate paint from cached metadata
@@ -1625,13 +1704,22 @@ function cycleDay(direction) {
     loadDay(allDays[newIdx].date);
 }
 
-function showAllTime() {
+function showAllTime(options) {
     if (!allDays.length) {
         showToast('No mapped drives yet. Try indexing videos first.', 'warning');
         return;
     }
+    const opts = options || {};
     showingAllTime = true;
     currentDate = null;
+    // Default to pushState — the only call site is the user clicking
+    // the "All time" button, which is a deliberate view change the
+    // user should be able to back out of. The popstate handler opts
+    // out via skipHistory.
+    writeUrlState({ view: 'all-time' }, {
+        pushHistory: opts.pushHistory !== false,
+        skipHistory: !!opts.skipHistory,
+    });
     // dayLoadSeq is bumped inside renderAllTime() — that single
     // increment also invalidates any in-flight loadDay() response.
     renderAllTimeCard();
@@ -1673,7 +1761,7 @@ function selectDayForTrip(tripId) {
             });
             allDays.sort((a, b) => b.date.localeCompare(a.date));
         }
-        loadDay(date);
+        loadDay(date, { pushHistory: true });
     }).catch(function (e) {
         if (seq !== tripSelectSeq) return;
         console.error('Failed to resolve trip day:', e);
@@ -2085,7 +2173,7 @@ async function renderAllTime() {
             const targetTrip = (candidates[0] && candidates[0].trip) || trip;
             const date = targetTrip && targetTrip.date;
             if (date && /^\d{4}-\d{2}-\d{2}$/.test(date)) {
-                loadDay(date);
+                loadDay(date, { pushHistory: true });
             }
         };
 
@@ -2555,7 +2643,7 @@ document.addEventListener('click', function(e) {
         const date = dayLink.dataset.date || '';
         if (/^\d{4}-\d{2}-\d{2}$/.test(date)) {
             map.closePopup();
-            loadDay(date);
+            loadDay(date, { pushHistory: true });
         }
         return;
     }
@@ -3441,7 +3529,39 @@ document.getElementById('vpList').addEventListener('click', function(e) {
 
 // --- Init ---
 loadStats();
-loadDays();
+
+// Restore selected day / view-mode from the URL before the first
+// loadDays() call so the page lands on the correct view on refresh /
+// shared link / bookmark. loadDays() consults ``currentDate`` and
+// ``showingAllTime`` when deciding what to render and falls back to
+// the most-recent day if the URL-supplied date isn't in allDays.
+(function initFromUrl() {
+    const urlState = readUrlState();
+    if (urlState && urlState.view === 'all-time') {
+        showingAllTime = true;
+    } else if (urlState && urlState.date) {
+        currentDate = urlState.date;
+    }
+    loadDays();
+})();
+
+// Browser back/forward — re-derive state from the URL and dispatch
+// without writing back to history (skipHistory). Guards against
+// firing before the initial loadDays() resolved by waiting for
+// allDays to be populated.
+window.addEventListener('popstate', function () {
+    const state = readUrlState();
+    if (state && state.view === 'all-time') {
+        if (allDays.length) showAllTime({ skipHistory: true });
+        return;
+    }
+    if (!allDays.length) return;
+    const target = (state && state.date &&
+                    allDays.some(d => d.date === state.date))
+        ? state.date
+        : allDays[0].date;
+    loadDay(target, { skipHistory: true });
+});
 
 // Keyboard shortcuts: left/right arrows cycle days. Skip while the
 // user is typing into a form control or has the video overlay open


### PR DESCRIPTION
## Summary

Persists the selected day and view-mode of the `/map` page in the URL query string so refresh, share, bookmark, and browser back/forward all work correctly. Closes #57.

Pure client-side change — single file (`scripts/web/templates/mapping.html`); no backend, no schema, no config, no dependencies.

## URL shapes

| URL | Behavior |
|-----|----------|
| `/map` | Default — most recent day with data (unchanged from before) |
| `/map?date=YYYY-MM-DD` | Land on the specified day |
| `/map?view=all-time` | Land on the all-time overview |

## How it works

- New `readUrlState()` and `writeUrlState()` helpers near the top of the existing `<script>` block.
- `loadDay(date, options)` and `showAllTime(options)` now accept `{ pushHistory, skipHistory }` and call `writeUrlState()` whenever they mutate state.
- Initial `loadDays()` call is wrapped in an IIFE that reads URL state first and seeds `currentDate` / `showingAllTime` so the existing fallback logic in `loadDays()` lands the user on the right view (and falls back to the most-recent day if the URL date isn't in `allDays`).
- A `popstate` listener restores state from the URL with `skipHistory: true` so back/forward navigation doesn't itself modify the history stack.

## `pushState` vs `replaceState` decisions

| Call site | History mode | Why |
|-----------|-------------|-----|
| `cycleDay()` chevrons | replace | Rapid cycling shouldn't flood back stack |
| Keyboard `ArrowLeft` / `ArrowRight` | replace | Same as chevrons |
| "All time" button → `showAllTime()` | push | Deliberate view change |
| Video panel "Trips" tap → `selectDayForTrip()` | push | Deliberate cross-day jump |
| Disambig popup pick (All-time mode) | push | Deliberate drill-in |
| All-time polyline click | push | Deliberate drill-in |
| Event-marker "Go to this day" link | push | Deliberate drill-in |
| popstate handler | skip | Restoring; must not re-write history |

## Validation

- `?date=` requires `^\d{4}-\d{2}-\d{2}$` **and** a real calendar date (round-trips through `new Date()` to reject `2026-13-99`, `2025-02-29`, etc.).
- `?view=` is only accepted as exactly `all-time`.
- Invalid params are silently dropped — no error toast, fall through to default.
- Date strings are never injected into the DOM unescaped (defense-in-depth).
- All `history.*` calls are wrapped in `try/catch` for sandboxed-iframe safety.

## Out of scope (excluded by the issue)

- `?trip=<id>` — opening a specific trip's video panel from URL.
- `?events=<list>` — pre-applying event filter pills.

## Files changed

- `scripts/web/templates/mapping.html` — only file changed (+127 / −7).

## Verification

- `python -c "from web_control import app"` — imports OK.
- `python -m pytest tests/ -q --ignore=tests/test_mapping_service.py --ignore=tests/test_sei_parser.py` → **129 passed** (the two ignored files have a pre-existing collection error from a missing generated `services.dashcam_pb2` protobuf module, unrelated to this change).
- No JS test infrastructure exists in the repo and the task scope rules out adding one.

## Manual smoke-test scenarios (mental walkthroughs)

1. Navigate via chevron to a non-most-recent day → URL bar shows `?date=YYYY-MM-DD`.
2. Refresh → same day still rendered.
3. Copy URL, paste in different browser → same day rendered.
4. Click "All time" → URL becomes `?view=all-time`. Refresh → still in all-time view.
5. Use prev/next chevrons rapidly → URL updates each time but back stack stays clean (chevrons use `replaceState`).
6. Type bogus URL `?date=not-a-date` or `?date=2026-13-99` → falls through to default, no JS error.
7. Type `?date=2026-01-01` for a day with no data → falls through to default.
8. Click a trip in the side panel that's on a different day → URL updates and back returns to the previous day.
9. In all-time view, click a polyline → drills into that day; back returns to all-time.

## Deployment notes

- This is a pure JavaScript change in one Jinja template. The template is read per-request, so a service restart isn't strictly required, but is recommended to guarantee open tabs see the change:
  ```
  cd /home/pi/TeslaUSB && git pull
  sudo systemctl restart gadget_web.service
  ```
- No `setup_usb.sh` re-run needed (no template placeholders changed).
- No `config.yaml` changes, no schema migration, no new systemd units.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
