### PR TITLE
feat(boombox): add Boombox sound management on Music drive

### DIFF
--- a/scripts/web/blueprints/__init__.py
+++ b/scripts/web/blueprints/__init__.py
@@ -11,6 +11,7 @@ from .cleanup import cleanup_bp
 from .api import api_bp
 from .fsck import fsck_bp
 from .music import music_bp
+from .boombox import boombox_bp
 from .media import media_bp
 from .captive_portal import captive_portal_bp, catch_all_redirect
 from .cloud_archive import cloud_archive_bp
@@ -27,6 +28,7 @@ __all__ = [
     'api_bp',
     'fsck_bp',
     'music_bp',
+    'boombox_bp',
     'media_bp',
     'captive_portal_bp',
     'catch_all_redirect',

--- a/scripts/web/blueprints/boombox.py
+++ b/scripts/web/blueprints/boombox.py
@@ -1,0 +1,174 @@
+"""Blueprint for Boombox sound management.
+
+Boombox sounds live in the ``/Boombox/`` folder at the root of the Music
+drive (``usb_music.img`` / part3). Tesla scans that folder for short
+MP3/WAV clips that play through the external pedestrian-warning speaker
+when the vehicle is parked.
+
+This blueprint is a focused UX wrapper around an already-possible
+operation (the existing Music browser can create the same folder). It
+adds strict per-Tesla-spec validation, a 5-file cap, and the NHTSA
+parked-only safety warning that the feature requires.
+"""
+
+import logging
+import os
+
+from flask import (
+    Blueprint, flash, jsonify, redirect, render_template, request, send_file,
+    url_for,
+)
+
+from config import IMG_MUSIC_PATH, MUSIC_ENABLED
+from utils import format_file_size, get_base_context
+from services.boombox_service import (
+    BOOMBOX_FOLDER,
+    BoomboxServiceError,
+    MAX_FILE_COUNT,
+    MAX_FILE_SIZE,
+    MAX_FILENAME_LENGTH,
+    delete_boombox_file,
+    get_all_boombox_files,
+    get_boombox_count_any_mode,
+    resolve_boombox_file_path,
+    upload_boombox_file,
+)
+
+boombox_bp = Blueprint('boombox', __name__, url_prefix='/boombox')
+logger = logging.getLogger(__name__)
+
+
+@boombox_bp.before_request
+def _require_music_image():
+    # Same gating condition as the music blueprint — the Boombox folder
+    # lives on the music drive, so without it there is nowhere to write.
+    if not MUSIC_ENABLED or not os.path.isfile(IMG_MUSIC_PATH):
+        if request.headers.get('X-Requested-With') == 'XMLHttpRequest':
+            return jsonify({"error": "Feature unavailable"}), 503
+        flash("This feature is not available because the required disk "
+              "image has not been created.")
+        return redirect(url_for('mode_control.index'))
+
+
+@boombox_bp.route("/")
+def boombox_home():
+    ctx = get_base_context()
+    files = get_all_boombox_files()
+    # Tag display strings on the server so the template stays simple.
+    for entry in files:
+        entry['size_str'] = format_file_size(entry['size'])
+    return render_template(
+        "boombox.html",
+        page='media',
+        media_tab='boombox',
+        **ctx,
+        files=files,
+        file_count=len(files),
+        max_file_count=MAX_FILE_COUNT,
+        max_file_size=MAX_FILE_SIZE,
+        max_file_size_mb=MAX_FILE_SIZE // (1024 * 1024),
+        max_filename_length=MAX_FILENAME_LENGTH,
+        boombox_folder=BOOMBOX_FOLDER,
+    )
+
+
+@boombox_bp.route("/upload", methods=["POST"])
+def upload():
+    is_ajax = request.headers.get('X-Requested-With') == 'XMLHttpRequest'
+
+    files = request.files.getlist('boombox_files')
+    if not files:
+        # Fall back to the single-file field name for the simple form.
+        single = request.files.get('boombox_file')
+        if single and single.filename:
+            files = [single]
+
+    if not files or all(not f or not f.filename for f in files):
+        if is_ajax:
+            return jsonify({
+                "success": False, "error": "No files selected"}), 400
+        flash("No files selected", "error")
+        return redirect(url_for('boombox.boombox_home'))
+
+    # Always re-check the count per file in the loop — the count check
+    # in upload_boombox_file is the authoritative guard, but echoing it
+    # here lets us return per-file results for AJAX callers without
+    # round-tripping through the service for files we already know
+    # would be rejected.
+    starting_count = get_boombox_count_any_mode()
+    accepted = starting_count
+    results = []
+    successes = 0
+
+    for f in files:
+        if not f or not f.filename:
+            continue
+        if accepted >= MAX_FILE_COUNT:
+            results.append({
+                'filename': f.filename,
+                'success': False,
+                'message': (f"Maximum of {MAX_FILE_COUNT} Boombox sounds "
+                            "allowed"),
+            })
+            continue
+        try:
+            ok, msg = upload_boombox_file(f, f.filename)
+        except BoomboxServiceError as exc:
+            ok, msg = False, str(exc)
+        except Exception as exc:  # pylint: disable=broad-except
+            logger.error("Boombox upload failed: %s", exc, exc_info=True)
+            ok, msg = False, "Server error"
+
+        results.append({'filename': f.filename, 'success': ok,
+                        'message': msg})
+        if ok:
+            successes += 1
+            accepted += 1
+
+    if is_ajax:
+        status = 200 if successes else 400
+        return jsonify({
+            'success': successes > 0,
+            'uploaded': successes,
+            'results': results,
+        }), status
+
+    if successes:
+        flash(f"Uploaded {successes} file(s)", "success")
+    failures = [r for r in results if not r['success']]
+    for r in failures:
+        flash(f"{r['filename']}: {r['message']}", "error")
+    return redirect(url_for('boombox.boombox_home'))
+
+
+@boombox_bp.route("/delete/<path:filename>", methods=["POST"])
+def delete(filename):
+    is_ajax = request.headers.get('X-Requested-With') == 'XMLHttpRequest'
+    try:
+        ok, msg = delete_boombox_file(filename)
+    except BoomboxServiceError as exc:
+        ok, msg = False, str(exc)
+    except Exception as exc:  # pylint: disable=broad-except
+        logger.error("Boombox delete failed: %s", exc, exc_info=True)
+        ok, msg = False, "Server error"
+
+    if is_ajax:
+        status = 200 if ok else 400
+        return jsonify({"success": ok, "message": msg}), status
+
+    flash(msg, "success" if ok else "error")
+    return redirect(url_for('boombox.boombox_home'))
+
+
+@boombox_bp.route("/play/<path:filename>")
+def play(filename):
+    """Stream a boombox file for in-browser HTML5 audio preview."""
+    try:
+        file_path = resolve_boombox_file_path(filename)
+    except BoomboxServiceError as exc:
+        flash(str(exc), "error")
+        return redirect(url_for('boombox.boombox_home'))
+
+    ext = os.path.splitext(file_path)[1].lower()
+    mimetype = 'audio/mpeg' if ext == '.mp3' else 'audio/wav'
+    return send_file(file_path, mimetype=mimetype)

--- a/scripts/web/blueprints/media.py
+++ b/scripts/web/blueprints/media.py
@@ -16,5 +16,9 @@ def media_home():
         return redirect(url_for('lock_chimes.lock_chimes'))
     if os.path.isfile(IMG_MUSIC_PATH) and MUSIC_ENABLED:
         return redirect(url_for('music.music_home'))
+    # Boombox lives on the music drive too — same gating as music. If
+    # somehow only Boombox is registered (a future config), surface it.
+    if os.path.isfile(IMG_MUSIC_PATH) and MUSIC_ENABLED:
+        return redirect(url_for('boombox.boombox_home'))
     # Fallback to lock_chimes even if not available (it will show the error message)
     return redirect(url_for('lock_chimes.lock_chimes'))

--- a/scripts/web/services/boombox_service.py
+++ b/scripts/web/services/boombox_service.py
@@ -1,0 +1,486 @@
+#!/usr/bin/env python3
+"""Boombox sound management for the Music drive (`/Boombox/` folder).
+
+Tesla's Boombox feature plays user-supplied short audio clips through the
+external pedestrian-warning speaker (PWS) when the vehicle is parked. Tesla
+scans the `Boombox` folder at the root of any USB LUN. Per Tesla's spec:
+
+* Folder name: ``Boombox`` (case-sensitive) at USB root.
+* Formats: MP3 / WAV only.
+* Tesla loads the first 5 files alphabetically; rest are ignored.
+* Recommended ≤ 1 MB and ≤ 5 seconds per file.
+* Hardware: vehicle must have a PWS (Model 3/Y/S/X built Sep 2019+, all
+  Cybertruck).
+* Per NHTSA recall 22V-068 (Feb 2022) custom Boombox sounds may only play
+  while the vehicle is in Park.
+
+This module is a *thin focused* wrapper around the existing music-drive
+plumbing — it deliberately reuses ``music_service``'s atomic-write helpers
+and ``partition_mount_service.quick_edit_part3`` rather than duplicating
+them, and it calls ``wrap_service.safe_rebind_usb_gadget`` after
+present-mode writes so Tesla picks up the new sound without a reboot.
+"""
+
+import logging
+import os
+import re
+import shutil
+import tempfile
+from typing import List, Tuple
+
+from config import MNT_DIR
+from services.mode_service import current_mode
+from services.partition_mount_service import quick_edit_part3
+from services.samba_service import close_samba_share
+# Helpers are imported (not duplicated) from music_service.
+from services.music_service import _fsync_dir, _fsync_path, _sanitize_name
+# Generic USB-rebind helper made public in PR #60. Boombox uses the same
+# Tesla cache invalidation pattern as wraps.
+from services.wrap_service import safe_rebind_usb_gadget
+
+logger = logging.getLogger(__name__)
+
+
+def _safe_fsync_path(path: str) -> None:
+    """Best-effort ``_fsync_path`` that swallows OSError.
+
+    fsync is a Linux-side crash-safety measure for the Pi. On platforms
+    without a working file fsync (test runners on Windows, weird
+    filesystems) we don't want a missing fsync to fail the upload —
+    the file is already written by ``open()`` + ``write()``.
+    """
+    try:
+        _fsync_path(path)
+    except OSError:
+        pass
+
+
+def _safe_fsync_dir(path: str) -> None:
+    """Best-effort ``_fsync_dir`` that swallows OSError / AttributeError.
+
+    Directory fsync uses ``os.O_DIRECTORY`` which only exists on
+    POSIX systems. On the Pi this still gives us crash-consistency on
+    renames; on Windows test runners it's a no-op.
+    """
+    try:
+        _fsync_dir(path)
+    except (OSError, AttributeError):
+        pass
+
+# Tesla constants — do NOT change these without checking Tesla's spec.
+BOOMBOX_FOLDER = "Boombox"
+MAX_FILE_COUNT = 5
+MAX_FILE_SIZE = 1 * 1024 * 1024  # 1 MiB
+ALLOWED_EXTS = {".mp3", ".wav"}
+MAX_FILENAME_LENGTH = 64
+
+# Filesystem-safe filename pattern. Tesla doesn't enforce a regex but we
+# do, so pre-existing filenames created via Samba that contain weird
+# characters (slashes, colons, control chars) get refused.
+VALID_FILENAME_PATTERN = re.compile(r'^[A-Za-z0-9 _\-.]+$')
+
+
+class BoomboxServiceError(Exception):
+    """Raised for user-facing boombox service errors."""
+
+
+def _looks_like_wav(file_bytes: bytes) -> bool:
+    """Return True if the bytes look like a RIFF/WAVE file."""
+    return (
+        len(file_bytes) >= 12
+        and file_bytes[0:4] == b'RIFF'
+        and file_bytes[8:12] == b'WAVE'
+    )
+
+
+def _looks_like_mp3(file_bytes: bytes) -> bool:
+    """Return True if the bytes look like an MP3 (ID3 tag or frame sync).
+
+    MP3 files start with either an ``ID3`` tag header or directly with an
+    MPEG audio frame, which begins with a frame-sync byte (``0xFF``)
+    followed by a byte whose top three bits are set (``0xE0`` mask).
+    """
+    if len(file_bytes) < 3:
+        return False
+    if file_bytes[:3] == b'ID3':
+        return True
+    return (
+        len(file_bytes) >= 2
+        and file_bytes[0] == 0xFF
+        and (file_bytes[1] & 0xE0) == 0xE0
+    )
+
+
+def validate_boombox_filename(filename: str) -> Tuple[bool, str]:
+    """Validate the filename against Tesla and filesystem rules.
+
+    Returns ``(is_valid, error_message)``. The error string is empty when
+    valid (suitable for direct use in flash messages).
+    """
+    safe = _sanitize_name(filename or "")
+    if not safe:
+        return False, "Filename cannot be empty"
+
+    # Length check applies to the whole filename including extension —
+    # the cap is generous enough (64 chars) that cutting off the
+    # extension would be confusing.
+    if len(safe) > MAX_FILENAME_LENGTH:
+        return False, (
+            f"Filename must be {MAX_FILENAME_LENGTH} characters or less "
+            f"(currently {len(safe)})"
+        )
+
+    ext = os.path.splitext(safe)[1].lower()
+    if ext not in ALLOWED_EXTS:
+        return False, "Only MP3 and WAV files are allowed"
+
+    # Reject path-traversal-ish or non-printable characters. _sanitize_name
+    # already strips the worst offenders, so this catches things like
+    # bracketed/escaped names that survived sanitization.
+    if not VALID_FILENAME_PATTERN.match(safe):
+        return False, (
+            "Filename can only contain letters, numbers, spaces, "
+            "underscores, dashes, and dots"
+        )
+
+    return True, ""
+
+
+def validate_boombox_file(file_bytes: bytes, filename: str) -> Tuple[bool, str]:
+    """Validate filename, size, and magic-bytes for a candidate file.
+
+    Returns ``(is_valid, error_message)``. Used by both the route layer
+    (to reject early before touching the filesystem) and any future
+    "scan existing files for compliance" feature.
+    """
+    ok, err = validate_boombox_filename(filename)
+    if not ok:
+        return False, err
+
+    if len(file_bytes) > MAX_FILE_SIZE:
+        size_mb = len(file_bytes) / (1024 * 1024)
+        return False, (
+            f"File size must be 1 MB or less (got {size_mb:.2f} MB)"
+        )
+
+    if len(file_bytes) == 0:
+        return False, "File is empty"
+
+    ext = os.path.splitext(filename)[1].lower()
+    if ext == ".wav":
+        if not _looks_like_wav(file_bytes):
+            return False, "File does not appear to be a valid WAV"
+    elif ext == ".mp3":
+        if not _looks_like_mp3(file_bytes):
+            return False, "File does not appear to be a valid MP3"
+
+    return True, ""
+
+
+def _boombox_dir_for(mount_path: str) -> str:
+    """Compose the boombox directory path under the given mount."""
+    return os.path.join(mount_path, BOOMBOX_FOLDER)
+
+
+def get_boombox_count(mount_path: str) -> int:
+    """Count files in the boombox folder at ``mount_path``.
+
+    Returns 0 if the mount is missing or the folder doesn't exist yet —
+    those are normal "no sounds" states, not errors.
+    """
+    if not mount_path:
+        return 0
+    boombox_dir = _boombox_dir_for(mount_path)
+    if not os.path.isdir(boombox_dir):
+        return 0
+    try:
+        count = 0
+        for entry in os.listdir(boombox_dir):
+            full = os.path.join(boombox_dir, entry)
+            if not os.path.isfile(full):
+                continue
+            ext = os.path.splitext(entry)[1].lower()
+            if ext in ALLOWED_EXTS:
+                count += 1
+        return count
+    except OSError as exc:
+        logger.warning("Could not list boombox folder %s: %s",
+                       boombox_dir, exc)
+        return 0
+
+
+def get_boombox_count_any_mode() -> int:
+    """Return the boombox file count from whichever mount is accessible.
+
+    Counting and writing are different concerns: writing in present mode
+    requires a temporary RW remount via ``quick_edit_part3``, but counting
+    only needs to read directory entries — the RO mount permanently held
+    in present mode is sufficient and avoids a needless RW cycle. In edit
+    mode the RW mount is the only mount.
+
+    This mirrors ``wrap_service.get_wrap_count_any_mode`` and exists for
+    the same reason: passing ``None`` (or the upload destination, which is
+    ``None`` in present mode) to the basic counter would silently return
+    0 and bypass ``MAX_FILE_COUNT`` enforcement entirely.
+    """
+    mode = current_mode()
+    if mode == 'present':
+        mount_path = os.path.join(MNT_DIR, 'part3-ro')
+    else:
+        mount_path = os.path.join(MNT_DIR, 'part3')
+    return get_boombox_count(mount_path)
+
+
+def get_all_boombox_files() -> List[dict]:
+    """List boombox files with size and a per-file compliance flag.
+
+    Reads from whichever mount is accessible in the current mode (RO in
+    present, RW in edit). Each entry has ``filename``, ``size``,
+    ``size_str``, ``valid``, and ``warning`` (empty when ``valid`` is
+    ``True``). Files that exist on disk but violate Boombox rules are
+    listed with a warning rather than hidden — users created them via
+    Samba and need to know why Tesla isn't loading them.
+    """
+    mode = current_mode()
+    if mode == 'present':
+        mount_path = os.path.join(MNT_DIR, 'part3-ro')
+    else:
+        mount_path = os.path.join(MNT_DIR, 'part3')
+
+    boombox_dir = _boombox_dir_for(mount_path)
+    if not os.path.isdir(boombox_dir):
+        return []
+
+    results = []
+    try:
+        entries = sorted(os.listdir(boombox_dir), key=str.lower)
+    except OSError as exc:
+        logger.warning("Could not list boombox folder %s: %s",
+                       boombox_dir, exc)
+        return []
+
+    for name in entries:
+        full = os.path.join(boombox_dir, name)
+        if not os.path.isfile(full):
+            continue
+        try:
+            size = os.path.getsize(full)
+        except OSError:
+            continue
+        ext = os.path.splitext(name)[1].lower()
+
+        warning = ""
+        # Filename and extension checks first — magic-byte sniff is too
+        # expensive to run on every file in the listing path, so we only
+        # do header checks at upload time. Filename / size / extension
+        # cover the most common pre-existing problems.
+        ok, err = validate_boombox_filename(name)
+        if not ok:
+            warning = err
+        elif ext not in ALLOWED_EXTS:
+            warning = "Only MP3 and WAV files are allowed"
+        elif size > MAX_FILE_SIZE:
+            size_mb = size / (1024 * 1024)
+            warning = (f"File size must be 1 MB or less (got {size_mb:.2f} MB)")
+
+        results.append({
+            'filename': name,
+            'size': size,
+            'valid': not warning,
+            'warning': warning,
+        })
+
+    return results
+
+
+def resolve_boombox_file_path(filename: str) -> str:
+    """Return the absolute filesystem path for a boombox file.
+
+    Raises ``BoomboxServiceError`` if the drive is not mounted, the
+    filename is invalid, or the file doesn't exist. The returned path is
+    always inside the mode-appropriate boombox folder — the basename is
+    re-derived after sanitization to defeat path traversal regardless of
+    what the route layer passed in.
+    """
+    safe = _sanitize_name(filename or "")
+    if not safe or os.sep in safe or '/' in safe or '\\' in safe:
+        raise BoomboxServiceError("Invalid filename")
+
+    ext = os.path.splitext(safe)[1].lower()
+    if ext not in ALLOWED_EXTS:
+        raise BoomboxServiceError("Unsupported file type")
+
+    mode = current_mode()
+    if mode == 'present':
+        mount_path = os.path.join(MNT_DIR, 'part3-ro')
+    else:
+        mount_path = os.path.join(MNT_DIR, 'part3')
+
+    boombox_dir = _boombox_dir_for(mount_path)
+    file_path = os.path.join(boombox_dir, safe)
+    # Belt-and-suspenders: confirm the resolved path is still inside the
+    # boombox folder after any symlink resolution.
+    if os.path.commonpath([os.path.realpath(boombox_dir),
+                           os.path.realpath(file_path)]) != \
+            os.path.realpath(boombox_dir):
+        raise BoomboxServiceError("Invalid path")
+
+    if not os.path.isfile(file_path):
+        raise BoomboxServiceError("File not found")
+    return file_path
+
+
+def upload_boombox_file(uploaded_file, filename: str) -> Tuple[bool, str]:
+    """Validate and persist a boombox file. Mode-aware.
+
+    In present mode uses ``quick_edit_part3`` for a short RW window plus a
+    USB rebind so Tesla notices. In edit mode writes directly to the RW
+    mount. Atomic write (temp-in-same-dir + fsync + ``os.replace``) is
+    used in both modes so a crash mid-write can never leave a partial
+    file that Tesla then tries to play.
+
+    Enforces ``MAX_FILE_COUNT`` in **both** modes by reading the count
+    from the RO mount in present mode — the same defense ``wrap_service``
+    uses to avoid the silent-bypass bug fixed in PR #60.
+    """
+    safe_filename = _sanitize_name(filename or "")
+    if not safe_filename:
+        return False, "Invalid filename"
+
+    # Read the whole file into memory once. The 1 MiB cap (MAX_FILE_SIZE)
+    # is small enough that this is fine even on Pi Zero 2 W; it lets us
+    # validate magic bytes before we touch the filesystem.
+    file_bytes = uploaded_file.read()
+    try:
+        uploaded_file.seek(0)
+    except Exception:
+        # Some FileStorage-likes don't support seek; not fatal here
+        # because we already have the bytes.
+        pass
+
+    ok, err = validate_boombox_file(file_bytes, safe_filename)
+    if not ok:
+        return False, err
+
+    # Count check — refuse before doing the expensive RW cycle. Uses the
+    # mode-aware helper so present mode reads the RO mount instead of
+    # silently returning 0 for a None destination path.
+    current_count = get_boombox_count_any_mode()
+    if current_count >= MAX_FILE_COUNT:
+        return False, (
+            f"Maximum of {MAX_FILE_COUNT} Boombox sounds allowed. "
+            "Delete one first."
+        )
+
+    mode = current_mode()
+    logger.info("Uploading boombox file %s (mode: %s)", safe_filename, mode)
+
+    def _do_save(rw_mount: str) -> Tuple[bool, str]:
+        boombox_dir = _boombox_dir_for(rw_mount)
+        try:
+            os.makedirs(boombox_dir, exist_ok=True)
+        except OSError as exc:
+            logger.error("Cannot create boombox dir %s: %s",
+                         boombox_dir, exc)
+            return False, "Unable to access Boombox folder"
+
+        final_path = os.path.join(boombox_dir, safe_filename)
+        # Atomic write: tmp file in the same directory, fsync, replace,
+        # fsync the parent directory so the rename survives a crash.
+        tmp_path = os.path.join(boombox_dir, f".{safe_filename}.upload")
+        try:
+            with open(tmp_path, "wb") as fh:
+                fh.write(file_bytes)
+            _safe_fsync_path(tmp_path)
+            _safe_fsync_dir(boombox_dir)
+            os.replace(tmp_path, final_path)
+            _safe_fsync_dir(boombox_dir)
+        except OSError as exc:
+            logger.error("Failed to write %s: %s", final_path, exc)
+            try:
+                if os.path.exists(tmp_path):
+                    os.remove(tmp_path)
+            except OSError:
+                pass
+            return False, "Failed to write file"
+        try:
+            close_samba_share("part3")
+        except Exception:
+            pass
+        return True, f"Uploaded {safe_filename}"
+
+    if mode == 'present':
+        # Stage to /var/tmp first to keep the RW window tiny — opening
+        # the destination file inside quick_edit_part3 is fine for a
+        # 1 MiB write but mirrors the pattern used by wrap_service for
+        # consistency. (Boombox files are smaller than wraps so we
+        # could write directly, but the indirection is cheap.)
+        temp_dir = tempfile.mkdtemp(prefix='boombox_upload_')
+        try:
+            staged = os.path.join(temp_dir, safe_filename)
+            with open(staged, "wb") as fh:
+                fh.write(file_bytes)
+
+            def _quick_callback():
+                rw_mount = os.path.join(MNT_DIR, 'part3')
+                return _do_save(rw_mount)
+
+            success, msg = quick_edit_part3(_quick_callback, timeout=30)
+        finally:
+            shutil.rmtree(temp_dir, ignore_errors=True)
+
+        if success:
+            # Tesla caches the USB filesystem; without this the new
+            # sound doesn't appear in the in-car Boombox menu until
+            # the next natural rebind. Failure of the rebind itself
+            # is non-fatal — the file is on disk and the safe_rebind
+            # helper logs a warning for operators.
+            safe_rebind_usb_gadget()
+        return success, msg
+
+    # Edit mode: gadget is unbound, no rebind needed.
+    rw_mount = os.path.join(MNT_DIR, 'part3')
+    return _do_save(rw_mount)
+
+
+def delete_boombox_file(filename: str) -> Tuple[bool, str]:
+    """Delete a boombox file. Mode-aware (mirrors upload)."""
+    safe_filename = _sanitize_name(filename or "")
+    if not safe_filename:
+        return False, "Invalid filename"
+    # Reject anything that resembles a path; the boombox folder is flat.
+    if os.sep in safe_filename or '/' in safe_filename or '\\' in safe_filename:
+        return False, "Invalid filename"
+
+    mode = current_mode()
+    logger.info("Deleting boombox file %s (mode: %s)", safe_filename, mode)
+
+    def _do_delete(rw_mount: str) -> Tuple[bool, str]:
+        boombox_dir = _boombox_dir_for(rw_mount)
+        target = os.path.join(boombox_dir, safe_filename)
+        if not os.path.isfile(target):
+            return False, "File not found"
+        try:
+            os.remove(target)
+            _safe_fsync_dir(boombox_dir)
+        except OSError as exc:
+            logger.error("Failed to delete %s: %s", target, exc)
+            return False, "Failed to delete file"
+        try:
+            close_samba_share("part3")
+        except Exception:
+            pass
+        return True, f"Deleted {safe_filename}"
+
+    if mode == 'present':
+        def _quick_callback():
+            rw_mount = os.path.join(MNT_DIR, 'part3')
+            return _do_delete(rw_mount)
+
+        success, msg = quick_edit_part3(_quick_callback, timeout=30)
+        if success:
+            safe_rebind_usb_gadget()
+        return success, msg
+
+    rw_mount = os.path.join(MNT_DIR, 'part3')
+    return _do_delete(rw_mount)

--- a/scripts/web/services/partition_service.py
+++ b/scripts/web/services/partition_service.py
@@ -51,6 +51,7 @@ def get_feature_availability():
         'shows_available': lightshow_exists,
         'wraps_available': lightshow_exists,
         'music_available': music_exists,
+        'boombox_available': music_exists,
         'cloud_archive_available': CLOUD_ARCHIVE_ENABLED,
         'cloud_provider_connected': CLOUD_ARCHIVE_ENABLED and bool(CLOUD_ARCHIVE_PROVIDER)
                                     and os.path.isfile(CLOUD_PROVIDER_CREDS_PATH),

--- a/scripts/web/static/icons/lucide-sprite.svg
+++ b/scripts/web/static/icons/lucide-sprite.svg
@@ -198,4 +198,7 @@
   <symbol id="icon-arrow-down-right" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
     <path d="m7 7 10 10"/><path d="M17 7v10H7"/>
   </symbol>
+  <symbol id="icon-megaphone" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M11 6a13 13 0 0 0 8.4-2.8A1 1 0 0 1 21 4v12a1 1 0 0 1-1.6.8A13 13 0 0 0 11 14H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2z"/><path d="M6 14a12 12 0 0 0 2.4 7.2 2 2 0 0 0 3.2-2.4A8 8 0 0 1 10 14"/><path d="M8 6v8"/>
+  </symbol>
 </svg>

--- a/scripts/web/templates/base.html
+++ b/scripts/web/templates/base.html
@@ -24,7 +24,7 @@
 </head>
 <body>
     {# Compute media_available from individual flags #}
-    {% set media_available = chimes_available or music_available or shows_available or wraps_available %}
+    {% set media_available = chimes_available or music_available or shows_available or wraps_available or boombox_available %}
 
     <!-- Top Bar -->
     <header class="top-bar">

--- a/scripts/web/templates/boombox.html
+++ b/scripts/web/templates/boombox.html
@@ -1,0 +1,503 @@
+{% extends "base.html" %}
+{% block head %}
+<style>
+    /* NHTSA safety banner — uses ios-warning tokens which are the
+       project's amber callout palette. The banner is the most important
+       UI element on this page; it must sit above the upload zone on
+       both desktop and 375px-wide mobile (no max-width hiding it under
+       the fold). */
+    .boombox-nhtsa-warning {
+        display: flex;
+        gap: 12px;
+        align-items: flex-start;
+        background-color: var(--ios-warning-bg);
+        border-left: 4px solid var(--ios-warning-border);
+        padding: 14px 16px;
+        border-radius: 5px;
+        margin: 16px 0 20px 0;
+        transition: background-color 0.3s ease, border-color 0.3s ease;
+    }
+
+    .boombox-nhtsa-warning .nhtsa-icon {
+        flex-shrink: 0;
+        width: 22px;
+        height: 22px;
+        color: var(--ios-warning-text);
+        margin-top: 2px;
+    }
+
+    .boombox-nhtsa-warning .nhtsa-body {
+        flex: 1;
+        min-width: 0;
+    }
+
+    .boombox-nhtsa-warning p {
+        margin: 0;
+        font-size: 14px;
+        line-height: 1.45;
+        color: var(--ios-warning-text);
+    }
+
+    .boombox-nhtsa-warning p + p {
+        margin-top: 6px;
+        font-size: 13px;
+        color: var(--text-secondary);
+    }
+
+    .boombox-nhtsa-warning strong {
+        font-weight: 600;
+    }
+
+    /* Requirements card */
+    .boombox-requirements {
+        background-color: var(--bg-info);
+        color: var(--text-info);
+        padding: 14px 16px;
+        border-radius: 5px;
+        margin-bottom: 20px;
+    }
+
+    .boombox-requirements ul {
+        margin: 8px 0 0 20px;
+        padding: 0;
+        font-size: 13px;
+        color: var(--text-secondary);
+    }
+
+    .boombox-requirements li {
+        margin-bottom: 2px;
+    }
+
+    /* Count badge */
+    .boombox-count-badge {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        padding: 4px 12px;
+        border-radius: 999px;
+        background: var(--bg-info);
+        color: var(--text-primary);
+        font-size: 13px;
+        font-weight: 600;
+        border: 1px solid var(--border-color);
+    }
+
+    .boombox-count-badge.full {
+        background: var(--ios-warning-bg);
+        color: var(--ios-warning-text);
+        border-color: var(--ios-warning-border);
+    }
+
+    /* Upload drop zone */
+    .boombox-drop-zone {
+        border: 2px dashed var(--border-input);
+        border-radius: 8px;
+        padding: 32px 20px;
+        text-align: center;
+        background: var(--form-input-bg);
+        cursor: pointer;
+        transition: border-color 0.2s ease, background-color 0.2s ease;
+        margin-bottom: 20px;
+    }
+
+    .boombox-drop-zone:hover,
+    .boombox-drop-zone.is-dragover {
+        border-color: var(--btn-primary-bg);
+        background: var(--bg-hover);
+    }
+
+    .boombox-drop-zone .drop-icon {
+        width: 40px;
+        height: 40px;
+        color: var(--btn-primary-bg);
+        margin-bottom: 10px;
+    }
+
+    .boombox-drop-zone .drop-title {
+        font-size: 15px;
+        font-weight: 600;
+        margin-bottom: 4px;
+        color: var(--text-primary);
+    }
+
+    .boombox-drop-zone .drop-hint {
+        font-size: 13px;
+        color: var(--text-secondary);
+    }
+
+    .boombox-drop-zone.is-disabled {
+        cursor: not-allowed;
+        opacity: 0.55;
+    }
+
+    /* File list */
+    .boombox-file-list {
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+        margin-top: 16px;
+    }
+
+    .boombox-file {
+        background: var(--bg-container);
+        border: 1px solid var(--border-color);
+        border-radius: 8px;
+        padding: 14px 16px;
+        transition: background-color 0.2s ease, border-color 0.2s ease;
+    }
+
+    .boombox-file.is-invalid {
+        border-left: 4px solid var(--ios-warning-border);
+    }
+
+    .boombox-file-header {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        margin-bottom: 8px;
+        flex-wrap: wrap;
+    }
+
+    .boombox-file-icon {
+        width: 18px;
+        height: 18px;
+        color: var(--btn-primary-bg);
+        flex-shrink: 0;
+    }
+
+    .boombox-file-name {
+        font-weight: 600;
+        color: var(--text-primary);
+        font-size: 15px;
+        flex: 1;
+        min-width: 0;
+        word-break: break-word;
+    }
+
+    .boombox-file-size {
+        font-size: 13px;
+        color: var(--text-secondary);
+        flex-shrink: 0;
+    }
+
+    .boombox-file-warning {
+        display: flex;
+        gap: 8px;
+        align-items: flex-start;
+        background: var(--ios-warning-bg);
+        border-radius: 4px;
+        padding: 8px 10px;
+        margin-bottom: 10px;
+        color: var(--ios-warning-text);
+        font-size: 13px;
+        line-height: 1.4;
+    }
+
+    .boombox-file-warning .warn-icon {
+        width: 16px;
+        height: 16px;
+        flex-shrink: 0;
+        margin-top: 2px;
+    }
+
+    .boombox-file audio {
+        width: 100%;
+        height: 40px;
+        margin-bottom: 10px;
+    }
+
+    .boombox-file-actions {
+        display: flex;
+        gap: 8px;
+        flex-wrap: wrap;
+    }
+
+    .boombox-file-actions .action-btn {
+        min-height: 44px;
+        min-width: 44px;
+    }
+
+    .boombox-empty {
+        text-align: center;
+        padding: 40px 20px;
+        color: var(--text-secondary);
+        background: var(--bg-container);
+        border: 1px dashed var(--border-color);
+        border-radius: 8px;
+    }
+
+    .boombox-empty .empty-icon {
+        width: 48px;
+        height: 48px;
+        color: var(--text-muted);
+        margin-bottom: 12px;
+    }
+
+    .boombox-empty p {
+        margin: 0;
+        font-size: 14px;
+        line-height: 1.5;
+    }
+
+    .boombox-section-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 12px;
+        flex-wrap: wrap;
+        margin: 24px 0 12px 0;
+    }
+
+    .boombox-section-header h3 {
+        margin: 0;
+        font-size: 18px;
+    }
+
+    /* Mobile: 375px */
+    @media (max-width: 480px) {
+        .boombox-drop-zone {
+            padding: 22px 14px;
+        }
+        .boombox-file-actions .action-btn {
+            flex: 1;
+        }
+        .boombox-file-header {
+            gap: 6px;
+        }
+    }
+</style>
+{% endblock %}
+
+{% block content %}
+<div class="container">
+    {% include 'media_hub_nav.html' %}
+
+    <h2>Boombox</h2>
+    <p style="margin: 4px 0 0 0; color: var(--text-secondary); font-size: 14px;">
+        Sounds Tesla plays through the external pedestrian-warning speaker.
+    </p>
+
+    {# === NHTSA SAFETY WARNING (must stay above the upload zone) === #}
+    <div class="boombox-nhtsa-warning" role="alert">
+        <svg class="nhtsa-icon" aria-hidden="true">
+            <use href="{{ url_for('static', filename='icons/lucide-sprite.svg') }}#icon-alert-triangle"></use>
+        </svg>
+        <div class="nhtsa-body">
+            <p>
+                <strong>Boombox sounds only play while the vehicle is in Park</strong>
+                (NHTSA safety restriction, Feb 2022).
+            </p>
+            <p>
+                Your vehicle must have an external pedestrian-warning speaker &mdash;
+                built September 2019 or later for Model 3, Y, S, or X, or any Cybertruck.
+            </p>
+        </div>
+    </div>
+
+    <div class="boombox-requirements">
+        <p style="margin: 0; display: flex; align-items: center; gap: 8px;">
+            <svg style="width: 18px; height: 18px; flex-shrink: 0;" aria-hidden="true">
+                <use href="{{ url_for('static', filename='icons/lucide-sprite.svg') }}#icon-info"></use>
+            </svg>
+            <strong>Tesla Boombox Requirements</strong>
+        </p>
+        <ul>
+            <li><strong>Folder:</strong> <code>/{{ boombox_folder }}</code> at the root of the Music drive (managed for you)</li>
+            <li><strong>Format:</strong> MP3 or WAV only</li>
+            <li><strong>Size:</strong> {{ max_file_size_mb }} MB maximum (≤ 5 seconds recommended)</li>
+            <li><strong>Filename:</strong> {{ max_filename_length }} characters max (letters, numbers, spaces, underscores, dashes, dots)</li>
+            <li><strong>Count:</strong> Up to {{ max_file_count }} sounds (Tesla loads the first {{ max_file_count }} alphabetically)</li>
+        </ul>
+    </div>
+
+    {# === UPLOAD ZONE === #}
+    <div class="boombox-section-header">
+        <h3>Add a sound</h3>
+        <span id="boomboxCountBadge"
+              class="boombox-count-badge {% if file_count >= max_file_count %}full{% endif %}">
+            <svg style="width: 14px; height: 14px;" aria-hidden="true">
+                <use href="{{ url_for('static', filename='icons/lucide-sprite.svg') }}#icon-music"></use>
+            </svg>
+            {{ file_count }} / {{ max_file_count }} sounds
+        </span>
+    </div>
+
+    <form method="post" action="{{ url_for('boombox.upload') }}"
+          enctype="multipart/form-data" id="boomboxUploadForm">
+        <label for="boomboxFileInput" class="boombox-drop-zone {% if file_count >= max_file_count %}is-disabled{% endif %}"
+               id="boomboxDropZone">
+            <svg class="drop-icon" aria-hidden="true">
+                <use href="{{ url_for('static', filename='icons/lucide-sprite.svg') }}#icon-upload"></use>
+            </svg>
+            <div class="drop-title">
+                {% if file_count >= max_file_count %}
+                Maximum sounds reached
+                {% else %}
+                Drop a file here or click to choose
+                {% endif %}
+            </div>
+            <div class="drop-hint">
+                MP3 or WAV &middot; up to {{ max_file_size_mb }} MB &middot;
+                {{ max_file_count - file_count }} slot{% if (max_file_count - file_count) != 1 %}s{% endif %} remaining
+            </div>
+            <input type="file" id="boomboxFileInput" name="boombox_files"
+                   accept=".mp3,.wav,audio/mpeg,audio/wav,audio/x-wav"
+                   {% if file_count < max_file_count %}multiple{% endif %}
+                   style="display: none;"
+                   {% if file_count >= max_file_count %}disabled{% endif %}>
+        </label>
+        <div style="display: flex; gap: 8px; justify-content: flex-end; margin-top: -8px; margin-bottom: 16px;">
+            <button type="submit" class="action-btn primary"
+                    id="boomboxSubmitBtn"
+                    {% if file_count >= max_file_count %}disabled{% endif %}
+                    style="display: none; min-height: 44px;">
+                <svg style="width: 16px; height: 16px; vertical-align: middle; margin-right: 4px;" aria-hidden="true">
+                    <use href="{{ url_for('static', filename='icons/lucide-sprite.svg') }}#icon-upload"></use>
+                </svg>
+                Upload
+            </button>
+        </div>
+    </form>
+
+    {# === FILE LIST === #}
+    <div class="boombox-section-header">
+        <h3>Current sounds</h3>
+    </div>
+
+    {% if files %}
+    <div class="boombox-file-list">
+        {% for file in files %}
+        <div class="boombox-file {% if not file.valid %}is-invalid{% endif %}">
+            <div class="boombox-file-header">
+                <svg class="boombox-file-icon" aria-hidden="true">
+                    <use href="{{ url_for('static', filename='icons/lucide-sprite.svg') }}#icon-music"></use>
+                </svg>
+                <span class="boombox-file-name">{{ file.filename }}</span>
+                <span class="boombox-file-size">{{ file.size_str }}</span>
+            </div>
+
+            {% if file.warning %}
+            <div class="boombox-file-warning" role="status">
+                <svg class="warn-icon" aria-hidden="true">
+                    <use href="{{ url_for('static', filename='icons/lucide-sprite.svg') }}#icon-alert-triangle"></use>
+                </svg>
+                <div>
+                    <strong>Tesla may ignore this file.</strong> {{ file.warning }}
+                </div>
+            </div>
+            {% endif %}
+
+            <audio controls preload="none">
+                {% set ext = file.filename.lower().rsplit('.', 1)[-1] %}
+                <source src="{{ url_for('boombox.play', filename=file.filename) }}"
+                        type="{{ 'audio/mpeg' if ext == 'mp3' else 'audio/wav' }}">
+                Your browser does not support the audio element.
+            </audio>
+
+            <div class="boombox-file-actions">
+                <form method="post"
+                      action="{{ url_for('boombox.delete', filename=file.filename) }}"
+                      style="display: inline; margin: 0;"
+                      onsubmit="return confirm('Delete {{ file.filename|e }}?');">
+                    <button type="submit" class="action-btn danger" aria-label="Delete {{ file.filename|e }}">
+                        <svg style="width: 16px; height: 16px; vertical-align: middle; margin-right: 4px;" aria-hidden="true">
+                            <use href="{{ url_for('static', filename='icons/lucide-sprite.svg') }}#icon-trash-2"></use>
+                        </svg>
+                        Delete
+                    </button>
+                </form>
+            </div>
+        </div>
+        {% endfor %}
+    </div>
+    {% else %}
+    <div class="boombox-empty">
+        <svg class="empty-icon" aria-hidden="true">
+            <use href="{{ url_for('static', filename='icons/lucide-sprite.svg') }}#icon-megaphone"></use>
+        </svg>
+        <p>
+            <strong>Add your first Boombox sound</strong> &mdash; it&rsquo;ll play through your car&rsquo;s
+            external speaker when you unlock or park.
+        </p>
+    </div>
+    {% endif %}
+</div>
+
+<script>
+(function() {
+    const dropZone = document.getElementById('boomboxDropZone');
+    const fileInput = document.getElementById('boomboxFileInput');
+    const submitBtn = document.getElementById('boomboxSubmitBtn');
+    const form = document.getElementById('boomboxUploadForm');
+    const maxFileSize = {{ max_file_size }};
+    const maxFileCount = {{ max_file_count }};
+    const currentCount = {{ file_count }};
+    const allowedExts = ['.mp3', '.wav'];
+
+    if (!dropZone || !fileInput || !form) return;
+
+    function validateFiles(fileList) {
+        const remaining = maxFileCount - currentCount;
+        if (fileList.length > remaining) {
+            alert('Only ' + remaining + ' more file(s) can be added '
+                  + '(max ' + maxFileCount + ' total).');
+            return false;
+        }
+        for (let i = 0; i < fileList.length; i++) {
+            const f = fileList[i];
+            const lower = f.name.toLowerCase();
+            const ext = '.' + (lower.split('.').pop() || '');
+            if (allowedExts.indexOf(ext) === -1) {
+                alert(f.name + ': only MP3 and WAV files are allowed.');
+                return false;
+            }
+            if (f.size > maxFileSize) {
+                alert(f.name + ': file is larger than 1 MB.');
+                return false;
+            }
+        }
+        return true;
+    }
+
+    fileInput.addEventListener('change', function() {
+        if (!fileInput.files || fileInput.files.length === 0) {
+            if (submitBtn) submitBtn.style.display = 'none';
+            return;
+        }
+        if (!validateFiles(fileInput.files)) {
+            fileInput.value = '';
+            if (submitBtn) submitBtn.style.display = 'none';
+            return;
+        }
+        // Auto-submit so the user doesn't need to click twice on mobile.
+        form.submit();
+    });
+
+    // Drag-and-drop wiring (desktop niceness; click-to-pick covers mobile).
+    ['dragenter', 'dragover'].forEach(function(ev) {
+        dropZone.addEventListener(ev, function(e) {
+            e.preventDefault();
+            e.stopPropagation();
+            if (!fileInput.disabled) {
+                dropZone.classList.add('is-dragover');
+            }
+        });
+    });
+    ['dragleave', 'drop'].forEach(function(ev) {
+        dropZone.addEventListener(ev, function(e) {
+            e.preventDefault();
+            e.stopPropagation();
+            dropZone.classList.remove('is-dragover');
+        });
+    });
+    dropZone.addEventListener('drop', function(e) {
+        if (fileInput.disabled) return;
+        const files = (e.dataTransfer && e.dataTransfer.files) || [];
+        if (!files.length) return;
+        if (!validateFiles(files)) return;
+        fileInput.files = files;
+        form.submit();
+    });
+})();
+</script>
+{% endblock %}

--- a/scripts/web/templates/media_hub_nav.html
+++ b/scripts/web/templates/media_hub_nav.html
@@ -12,6 +12,12 @@
     Music
   </a>
   {% endif %}
+  {% if boombox_available %}
+  <a href="{{ url_for('boombox.boombox_home') }}" class="media-pill {% if media_tab == 'boombox' %}active{% endif %}">
+    <svg class="nav-icon" aria-hidden="true"><use href="{{ url_for('static', filename='icons/lucide-sprite.svg') }}#icon-megaphone"></use></svg>
+    Boombox
+  </a>
+  {% endif %}
   {% if shows_available %}
   <a href="{{ url_for('light_shows.light_shows') }}" class="media-pill {% if media_tab == 'shows' %}active{% endif %}">
     <svg class="nav-icon" aria-hidden="true"><use href="{{ url_for('static', filename='icons/lucide-sprite.svg') }}#icon-sparkles"></use></svg>

--- a/scripts/web/web_control.py
+++ b/scripts/web/web_control.py
@@ -41,6 +41,7 @@ from blueprints import (
     lock_chimes_bp,
     light_shows_bp,
     music_bp,
+    boombox_bp,
     wraps_bp,
     media_bp,
     analytics_bp,
@@ -59,6 +60,7 @@ app.register_blueprint(videos_bp)
 app.register_blueprint(lock_chimes_bp)
 app.register_blueprint(light_shows_bp)
 app.register_blueprint(music_bp)
+app.register_blueprint(boombox_bp)
 app.register_blueprint(wraps_bp)
 app.register_blueprint(media_bp)
 app.register_blueprint(analytics_bp)

--- a/tests/test_boombox_service.py
+++ b/tests/test_boombox_service.py
@@ -1,0 +1,540 @@
+"""Tests for the boombox_service module — validation, count enforcement
+in BOTH modes (explicit regression for the wraps-style bypass that was
+fixed in PR #60), atomic upload + delete, and the MP3/WAV magic-byte
+sniff that catches files renamed to .mp3/.wav.
+"""
+
+import io
+import os
+import struct
+from unittest.mock import MagicMock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+def _build_minimal_wav_bytes(payload_size: int = 64) -> bytes:
+    """Return a syntactically-valid RIFF/WAVE file of the requested length.
+
+    Only the magic bytes matter for the validator's sniff check, but we
+    produce a header that any sane WAV parser will accept too.
+    """
+    fmt_chunk = b'fmt ' + struct.pack('<IHHIIHH', 16, 1, 1, 8000, 8000, 1, 8)
+    data = b'\x00' * payload_size
+    data_chunk = b'data' + struct.pack('<I', len(data)) + data
+    payload = fmt_chunk + data_chunk
+    riff = b'RIFF' + struct.pack('<I', 4 + len(payload)) + b'WAVE' + payload
+    return riff
+
+
+def _build_minimal_mp3_bytes(prefix: str = 'sync') -> bytes:
+    """Return MP3-shaped bytes the sniffer will accept.
+
+    ``prefix='sync'``  -> starts with 0xFF E0 (MPEG frame sync)
+    ``prefix='id3'``   -> starts with the ASCII tag ``ID3``
+    """
+    if prefix == 'id3':
+        # ID3v2 header: "ID3" + version (2 bytes) + flags + size (4 bytes)
+        return b'ID3' + b'\x03\x00' + b'\x00' + b'\x00\x00\x00\x00' + b'\x00' * 256
+    # Frame sync: 0xFF + 0xE0 mask in second byte
+    return b'\xff\xfb\x90\x00' + b'\x00' * 256
+
+
+class _FakeUploadFile:
+    """Mimic the bits of ``werkzeug.FileStorage`` that
+    ``upload_boombox_file`` actually uses (read + seek + filename).
+    """
+
+    def __init__(self, filename, data):
+        self.filename = filename
+        self._buf = io.BytesIO(data)
+
+    def read(self):
+        return self._buf.read()
+
+    def seek(self, pos):
+        self._buf.seek(pos)
+
+
+@pytest.fixture
+def fake_music_drive(tmp_path, monkeypatch):
+    """Build a fake Music drive layout matching what the boombox service
+    expects in both modes:
+
+        <root>/part3-ro/Boombox/   (present-mode RO mount; count source)
+        <root>/part3/Boombox/      (edit-mode RW mount; also the
+                                    destination from quick_edit_part3)
+
+    Patch ``MNT_DIR`` everywhere it's already imported so neither the
+    service nor the music helpers it reuses touch real mounts.
+    """
+    root = tmp_path / 'mnt' / 'gadget'
+    (root / 'part3-ro' / 'Boombox').mkdir(parents=True)
+    (root / 'part3' / 'Boombox').mkdir(parents=True)
+
+    from services import boombox_service
+    monkeypatch.setattr('config.MNT_DIR', str(root), raising=False)
+    # Service modules cached MNT_DIR at import time (top-level
+    # ``from config import MNT_DIR``); patch their references too.
+    monkeypatch.setattr(boombox_service, 'MNT_DIR', str(root),
+                        raising=False)
+
+    return {
+        'root': root,
+        'ro_boombox': root / 'part3-ro' / 'Boombox',
+        'rw_boombox': root / 'part3' / 'Boombox',
+    }
+
+
+def _set_mode(monkeypatch, mode_value):
+    """Patch ``current_mode`` everywhere callers might look it up.
+
+    ``boombox_service`` does ``from services.mode_service import
+    current_mode`` at import time, so we have to overwrite the bound
+    name on the service module — patching the source module alone
+    doesn't reach the alias. We patch both for belt-and-suspenders.
+    """
+    from services import boombox_service
+    monkeypatch.setattr(boombox_service, 'current_mode',
+                        lambda: mode_value)
+    monkeypatch.setattr('services.mode_service.current_mode',
+                        lambda: mode_value)
+
+
+def _populate(folder, count, prefix='sound', ext='.mp3'):
+    """Create ``count`` placeholder boombox files in ``folder``."""
+    for i in range(count):
+        (folder / f'{prefix}_{i}{ext}').write_bytes(_build_minimal_mp3_bytes())
+
+
+# ---------------------------------------------------------------------------
+# Filename validation
+# ---------------------------------------------------------------------------
+
+class TestValidateBoomboxFilename:
+
+    def test_empty_filename_rejected(self):
+        from services.boombox_service import validate_boombox_filename
+        ok, err = validate_boombox_filename("")
+        assert not ok
+        assert "empty" in err.lower()
+
+    def test_whitespace_only_rejected(self):
+        from services.boombox_service import validate_boombox_filename
+        ok, err = validate_boombox_filename("   ")
+        assert not ok
+
+    def test_too_long_rejected(self):
+        from services.boombox_service import (
+            MAX_FILENAME_LENGTH, validate_boombox_filename,
+        )
+        # 65 chars total (above the 64-char cap), still ending in .mp3
+        name = ('a' * (MAX_FILENAME_LENGTH - 4 + 1)) + '.mp3'
+        ok, err = validate_boombox_filename(name)
+        assert not ok
+        assert str(MAX_FILENAME_LENGTH) in err
+
+    def test_disallowed_chars_rejected(self):
+        from services.boombox_service import validate_boombox_filename
+        # Pipe/star/question mark are not in the allowed character set.
+        # NB: ``_sanitize_name`` already strips colons, slashes, and
+        # control chars before validation, so those don't appear here —
+        # the regex only sees what survived sanitization.
+        for bad in ['hello*.mp3', 'a?b.mp3', 'pipe|name.mp3',
+                    'paren(name).mp3']:
+            ok, err = validate_boombox_filename(bad)
+            assert not ok, f"Should have rejected {bad}"
+
+    def test_wrong_extension_rejected(self):
+        from services.boombox_service import validate_boombox_filename
+        for bad in ['song.aac', 'song.flac', 'song.m4a', 'song.txt',
+                    'song']:
+            ok, err = validate_boombox_filename(bad)
+            assert not ok, f"Should have rejected {bad}"
+            assert 'mp3' in err.lower() or 'wav' in err.lower()
+
+    def test_valid_names_accepted(self):
+        from services.boombox_service import validate_boombox_filename
+        for good in ['horn.mp3', 'la cucaracha.wav',
+                     'duck-quack_v2.mp3',
+                     'A.MP3', 'song.WAV', 'name.with.dots.mp3']:
+            ok, err = validate_boombox_filename(good)
+            assert ok, f"Should have accepted {good}: {err}"
+
+
+# ---------------------------------------------------------------------------
+# Magic-byte sniffing
+# ---------------------------------------------------------------------------
+
+class TestMagicByteSniff:
+
+    def test_wav_riff_wave_accepted(self):
+        from services.boombox_service import validate_boombox_file
+        wav = _build_minimal_wav_bytes()
+        ok, err = validate_boombox_file(wav, 'horn.wav')
+        assert ok, err
+
+    def test_wav_with_wrong_magic_rejected(self):
+        from services.boombox_service import validate_boombox_file
+        # Looks like nothing — definitely not RIFF/WAVE
+        bogus = b'NOTAWAVE' + b'\x00' * 32
+        ok, err = validate_boombox_file(bogus, 'horn.wav')
+        assert not ok
+        assert 'wav' in err.lower()
+
+    def test_mp3_id3_tag_accepted(self):
+        from services.boombox_service import validate_boombox_file
+        mp3 = _build_minimal_mp3_bytes(prefix='id3')
+        ok, err = validate_boombox_file(mp3, 'horn.mp3')
+        assert ok, err
+
+    def test_mp3_frame_sync_accepted(self):
+        from services.boombox_service import validate_boombox_file
+        mp3 = _build_minimal_mp3_bytes(prefix='sync')
+        ok, err = validate_boombox_file(mp3, 'horn.mp3')
+        assert ok, err
+
+    def test_mp3_with_wrong_magic_rejected(self):
+        from services.boombox_service import validate_boombox_file
+        # AAC ADTS sync (0xFF, 0xF1) does NOT match MPEG-1/2 audio.
+        # Wait — 0xF1 IS top three bits set. Use a clearly non-MP3 one:
+        # plain text bytes.
+        bogus = b'<html>' + b'\x00' * 32
+        ok, err = validate_boombox_file(bogus, 'horn.mp3')
+        assert not ok
+        assert 'mp3' in err.lower()
+
+    def test_aac_renamed_to_mp3_rejected(self):
+        # User saved an AAC file with a .mp3 extension. The first byte
+        # might happen to be 0xFF, but only if it's an ADTS-framed stream
+        # — and even then the second byte's mask differs. A plain .aac
+        # MP4-style file starts with 'ftyp' which fails the sync test.
+        from services.boombox_service import validate_boombox_file
+        fake_aac = b'\x00\x00\x00\x20ftypM4A ' + b'\x00' * 128
+        ok, err = validate_boombox_file(fake_aac, 'song.mp3')
+        assert not ok
+
+
+# ---------------------------------------------------------------------------
+# Size enforcement
+# ---------------------------------------------------------------------------
+
+class TestSizeEnforcement:
+
+    def test_just_under_one_mb_accepted(self):
+        from services.boombox_service import (
+            MAX_FILE_SIZE, validate_boombox_file,
+        )
+        # 1 MB minus 100 bytes — should pass.
+        size = MAX_FILE_SIZE - 100
+        # Build a syntactically valid MP3 of that size.
+        mp3 = _build_minimal_mp3_bytes(prefix='id3')
+        if len(mp3) < size:
+            mp3 = mp3 + b'\x00' * (size - len(mp3))
+        else:
+            mp3 = mp3[:size]
+        ok, err = validate_boombox_file(mp3, 'horn.mp3')
+        assert ok, err
+
+    def test_just_over_one_mb_rejected(self):
+        from services.boombox_service import (
+            MAX_FILE_SIZE, validate_boombox_file,
+        )
+        # 1 MB plus 1 byte.
+        oversized = _build_minimal_mp3_bytes(prefix='id3') + b'\x00' * (
+            MAX_FILE_SIZE + 1)
+        ok, err = validate_boombox_file(oversized, 'horn.mp3')
+        assert not ok
+        assert '1 MB' in err
+
+    def test_zero_byte_file_rejected(self):
+        from services.boombox_service import validate_boombox_file
+        ok, err = validate_boombox_file(b'', 'horn.mp3')
+        assert not ok
+        assert 'empty' in err.lower()
+
+
+# ---------------------------------------------------------------------------
+# Count helpers
+# ---------------------------------------------------------------------------
+
+class TestGetBoomboxCountAnyMode:
+    """The count helper must read from the mode-appropriate mount.
+
+    Counting against ``None`` (which is what callers would pass in
+    present mode if they used the upload destination) silently returned
+    0 in the wraps service — that bug let the user fill the drive past
+    the limit. ``get_boombox_count_any_mode`` is the same defense.
+    """
+
+    def test_present_mode_reads_from_ro(self, fake_music_drive,
+                                        monkeypatch):
+        # Populate ONLY the RO side. A bug that read from RW would
+        # observably return 0 instead of 5.
+        _populate(fake_music_drive['ro_boombox'], 5)
+        from services import boombox_service
+        _set_mode(monkeypatch, 'present')
+
+        assert boombox_service.get_boombox_count_any_mode() == 5
+
+    def test_edit_mode_reads_from_rw(self, fake_music_drive, monkeypatch):
+        # In edit mode the RO mount may not exist (gadget unbound).
+        _populate(fake_music_drive['rw_boombox'], 3)
+        from services import boombox_service
+        _set_mode(monkeypatch, 'edit')
+
+        assert boombox_service.get_boombox_count_any_mode() == 3
+
+    def test_does_not_count_non_audio_files(self, fake_music_drive,
+                                            monkeypatch):
+        # Stray macOS .DS_Store / README / .txt files don't count.
+        _populate(fake_music_drive['ro_boombox'], 2)
+        (fake_music_drive['ro_boombox'] / '.DS_Store').write_bytes(b'')
+        (fake_music_drive['ro_boombox'] / 'README.txt').write_text('hi')
+        from services import boombox_service
+        _set_mode(monkeypatch, 'present')
+
+        assert boombox_service.get_boombox_count_any_mode() == 2
+
+    def test_missing_folder_returns_zero(self, fake_music_drive,
+                                         monkeypatch):
+        # Fresh device — no /Boombox/ yet.
+        from services import boombox_service
+        # Remove the folder we created in the fixture for this test only.
+        import shutil
+        shutil.rmtree(fake_music_drive['ro_boombox'])
+        shutil.rmtree(fake_music_drive['rw_boombox'])
+        _set_mode(monkeypatch, 'present')
+
+        assert boombox_service.get_boombox_count_any_mode() == 0
+
+
+# ---------------------------------------------------------------------------
+# Count-enforcement regressions — the wraps-style bypass
+# ---------------------------------------------------------------------------
+
+class TestUploadCountEnforcement:
+    """The original wraps-service bug: in present mode the count check
+    silently returned 0 so the 11th upload was accepted. We must not
+    reproduce that here.
+    """
+
+    def _stub_quick_edit(self, monkeypatch):
+        """Make ``quick_edit_part3`` execute its callback inline so we
+        actually exercise the inner save logic in tests.
+        """
+        from services import boombox_service
+
+        def _fake_quick_edit(fn, timeout=None):
+            return fn()
+        monkeypatch.setattr(
+            'services.partition_mount_service.quick_edit_part3',
+            _fake_quick_edit)
+        # Patch the bound name on the service too — boombox_service did
+        # ``from services.partition_mount_service import quick_edit_part3``
+        # at import time, so patching the source module doesn't reach
+        # the alias and the real preflight check would run.
+        monkeypatch.setattr(boombox_service, 'quick_edit_part3',
+                            _fake_quick_edit)
+        # Stub the rebind so we don't poke configfs. Same alias-patch
+        # rule applies to ``safe_rebind_usb_gadget``.
+        monkeypatch.setattr(
+            'services.wrap_service.safe_rebind_usb_gadget',
+            lambda: None)
+        monkeypatch.setattr(
+            boombox_service, 'safe_rebind_usb_gadget', lambda: None)
+        # Stub samba close — it tries to talk to a real socket otherwise.
+        monkeypatch.setattr(
+            'services.samba_service.close_samba_share',
+            lambda part: None)
+        return boombox_service
+
+    def test_sixth_upload_present_mode_rejected(self, fake_music_drive,
+                                                monkeypatch):
+        # Pre-populate 5 sounds on the RO side (count source of truth
+        # in present mode).
+        _populate(fake_music_drive['ro_boombox'], 5)
+        bs = self._stub_quick_edit(monkeypatch)
+        _set_mode(monkeypatch, 'present')
+
+        upload = _FakeUploadFile(
+            'sixth.mp3', _build_minimal_mp3_bytes(prefix='id3'))
+        ok, msg = bs.upload_boombox_file(upload, 'sixth.mp3')
+
+        assert not ok
+        assert 'maximum' in msg.lower() or '5' in msg
+
+    def test_sixth_upload_edit_mode_rejected(self, fake_music_drive,
+                                             monkeypatch):
+        # Same defense in edit mode: 5 already on the RW mount.
+        _populate(fake_music_drive['rw_boombox'], 5)
+        bs = self._stub_quick_edit(monkeypatch)
+        _set_mode(monkeypatch, 'edit')
+
+        upload = _FakeUploadFile(
+            'sixth.mp3', _build_minimal_mp3_bytes(prefix='id3'))
+        ok, msg = bs.upload_boombox_file(upload, 'sixth.mp3')
+
+        assert not ok
+        assert 'maximum' in msg.lower() or '5' in msg
+
+    def test_fifth_upload_accepted_in_both_modes(self, fake_music_drive,
+                                                 monkeypatch):
+        # Only 4 present — the 5th should be accepted in both modes.
+        bs = self._stub_quick_edit(monkeypatch)
+
+        # Present mode: pre-populate 4 on RO. The new file lands on RW
+        # (which is what quick_edit_part3 would mount).
+        _populate(fake_music_drive['ro_boombox'], 4)
+        _set_mode(monkeypatch, 'present')
+        upload = _FakeUploadFile(
+            'fifth.mp3', _build_minimal_mp3_bytes(prefix='id3'))
+        ok, msg = bs.upload_boombox_file(upload, 'fifth.mp3')
+        assert ok, msg
+        assert (fake_music_drive['rw_boombox'] / 'fifth.mp3').is_file()
+
+        # Reset for edit-mode check: clear RW, populate 4 on RW.
+        for f in fake_music_drive['rw_boombox'].iterdir():
+            f.unlink()
+        _populate(fake_music_drive['rw_boombox'], 4)
+        _set_mode(monkeypatch, 'edit')
+        upload = _FakeUploadFile(
+            'fifth.mp3', _build_minimal_mp3_bytes(prefix='id3'))
+        ok, msg = bs.upload_boombox_file(upload, 'fifth.mp3')
+        assert ok, msg
+
+
+# ---------------------------------------------------------------------------
+# Upload + delete cycle (edit mode, atomic on real tmp filesystem)
+# ---------------------------------------------------------------------------
+
+class TestUploadDeleteCycleEditMode:
+
+    def test_upload_then_delete_round_trip(self, fake_music_drive,
+                                           monkeypatch):
+        from services import boombox_service
+        _set_mode(monkeypatch, 'edit')
+        # Stub the samba close call (needs a real socket).
+        monkeypatch.setattr(
+            'services.samba_service.close_samba_share',
+            lambda part: None)
+
+        # Upload
+        wav = _build_minimal_wav_bytes(payload_size=128)
+        upload = _FakeUploadFile('horn.wav', wav)
+        ok, msg = boombox_service.upload_boombox_file(upload, 'horn.wav')
+        assert ok, msg
+
+        target = fake_music_drive['rw_boombox'] / 'horn.wav'
+        assert target.is_file()
+        assert target.read_bytes() == wav
+
+        # No leftover .upload temp file in the boombox directory.
+        leftovers = [p.name for p in fake_music_drive['rw_boombox'].iterdir()
+                     if p.name.startswith('.')]
+        assert not leftovers, f"Unexpected temp files: {leftovers}"
+
+        # Delete
+        ok, msg = boombox_service.delete_boombox_file('horn.wav')
+        assert ok, msg
+        assert not target.exists()
+
+    def test_delete_missing_file_returns_error(self, fake_music_drive,
+                                               monkeypatch):
+        from services import boombox_service
+        _set_mode(monkeypatch, 'edit')
+        monkeypatch.setattr(
+            'services.samba_service.close_samba_share',
+            lambda part: None)
+
+        ok, msg = boombox_service.delete_boombox_file('nonexistent.mp3')
+        assert not ok
+        assert 'not found' in msg.lower()
+
+    def test_delete_rejects_path_traversal(self, fake_music_drive,
+                                           monkeypatch):
+        from services import boombox_service
+        _set_mode(monkeypatch, 'edit')
+        # _sanitize_name strips the path prefix; the basename ends up
+        # being 'evil.mp3' — but it does not exist in /Boombox/, so the
+        # delete returns "File not found" rather than reaching outside.
+        ok, msg = boombox_service.delete_boombox_file('../../evil.mp3')
+        assert not ok
+        # The important guarantee: nothing outside /Boombox/ was touched.
+        # (No file existed at the sanitized name, so we got "not found".)
+
+
+# ---------------------------------------------------------------------------
+# USB rebind on present-mode writes (PR #60 invariant for this service)
+# ---------------------------------------------------------------------------
+
+class TestRebindAfterPresentModeWrites:
+
+    def test_present_upload_calls_safe_rebind(self, fake_music_drive,
+                                              monkeypatch):
+        from services import boombox_service
+
+        def _fake_quick_edit(fn, timeout=None):
+            return fn()
+        monkeypatch.setattr('services.partition_mount_service.quick_edit_part3', _fake_quick_edit)
+        monkeypatch.setattr(boombox_service, 'quick_edit_part3', _fake_quick_edit)
+        monkeypatch.setattr(
+            'services.samba_service.close_samba_share',
+            lambda part: None)
+        rebind = MagicMock()
+        # The service imported the function as a bound name, patch the
+        # service's view of it.
+        monkeypatch.setattr(
+            boombox_service, 'safe_rebind_usb_gadget', rebind)
+        _set_mode(monkeypatch, 'present')
+
+        upload = _FakeUploadFile(
+            'horn.mp3', _build_minimal_mp3_bytes(prefix='id3'))
+        ok, msg = boombox_service.upload_boombox_file(upload, 'horn.mp3')
+        assert ok, msg
+        rebind.assert_called_once()
+
+    def test_edit_upload_does_not_call_safe_rebind(self, fake_music_drive,
+                                                   monkeypatch):
+        from services import boombox_service
+        monkeypatch.setattr(
+            'services.samba_service.close_samba_share',
+            lambda part: None)
+        rebind = MagicMock()
+        monkeypatch.setattr(
+            boombox_service, 'safe_rebind_usb_gadget', rebind)
+        _set_mode(monkeypatch, 'edit')
+
+        upload = _FakeUploadFile(
+            'horn.mp3', _build_minimal_mp3_bytes(prefix='id3'))
+        ok, msg = boombox_service.upload_boombox_file(upload, 'horn.mp3')
+        assert ok, msg
+        rebind.assert_not_called()
+
+    def test_present_delete_calls_safe_rebind(self, fake_music_drive,
+                                              monkeypatch):
+        from services import boombox_service
+
+        # Pre-create the file on the RW mount (where the delete writes
+        # via the inline-stubbed quick_edit_part3).
+        target = fake_music_drive['rw_boombox'] / 'horn.mp3'
+        target.write_bytes(_build_minimal_mp3_bytes(prefix='id3'))
+
+        def _fake_quick_edit(fn, timeout=None):
+            return fn()
+        monkeypatch.setattr('services.partition_mount_service.quick_edit_part3', _fake_quick_edit)
+        monkeypatch.setattr(boombox_service, 'quick_edit_part3', _fake_quick_edit)
+        monkeypatch.setattr(
+            'services.samba_service.close_samba_share',
+            lambda part: None)
+        rebind = MagicMock()
+        monkeypatch.setattr(
+            boombox_service, 'safe_rebind_usb_gadget', rebind)
+        _set_mode(monkeypatch, 'present')
+
+        ok, msg = boombox_service.delete_boombox_file('horn.mp3')
+        assert ok, msg
+        rebind.assert_called_once()


### PR DESCRIPTION
## Summary

Adds Boombox sound management on the Music drive (`usb_music.img` part3). New service + blueprint + template that wraps the existing `/Boombox/` folder with Tesla's per-vehicle constraints (5 files max, 1 MiB each, MP3/WAV only) and a prominent NHTSA parked-only safety notice. The folder remains visible in the regular Music browser — Boombox is a focused UX layer on top of the same disk location.

Closes #56

## Files added
- `scripts/web/services/boombox_service.py` — single-folder service. Reuses `_sanitize_name`, `_fsync_path`, `_fsync_dir`, `_stream_to_file` from `music_service` and `safe_rebind_usb_gadget` from `wrap_service` (no duplication). Mode-aware via `partition_mount_service.quick_edit_part3`.
- `scripts/web/blueprints/boombox.py` — `before_request` guard on `MUSIC_ENABLED and os.path.isfile(IMG_MUSIC_PATH)`. Routes: `GET /`, `POST /upload`, `POST /delete/<filename>`, `GET /play/<filename>`.
- `scripts/web/templates/boombox.html` — NHTSA amber warning banner above the upload zone, requirements card, drag-and-drop upload, file list with HTML5 `<audio>` preview + delete, count badge `N / 5`. All Lucide SVG icons (`#icon-megaphone`, `#icon-alert-triangle`, …), no emoji, no raster, no hex colors.
- `tests/test_boombox_service.py` — **28 new tests** covering filename validation, magic-byte sniff, size enforcement, count enforcement in **both** modes, edit-mode upload+delete cycle, rebind invariants.

## Files modified
- `scripts/web/services/partition_service.py` — added `'boombox_available': music_exists` to `get_feature_availability()`.
- `scripts/web/templates/base.html` — extended `media_available` with `or boombox_available`.
- `scripts/web/templates/media_hub_nav.html` — new pill after Music using `#icon-megaphone`.
- `scripts/web/static/icons/lucide-sprite.svg` — added `icon-megaphone` symbol (sourced from lucide-icons/lucide).
- `scripts/web/blueprints/__init__.py`, `scripts/web/web_control.py` — register `boombox_bp`.
- `scripts/web/blueprints/media.py` — extended `media_home()` redirect cascade.

## Spec compliance
- ✅ **MAX_FILE_COUNT enforced in BOTH modes** via `get_boombox_count_any_mode()` — reads from `MNT_DIR/part3-ro/Boombox` in present and `MNT_DIR/part3/Boombox` in edit. Closes the silent-bypass class of bug PR #60 fixed for wraps.
- ✅ **Tesla cache invalidation** — `safe_rebind_usb_gadget()` invoked after every successful present-mode upload and delete.
- ✅ **Magic-byte sniffing** rejects mislabeled files (WAV `RIFF`/`WAVE`, MP3 `ID3` tag or `0xFF` sync byte). Tested with an "AAC renamed to .mp3" rejection case.
- ✅ **Helpers reused** — no duplication of music_service / wrap_service plumbing.
- ✅ **No new dependencies** — `mutagen` deliberately not added; file size is the v1 quota mechanism.
- ✅ **Existing folder browsing preserved** — `/Boombox/` still appears in the Music UI.
- ✅ **No `config.yaml` changes**.
- ✅ **No `setup_usb.sh` placeholders touched**.

## UI/UX compliance
- No emoji (verified by regex scan).
- No raster icons (verified by regex scan).
- No hardcoded hex colors (verified by regex scan).
- No "Edit Mode" / "Present Mode" terminology in any user-facing string.
- NHTSA warning above the upload zone — visible above the fold at 375px.
- All touch targets ≥44×44px.
- Lucide SVG icons via the existing sprite (added `icon-megaphone`).

## Tests

```
$ python -m pytest tests/ -q --ignore=tests/test_mapping_service.py --ignore=tests/test_sei_parser.py
157 passed in 19.06s
```

The two ignored modules fail to import on `main` too — pre-existing missing protobuf-generated `services.dashcam_pb2` module, unrelated to this change. The 28 new boombox tests are part of the 157 count.

## Deviation

The issue body called for the NHTSA banner to use `--accent-warning` / `--bg-warning` CSS tokens. Those tokens **do not exist** in `style.css` — the codebase uses `--ios-warning-bg` / `--ios-warning-border` / `--ios-warning-text` for amber callouts (verified against `lock_chimes.html` and `wraps.html`). Followed the standing instruction in `.github/copilot-instructions.md` to verify and use existing tokens so dark/light mode work consistently.

## Deployment

```
cd /home/pi/TeslaUSB
git pull
sudo systemctl restart gadget_web.service
```

No `setup_usb.sh` rerun needed. No `config.yaml` changes.

---

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
