### PR TITLE
feat(license-plates): add License Plate management on LightShow drive

### DIFF
--- a/scripts/web/blueprints/__init__.py
+++ b/scripts/web/blueprints/__init__.py
@@ -5,6 +5,7 @@ from .videos import videos_bp
 from .lock_chimes import lock_chimes_bp
 from .light_shows import light_shows_bp
 from .wraps import wraps_bp
+from .license_plates import license_plates_bp
 from .analytics import analytics_bp
 from .mapping import mapping_bp
 from .cleanup import cleanup_bp
@@ -22,6 +23,7 @@ __all__ = [
     'lock_chimes_bp',
     'light_shows_bp',
     'wraps_bp',
+    'license_plates_bp',
     'analytics_bp',
     'mapping_bp',
     'cleanup_bp',

--- a/scripts/web/blueprints/license_plates.py
+++ b/scripts/web/blueprints/license_plates.py
@@ -1,0 +1,320 @@
+"""Blueprint for custom license-plate management routes.
+
+License plates live on the LightShow drive (part2) alongside wraps
+and light shows. The routes mirror the wraps blueprint pattern but
+use the stricter license-plate validators and the count helper that
+doesn't bypass the limit in present mode.
+"""
+
+import os
+import time
+import logging
+
+from flask import (
+    Blueprint, render_template, request, redirect,
+    url_for, flash, send_file, jsonify,
+)
+
+logger = logging.getLogger(__name__)
+
+from config import USB_PARTITIONS, PART_LABEL_MAP, IMG_LIGHTSHOW_PATH
+from utils import format_file_size, get_base_context
+from services.mode_service import current_mode
+from services.partition_service import get_mount_path, iter_all_partitions
+from services.partition_mount_service import check_operation_in_progress
+from services.license_plate_service import (
+    upload_plate_file,
+    delete_plate_file,
+    list_plate_files,
+    get_plate_count_any_mode,
+    safe_rebind_usb_gadget,
+    LICENSE_PLATE_FOLDER,
+    MAX_PLATE_COUNT,
+    MAX_PLATE_SIZE,
+    MAX_FILENAME_LENGTH,
+    PLATE_DIMENSIONS_NA,
+    PLATE_DIMENSIONS_EU,
+)
+from services.samba_service import close_samba_share, restart_samba_services
+
+license_plates_bp = Blueprint(
+    'license_plates', __name__, url_prefix='/license_plates',
+)
+
+
+@license_plates_bp.before_request
+def _require_lightshow_image():
+    """Block all routes when the LightShow disk image is missing.
+
+    Mirrors the wraps gating pattern — AJAX gets a 503 JSON, browser
+    requests get a flash + redirect to the settings page.
+    """
+    if not os.path.isfile(IMG_LIGHTSHOW_PATH):
+        if request.headers.get('X-Requested-With') == 'XMLHttpRequest':
+            return jsonify({"error": "Feature unavailable"}), 503
+        flash(
+            "This feature is not available because the required disk "
+            "image has not been created."
+        )
+        return redirect(url_for('mode_control.index'))
+
+
+def _render_plate_page(plate_files, plate_count, op_status=None):
+    """Common renderer for the license-plate page.
+
+    Centralized so the operation-in-progress branch and the normal
+    branch share the same template kwargs and we can't accidentally
+    diverge them.
+    """
+    ctx = get_base_context()
+    operation_in_progress = bool(op_status and op_status['in_progress'])
+    return render_template(
+        'license_plates.html',
+        page='media',
+        media_tab='plates',
+        **ctx,
+        plate_files=plate_files,
+        plate_count=plate_count,
+        max_plate_count=MAX_PLATE_COUNT,
+        auto_refresh=False,
+        operation_in_progress=operation_in_progress,
+        lock_age=(op_status or {}).get('lock_age', 0),
+        estimated_completion=(op_status or {}).get('estimated_completion', 0),
+        # Tesla spec values for client-side validation + UI display.
+        max_file_size=MAX_PLATE_SIZE,
+        max_filename_length=MAX_FILENAME_LENGTH,
+        plate_width_na=PLATE_DIMENSIONS_NA[0],
+        plate_height_na=PLATE_DIMENSIONS_NA[1],
+        plate_width_eu=PLATE_DIMENSIONS_EU[0],
+        plate_height_eu=PLATE_DIMENSIONS_EU[1],
+    )
+
+
+@license_plates_bp.route("/")
+def license_plates():
+    """License-plate management page."""
+    op_status = check_operation_in_progress()
+
+    if op_status['in_progress']:
+        # While quick_edit_part2 is held by another caller, render
+        # the operation banner and an empty list.
+        return _render_plate_page([], 0, op_status=op_status)
+
+    plate_files = []
+    for part, mount_path in iter_all_partitions():
+        for file_info in list_plate_files(mount_path):
+            file_info['partition_key'] = part
+            file_info['partition'] = PART_LABEL_MAP.get(part, part)
+            file_info['size_str'] = format_file_size(file_info['size'])
+            if file_info['width'] and file_info['height']:
+                file_info['dimensions'] = (
+                    f"{file_info['width']}x{file_info['height']}"
+                )
+            else:
+                file_info['dimensions'] = "Unknown"
+            plate_files.append(file_info)
+
+    plate_files.sort(key=lambda x: x['filename'].lower())
+    return _render_plate_page(plate_files, len(plate_files))
+
+
+@license_plates_bp.route("/download/<partition>/<filename>")
+def download_plate(partition, filename):
+    """Download a license-plate PNG file."""
+    if partition not in USB_PARTITIONS:
+        flash("Invalid partition", "error")
+        return redirect(url_for("license_plates.license_plates"))
+
+    mount_path = get_mount_path(partition)
+    if not mount_path:
+        flash("Partition not mounted", "error")
+        return redirect(url_for("license_plates.license_plates"))
+
+    # Strip any path components from a hostile filename and re-check
+    # the extension before joining with the destination directory.
+    safe_name = os.path.basename(filename)
+    if not safe_name.lower().endswith('.png'):
+        flash("File not found", "error")
+        return redirect(url_for("license_plates.license_plates"))
+
+    file_path = os.path.join(mount_path, LICENSE_PLATE_FOLDER, safe_name)
+    if not os.path.isfile(file_path):
+        flash("File not found", "error")
+        return redirect(url_for("license_plates.license_plates"))
+
+    return send_file(
+        file_path,
+        mimetype='image/png',
+        as_attachment=True,
+        download_name=safe_name,
+    )
+
+
+@license_plates_bp.route("/upload_multiple", methods=["POST"])
+def upload_multiple_plates():
+    """Upload multiple license-plate files in one batch."""
+    is_ajax = request.headers.get('X-Requested-With') == 'XMLHttpRequest'
+    mode = current_mode()
+
+    files = request.files.getlist('plate_files')
+    if not files:
+        if is_ajax:
+            return jsonify({"success": False, "error": "No files selected"}), 400
+        flash("No files selected", "error")
+        return redirect(url_for("license_plates.license_plates"))
+
+    # Edit mode needs the explicit RW path; present mode infers it via
+    # quick_edit_part2 inside the service.
+    part2_mount_path = get_mount_path("part2") if mode == "edit" else None
+
+    # Mode-aware count check — uses the RO mount in present mode so
+    # MAX_PLATE_COUNT is enforced before quick_edit fires.
+    current_count = get_plate_count_any_mode()
+
+    results = []
+    total_uploaded = 0
+
+    for file in files:
+        if not file.filename:
+            continue
+
+        if current_count + total_uploaded >= MAX_PLATE_COUNT:
+            results.append({
+                'filename': file.filename,
+                'success': False,
+                'message': f"Maximum of {MAX_PLATE_COUNT} license plates allowed",
+            })
+            continue
+
+        # defer_rebind=True per file — one batch rebind below.
+        success, message, dimensions = upload_plate_file(
+            file, file.filename, part2_mount_path, defer_rebind=True,
+        )
+        results.append({
+            'filename': file.filename,
+            'success': success,
+            'message': message,
+            'dimensions': (
+                f"{dimensions[0]}x{dimensions[1]}" if dimensions else None
+            ),
+        })
+        if success:
+            total_uploaded += 1
+
+    if mode == "edit" and total_uploaded > 0:
+        try:
+            close_samba_share('gadget_part2')
+            restart_samba_services()
+        except Exception as e:
+            logger.error(f"Samba refresh failed: {e}")
+
+    # One USB rebind for the whole batch (present mode only).
+    if mode == "present" and total_uploaded > 0:
+        safe_rebind_usb_gadget()
+
+    if is_ajax:
+        success_count = sum(1 for r in results if r['success'])
+        return jsonify({
+            'success': success_count > 0,
+            'results': results,
+            'total_uploaded': total_uploaded,
+            'summary': (
+                f"Successfully uploaded {total_uploaded} license "
+                f"plate(s) from {success_count}/{len(results)} file(s)"
+            ),
+        }), 200
+
+    success_count = sum(1 for r in results if r['success'])
+    if success_count > 0:
+        flash(
+            f"Successfully uploaded {total_uploaded} license plate(s)",
+            "success",
+        )
+    else:
+        flash("Failed to upload license plates", "error")
+
+    return redirect(
+        url_for("license_plates.license_plates", _=int(time.time()))
+    )
+
+
+@license_plates_bp.route("/upload", methods=["POST"])
+def upload_plate():
+    """Upload a single license-plate PNG."""
+    mode = current_mode()
+
+    if "plate_file" not in request.files:
+        flash("No file selected", "error")
+        return redirect(url_for("license_plates.license_plates"))
+
+    file = request.files["plate_file"]
+    if file.filename == "":
+        flash("No file selected", "error")
+        return redirect(url_for("license_plates.license_plates"))
+
+    part2_mount_path = get_mount_path("part2") if mode == "edit" else None
+
+    current_count = get_plate_count_any_mode()
+    if current_count >= MAX_PLATE_COUNT:
+        flash(
+            f"Maximum of {MAX_PLATE_COUNT} license plates allowed. "
+            f"Delete some plates first.",
+            "error",
+        )
+        return redirect(url_for("license_plates.license_plates"))
+
+    # The service handles the post-upload USB rebind in present mode.
+    success, message, dimensions = upload_plate_file(
+        file, file.filename, part2_mount_path,
+    )
+
+    if success:
+        flash(message, "success")
+        if mode == "edit":
+            try:
+                close_samba_share('gadget_part2')
+                restart_samba_services()
+            except Exception as e:
+                flash(
+                    f"File uploaded but Samba refresh failed: {str(e)}",
+                    "warning",
+                )
+    else:
+        flash(message, "error")
+
+    # Cache-bust the redirect so the freshly-uploaded plate appears.
+    return redirect(
+        url_for("license_plates.license_plates", _=int(time.time()))
+    )
+
+
+@license_plates_bp.route("/delete/<partition>/<filename>", methods=["POST"])
+def delete_plate(partition, filename):
+    """Delete a license-plate PNG."""
+    mode = current_mode()
+
+    if partition not in USB_PARTITIONS:
+        flash("Invalid partition", "error")
+        return redirect(url_for("license_plates.license_plates"))
+
+    part2_mount_path = get_mount_path(partition) if mode == "edit" else None
+
+    # The service rebinds the USB gadget after a successful present-mode
+    # delete so Tesla drops the plate from its cache without a reboot.
+    success, message = delete_plate_file(filename, part2_mount_path)
+
+    if success:
+        flash(message, "success")
+        if mode == "edit":
+            try:
+                close_samba_share('gadget_part2')
+                restart_samba_services()
+            except Exception as e:
+                flash(
+                    f"File deleted but Samba refresh failed: {str(e)}",
+                    "warning",
+                )
+    else:
+        flash(message, "error")
+
+    return redirect(url_for("license_plates.license_plates"))

--- a/scripts/web/blueprints/license_plates.py
+++ b/scripts/web/blueprints/license_plates.py
@@ -138,6 +138,25 @@ def download_plate(partition, filename):
         return redirect(url_for("license_plates.license_plates"))
 
     file_path = os.path.join(mount_path, LICENSE_PLATE_FOLDER, safe_name)
+
+    # Defense-in-depth: verify the resolved path lives under the
+    # LicensePlate folder before serving it. basename() defangs `..`
+    # traversal in the filename itself, but a symlink under
+    # LicensePlate/ pointing outside the folder would still be served
+    # without this check. realpath() follows symlinks; commonpath()
+    # confirms containment under the expected root.
+    expected_dir = os.path.realpath(os.path.join(mount_path, LICENSE_PLATE_FOLDER))
+    try:
+        resolved = os.path.realpath(file_path)
+        if os.path.commonpath([expected_dir, resolved]) != expected_dir:
+            flash("File not found", "error")
+            return redirect(url_for("license_plates.license_plates"))
+    except ValueError:
+        # commonpath raises ValueError on mixed drives (Windows) or
+        # when paths cannot be compared. Treat as not-found.
+        flash("File not found", "error")
+        return redirect(url_for("license_plates.license_plates"))
+
     if not os.path.isfile(file_path):
         flash("File not found", "error")
         return redirect(url_for("license_plates.license_plates"))

--- a/scripts/web/blueprints/media.py
+++ b/scripts/web/blueprints/media.py
@@ -11,7 +11,14 @@ media_bp = Blueprint('media', __name__, url_prefix='/media')
 
 @media_bp.route("/")
 def media_home():
-    """Redirect to the first available media sub-page."""
+    """Redirect to the first available media sub-page.
+
+    The cascade prefers the LightShow drive (chimes/shows/wraps/plates)
+    when present. License plates share the same image as chimes so the
+    same gating applies — chimes remains the primary landing page when
+    the LightShow drive is mounted; the dedicated plates page is reached
+    via the Media pill bar.
+    """
     if os.path.isfile(IMG_LIGHTSHOW_PATH):
         return redirect(url_for('lock_chimes.lock_chimes'))
     if os.path.isfile(IMG_MUSIC_PATH) and MUSIC_ENABLED:

--- a/scripts/web/services/license_plate_service.py
+++ b/scripts/web/services/license_plate_service.py
@@ -1,0 +1,449 @@
+"""Service layer for custom license-plate background management.
+
+Tesla supports custom PNG license-plate background images on
+Cybertruck (2024 Holiday Update), Model Y/3 (2025 firmware), and is
+rolling out to S/X. The car reads PNG files from a ``LicensePlate/``
+folder at the root of any attached USB drive.
+
+Tesla requirements (community-verified at
+https://github.com/teslamotors/custom-wraps/issues/13):
+
+- Folder: ``LicensePlate`` at USB root (case-sensitive, no trailing s)
+- Format: PNG only
+- Dimensions (NA): 420 x 200 px
+- Dimensions (EU/Italy): 420 x 100 px
+- Max file size: 0.5 MB (512 KB)
+- Filename: alphanumeric only, <= 32 characters (no spaces, dashes, underscores)
+- Max files: 10
+
+The service mirrors :mod:`services.wrap_service` but with the
+plate-specific constants and a stricter dimension validator. It also
+incorporates the three fixes called out in issue #58 from day one:
+
+1. Count check reads from the RO mount in present mode (no silent
+   bypass when ``part2_mount_path`` is ``None``).
+2. No unconditional ``time.sleep`` after writes — the blueprint and
+   service finish their work synchronously.
+3. After a successful present-mode write or delete, the USB gadget is
+   unbound/rebound via :func:`services.wrap_service.safe_rebind_usb_gadget`
+   so Tesla picks up the new plate without a reboot.
+"""
+
+import os
+import re
+import shutil
+import logging
+import tempfile
+import struct
+
+logger = logging.getLogger(__name__)
+
+# License-plate folder name (at the root of the USB drive)
+LICENSE_PLATE_FOLDER = "LicensePlate"
+
+# Tesla requirements
+MAX_PLATE_SIZE = 512 * 1024  # 512 KB ("0.5 MB")
+MAX_PLATE_COUNT = 10
+MAX_FILENAME_LENGTH = 32
+
+# Tesla-allowed dimensions for license-plate backgrounds.
+PLATE_DIMENSIONS_NA = (420, 200)
+PLATE_DIMENSIONS_EU = (420, 100)
+ALLOWED_PLATE_DIMENSIONS = (PLATE_DIMENSIONS_NA, PLATE_DIMENSIONS_EU)
+
+# Strict alphanumeric pattern — no underscores, dashes, or spaces.
+# This is intentionally tighter than the wraps pattern; Tesla's plate
+# parser rejects anything that isn't [A-Za-z0-9]+ before the .png.
+VALID_FILENAME_PATTERN = re.compile(r'^[A-Za-z0-9]+$')
+
+
+def get_png_dimensions(file_path):
+    """Return ``(width, height)`` for a PNG on disk, or ``(None, None)``.
+
+    Reads only the 8-byte signature and the IHDR chunk header, so it
+    works on multi-megabyte files without loading the whole image.
+    """
+    try:
+        with open(file_path, 'rb') as f:
+            signature = f.read(8)
+            if signature != b'\x89PNG\r\n\x1a\n':
+                return None, None
+            # IHDR chunk: 4 bytes length, 4 bytes type, then data
+            f.read(4)  # length, ignored
+            chunk_type = f.read(4)
+            if chunk_type != b'IHDR':
+                return None, None
+            width = struct.unpack('>I', f.read(4))[0]
+            height = struct.unpack('>I', f.read(4))[0]
+            return width, height
+    except Exception as e:
+        logger.error(f"Error reading PNG dimensions: {e}")
+        return None, None
+
+
+def get_png_dimensions_from_bytes(file_bytes):
+    """Return ``(width, height)`` from a PNG byte buffer, or ``(None, None)``."""
+    try:
+        if file_bytes[:8] != b'\x89PNG\r\n\x1a\n':
+            return None, None
+        chunk_type = file_bytes[12:16]
+        if chunk_type != b'IHDR':
+            return None, None
+        width = struct.unpack('>I', file_bytes[16:20])[0]
+        height = struct.unpack('>I', file_bytes[20:24])[0]
+        return width, height
+    except Exception as e:
+        logger.error(f"Error reading PNG dimensions from bytes: {e}")
+        return None, None
+
+
+def validate_plate_filename(filename):
+    """Validate a license-plate filename.
+
+    Returns ``(is_valid, error_message)``.
+    """
+    if not filename.lower().endswith('.png'):
+        return False, "Only PNG files are allowed"
+
+    base_name = os.path.splitext(filename)[0]
+
+    if len(base_name) == 0:
+        return False, "Filename cannot be empty"
+
+    if len(base_name) > MAX_FILENAME_LENGTH:
+        return False, (
+            f"Filename must be {MAX_FILENAME_LENGTH} characters or less "
+            f"(currently {len(base_name)})"
+        )
+
+    if not VALID_FILENAME_PATTERN.match(base_name):
+        return False, (
+            "Filename can only contain letters and numbers "
+            "(no spaces, dashes, or underscores)"
+        )
+
+    return True, None
+
+
+def validate_plate_dimensions(width, height):
+    """Validate license-plate dimensions.
+
+    Tesla accepts only two exact sizes: 420x200 (NA) or 420x100 (EU).
+    The smart-resize cropper in the UI is responsible for producing
+    one of these — by the time bytes hit the server they must match.
+
+    Returns ``(is_valid, error_message)``.
+    """
+    if width is None or height is None:
+        return False, "Could not read image dimensions - file may be corrupted"
+
+    if (width, height) not in ALLOWED_PLATE_DIMENSIONS:
+        return False, (
+            f"License plate must be exactly 420x200 (NA) or 420x100 (EU); "
+            f"got {width}x{height}. Use the in-browser cropper to produce "
+            f"a compliant size."
+        )
+
+    return True, None
+
+
+def validate_plate_file(file_bytes, filename):
+    """Validate a license-plate file end-to-end.
+
+    Returns ``(is_valid, error_message, dimensions_or_None)``.
+    """
+    is_valid, error = validate_plate_filename(filename)
+    if not is_valid:
+        return False, error, None
+
+    if len(file_bytes) > MAX_PLATE_SIZE:
+        size_kb = len(file_bytes) / 1024
+        return False, (
+            f"File size must be 512 KB or less (got {size_kb:.1f} KB). "
+            f"Try a simpler image or reduce the color depth."
+        ), None
+
+    width, height = get_png_dimensions_from_bytes(file_bytes)
+    is_valid, error = validate_plate_dimensions(width, height)
+    if not is_valid:
+        return False, error, None
+
+    return True, None, (width, height)
+
+
+def _safe_rebind_usb_gadget():
+    """Rebind the USB gadget so Tesla notices the new plate.
+
+    Delegates to :func:`services.wrap_service.safe_rebind_usb_gadget`
+    so we share one helper. The function swallows failures (rebind
+    issues are logged but never block the user-facing operation —
+    the file is already on disk by the time we get here).
+    """
+    from services.wrap_service import safe_rebind_usb_gadget
+    safe_rebind_usb_gadget()
+
+
+# Re-exported for callers that want to call the helper directly
+# (the blueprint uses this name in a batch-rebind path).
+safe_rebind_usb_gadget = _safe_rebind_usb_gadget
+
+
+def upload_plate_file(uploaded_file, filename, part2_mount_path=None,
+                      defer_rebind=False):
+    """Upload a license-plate PNG to the LicensePlate/ folder.
+
+    Mode-aware:
+        - In edit mode: writes directly to ``part2_mount_path``.
+        - In present mode: uses ``quick_edit_part2()`` to temporarily
+          mount RW. After a successful write the USB gadget is
+          rebound (unless ``defer_rebind=True``) so Tesla invalidates
+          its cache and shows the plate without a reboot.
+
+    Args:
+        uploaded_file: Flask ``FileStorage`` (provides ``read`` + ``seek``).
+        filename: Destination filename (basename only — sanitized here).
+        part2_mount_path: RW mount path for part2 in edit mode. Ignored
+            in present mode (we use ``MNT_DIR/part2`` after quick_edit
+            remounts it RW).
+        defer_rebind: When ``True``, skip the post-write USB rebind so
+            a bulk caller can issue one rebind for the whole batch.
+
+    Returns:
+        ``(success, message, dimensions_or_None)``
+    """
+    from services.mode_service import current_mode
+    from services.partition_mount_service import quick_edit_part2
+    from config import MNT_DIR
+
+    mode = current_mode()
+    logger.info(f"Uploading license plate {filename} (mode: {mode})")
+
+    file_bytes = uploaded_file.read()
+    uploaded_file.seek(0)
+
+    is_valid, error, dimensions = validate_plate_file(file_bytes, filename)
+    if not is_valid:
+        return False, error, None
+
+    # Strip any path components from a hostile filename before joining
+    # it with the destination directory.
+    filename = os.path.basename(filename)
+
+    if mode == 'present':
+        # Stage the bytes in a temp file so the quick-edit window stays
+        # short (the RW remount is what's expensive — the copy itself
+        # is sub-second).
+        temp_dir = tempfile.mkdtemp(prefix='plate_upload_')
+        try:
+            temp_file_path = os.path.join(temp_dir, filename)
+            with open(temp_file_path, 'wb') as f:
+                f.write(file_bytes)
+
+            def _do_quick_copy():
+                try:
+                    rw_mount = os.path.join(MNT_DIR, 'part2')
+                    plates_dir = os.path.join(rw_mount, LICENSE_PLATE_FOLDER)
+                    if not os.path.isdir(plates_dir):
+                        os.makedirs(plates_dir, exist_ok=True)
+                    dest_path = os.path.join(plates_dir, filename)
+                    shutil.copy2(temp_file_path, dest_path)
+                    return True, "File copied successfully"
+                except Exception as e:
+                    logger.error(f"Error copying plate: {e}", exc_info=True)
+                    return False, f"Error copying file: {str(e)}"
+
+            logger.info("Using quick edit part2 for license-plate upload")
+            success, copy_msg = quick_edit_part2(_do_quick_copy, timeout=30)
+
+            shutil.rmtree(temp_dir, ignore_errors=True)
+
+            if success:
+                if not defer_rebind:
+                    _safe_rebind_usb_gadget()
+                return True, (
+                    f"Successfully uploaded {filename} "
+                    f"({dimensions[0]}x{dimensions[1]})"
+                ), dimensions
+            return False, copy_msg, None
+
+        except Exception as e:
+            shutil.rmtree(temp_dir, ignore_errors=True)
+            logger.error(f"Error uploading plate: {e}", exc_info=True)
+            return False, f"Error uploading file: {str(e)}", None
+
+    # Edit mode — write directly. The gadget is unbound, so no rebind.
+    def _do_upload():
+        try:
+            if not part2_mount_path:
+                return False, "Part2 mount path required in edit mode", None
+            plates_dir = os.path.join(part2_mount_path, LICENSE_PLATE_FOLDER)
+            if not os.path.isdir(plates_dir):
+                os.makedirs(plates_dir, exist_ok=True)
+            dest_path = os.path.join(plates_dir, filename)
+            with open(dest_path, 'wb') as f:
+                f.write(file_bytes)
+            return True, (
+                f"Successfully uploaded {filename} "
+                f"({dimensions[0]}x{dimensions[1]})"
+            ), dimensions
+        except Exception as e:
+            logger.error(f"Error uploading plate: {e}", exc_info=True)
+            return False, f"Error uploading file: {str(e)}", None
+
+    return _do_upload()
+
+
+def delete_plate_file(filename, part2_mount_path=None, defer_rebind=False):
+    """Delete a license-plate PNG.
+
+    Mode-aware (mirrors :func:`upload_plate_file`). Present-mode
+    deletes go through ``quick_edit_part2`` and then rebind the USB
+    gadget so Tesla drops the file from its cache.
+
+    Returns ``(success, message)``.
+    """
+    from services.mode_service import current_mode
+    from services.partition_mount_service import quick_edit_part2
+    from config import MNT_DIR
+
+    mode = current_mode()
+    logger.info(f"Deleting license plate {filename} (mode: {mode})")
+
+    # Sanitize — never let path separators leak into the join.
+    filename = os.path.basename(filename)
+
+    def _do_delete():
+        try:
+            if mode == 'present':
+                rw_mount = os.path.join(MNT_DIR, 'part2')
+            else:
+                if not part2_mount_path:
+                    return False, "Part2 mount path required in edit mode"
+                rw_mount = part2_mount_path
+
+            plates_dir = os.path.join(rw_mount, LICENSE_PLATE_FOLDER)
+            file_path = os.path.join(plates_dir, filename)
+
+            if os.path.isfile(file_path):
+                os.remove(file_path)
+                logger.info(f"Deleted plate {filename}")
+                return True, f"Deleted {filename}"
+            return False, "File not found"
+        except Exception as e:
+            logger.error(f"Error deleting plate: {e}", exc_info=True)
+            return False, f"Error deleting file: {str(e)}"
+
+    if mode == 'present':
+        logger.info("Using quick edit part2 for license-plate deletion")
+        success, msg = quick_edit_part2(_do_delete)
+        if success and not defer_rebind:
+            _safe_rebind_usb_gadget()
+        return success, msg
+
+    return _do_delete()
+
+
+def get_plate_count(mount_path):
+    """Count PNG files in the LicensePlate folder under ``mount_path``."""
+    if not mount_path:
+        return 0
+    plates_dir = os.path.join(mount_path, LICENSE_PLATE_FOLDER)
+    if not os.path.isdir(plates_dir):
+        return 0
+    try:
+        return sum(
+            1 for entry in os.listdir(plates_dir)
+            if entry.lower().endswith('.png')
+        )
+    except OSError:
+        return 0
+
+
+def get_plate_count_any_mode():
+    """Return the plate count from whichever mount is accessible.
+
+    The original wraps blueprint passed ``None`` in present mode,
+    which silently bypassed the count limit. This helper picks the
+    right mount per current mode (RO in present, RW in edit) so the
+    limit is enforced before any expensive ``quick_edit_part2`` call.
+
+    Returns:
+        int: Number of PNG plate files on the LightShow drive.
+    """
+    from services.mode_service import current_mode
+    from config import MNT_DIR
+
+    if current_mode() == 'present':
+        mount_path = os.path.join(MNT_DIR, 'part2-ro')
+    else:
+        mount_path = os.path.join(MNT_DIR, 'part2')
+    return get_plate_count(mount_path)
+
+
+def list_plate_files(mount_path):
+    """List every PNG in the LicensePlate folder with compliance metadata.
+
+    Unlike the wraps listing, this surfaces non-compliant files (wrong
+    dimensions, oversize, bad filename) with an ``issues`` array so
+    users who dropped junk in via Samba can see it and clean up. Files
+    are never silently filtered or hidden.
+
+    Returns a list of dicts with keys: ``filename``, ``size``,
+    ``width``, ``height``, ``path``, ``compliant`` (bool), ``issues``
+    (list of human-readable strings).
+    """
+    if not mount_path:
+        return []
+
+    plates_dir = os.path.join(mount_path, LICENSE_PLATE_FOLDER)
+    if not os.path.isdir(plates_dir):
+        return []
+
+    files = []
+    try:
+        for entry in os.listdir(plates_dir):
+            if not entry.lower().endswith('.png'):
+                continue
+
+            full_path = os.path.join(plates_dir, entry)
+            if not os.path.isfile(full_path):
+                continue
+
+            try:
+                size = os.path.getsize(full_path)
+                width, height = get_png_dimensions(full_path)
+            except OSError as e:
+                logger.warning(f"Could not read plate file {entry}: {e}")
+                continue
+
+            issues = []
+            name_ok, name_err = validate_plate_filename(entry)
+            if not name_ok:
+                issues.append(name_err)
+            if size > MAX_PLATE_SIZE:
+                issues.append(
+                    f"File is {size / 1024:.1f} KB (limit 512 KB)"
+                )
+            if width is None or height is None:
+                issues.append("Could not read PNG dimensions")
+            elif (width, height) not in ALLOWED_PLATE_DIMENSIONS:
+                issues.append(
+                    f"Dimensions {width}x{height} are not 420x200 (NA) "
+                    f"or 420x100 (EU)"
+                )
+
+            files.append({
+                'filename': entry,
+                'size': size,
+                'width': width,
+                'height': height,
+                'path': full_path,
+                'compliant': len(issues) == 0,
+                'issues': issues,
+            })
+
+        files.sort(key=lambda x: x['filename'].lower())
+    except OSError as e:
+        logger.error(f"Error listing license-plate files: {e}")
+
+    return files

--- a/scripts/web/services/partition_service.py
+++ b/scripts/web/services/partition_service.py
@@ -50,6 +50,7 @@ def get_feature_availability():
         'chimes_available': lightshow_exists,
         'shows_available': lightshow_exists,
         'wraps_available': lightshow_exists,
+        'license_plates_available': lightshow_exists,
         'music_available': music_exists,
         'boombox_available': music_exists,
         'cloud_archive_available': CLOUD_ARCHIVE_ENABLED,

--- a/scripts/web/static/css/style.css
+++ b/scripts/web/static/css/style.css
@@ -40,6 +40,15 @@
     --ios-warning-border: #ffc107;
     --ios-warning-text: #856404;
 
+    /* Cropper overlay (canvas) — intentionally theme-invariant.
+       The crop outline + handle fill/stroke must stay visible against
+       arbitrary user image content, so the standard white-on-black
+       halo is used in BOTH themes. Centralised here so the values
+       can be tuned in one place rather than scattered across JS. */
+    --cropper-handle-fill: #ffffff;
+    --cropper-handle-stroke: #000000;
+    --cropper-bg-fallback: #000000;
+
     --text-primary: #333333;
     --text-secondary: #666666;
     --text-navbar: #ffffff;
@@ -124,6 +133,11 @@
     --ios-warning-bg: #2d2a1e;
     --ios-warning-border: #9e6a03;
     --ios-warning-text: #e3b341;
+
+    /* Cropper overlay — same values in dark mode (see :root comment). */
+    --cropper-handle-fill: #ffffff;
+    --cropper-handle-stroke: #000000;
+    --cropper-bg-fallback: #000000;
 
     --text-primary: #e6edf3;
     --text-secondary: #8b949e;

--- a/scripts/web/static/icons/lucide-sprite.svg
+++ b/scripts/web/static/icons/lucide-sprite.svg
@@ -201,4 +201,7 @@
   <symbol id="icon-megaphone" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
     <path d="M11 6a13 13 0 0 0 8.4-2.8A1 1 0 0 1 21 4v12a1 1 0 0 1-1.6.8A13 13 0 0 0 11 14H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2z"/><path d="M6 14a12 12 0 0 0 2.4 7.2 2 2 0 0 0 3.2-2.4A8 8 0 0 1 10 14"/><path d="M8 6v8"/>
   </symbol>
+  <symbol id="icon-image" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <rect width="18" height="18" x="3" y="3" rx="2" ry="2"/><circle cx="9" cy="9" r="2"/><path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21"/>
+  </symbol>
 </svg>

--- a/scripts/web/templates/base.html
+++ b/scripts/web/templates/base.html
@@ -24,7 +24,7 @@
 </head>
 <body>
     {# Compute media_available from individual flags #}
-    {% set media_available = chimes_available or music_available or shows_available or wraps_available or boombox_available %}
+    {% set media_available = chimes_available or music_available or shows_available or wraps_available or boombox_available or license_plates_available %}
 
     <!-- Top Bar -->
     <header class="top-bar">

--- a/scripts/web/templates/license_plates.html
+++ b/scripts/web/templates/license_plates.html
@@ -1,0 +1,1088 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="container">
+    {% include 'media_hub_nav.html' %}
+    <h2>Custom License Plates</h2>
+
+    {# iOS Safari Warning — file uploads only work in mobile Safari on iOS #}
+    <div id="iosWarning" class="ios-warning" style="display: none;">
+        <p>
+            <svg class="inline-icon" aria-hidden="true"><use href="{{ url_for('static', filename='icons/lucide-sprite.svg') }}#icon-alert-triangle"></use></svg>
+            <strong>iOS Browser Limitation:</strong>
+            File uploading is only available through Safari when running on iOS. Please open this page in Safari to upload files.
+        </p>
+        <p>Note: Desktop browsers (Windows/Mac/Linux) work normally regardless of browser choice.</p>
+    </div>
+
+    {# Tesla Requirements Info #}
+    <div class="info-box" style="margin-bottom: 20px;">
+        <p>
+            <svg class="inline-icon" aria-hidden="true"><use href="{{ url_for('static', filename='icons/lucide-sprite.svg') }}#icon-info"></use></svg>
+            <strong>Tesla License-Plate Requirements:</strong>
+        </p>
+        <ul style="margin: 10px 0 0 20px; padding: 0; font-size: 13px; color: var(--text-secondary);">
+            <li><strong>Format:</strong> PNG only</li>
+            <li><strong>Size:</strong> {{ (max_file_size / 1024)|round(0)|int }} KB maximum</li>
+            <li><strong>Dimensions:</strong> {{ plate_width_na }}x{{ plate_height_na }} (North America) or {{ plate_width_eu }}x{{ plate_height_eu }} (Europe / Italy)</li>
+            <li><strong>Filename:</strong> {{ max_filename_length }} characters max, letters and numbers only (no spaces, dashes, or underscores)</li>
+            <li><strong>Count:</strong> Up to {{ max_plate_count }} plates at a time (currently: {{ plate_count }}/{{ max_plate_count }})</li>
+        </ul>
+        <p style="margin-top: 10px; font-size: 13px; color: var(--text-secondary);">
+            <strong>Usage:</strong> License plates appear in the in-car Background &rarr; Image selector under license plate config.
+            <a href="https://github.com/teslamotors/custom-wraps" target="_blank" rel="noopener" style="color: var(--text-link);">View Tesla's custom-wraps repository</a> (license-plate spec is documented in <a href="https://github.com/teslamotors/custom-wraps/issues/13" target="_blank" rel="noopener" style="color: var(--text-link);">issue #13</a>).
+        </p>
+        <p style="margin-top: 10px; font-size: 13px; color: var(--text-secondary);">
+            Drop any image and we'll open a cropper to produce a Tesla-compliant PNG &mdash; no need to resize ahead of time.
+        </p>
+    </div>
+
+    <div class="folder-controls" id="plateUploadControls">
+        {# Desktop drag-and-drop interface (hidden by default; JS shows it when supported) #}
+        <div id="desktopUploadInterface" style="display: none;">
+            <div class="drag-drop-zone" id="dragDropZone" style="border: 3px dashed var(--border-input); border-radius: 8px; padding: 40px; text-align: center; background: var(--form-input-bg); cursor: pointer; transition: all 0.3s; margin-bottom: 20px; min-height: 44px;">
+                <div style="pointer-events: none;">
+                    <svg class="drop-zone-icon" aria-hidden="true" style="width: 48px; height: 48px; color: var(--accent); display: block; margin: 0 auto 15px;"><use href="{{ url_for('static', filename='icons/lucide-sprite.svg') }}#icon-image"></use></svg>
+                    <p style="font-size: 16px; font-weight: 600; margin-bottom: 8px; color: var(--text-primary);">Drag &amp; drop image files here or click to browse</p>
+                    <p style="font-size: 13px; color: var(--text-secondary); margin: 0;">
+                        Any image format &middot; we'll crop to {{ plate_width_na }}x{{ plate_height_na }} or {{ plate_width_eu }}x{{ plate_height_eu }} &middot; max {{ (max_file_size / 1024)|round(0)|int }} KB output
+                    </p>
+                </div>
+            </div>
+
+            <input type="file" id="plate_files_multi" accept="image/png,image/jpeg,image/webp,image/gif,image/bmp" multiple style="display: none;">
+
+            <div id="selectedFilesPreview" style="display: none; margin-bottom: 20px;">
+                <h4 style="margin: 0 0 10px 0; font-size: 15px; color: var(--text-primary);">
+                    <svg class="inline-icon" aria-hidden="true"><use href="{{ url_for('static', filename='icons/lucide-sprite.svg') }}#icon-list"></use></svg>
+                    Selected Files
+                </h4>
+                <div id="filesList" style="background: var(--form-input-bg); border: 1px solid var(--border-input); border-radius: 4px; padding: 10px; max-height: 300px; overflow-y: auto;"></div>
+                <div style="display: flex; gap: 10px; margin-top: 10px; flex-wrap: wrap;">
+                    <button type="button" class="action-btn" id="uploadSelectedBtn" style="min-height: 44px;">Upload All Files</button>
+                    <button type="button" class="action-btn danger" id="clearSelectedBtn" style="min-height: 44px;">Clear All</button>
+                </div>
+            </div>
+        </div>
+
+        {# Mobile / fallback simple form (always rendered; JS hides it when desktop interface is active) #}
+        <form method="post" action="{{ url_for('license_plates.upload_plate') }}" enctype="multipart/form-data" style="margin-bottom: 20px;" id="plateUploadForm">
+            <label for="plate_file" style="display: block; margin-bottom: 8px; font-weight: 600;">Upload Custom License Plate:</label>
+            <p style="margin: 0 0 10px 0; font-size: 13px; color: var(--text-secondary);">
+                Any image &middot; we'll crop to {{ plate_width_na }}x{{ plate_height_na }} or {{ plate_width_eu }}x{{ plate_height_eu }} &middot; max {{ (max_file_size / 1024)|round(0)|int }} KB output
+            </p>
+            <input type="file" name="plate_file" id="plate_file" accept="image/png,image/jpeg,image/webp,image/gif,image/bmp" required
+                   style="display: block; margin-bottom: 10px; padding: 10px; border: 2px solid var(--border-input); border-radius: 4px; background: var(--form-input-bg); width: 100%; max-width: 400px; font-size: 14px; color: var(--text-primary); min-height: 44px;">
+            <button type="submit" class="action-btn" id="plateUploadBtn" style="min-height: 44px;">Upload</button>
+        </form>
+
+        <div id="plateUploadProgress" style="display: none; margin-bottom: 20px;">
+            <div style="background: var(--upload-progress-bg, var(--form-input-bg)); border-radius: 8px; padding: 15px; border: 2px solid var(--accent);">
+                <h4 style="margin: 0 0 10px 0; color: var(--accent);">
+                    <svg class="inline-icon" aria-hidden="true"><use href="{{ url_for('static', filename='icons/lucide-sprite.svg') }}#icon-upload"></use></svg>
+                    Uploading License Plate&hellip;
+                </h4>
+                <div style="background: var(--upload-progress-bar-bg, var(--bg-secondary)); border-radius: 4px; height: 30px; overflow: hidden; margin-bottom: 10px;">
+                    <div id="plateProgressBar" style="background: var(--accent); height: 100%; width: 0%; transition: width 0.3s; display: flex; align-items: center; justify-content: center; color: var(--bg-primary); font-weight: bold; font-size: 14px;">
+                        0%
+                    </div>
+                </div>
+                <p id="plateUploadStatus" style="margin: 0; font-size: 13px; color: var(--text-secondary);">Preparing upload&hellip;</p>
+            </div>
+        </div>
+    </div>
+
+    {% if plate_files %}
+    {# Desktop table layout #}
+    <div class="video-table-container">
+        <table class="video-table" style="table-layout: fixed;">
+            <thead>
+                <tr>
+                    <th style="width: 18%;">Preview</th>
+                    <th style="width: 28%;">Filename</th>
+                    <th style="width: 14%;">Dimensions</th>
+                    <th style="width: 12%;">Size</th>
+                    <th style="width: 28%;">Actions</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for plate in plate_files %}
+                <tr{% if not plate.compliant %} style="background: var(--bg-warning, var(--form-input-bg));"{% endif %}>
+                    <td>
+                        {# User-uploaded PNG rendered as a thumbnail — exempt from the SVG-only rule per design system #}
+                        <img src="{{ url_for('license_plates.download_plate', partition=plate.partition_key, filename=plate.filename) }}"
+                             alt="License plate {{ plate.filename }}"
+                             style="max-width: 120px; max-height: 60px; border: 1px solid var(--border-input); border-radius: 4px; background: var(--bg-secondary);"
+                             loading="lazy">
+                    </td>
+                    <td style="word-wrap: break-word; overflow-wrap: break-word;">
+                        {{ plate.filename }}
+                        {% if not plate.compliant %}
+                        <div style="margin-top: 6px; font-size: 12px; color: var(--accent-danger, var(--text-secondary));">
+                            <svg class="inline-icon" aria-hidden="true"><use href="{{ url_for('static', filename='icons/lucide-sprite.svg') }}#icon-alert-triangle"></use></svg>
+                            {% for issue in plate.issues %}
+                            {{ issue }}{% if not loop.last %}; {% endif %}
+                            {% endfor %}
+                        </div>
+                        {% endif %}
+                    </td>
+                    <td>{{ plate.dimensions }}</td>
+                    <td>{{ plate.size_str }}</td>
+                    <td>
+                        <div style="display: flex; gap: 8px; flex-wrap: wrap; align-items: center;">
+                            <a href="{{ url_for('license_plates.download_plate', partition=plate.partition_key, filename=plate.filename) }}"
+                               class="action-btn" style="min-height: 44px; display: inline-flex; align-items: center;">
+                                Download
+                            </a>
+                            <form method="post" action="{{ url_for('license_plates.delete_plate', partition=plate.partition_key, filename=plate.filename) }}" style="display: inline; margin: 0;"
+                                  onsubmit="return confirm('Are you sure you want to delete {{ plate.filename }}?');">
+                                <button type="submit" class="action-btn danger" style="min-height: 44px;">Delete</button>
+                            </form>
+                        </div>
+                    </td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+
+    {# Mobile card layout #}
+    <div class="mobile-card-container">
+        {% for plate in plate_files %}
+        <div class="mobile-card plate-card"{% if not plate.compliant %} style="border-color: var(--accent-danger, var(--border-input));"{% endif %}>
+            <div style="text-align: center; margin-bottom: 8px;">
+                <img src="{{ url_for('license_plates.download_plate', partition=plate.partition_key, filename=plate.filename) }}"
+                     alt="License plate {{ plate.filename }}"
+                     style="max-width: 100%; max-height: 80px; border: 1px solid var(--border-input); border-radius: 4px; background: var(--bg-secondary);"
+                     loading="lazy">
+            </div>
+            <div class="mobile-card-title">
+                <strong>{{ plate.filename }}</strong>
+            </div>
+            {% if not plate.compliant %}
+            <div style="margin: 6px 0; padding: 6px 8px; background: var(--bg-warning, var(--form-input-bg)); border-radius: 4px; font-size: 12px; color: var(--accent-danger, var(--text-secondary));">
+                <svg class="inline-icon" aria-hidden="true"><use href="{{ url_for('static', filename='icons/lucide-sprite.svg') }}#icon-alert-triangle"></use></svg>
+                {% for issue in plate.issues %}
+                {{ issue }}{% if not loop.last %}; {% endif %}
+                {% endfor %}
+            </div>
+            {% endif %}
+            <div class="mobile-card-info">
+                <div class="mobile-card-info-row">
+                    <span class="mobile-card-info-label">Dimensions:</span>
+                    <span class="mobile-card-info-value">{{ plate.dimensions }}</span>
+                </div>
+                <div class="mobile-card-info-row">
+                    <span class="mobile-card-info-label">Size:</span>
+                    <span class="mobile-card-info-value">{{ plate.size_str }}</span>
+                </div>
+            </div>
+            <div class="mobile-card-actions" style="display: flex; gap: 8px; flex-wrap: wrap; align-items: center;">
+                <a href="{{ url_for('license_plates.download_plate', partition=plate.partition_key, filename=plate.filename) }}"
+                   class="action-btn" style="flex: 1; min-height: 44px; display: inline-flex; align-items: center; justify-content: center;">
+                    Download
+                </a>
+                <form method="post" action="{{ url_for('license_plates.delete_plate', partition=plate.partition_key, filename=plate.filename) }}"
+                      onsubmit="return confirm('Are you sure you want to delete {{ plate.filename }}?');"
+                      style="flex: 1; margin: 0; display: flex;">
+                    <button type="submit" class="action-btn danger" style="width: 100%; min-height: 44px;">Delete</button>
+                </form>
+            </div>
+        </div>
+        {% endfor %}
+    </div>
+    {% else %}
+    <div class="info-box">
+        <p>No license-plate files found in the LicensePlate folder.</p>
+        <p style="margin-top: 10px; font-size: 13px; color: var(--text-secondary);">
+            Upload a PNG to set a custom background image behind the license plate in your Tesla.
+        </p>
+    </div>
+    {% endif %}
+</div>
+
+{# ============================================================== #}
+{# Smart-resize cropper modal — pure vanilla JS / canvas / pointer #}
+{# ============================================================== #}
+<div id="cropperModal" class="cropper-modal" role="dialog" aria-modal="true" aria-labelledby="cropperTitle" style="display: none;">
+    <div class="cropper-content">
+        <header class="cropper-header">
+            <h3 id="cropperTitle" style="margin: 0;">
+                <svg class="inline-icon" aria-hidden="true"><use href="{{ url_for('static', filename='icons/lucide-sprite.svg') }}#icon-image"></use></svg>
+                Crop License Plate Image
+            </h3>
+            <button type="button" id="cropperCloseBtn" class="action-btn" aria-label="Close cropper" style="min-width: 44px; min-height: 44px;">
+                <svg class="inline-icon" aria-hidden="true"><use href="{{ url_for('static', filename='icons/lucide-sprite.svg') }}#icon-x"></use></svg>
+            </button>
+        </header>
+
+        <div class="cropper-body">
+            <div id="cropperFileInfo" style="margin-bottom: 10px; font-size: 13px; color: var(--text-secondary);"></div>
+
+            <fieldset style="border: 1px solid var(--border-input); border-radius: 4px; padding: 10px 14px; margin-bottom: 12px;">
+                <legend style="font-size: 13px; font-weight: 600; padding: 0 6px;">Region</legend>
+                <label style="display: inline-flex; align-items: center; gap: 6px; margin-right: 16px; min-height: 44px; cursor: pointer;">
+                    <input type="radio" name="plateRegion" value="na" id="cropperRegionNa" checked style="width: 18px; height: 18px;">
+                    <span>North America ({{ plate_width_na }}&times;{{ plate_height_na }})</span>
+                </label>
+                <label style="display: inline-flex; align-items: center; gap: 6px; min-height: 44px; cursor: pointer;">
+                    <input type="radio" name="plateRegion" value="eu" id="cropperRegionEu" style="width: 18px; height: 18px;">
+                    <span>Europe / Italy ({{ plate_width_eu }}&times;{{ plate_height_eu }})</span>
+                </label>
+            </fieldset>
+
+            <div class="cropper-canvas-wrapper" style="position: relative; max-width: 100%; overflow: hidden; background: var(--bg-secondary); border: 1px solid var(--border-input); border-radius: 4px; touch-action: none;">
+                <canvas id="cropperCanvas" style="display: block; max-width: 100%; touch-action: none;"></canvas>
+            </div>
+
+            <div style="display: flex; gap: 8px; flex-wrap: wrap; margin-top: 10px;">
+                <button type="button" id="cropperResetBtn" class="action-btn" style="min-height: 44px;">Reset crop</button>
+                <button type="button" id="cropperMaximizeBtn" class="action-btn" style="min-height: 44px;">Maximize crop</button>
+            </div>
+
+            <div style="margin-top: 14px;">
+                <p style="margin: 0 0 6px 0; font-size: 13px; font-weight: 600; color: var(--text-primary);">Live preview (actual size):</p>
+                <div style="background: var(--bg-secondary); padding: 8px; border-radius: 4px; border: 1px solid var(--border-input); display: inline-block;">
+                    <canvas id="cropperPreview" style="display: block; image-rendering: auto; background: var(--bg-primary);"></canvas>
+                </div>
+                <p id="cropperOutputInfo" style="margin: 6px 0 0 0; font-size: 12px; color: var(--text-secondary);"></p>
+            </div>
+        </div>
+
+        <footer class="cropper-footer" style="display: flex; gap: 8px; flex-wrap: wrap; justify-content: flex-end; margin-top: 16px;">
+            <button type="button" id="cropperCancelBtn" class="action-btn" style="min-height: 44px;">Cancel</button>
+            <button type="button" id="cropperConfirmBtn" class="action-btn" style="min-height: 44px;">Use this image</button>
+        </footer>
+    </div>
+</div>
+
+<style>
+.cropper-modal {
+    position: fixed; inset: 0; z-index: 9999;
+    background: var(--modal-overlay-bg, rgba(0, 0, 0, 0.65));
+    display: flex; align-items: center; justify-content: center;
+    padding: 12px;
+    overflow-y: auto;
+}
+.cropper-content {
+    background: var(--bg-modal, var(--bg-primary));
+    color: var(--text-primary);
+    border: 1px solid var(--border-input);
+    border-radius: 8px;
+    padding: 16px;
+    width: 100%;
+    max-width: 720px;
+    max-height: 95vh;
+    overflow-y: auto;
+}
+.cropper-header {
+    display: flex; align-items: center; justify-content: space-between;
+    margin-bottom: 12px; gap: 8px;
+}
+.cropper-body {
+    display: flex; flex-direction: column;
+}
+.inline-icon {
+    width: 16px; height: 16px;
+    display: inline-block; vertical-align: text-bottom;
+}
+.drop-zone-icon { display: block; }
+@media (max-width: 480px) {
+    .cropper-content { padding: 12px; }
+}
+[data-theme="dark"] .cropper-modal {
+    background: var(--modal-overlay-bg, rgba(0, 0, 0, 0.8));
+}
+</style>
+
+<script>
+// ---------------------------------------------------------------
+// Server-supplied limits & target dimensions
+// ---------------------------------------------------------------
+const MAX_FILE_SIZE = {{ max_file_size }};
+const MAX_FILENAME_LENGTH = {{ max_filename_length }};
+const MAX_PLATE_COUNT = {{ max_plate_count }};
+const CURRENT_PLATE_COUNT = {{ plate_count }};
+const PLATE_NA = { width: {{ plate_width_na }}, height: {{ plate_height_na }} };
+const PLATE_EU = { width: {{ plate_width_eu }}, height: {{ plate_height_eu }} };
+const VALID_FILENAME_RE = /^[A-Za-z0-9]+$/;
+
+function isMobileDevice() {
+    return /(iPad|iPhone|iPod|Android|Mobile)/i.test(navigator.userAgent) ||
+           window.matchMedia("(max-width: 768px)").matches;
+}
+function isIOS() {
+    return /(iPad|iPhone|iPod)/i.test(navigator.userAgent) && !window.MSStream;
+}
+function isSafari() {
+    var ua = navigator.userAgent;
+    return /Safari/i.test(ua) && !/Chrome|CriOS|EdgiOS|FxiOS|OPiOS/i.test(ua);
+}
+function supportsMultipleUpload() {
+    const input = document.createElement('input');
+    return 'multiple' in input && !isIOS();
+}
+
+document.addEventListener('DOMContentLoaded', function() {
+    const isMobile = isMobileDevice();
+    const supportsMulti = supportsMultipleUpload();
+
+    const desktopInterface = document.getElementById('desktopUploadInterface');
+    const mobileForm = document.getElementById('plateUploadForm');
+    const iosWarning = document.getElementById('iosWarning');
+    const uploadControls = document.getElementById('plateUploadControls');
+
+    if (isIOS() && !isSafari()) {
+        if (iosWarning) iosWarning.style.display = 'block';
+        if (uploadControls) uploadControls.style.display = 'none';
+        return;
+    }
+
+    if (!isMobile && supportsMulti) {
+        if (desktopInterface) desktopInterface.style.display = 'block';
+        if (mobileForm) mobileForm.style.display = 'none';
+        initializeDragDrop();
+    } else {
+        if (desktopInterface) desktopInterface.style.display = 'none';
+        if (mobileForm) mobileForm.style.display = 'block';
+        initializeSimpleUpload();
+    }
+});
+
+// ---------------------------------------------------------------
+// Multi-file selection state (post-cropper, validated PNG blobs)
+// ---------------------------------------------------------------
+let selectedFiles = [];          // Array of { name, blob, dimensions }
+let validationResults = new Map(); // name -> { valid, errors }
+
+function initializeDragDrop() {
+    const dropZone = document.getElementById('dragDropZone');
+    const fileInput = document.getElementById('plate_files_multi');
+    const uploadBtn = document.getElementById('uploadSelectedBtn');
+    const clearBtn = document.getElementById('clearSelectedBtn');
+    if (!dropZone || !fileInput) return;
+
+    dropZone.addEventListener('click', function() { fileInput.click(); });
+    fileInput.addEventListener('change', function(e) {
+        handleSelectedFiles(Array.from(e.target.files));
+        // Reset so selecting the same filename twice still triggers change.
+        fileInput.value = '';
+    });
+
+    dropZone.addEventListener('dragenter', function(e) {
+        e.preventDefault(); e.stopPropagation();
+        dropZone.style.borderColor = 'var(--accent)';
+        dropZone.style.background = 'var(--hover-bg, var(--form-input-bg))';
+    });
+    dropZone.addEventListener('dragover', function(e) {
+        e.preventDefault(); e.stopPropagation();
+    });
+    dropZone.addEventListener('dragleave', function(e) {
+        e.preventDefault(); e.stopPropagation();
+        dropZone.style.borderColor = 'var(--border-input)';
+        dropZone.style.background = 'var(--form-input-bg)';
+    });
+    dropZone.addEventListener('drop', function(e) {
+        e.preventDefault(); e.stopPropagation();
+        dropZone.style.borderColor = 'var(--border-input)';
+        dropZone.style.background = 'var(--form-input-bg)';
+        handleSelectedFiles(Array.from(e.dataTransfer.files));
+    });
+
+    if (uploadBtn) uploadBtn.addEventListener('click', uploadAllFiles);
+    if (clearBtn) clearBtn.addEventListener('click', function() {
+        selectedFiles = [];
+        validationResults.clear();
+        renderFilesList();
+    });
+}
+
+async function handleSelectedFiles(files) {
+    const remainingSlots = MAX_PLATE_COUNT - CURRENT_PLATE_COUNT - selectedFiles.length;
+    if (remainingSlots <= 0) {
+        alert('Maximum of ' + MAX_PLATE_COUNT + ' license plates allowed. ' +
+              'You already have ' + CURRENT_PLATE_COUNT + ' plates.');
+        return;
+    }
+
+    // Filter to images only.
+    const images = files.filter(f => f.type.startsWith('image/'));
+    if (images.length === 0) {
+        alert('Please select image files (PNG, JPEG, WebP, GIF, BMP).');
+        return;
+    }
+
+    let added = 0;
+    for (const file of images) {
+        if (added >= remainingSlots) {
+            alert('Only ' + remainingSlots + ' slot(s) remaining. ' +
+                  'Some files were not added.');
+            break;
+        }
+        // Each file goes through the cropper (or bypass if already exact dims).
+        const result = await processOneFile(file);
+        if (result) {
+            selectedFiles.push(result);
+            validationResults.set(result.name, validatePlateBlob(result));
+            added++;
+        }
+    }
+    renderFilesList();
+}
+
+function deriveBaseName(originalFilename) {
+    // Strip extension, then strip invalid characters so the user has
+    // a fighting chance of getting an alphanumeric default.
+    const noExt = originalFilename.replace(/\.[^.]+$/, '');
+    const cleaned = noExt.replace(/[^A-Za-z0-9]/g, '');
+    return cleaned.slice(0, MAX_FILENAME_LENGTH) || 'plate';
+}
+
+function loadImageFromFile(file) {
+    return new Promise((resolve, reject) => {
+        const url = URL.createObjectURL(file);
+        const img = new Image();
+        img.onload = function() {
+            // Don't revoke yet — the cropper still needs the image.
+            img._objectUrl = url;
+            resolve(img);
+        };
+        img.onerror = function() {
+            URL.revokeObjectURL(url);
+            reject(new Error('Failed to load image'));
+        };
+        img.src = url;
+    });
+}
+
+async function processOneFile(file) {
+    let img;
+    try {
+        img = await loadImageFromFile(file);
+    } catch (e) {
+        alert('Could not read ' + file.name + ': ' + e.message);
+        return null;
+    }
+
+    const isExactNa = (img.naturalWidth === PLATE_NA.width &&
+                       img.naturalHeight === PLATE_NA.height);
+    const isExactEu = (img.naturalWidth === PLATE_EU.width &&
+                       img.naturalHeight === PLATE_EU.height);
+
+    // Already-compliant PNGs bypass the cropper entirely.
+    if ((isExactNa || isExactEu) && file.type === 'image/png') {
+        if (img._objectUrl) URL.revokeObjectURL(img._objectUrl);
+        const baseName = deriveBaseName(file.name);
+        return {
+            name: baseName + '.png',
+            originalName: file.name,
+            blob: file,
+            dimensions: {
+                width: img.naturalWidth,
+                height: img.naturalHeight,
+            },
+        };
+    }
+
+    // Otherwise open the cropper — returns a Promise<{name, blob, dims}|null>
+    const cropResult = await openCropper(file, img);
+    if (img._objectUrl) URL.revokeObjectURL(img._objectUrl);
+    return cropResult;
+}
+
+function validatePlateBlob(item) {
+    const errors = [];
+    const baseName = item.name.replace(/\.png$/i, '');
+    if (baseName.length === 0) errors.push('Filename is empty');
+    if (baseName.length > MAX_FILENAME_LENGTH) {
+        errors.push('Filename too long (' + baseName.length + '/' +
+                    MAX_FILENAME_LENGTH + ')');
+    }
+    if (!VALID_FILENAME_RE.test(baseName)) {
+        errors.push('Filename must be letters and numbers only');
+    }
+    if (item.blob.size > MAX_FILE_SIZE) {
+        errors.push('Output is ' + (item.blob.size / 1024).toFixed(1) +
+                    ' KB (limit ' + (MAX_FILE_SIZE / 1024).toFixed(0) +
+                    ' KB) — try a simpler image');
+    }
+    return { valid: errors.length === 0, errors: errors };
+}
+
+function renderFilesList() {
+    const preview = document.getElementById('selectedFilesPreview');
+    const filesList = document.getElementById('filesList');
+    const uploadBtn = document.getElementById('uploadSelectedBtn');
+    if (!preview || !filesList) return;
+
+    if (selectedFiles.length === 0) {
+        preview.style.display = 'none';
+        return;
+    }
+    preview.style.display = 'block';
+
+    filesList.innerHTML = '';
+    let hasValid = false;
+
+    selectedFiles.forEach((item, index) => {
+        const v = validationResults.get(item.name) || { valid: false, errors: [] };
+        if (v.valid) hasValid = true;
+
+        const row = document.createElement('div');
+        row.style.cssText = 'display: flex; flex-direction: column; padding: 10px; ' +
+            'border-bottom: 1px solid ' +
+            (v.valid ? 'var(--border-input)' : 'var(--accent-danger, var(--border-input))') +
+            '; color: var(--text-primary);';
+
+        const top = document.createElement('div');
+        top.style.cssText = 'display: flex; justify-content: space-between; align-items: center; gap: 8px;';
+
+        const left = document.createElement('div');
+        left.style.cssText = 'flex: 1; overflow: hidden; display: flex; align-items: center; gap: 8px;';
+
+        const icon = document.createElement('span');
+        icon.style.color = v.valid ? 'var(--accent-success, var(--text-primary))'
+                                   : 'var(--accent-danger, var(--text-primary))';
+        icon.innerHTML = v.valid
+            ? '<svg class="inline-icon" aria-hidden="true"><use href="{{ url_for("static", filename="icons/lucide-sprite.svg") }}#icon-check-circle"></use></svg>'
+            : '<svg class="inline-icon" aria-hidden="true"><use href="{{ url_for("static", filename="icons/lucide-sprite.svg") }}#icon-x-circle"></use></svg>';
+
+        const name = document.createElement('strong');
+        name.textContent = item.name;
+        name.style.wordBreak = 'break-word';
+
+        const meta = document.createElement('span');
+        meta.style.cssText = 'color: var(--text-secondary); font-size: 12px;';
+        meta.textContent = ' (' + (item.blob.size / 1024).toFixed(1) + ' KB' +
+            (item.dimensions ? ', ' + item.dimensions.width + 'x' + item.dimensions.height : '') +
+            ')';
+
+        left.appendChild(icon);
+        left.appendChild(name);
+        left.appendChild(meta);
+
+        const removeBtn = document.createElement('button');
+        removeBtn.type = 'button';
+        removeBtn.setAttribute('aria-label', 'Remove ' + item.name);
+        removeBtn.style.cssText = 'background: none; border: none; cursor: pointer; ' +
+            'color: var(--accent-danger, var(--text-primary)); padding: 8px; ' +
+            'min-width: 44px; min-height: 44px; flex-shrink: 0;';
+        removeBtn.innerHTML = '<svg class="inline-icon" aria-hidden="true"><use href="{{ url_for("static", filename="icons/lucide-sprite.svg") }}#icon-x"></use></svg>';
+        removeBtn.addEventListener('click', function() {
+            validationResults.delete(item.name);
+            selectedFiles.splice(index, 1);
+            renderFilesList();
+        });
+
+        top.appendChild(left);
+        top.appendChild(removeBtn);
+        row.appendChild(top);
+
+        if (!v.valid && v.errors.length > 0) {
+            const err = document.createElement('div');
+            err.style.cssText = 'margin-top: 5px; font-size: 12px; ' +
+                'color: var(--accent-danger, var(--text-secondary)); padding-left: 24px;';
+            err.textContent = v.errors.join('; ');
+            row.appendChild(err);
+        }
+        filesList.appendChild(row);
+    });
+
+    if (uploadBtn) uploadBtn.disabled = !hasValid;
+}
+
+async function uploadAllFiles() {
+    const valid = selectedFiles.filter(item =>
+        (validationResults.get(item.name) || {}).valid
+    );
+    if (valid.length === 0) {
+        alert('No valid files to upload. Please fix validation errors first.');
+        return;
+    }
+
+    const uploadBtn = document.getElementById('uploadSelectedBtn');
+    const clearBtn = document.getElementById('clearSelectedBtn');
+    const progressDiv = document.getElementById('plateUploadProgress');
+    const progressBar = document.getElementById('plateProgressBar');
+    const statusText = document.getElementById('plateUploadStatus');
+
+    if (uploadBtn) uploadBtn.disabled = true;
+    if (clearBtn) clearBtn.disabled = true;
+
+    if (progressDiv) {
+        progressDiv.style.display = 'block';
+        progressBar.style.width = '0%';
+        progressBar.textContent = '0%';
+        statusText.textContent = 'Preparing upload...';
+    }
+
+    const formData = new FormData();
+    valid.forEach(item => {
+        formData.append('plate_files', item.blob, item.name);
+    });
+
+    const xhr = new XMLHttpRequest();
+    xhr.upload.addEventListener('progress', function(e) {
+        if (!e.lengthComputable) return;
+        const pct = Math.round((e.loaded / e.total) * 100);
+        progressBar.style.width = pct + '%';
+        progressBar.textContent = pct + '%';
+        statusText.textContent = 'Uploading ' + valid.length + ' file(s)... (' +
+            (e.loaded / 1024).toFixed(1) + ' KB / ' +
+            (e.total / 1024).toFixed(1) + ' KB)';
+    });
+    xhr.addEventListener('load', function() {
+        if (xhr.status === 200) {
+            try {
+                const resp = JSON.parse(xhr.responseText);
+                progressBar.style.width = '100%';
+                progressBar.textContent = '100%';
+                progressBar.style.background = 'var(--accent-success, var(--accent))';
+                statusText.textContent = resp.summary || 'Upload complete';
+                statusText.style.color = 'var(--accent-success, var(--text-primary))';
+                setTimeout(function() { window.location.reload(); }, 1500);
+            } catch (e) {
+                statusText.textContent = 'Upload complete. Reloading...';
+                setTimeout(function() { window.location.reload(); }, 1000);
+            }
+        } else {
+            progressBar.style.background = 'var(--accent-danger, var(--accent))';
+            statusText.textContent = 'Upload failed: ' + xhr.statusText;
+            statusText.style.color = 'var(--accent-danger, var(--text-primary))';
+            if (uploadBtn) uploadBtn.disabled = false;
+            if (clearBtn) clearBtn.disabled = false;
+        }
+    });
+    xhr.addEventListener('error', function() {
+        progressBar.style.background = 'var(--accent-danger, var(--accent))';
+        statusText.textContent = 'Upload failed: network error';
+        statusText.style.color = 'var(--accent-danger, var(--text-primary))';
+        if (uploadBtn) uploadBtn.disabled = false;
+        if (clearBtn) clearBtn.disabled = false;
+    });
+    xhr.open('POST', '{{ url_for("license_plates.upload_multiple_plates") }}');
+    xhr.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
+    xhr.send(formData);
+}
+
+function initializeSimpleUpload() {
+    // Mobile / fallback path — intercept the form submit, run the
+    // cropper (or pass-through if already exact dims), then submit
+    // the resulting blob via fetch.
+    const form = document.getElementById('plateUploadForm');
+    const fileInput = document.getElementById('plate_file');
+    if (!form || !fileInput) return;
+
+    form.addEventListener('submit', async function(e) {
+        e.preventDefault();
+        if (!fileInput.files || !fileInput.files[0]) {
+            alert('Please select an image file.');
+            return;
+        }
+        const file = fileInput.files[0];
+        const item = await processOneFile(file);
+        if (!item) return;
+        const v = validatePlateBlob(item);
+        if (!v.valid) {
+            alert('Cannot upload: ' + v.errors.join('; '));
+            return;
+        }
+        // Build a one-file FormData and submit to the single-file endpoint.
+        const fd = new FormData();
+        fd.append('plate_file', item.blob, item.name);
+
+        const btn = document.getElementById('plateUploadBtn');
+        if (btn) btn.disabled = true;
+
+        try {
+            const resp = await fetch('{{ url_for("license_plates.upload_plate") }}', {
+                method: 'POST',
+                body: fd,
+            });
+            // Server redirects on success — the response will be the
+            // re-rendered page. Easiest path: just reload to pick up
+            // the flash message.
+            window.location.reload();
+        } catch (err) {
+            alert('Upload failed: ' + err.message);
+            if (btn) btn.disabled = false;
+        }
+    });
+}
+
+// ---------------------------------------------------------------
+// Cropper modal — vanilla canvas + pointer events
+// ---------------------------------------------------------------
+const cropperState = {
+    file: null,
+    img: null,
+    target: PLATE_NA,         // Active target dimensions
+    rect: { x: 0, y: 0, w: 0, h: 0 }, // Crop rect in source image coords
+    canvasScale: 1,           // Source-px per displayed-px
+    drag: null,               // { mode: 'move'|'resize-XX', anchor: ... }
+    resolve: null,            // Promise resolver for openCropper
+    fileBaseName: 'plate',
+};
+
+function openCropper(file, img) {
+    return new Promise((resolve) => {
+        cropperState.file = file;
+        cropperState.img = img;
+        cropperState.target = PLATE_NA;
+        cropperState.fileBaseName = deriveBaseName(file.name);
+        cropperState.resolve = resolve;
+
+        // Default region: pick the one whose aspect ratio is closer to
+        // the source image.
+        const srcAspect = img.naturalWidth / img.naturalHeight;
+        const naDiff = Math.abs(srcAspect - PLATE_NA.width / PLATE_NA.height);
+        const euDiff = Math.abs(srcAspect - PLATE_EU.width / PLATE_EU.height);
+        const useEu = euDiff < naDiff;
+        document.getElementById('cropperRegionNa').checked = !useEu;
+        document.getElementById('cropperRegionEu').checked = useEu;
+        cropperState.target = useEu ? PLATE_EU : PLATE_NA;
+
+        const info = document.getElementById('cropperFileInfo');
+        if (info) {
+            info.textContent = file.name + ' — source ' + img.naturalWidth +
+                'x' + img.naturalHeight + ' (' +
+                (file.size / 1024).toFixed(1) + ' KB)';
+        }
+
+        setupCropperCanvas();
+        resetCropRect();
+        renderCropper();
+
+        const modal = document.getElementById('cropperModal');
+        modal.style.display = 'flex';
+    });
+}
+
+function closeCropper(result) {
+    document.getElementById('cropperModal').style.display = 'none';
+    const r = cropperState.resolve;
+    cropperState.resolve = null;
+    cropperState.img = null;
+    cropperState.file = null;
+    if (r) r(result);
+}
+
+function setupCropperCanvas() {
+    const canvas = document.getElementById('cropperCanvas');
+    const wrapper = canvas.parentElement;
+    // Fit the source image inside the available wrapper width while
+    // keeping a max display height for usability.
+    const maxW = Math.min(wrapper.clientWidth || 600, 720);
+    const maxH = Math.max(220, Math.min(window.innerHeight * 0.45, 500));
+    const img = cropperState.img;
+    let displayW = img.naturalWidth;
+    let displayH = img.naturalHeight;
+    const widthScale = maxW / displayW;
+    const heightScale = maxH / displayH;
+    const scale = Math.min(1, widthScale, heightScale);
+    displayW = Math.round(displayW * scale);
+    displayH = Math.round(displayH * scale);
+    canvas.width = displayW;
+    canvas.height = displayH;
+    canvas.style.width = displayW + 'px';
+    canvas.style.height = displayH + 'px';
+    cropperState.canvasScale = img.naturalWidth / displayW; // src px / display px
+}
+
+function resetCropRect() {
+    // Center a max-size aspect-locked crop inside the source image.
+    const img = cropperState.img;
+    const target = cropperState.target;
+    const targetAspect = target.width / target.height;
+    let cw = img.naturalWidth;
+    let ch = Math.round(cw / targetAspect);
+    if (ch > img.naturalHeight) {
+        ch = img.naturalHeight;
+        cw = Math.round(ch * targetAspect);
+    }
+    cropperState.rect = {
+        x: Math.round((img.naturalWidth - cw) / 2),
+        y: Math.round((img.naturalHeight - ch) / 2),
+        w: cw,
+        h: ch,
+    };
+}
+
+function maximizeCrop() {
+    resetCropRect();
+    renderCropper();
+}
+
+function renderCropper() {
+    const canvas = document.getElementById('cropperCanvas');
+    const ctx = canvas.getContext('2d');
+    const img = cropperState.img;
+    const scale = cropperState.canvasScale;
+
+    ctx.fillStyle = getComputedStyle(document.body).getPropertyValue('--bg-secondary') || '#000';
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+
+    const r = cropperState.rect;
+    const dx = r.x / scale, dy = r.y / scale;
+    const dw = r.w / scale, dh = r.h / scale;
+
+    // Dim the area outside the crop.
+    ctx.save();
+    ctx.fillStyle = 'rgba(0,0,0,0.55)';
+    ctx.beginPath();
+    ctx.rect(0, 0, canvas.width, canvas.height);
+    ctx.rect(dx + dw, dy, -dw, dh); // counter-clockwise hole
+    ctx.fill('evenodd');
+    ctx.restore();
+
+    // Crop border + handles.
+    // White-with-black-halo is the standard cropper convention so the
+    // rectangle stays visible against arbitrary user image content.
+    // CSS theme tokens deliberately not used here — those would make
+    // the outline invisible against ~half of possible source images.
+    ctx.strokeStyle = '#ffffff';
+    ctx.lineWidth = 2;
+    ctx.strokeRect(dx + 1, dy + 1, dw - 2, dh - 2);
+    ctx.strokeStyle = '#000000';
+    ctx.lineWidth = 1;
+    ctx.strokeRect(dx + 0.5, dy + 0.5, dw - 1, dh - 1);
+
+    // Corner handles (drawn in display-space).
+    drawHandle(ctx, dx, dy);
+    drawHandle(ctx, dx + dw, dy);
+    drawHandle(ctx, dx, dy + dh);
+    drawHandle(ctx, dx + dw, dy + dh);
+
+    renderPreview();
+    updateOutputInfo();
+}
+
+function drawHandle(ctx, x, y) {
+    const s = 10;
+    ctx.fillStyle = '#ffffff';
+    ctx.fillRect(x - s/2, y - s/2, s, s);
+    ctx.strokeStyle = '#000000';
+    ctx.lineWidth = 1;
+    ctx.strokeRect(x - s/2 + 0.5, y - s/2 + 0.5, s - 1, s - 1);
+}
+
+function renderPreview() {
+    const preview = document.getElementById('cropperPreview');
+    preview.width = cropperState.target.width;
+    preview.height = cropperState.target.height;
+    // CSS size: clamp so a 420px canvas still fits on a 375px viewport.
+    const maxCssW = Math.min(cropperState.target.width, 320);
+    const cssScale = maxCssW / cropperState.target.width;
+    preview.style.width = Math.round(cropperState.target.width * cssScale) + 'px';
+    preview.style.height = Math.round(cropperState.target.height * cssScale) + 'px';
+
+    const ctx = preview.getContext('2d');
+    ctx.imageSmoothingEnabled = true;
+    ctx.imageSmoothingQuality = 'high';
+    ctx.clearRect(0, 0, preview.width, preview.height);
+    const r = cropperState.rect;
+    ctx.drawImage(
+        cropperState.img,
+        r.x, r.y, r.w, r.h,
+        0, 0, preview.width, preview.height
+    );
+}
+
+function updateOutputInfo() {
+    const info = document.getElementById('cropperOutputInfo');
+    if (!info) return;
+    info.textContent = 'Output ' + cropperState.target.width + 'x' +
+        cropperState.target.height + ' PNG, filename ' +
+        cropperState.fileBaseName + '.png. Max ' +
+        (MAX_FILE_SIZE / 1024).toFixed(0) + ' KB.';
+}
+
+// ---------------------------------------------------------------
+// Pointer-based drag (works for mouse + touch + stylus)
+// ---------------------------------------------------------------
+function attachCropperPointerHandlers() {
+    const canvas = document.getElementById('cropperCanvas');
+    if (!canvas) return;
+
+    const HANDLE_HIT = 14; // px in display coords
+
+    canvas.addEventListener('pointerdown', function(e) {
+        e.preventDefault();
+        canvas.setPointerCapture(e.pointerId);
+        const pt = canvasPoint(e);
+        const r = cropperState.rect;
+        const scale = cropperState.canvasScale;
+        const dx = r.x / scale, dy = r.y / scale;
+        const dw = r.w / scale, dh = r.h / scale;
+        const corners = [
+            { name: 'tl', x: dx, y: dy },
+            { name: 'tr', x: dx + dw, y: dy },
+            { name: 'bl', x: dx, y: dy + dh },
+            { name: 'br', x: dx + dw, y: dy + dh },
+        ];
+        for (const c of corners) {
+            if (Math.abs(c.x - pt.x) <= HANDLE_HIT &&
+                Math.abs(c.y - pt.y) <= HANDLE_HIT) {
+                cropperState.drag = {
+                    mode: 'resize-' + c.name,
+                    startPt: pt,
+                    startRect: { ...r },
+                };
+                return;
+            }
+        }
+        if (pt.x >= dx && pt.x <= dx + dw &&
+            pt.y >= dy && pt.y <= dy + dh) {
+            cropperState.drag = {
+                mode: 'move',
+                startPt: pt,
+                startRect: { ...r },
+            };
+        }
+    });
+
+    canvas.addEventListener('pointermove', function(e) {
+        if (!cropperState.drag) return;
+        e.preventDefault();
+        const pt = canvasPoint(e);
+        const scale = cropperState.canvasScale;
+        const dxSrc = (pt.x - cropperState.drag.startPt.x) * scale;
+        const dySrc = (pt.y - cropperState.drag.startPt.y) * scale;
+        const sr = cropperState.drag.startRect;
+        const img = cropperState.img;
+        const targetAspect = cropperState.target.width / cropperState.target.height;
+
+        if (cropperState.drag.mode === 'move') {
+            let nx = sr.x + dxSrc;
+            let ny = sr.y + dySrc;
+            nx = Math.max(0, Math.min(img.naturalWidth - sr.w, nx));
+            ny = Math.max(0, Math.min(img.naturalHeight - sr.h, ny));
+            cropperState.rect = { x: Math.round(nx), y: Math.round(ny), w: sr.w, h: sr.h };
+        } else {
+            // Resize from a corner; keep aspect locked to target.
+            const corner = cropperState.drag.mode.split('-')[1];
+            // Anchor is the opposite corner.
+            const anchorX = (corner === 'tr' || corner === 'br') ? sr.x : sr.x + sr.w;
+            const anchorY = (corner === 'bl' || corner === 'br') ? sr.y : sr.y + sr.h;
+            // Pointer position in source coords.
+            const px = sr.x + (corner.endsWith('l') ? dxSrc : sr.w + dxSrc);
+            const py = sr.y + (corner.startsWith('t') ? dySrc : sr.h + dySrc);
+            // New width/height = distance from anchor; aspect-lock by
+            // snapping width to height * targetAspect.
+            let newW = Math.abs(px - anchorX);
+            let newH = Math.abs(py - anchorY);
+            if (newW / newH > targetAspect) {
+                newW = newH * targetAspect;
+            } else {
+                newH = newW / targetAspect;
+            }
+            // Compute new origin from anchor + sign.
+            const sx = (corner === 'tr' || corner === 'br') ? 1 : -1;
+            const sy = (corner === 'bl' || corner === 'br') ? 1 : -1;
+            let nx = sx > 0 ? anchorX : anchorX - newW;
+            let ny = sy > 0 ? anchorY : anchorY - newH;
+            // Clamp inside source.
+            if (nx < 0) { newW += nx; nx = 0; newH = newW / targetAspect; }
+            if (ny < 0) { newH += ny; ny = 0; newW = newH * targetAspect; }
+            if (nx + newW > img.naturalWidth) {
+                newW = img.naturalWidth - nx;
+                newH = newW / targetAspect;
+            }
+            if (ny + newH > img.naturalHeight) {
+                newH = img.naturalHeight - ny;
+                newW = newH * targetAspect;
+            }
+            // Floor a minimum size so the crop never collapses to 0.
+            if (newW < 16 || newH < 16) return;
+            cropperState.rect = {
+                x: Math.round(nx), y: Math.round(ny),
+                w: Math.round(newW), h: Math.round(newH),
+            };
+        }
+        renderCropper();
+    });
+
+    function endDrag(e) {
+        if (cropperState.drag) cropperState.drag = null;
+        try { canvas.releasePointerCapture(e.pointerId); } catch (_) {}
+    }
+    canvas.addEventListener('pointerup', endDrag);
+    canvas.addEventListener('pointercancel', endDrag);
+}
+
+function canvasPoint(e) {
+    const canvas = document.getElementById('cropperCanvas');
+    const rect = canvas.getBoundingClientRect();
+    return {
+        x: (e.clientX - rect.left) * (canvas.width / rect.width),
+        y: (e.clientY - rect.top) * (canvas.height / rect.height),
+    };
+}
+
+document.addEventListener('DOMContentLoaded', function() {
+    attachCropperPointerHandlers();
+
+    document.getElementById('cropperRegionNa').addEventListener('change', function() {
+        cropperState.target = PLATE_NA;
+        resetCropRect();
+        renderCropper();
+    });
+    document.getElementById('cropperRegionEu').addEventListener('change', function() {
+        cropperState.target = PLATE_EU;
+        resetCropRect();
+        renderCropper();
+    });
+    document.getElementById('cropperResetBtn').addEventListener('click', function() {
+        resetCropRect();
+        renderCropper();
+    });
+    document.getElementById('cropperMaximizeBtn').addEventListener('click', maximizeCrop);
+    document.getElementById('cropperCancelBtn').addEventListener('click', function() {
+        closeCropper(null);
+    });
+    document.getElementById('cropperCloseBtn').addEventListener('click', function() {
+        closeCropper(null);
+    });
+    document.getElementById('cropperConfirmBtn').addEventListener('click', confirmCrop);
+
+    // Re-fit the canvas if the viewport changes while the modal is open.
+    window.addEventListener('resize', function() {
+        if (document.getElementById('cropperModal').style.display !== 'none' &&
+            cropperState.img) {
+            setupCropperCanvas();
+            renderCropper();
+        }
+    });
+});
+
+function confirmCrop() {
+    const r = cropperState.rect;
+    const target = cropperState.target;
+    // Render to an offscreen canvas at exact target dimensions.
+    const out = document.createElement('canvas');
+    out.width = target.width;
+    out.height = target.height;
+    const ctx = out.getContext('2d');
+    ctx.imageSmoothingEnabled = true;
+    ctx.imageSmoothingQuality = 'high';
+    ctx.drawImage(
+        cropperState.img,
+        r.x, r.y, r.w, r.h,
+        0, 0, target.width, target.height
+    );
+    out.toBlob(function(blob) {
+        if (!blob) {
+            alert('Could not create the cropped PNG.');
+            return;
+        }
+        const finalName = cropperState.fileBaseName + '.png';
+        closeCropper({
+            name: finalName,
+            originalName: cropperState.file.name,
+            blob: blob,
+            dimensions: { width: target.width, height: target.height },
+        });
+    }, 'image/png');
+}
+</script>
+{% endblock %}

--- a/scripts/web/templates/license_plates.html
+++ b/scripts/web/templates/license_plates.html
@@ -818,7 +818,17 @@ function renderCropper() {
     const img = cropperState.img;
     const scale = cropperState.canvasScale;
 
-    ctx.fillStyle = getComputedStyle(document.body).getPropertyValue('--bg-secondary') || '#000';
+    // Read theme-invariant cropper colours from CSS custom properties
+    // (defined in style.css :root and [data-theme="dark"] :root). The
+    // values are intentionally white/black for visibility against
+    // arbitrary user content; centralising them in CSS lets a future
+    // themer override them without touching this JS.
+    const styles = getComputedStyle(document.body);
+    const handleFill = styles.getPropertyValue('--cropper-handle-fill').trim() || '#ffffff';
+    const handleStroke = styles.getPropertyValue('--cropper-handle-stroke').trim() || '#000000';
+    const bgFallback = styles.getPropertyValue('--cropper-bg-fallback').trim() || '#000000';
+
+    ctx.fillStyle = styles.getPropertyValue('--bg-secondary').trim() || bgFallback;
     ctx.fillRect(0, 0, canvas.width, canvas.height);
     ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
 
@@ -838,30 +848,30 @@ function renderCropper() {
     // Crop border + handles.
     // White-with-black-halo is the standard cropper convention so the
     // rectangle stays visible against arbitrary user image content.
-    // CSS theme tokens deliberately not used here — those would make
-    // the outline invisible against ~half of possible source images.
-    ctx.strokeStyle = '#ffffff';
+    // The hex values come from --cropper-handle-fill / --cropper-handle-stroke
+    // in style.css (theme-invariant by design — see comment there).
+    ctx.strokeStyle = handleFill;
     ctx.lineWidth = 2;
     ctx.strokeRect(dx + 1, dy + 1, dw - 2, dh - 2);
-    ctx.strokeStyle = '#000000';
+    ctx.strokeStyle = handleStroke;
     ctx.lineWidth = 1;
     ctx.strokeRect(dx + 0.5, dy + 0.5, dw - 1, dh - 1);
 
     // Corner handles (drawn in display-space).
-    drawHandle(ctx, dx, dy);
-    drawHandle(ctx, dx + dw, dy);
-    drawHandle(ctx, dx, dy + dh);
-    drawHandle(ctx, dx + dw, dy + dh);
+    drawHandle(ctx, dx, dy, handleFill, handleStroke);
+    drawHandle(ctx, dx + dw, dy, handleFill, handleStroke);
+    drawHandle(ctx, dx, dy + dh, handleFill, handleStroke);
+    drawHandle(ctx, dx + dw, dy + dh, handleFill, handleStroke);
 
     renderPreview();
     updateOutputInfo();
 }
 
-function drawHandle(ctx, x, y) {
-    const s = 10;
-    ctx.fillStyle = '#ffffff';
+function drawHandle(ctx, x, y, fill, stroke) {
+    const s = 12;
+    ctx.fillStyle = fill;
     ctx.fillRect(x - s/2, y - s/2, s, s);
-    ctx.strokeStyle = '#000000';
+    ctx.strokeStyle = stroke;
     ctx.lineWidth = 1;
     ctx.strokeRect(x - s/2 + 0.5, y - s/2 + 0.5, s - 1, s - 1);
 }
@@ -904,7 +914,11 @@ function attachCropperPointerHandlers() {
     const canvas = document.getElementById('cropperCanvas');
     if (!canvas) return;
 
-    const HANDLE_HIT = 14; // px in display coords
+    // 22px half-extent → 44×44px effective hit area, meeting the
+    // design system's minimum touch-target size for the corner handles.
+    // The visual handle (drawn in drawHandle()) stays smaller for
+    // aesthetic reasons; the larger hit area is invisible.
+    const HANDLE_HIT = 22; // px in display coords
 
     canvas.addEventListener('pointerdown', function(e) {
         e.preventDefault();

--- a/scripts/web/templates/media_hub_nav.html
+++ b/scripts/web/templates/media_hub_nav.html
@@ -30,4 +30,10 @@
     Wraps
   </a>
   {% endif %}
+  {% if license_plates_available %}
+  <a href="{{ url_for('license_plates.license_plates') }}" class="media-pill {% if media_tab == 'plates' %}active{% endif %}">
+    <svg class="nav-icon" aria-hidden="true"><use href="{{ url_for('static', filename='icons/lucide-sprite.svg') }}#icon-image"></use></svg>
+    Plates
+  </a>
+  {% endif %}
 </div>

--- a/scripts/web/web_control.py
+++ b/scripts/web/web_control.py
@@ -43,6 +43,7 @@ from blueprints import (
     music_bp,
     boombox_bp,
     wraps_bp,
+    license_plates_bp,
     media_bp,
     analytics_bp,
     mapping_bp,
@@ -62,6 +63,7 @@ app.register_blueprint(light_shows_bp)
 app.register_blueprint(music_bp)
 app.register_blueprint(boombox_bp)
 app.register_blueprint(wraps_bp)
+app.register_blueprint(license_plates_bp)
 app.register_blueprint(media_bp)
 app.register_blueprint(analytics_bp)
 app.register_blueprint(cleanup_bp)

--- a/tests/test_license_plate_service.py
+++ b/tests/test_license_plate_service.py
@@ -1,0 +1,599 @@
+"""Tests for the license_plate_service module.
+
+These tests cover:
+
+- Filename validation: empty, too long, contains underscore/dash/space,
+  non-PNG extension. The license-plate filename rules are stricter than
+  the wraps rules — alphanumeric only, ≤ 32 chars.
+- Dimension validation: only 420x200 (NA) and 420x100 (EU) accepted.
+- Size validation: 511 KB ≤ 512 KB pass; 513 KB fail.
+- PNG signature validation: random bytes rejected.
+- Count enforcement (the regression bug from wraps): 10 plates → 11th
+  rejected in BOTH present and edit mode. ``get_plate_count_any_mode``
+  reads the RO mount in present mode so the limit can't be bypassed.
+- USB rebind: present-mode upload/delete invokes
+  ``safe_rebind_usb_gadget`` exactly once; edit-mode does not.
+- Rebind failures (return ``(False, msg)`` or raise) must NOT fail the
+  upload/delete — the file is already on disk.
+"""
+
+import io
+import os
+import struct
+import zlib
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _build_minimal_png_bytes(width: int, height: int) -> bytes:
+    """Return a syntactically valid PNG with the requested IHDR dims.
+
+    Only IHDR is inspected by the service, so empty IDAT is fine.
+    """
+    sig = b'\x89PNG\r\n\x1a\n'
+    ihdr_data = struct.pack('>IIBBBBB', width, height, 8, 6, 0, 0, 0)
+    ihdr = b'IHDR' + ihdr_data
+    ihdr_chunk = (
+        struct.pack('>I', len(ihdr_data)) + ihdr +
+        struct.pack('>I', zlib.crc32(ihdr))
+    )
+    idat_data = zlib.compress(b'')
+    idat = b'IDAT' + idat_data
+    idat_chunk = (
+        struct.pack('>I', len(idat_data)) + idat +
+        struct.pack('>I', zlib.crc32(idat))
+    )
+    iend_chunk = (
+        struct.pack('>I', 0) + b'IEND' + struct.pack('>I', zlib.crc32(b'IEND'))
+    )
+    return sig + ihdr_chunk + idat_chunk + iend_chunk
+
+
+def _build_png_with_padding(width: int, height: int, total_bytes: int) -> bytes:
+    """Return a PNG of approximately ``total_bytes`` size by stuffing
+    a long IDAT comment-style chunk. Used to test the size limit
+    without producing megabytes of pixels."""
+    base = _build_minimal_png_bytes(width, height)
+    needed = total_bytes - len(base)
+    if needed <= 0:
+        return base
+    # Insert a fake ancillary chunk before IEND. We rebuild from base by
+    # splitting at IEND (12-byte chunk: length+type+crc).
+    iend_offset = len(base) - 12
+    head = base[:iend_offset]
+    tail = base[iend_offset:]
+    payload = b'\x00' * max(needed - 12, 1)  # extra 12 = chunk header+crc
+    chunk_type = b'tEXt'
+    chunk = (
+        struct.pack('>I', len(payload)) + chunk_type + payload +
+        struct.pack('>I', zlib.crc32(chunk_type + payload))
+    )
+    return head + chunk + tail
+
+
+class _FakeUploadFile:
+    """Mimics werkzeug.FileStorage's read/seek/filename surface."""
+
+    def __init__(self, filename, data):
+        self.filename = filename
+        self._buf = io.BytesIO(data)
+
+    def read(self):
+        return self._buf.read()
+
+    def seek(self, pos):
+        self._buf.seek(pos)
+
+
+@pytest.fixture
+def fake_lightshow(tmp_path, monkeypatch):
+    """Build the same fake LightShow drive layout used by wrap tests:
+
+        <root>/part2-ro/LicensePlate/   (present-mode RO)
+        <root>/part2/LicensePlate/      (edit-mode RW; also the dest in
+                                         present mode after quick_edit)
+
+    Patch MNT_DIR so no real mounts are touched.
+    """
+    root = tmp_path / 'mnt' / 'gadget'
+    (root / 'part2-ro' / 'LicensePlate').mkdir(parents=True)
+    (root / 'part2' / 'LicensePlate').mkdir(parents=True)
+    monkeypatch.setattr('config.MNT_DIR', str(root), raising=False)
+    return {
+        'root': root,
+        'ro_plates': root / 'part2-ro' / 'LicensePlate',
+        'rw_plates': root / 'part2' / 'LicensePlate',
+    }
+
+
+def _populate_plates(folder, count, prefix='plate'):
+    for i in range(count):
+        # Real PNG signature so list_plate_files counts them.
+        (folder / f'{prefix}{i}.png').write_bytes(b'\x89PNG\r\n\x1a\n')
+
+
+# ---------------------------------------------------------------
+# Filename validation
+# ---------------------------------------------------------------
+class TestValidatePlateFilename:
+
+    @pytest.mark.parametrize('name', [
+        'plate.png', 'PLATE.png', 'Abc123.png', 'a.png',
+        ('a' * 32) + '.png',
+    ])
+    def test_valid_names(self, name):
+        from services.license_plate_service import validate_plate_filename
+        ok, err = validate_plate_filename(name)
+        assert ok, f'{name!r} should be valid; got error: {err!r}'
+
+    @pytest.mark.parametrize('name,reason', [
+        ('.png', 'empty base'),
+        ((('a' * 33) + '.png'), 'too long'),
+        ('my_plate.png', 'underscore'),
+        ('my-plate.png', 'dash'),
+        ('my plate.png', 'space'),
+        ('plate!.png', 'punctuation'),
+        ('plate.txt', 'wrong ext'),
+        ('plate', 'no ext'),
+    ])
+    def test_invalid_names(self, name, reason):
+        from services.license_plate_service import validate_plate_filename
+        ok, err = validate_plate_filename(name)
+        assert not ok, f'{name!r} ({reason}) should be invalid'
+        assert err  # message present
+
+    def test_uppercase_extension_accepted(self):
+        # The service uses .lower().endswith('.png'), so .PNG works.
+        from services.license_plate_service import validate_plate_filename
+        ok, err = validate_plate_filename('Abc123.PNG')
+        assert ok, err
+
+
+# ---------------------------------------------------------------
+# Dimension validation
+# ---------------------------------------------------------------
+class TestValidatePlateDimensions:
+
+    def test_na_passes(self):
+        from services.license_plate_service import validate_plate_dimensions
+        ok, err = validate_plate_dimensions(420, 200)
+        assert ok, err
+
+    def test_eu_passes(self):
+        from services.license_plate_service import validate_plate_dimensions
+        ok, err = validate_plate_dimensions(420, 100)
+        assert ok, err
+
+    @pytest.mark.parametrize('w,h', [
+        (419, 200),     # one px off NA width
+        (421, 100),     # one px off EU width
+        (420, 199),     # one px off NA height
+        (420, 101),     # one px off EU height
+        (200, 420),     # transposed
+        (512, 512),     # wrap-spec dims (deliberately NOT accepted)
+        (1920, 1080),   # arbitrary photo
+        (0, 0),         # degenerate
+    ])
+    def test_off_spec_rejected(self, w, h):
+        from services.license_plate_service import validate_plate_dimensions
+        ok, err = validate_plate_dimensions(w, h)
+        assert not ok, f'({w}, {h}) should be rejected'
+        assert err
+
+    def test_none_dimensions_rejected(self):
+        from services.license_plate_service import validate_plate_dimensions
+        ok, err = validate_plate_dimensions(None, None)
+        assert not ok
+        assert 'corrupted' in err.lower()
+
+
+# ---------------------------------------------------------------
+# Whole-file validation (size + signature + dims + name)
+# ---------------------------------------------------------------
+class TestValidatePlateFile:
+
+    def test_valid_na_png(self):
+        from services.license_plate_service import validate_plate_file
+        png = _build_minimal_png_bytes(420, 200)
+        ok, err, dims = validate_plate_file(png, 'plate.png')
+        assert ok, err
+        assert dims == (420, 200)
+
+    def test_valid_eu_png(self):
+        from services.license_plate_service import validate_plate_file
+        png = _build_minimal_png_bytes(420, 100)
+        ok, err, dims = validate_plate_file(png, 'plate.png')
+        assert ok, err
+        assert dims == (420, 100)
+
+    def test_511kb_passes(self):
+        from services.license_plate_service import (
+            validate_plate_file, MAX_PLATE_SIZE,
+        )
+        png = _build_png_with_padding(420, 200, 511 * 1024)
+        # Some platforms produce slightly larger; ensure under limit.
+        assert len(png) <= MAX_PLATE_SIZE
+        ok, err, dims = validate_plate_file(png, 'plate.png')
+        assert ok, err
+
+    def test_513kb_fails(self):
+        from services.license_plate_service import validate_plate_file
+        png = _build_png_with_padding(420, 200, 513 * 1024)
+        assert len(png) > 512 * 1024
+        ok, err, dims = validate_plate_file(png, 'plate.png')
+        assert not ok
+        assert '512 KB' in err
+
+    def test_bogus_bytes_rejected(self):
+        from services.license_plate_service import validate_plate_file
+        ok, err, dims = validate_plate_file(b'not-a-png-at-all', 'plate.png')
+        assert not ok
+        # Failure surfaces as a dimension/corruption error since the
+        # PNG signature check fails inside the dimension reader.
+        assert err and dims is None
+
+    def test_off_dim_png_rejected(self):
+        from services.license_plate_service import validate_plate_file
+        png = _build_minimal_png_bytes(512, 512)
+        ok, err, dims = validate_plate_file(png, 'plate.png')
+        assert not ok
+        assert dims is None
+        assert '420' in err  # message references the allowed dims
+
+    def test_bad_filename_rejected_before_dims(self):
+        # If the filename is invalid, error mentions filename, not dims.
+        from services.license_plate_service import validate_plate_file
+        png = _build_minimal_png_bytes(420, 200)
+        ok, err, dims = validate_plate_file(png, 'my-plate.png')
+        assert not ok
+        assert dims is None
+        assert 'letters' in err.lower() or 'numbers' in err.lower()
+
+
+# ---------------------------------------------------------------
+# Count enforcement (the regression bug from wraps)
+# ---------------------------------------------------------------
+class TestGetPlateCountAnyMode:
+
+    def test_present_mode_reads_from_ro(self, fake_lightshow, monkeypatch):
+        # Populate ONLY the RO side — a buggy reader would return 0.
+        _populate_plates(fake_lightshow['ro_plates'], 5)
+        from services import license_plate_service
+        monkeypatch.setattr(
+            'services.mode_service.current_mode', lambda: 'present')
+        assert license_plate_service.get_plate_count_any_mode() == 5
+
+    def test_edit_mode_reads_from_rw(self, fake_lightshow, monkeypatch):
+        _populate_plates(fake_lightshow['rw_plates'], 7)
+        from services import license_plate_service
+        monkeypatch.setattr(
+            'services.mode_service.current_mode', lambda: 'edit')
+        assert license_plate_service.get_plate_count_any_mode() == 7
+
+    def test_present_mode_no_plates_returns_zero(
+            self, fake_lightshow, monkeypatch):
+        from services import license_plate_service
+        monkeypatch.setattr(
+            'services.mode_service.current_mode', lambda: 'present')
+        assert license_plate_service.get_plate_count_any_mode() == 0
+
+    def test_does_not_count_non_png_files(
+            self, fake_lightshow, monkeypatch):
+        _populate_plates(fake_lightshow['ro_plates'], 3)
+        (fake_lightshow['ro_plates'] / '.DS_Store').write_bytes(b'')
+        (fake_lightshow['ro_plates'] / 'README.txt').write_text('hi')
+        from services import license_plate_service
+        monkeypatch.setattr(
+            'services.mode_service.current_mode', lambda: 'present')
+        assert license_plate_service.get_plate_count_any_mode() == 3
+
+    def test_present_mode_count_at_limit_in_present_mode(
+            self, fake_lightshow, monkeypatch):
+        # Regression: in present mode, blueprint used to call
+        # get_plate_count(None) which silently returned 0 and bypassed
+        # MAX_PLATE_COUNT. With the helper, the limit is enforced.
+        _populate_plates(fake_lightshow['ro_plates'], 10)
+        # quick_edit_part2 must NOT be called — the count gate fires
+        # before any expensive RW remount.
+        mock_quick_edit = MagicMock()
+        monkeypatch.setattr(
+            'services.partition_mount_service.quick_edit_part2',
+            mock_quick_edit)
+        monkeypatch.setattr(
+            'services.mode_service.current_mode', lambda: 'present')
+
+        from services import license_plate_service
+        from services.license_plate_service import MAX_PLATE_COUNT
+
+        assert license_plate_service.get_plate_count_any_mode() == 10
+        assert (
+            license_plate_service.get_plate_count_any_mode() >= MAX_PLATE_COUNT
+        )
+        mock_quick_edit.assert_not_called()
+
+    def test_edit_mode_count_at_limit(self, fake_lightshow, monkeypatch):
+        # Edit mode has always counted correctly via the RW mount —
+        # confirm this still holds in the new helper.
+        _populate_plates(fake_lightshow['rw_plates'], 10)
+        monkeypatch.setattr(
+            'services.mode_service.current_mode', lambda: 'edit')
+        from services import license_plate_service
+        from services.license_plate_service import MAX_PLATE_COUNT
+        assert (
+            license_plate_service.get_plate_count_any_mode() >= MAX_PLATE_COUNT
+        )
+
+
+# ---------------------------------------------------------------
+# Rebind behavior on present-mode upload / delete
+# ---------------------------------------------------------------
+class TestRebindAfterUpload:
+
+    def _do_upload(self, fake_lightshow, mode_value, monkeypatch,
+                   defer_rebind=False):
+        monkeypatch.setattr(
+            'services.mode_service.current_mode', lambda: mode_value)
+
+        def _fake_quick_edit(fn, timeout=None):
+            return fn()
+        monkeypatch.setattr(
+            'services.partition_mount_service.quick_edit_part2',
+            _fake_quick_edit)
+
+        from services import license_plate_service
+        png = _build_minimal_png_bytes(420, 200)
+        upload = _FakeUploadFile('plate.png', png)
+        part2_path = (
+            str(fake_lightshow['rw_plates'].parent)
+            if mode_value == 'edit' else None
+        )
+        return license_plate_service.upload_plate_file(
+            upload, 'plate.png', part2_path, defer_rebind=defer_rebind)
+
+    def test_present_mode_upload_calls_rebind(
+            self, fake_lightshow, monkeypatch):
+        rebind = MagicMock(return_value=(True, 'ok'))
+        monkeypatch.setattr(
+            'services.partition_mount_service.rebind_usb_gadget', rebind)
+
+        ok, msg, dims = self._do_upload(
+            fake_lightshow, 'present', monkeypatch)
+        assert ok, msg
+        rebind.assert_called_once()
+
+    def test_edit_mode_upload_does_not_rebind(
+            self, fake_lightshow, monkeypatch):
+        rebind = MagicMock(return_value=(True, 'ok'))
+        monkeypatch.setattr(
+            'services.partition_mount_service.rebind_usb_gadget', rebind)
+        ok, msg, dims = self._do_upload(
+            fake_lightshow, 'edit', monkeypatch)
+        assert ok, msg
+        rebind.assert_not_called()
+
+    def test_rebind_failure_does_not_fail_upload(
+            self, fake_lightshow, monkeypatch, caplog):
+        rebind = MagicMock(return_value=(False, 'gadget busy'))
+        monkeypatch.setattr(
+            'services.partition_mount_service.rebind_usb_gadget', rebind)
+        with caplog.at_level('WARNING'):
+            ok, msg, dims = self._do_upload(
+                fake_lightshow, 'present', monkeypatch)
+        assert ok
+        rebind.assert_called_once()
+        assert any(
+            'rebind' in rec.message.lower() for rec in caplog.records
+        )
+
+    def test_rebind_exception_does_not_fail_upload(
+            self, fake_lightshow, monkeypatch, caplog):
+        rebind = MagicMock(side_effect=RuntimeError('configfs not mounted'))
+        monkeypatch.setattr(
+            'services.partition_mount_service.rebind_usb_gadget', rebind)
+        with caplog.at_level('WARNING'):
+            ok, msg, dims = self._do_upload(
+                fake_lightshow, 'present', monkeypatch)
+        assert ok
+        rebind.assert_called_once()
+
+    def test_defer_rebind_suppresses_call(
+            self, fake_lightshow, monkeypatch):
+        rebind = MagicMock(return_value=(True, 'ok'))
+        monkeypatch.setattr(
+            'services.partition_mount_service.rebind_usb_gadget', rebind)
+        ok, msg, dims = self._do_upload(
+            fake_lightshow, 'present', monkeypatch, defer_rebind=True)
+        assert ok, msg
+        rebind.assert_not_called()
+
+    def test_invalid_upload_skips_quick_edit(
+            self, fake_lightshow, monkeypatch):
+        # If the file fails validation, quick_edit_part2 must never run.
+        mock_quick = MagicMock()
+        monkeypatch.setattr(
+            'services.partition_mount_service.quick_edit_part2',
+            mock_quick)
+        monkeypatch.setattr(
+            'services.mode_service.current_mode', lambda: 'present')
+        from services import license_plate_service
+        bad = _FakeUploadFile('plate.png', _build_minimal_png_bytes(512, 512))
+        ok, msg, dims = license_plate_service.upload_plate_file(
+            bad, 'plate.png', None)
+        assert not ok
+        mock_quick.assert_not_called()
+
+
+class TestRebindAfterDelete:
+
+    def _do_delete(self, fake_lightshow, mode_value, monkeypatch,
+                   defer_rebind=False):
+        # Pre-place a file in the RW location (where present-mode
+        # delete writes via quick_edit_part2 -> MNT_DIR/part2).
+        target = fake_lightshow['rw_plates'] / 'doomed.png'
+        target.write_bytes(b'\x89PNG\r\n\x1a\n')
+        monkeypatch.setattr(
+            'services.mode_service.current_mode', lambda: mode_value)
+
+        def _fake_quick_edit(fn, timeout=None):
+            return fn()
+        monkeypatch.setattr(
+            'services.partition_mount_service.quick_edit_part2',
+            _fake_quick_edit)
+
+        from services import license_plate_service
+        part2_path = (
+            str(fake_lightshow['rw_plates'].parent)
+            if mode_value == 'edit' else None
+        )
+        return license_plate_service.delete_plate_file(
+            'doomed.png', part2_path, defer_rebind=defer_rebind)
+
+    def test_present_mode_delete_calls_rebind(
+            self, fake_lightshow, monkeypatch):
+        rebind = MagicMock(return_value=(True, 'ok'))
+        monkeypatch.setattr(
+            'services.partition_mount_service.rebind_usb_gadget', rebind)
+        ok, msg = self._do_delete(fake_lightshow, 'present', monkeypatch)
+        assert ok, msg
+        rebind.assert_called_once()
+
+    def test_edit_mode_delete_does_not_rebind(
+            self, fake_lightshow, monkeypatch):
+        rebind = MagicMock(return_value=(True, 'ok'))
+        monkeypatch.setattr(
+            'services.partition_mount_service.rebind_usb_gadget', rebind)
+        ok, msg = self._do_delete(fake_lightshow, 'edit', monkeypatch)
+        assert ok, msg
+        rebind.assert_not_called()
+
+    def test_rebind_failure_does_not_fail_delete(
+            self, fake_lightshow, monkeypatch, caplog):
+        rebind = MagicMock(return_value=(False, 'gadget busy'))
+        monkeypatch.setattr(
+            'services.partition_mount_service.rebind_usb_gadget', rebind)
+        with caplog.at_level('WARNING'):
+            ok, msg = self._do_delete(
+                fake_lightshow, 'present', monkeypatch)
+        assert ok
+        rebind.assert_called_once()
+        assert any(
+            'rebind' in rec.message.lower() for rec in caplog.records
+        )
+
+    def test_rebind_exception_does_not_fail_delete(
+            self, fake_lightshow, monkeypatch, caplog):
+        rebind = MagicMock(side_effect=RuntimeError('configfs not mounted'))
+        monkeypatch.setattr(
+            'services.partition_mount_service.rebind_usb_gadget', rebind)
+        with caplog.at_level('WARNING'):
+            ok, msg = self._do_delete(
+                fake_lightshow, 'present', monkeypatch)
+        assert ok
+        rebind.assert_called_once()
+
+
+# ---------------------------------------------------------------
+# Path-traversal sanitization
+# ---------------------------------------------------------------
+class TestPathSanitization:
+
+    def test_upload_strips_path_components_from_filename(
+            self, fake_lightshow, monkeypatch):
+        # A hostile client could submit "../../etc/passwd". The service
+        # must basename() the filename before joining with the destination.
+        monkeypatch.setattr(
+            'services.mode_service.current_mode', lambda: 'edit')
+        from services import license_plate_service
+        png = _build_minimal_png_bytes(420, 200)
+        # Filename validation rejects path-y names anyway because '/'
+        # isn't alphanumeric — but if a future relaxation lets '/'
+        # through, basename() still saves us.
+        upload = _FakeUploadFile('../../etc/passwd.png', png)
+        part2_path = str(fake_lightshow['rw_plates'].parent)
+        ok, msg, dims = license_plate_service.upload_plate_file(
+            upload, '../../etc/passwd.png', part2_path)
+        # Filename validator rejects the slash/dot-dot first.
+        assert not ok
+        assert dims is None
+
+    def test_delete_strips_path_components(
+            self, fake_lightshow, monkeypatch):
+        # delete_plate_file uses basename() on the input. Even if a
+        # hostile request reaches the service with a traversal path,
+        # the join can't escape the LicensePlate folder.
+        monkeypatch.setattr(
+            'services.mode_service.current_mode', lambda: 'edit')
+        from services import license_plate_service
+        # Pre-place a file the attacker is "trying" to overwrite —
+        # outside the plate folder.
+        outside = fake_lightshow['root'] / 'outside.txt'
+        outside.write_text('hands off')
+        # And a real plate to delete.
+        target = fake_lightshow['rw_plates'] / 'realplate.png'
+        target.write_bytes(b'\x89PNG\r\n\x1a\n')
+        part2_path = str(fake_lightshow['rw_plates'].parent)
+
+        # Attempt to delete via a traversal path. basename() reduces
+        # this to 'outside.txt', which doesn't exist in plates dir.
+        ok, msg = license_plate_service.delete_plate_file(
+            '../outside.txt', part2_path)
+        assert not ok
+        assert outside.exists(), 'File outside plate folder must be untouched'
+
+
+# ---------------------------------------------------------------
+# Listing surfaces non-compliant files (per "first-launch behavior")
+# ---------------------------------------------------------------
+class TestListPlateFiles:
+
+    def test_compliant_file_listed_without_issues(self, fake_lightshow):
+        png = _build_minimal_png_bytes(420, 200)
+        (fake_lightshow['ro_plates'] / 'goodplate.png').write_bytes(png)
+        from services import license_plate_service
+        files = license_plate_service.list_plate_files(
+            str(fake_lightshow['ro_plates'].parent))
+        names = {f['filename']: f for f in files}
+        assert 'goodplate.png' in names
+        assert names['goodplate.png']['compliant'] is True
+        assert names['goodplate.png']['issues'] == []
+        assert names['goodplate.png']['width'] == 420
+        assert names['goodplate.png']['height'] == 200
+
+    def test_off_spec_file_listed_with_issues(self, fake_lightshow):
+        # A user dropped a 1920x1080 PNG via Samba — must be visible
+        # in the listing with a warning so they can clean up.
+        bad = _build_minimal_png_bytes(1920, 1080)
+        (fake_lightshow['ro_plates'] / 'badsize.png').write_bytes(bad)
+        from services import license_plate_service
+        files = license_plate_service.list_plate_files(
+            str(fake_lightshow['ro_plates'].parent))
+        names = {f['filename']: f for f in files}
+        assert 'badsize.png' in names
+        assert names['badsize.png']['compliant'] is False
+        assert any('420' in i for i in names['badsize.png']['issues'])
+
+    def test_bad_filename_listed_with_issues(self, fake_lightshow):
+        # User dropped a file with a dash — must surface, not hide.
+        png = _build_minimal_png_bytes(420, 200)
+        (fake_lightshow['ro_plates'] / 'my-plate.png').write_bytes(png)
+        from services import license_plate_service
+        files = license_plate_service.list_plate_files(
+            str(fake_lightshow['ro_plates'].parent))
+        names = {f['filename']: f for f in files}
+        assert 'my-plate.png' in names
+        assert names['my-plate.png']['compliant'] is False
+        assert any(
+            'letters' in i.lower() or 'numbers' in i.lower()
+            for i in names['my-plate.png']['issues']
+        )
+
+    def test_missing_folder_returns_empty(self, tmp_path):
+        # Existing devices won't have a LicensePlate folder yet.
+        from services import license_plate_service
+        files = license_plate_service.list_plate_files(str(tmp_path))
+        assert files == []
+
+    def test_none_mount_path_returns_empty(self):
+        from services import license_plate_service
+        assert license_plate_service.list_plate_files(None) == []

--- a/tests/test_license_plates_blueprint.py
+++ b/tests/test_license_plates_blueprint.py
@@ -1,0 +1,247 @@
+"""Blueprint-level tests for license_plates routes.
+
+These cover behaviour that lives in the route layer (not the service):
+
+* Image gating via the ``before_request`` hook.
+* Filename / partition validation in ``download_plate``.
+* The defense-in-depth ``os.path.commonpath()`` containment check
+  added to ``download_plate`` — a symlink under ``LicensePlate/``
+  pointing outside the folder must NOT be served.
+
+The wider blueprint imports plenty of optional Pi-runtime modules
+(samba, mode-control), so we mount it inside a hermetic Flask app and
+patch the image-path / mount-path indirection points used by the
+route.
+"""
+import os
+import sys
+
+import pytest
+from flask import Flask
+
+
+def _tmp_image_file(tmp_path, name='usb_lightshow.img'):
+    """Create a sentinel file the ``before_request`` hook checks."""
+    f = tmp_path / name
+    f.write_bytes(b"\x00")
+    return str(f)
+
+
+@pytest.fixture
+def app(tmp_path, monkeypatch):
+    """Build a hermetic Flask app with the license_plates blueprint mounted.
+
+    Patches ``IMG_LIGHTSHOW_PATH`` so the gating hook passes, and
+    monkey-patches ``get_mount_path`` (imported into the blueprint
+    module) so the route reads from a tmp directory rather than a
+    real USB mount.
+    """
+    from blueprints import license_plates as lp_module
+
+    img_path = _tmp_image_file(tmp_path)
+    mount_path = tmp_path / 'mnt' / 'gadget' / 'part2'
+    plates_dir = mount_path / 'LicensePlate'
+    plates_dir.mkdir(parents=True)
+
+    monkeypatch.setattr(lp_module, 'IMG_LIGHTSHOW_PATH', img_path)
+    monkeypatch.setattr(lp_module, 'get_mount_path', lambda part: str(mount_path))
+
+    flask_app = Flask(__name__)
+    flask_app.secret_key = 'test'
+    flask_app.register_blueprint(lp_module.license_plates_bp)
+
+    # Stub the mode_control blueprint the gating hook redirects to
+    # so the 302 response can resolve cleanly.
+    from flask import Blueprint
+    mode_bp = Blueprint('mode_control', __name__)
+
+    @mode_bp.route('/mode_control/')
+    def index():
+        return 'index', 200
+
+    flask_app.register_blueprint(mode_bp)
+
+    flask_app.config['TESTING'] = True
+    flask_app.plates_dir = plates_dir
+    flask_app.mount_path = mount_path
+    return flask_app
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+# ---------------------------------------------------------------
+# download_plate path-traversal containment
+# ---------------------------------------------------------------
+class TestDownloadPlateContainment:
+    """The download route MUST verify the resolved path lives under
+    the LicensePlate folder before serving it. ``basename()`` defangs
+    ``../`` traversal in the filename string itself, but a symlink
+    living under LicensePlate/ pointing outside the folder would
+    still be served without the ``commonpath()`` check.
+    """
+
+    def test_download_normal_file_succeeds(self, app, client):
+        """Sanity: a real PNG in the plates dir downloads OK."""
+        png = app.plates_dir / 'realplate.png'
+        png.write_bytes(b'\x89PNG\r\n\x1a\n')
+        r = client.get('/license_plates/download/part2/realplate.png')
+        assert r.status_code == 200
+        assert r.data.startswith(b'\x89PNG')
+
+    def test_download_traversal_in_filename_blocked_by_routing(self, app, client):
+        """Defense-in-depth check #1: werkzeug URL routing rejects
+        URL-encoded slashes (``%2F``) in the ``<filename>`` segment
+        because the default string converter doesn't allow them.
+        Result is a 404 from the routing layer — the request never
+        reaches our handler. This is the *first* line of defense
+        against traversal; ``basename()`` and ``commonpath()`` are
+        the second and third."""
+        r = client.get(
+            '/license_plates/download/part2/..%2F..%2Fetc%2Fpasswd.png',
+            follow_redirects=False,
+        )
+        # 404 from routing OR 302 from missing-file branch — both
+        # mean "did not serve a file outside the plates dir". The
+        # critical assertion is that no sensitive data leaks.
+        assert r.status_code in (302, 404)
+
+    def test_download_missing_file_redirects(self, app, client):
+        """A request for a non-existent .png inside the plates dir
+        flashes + redirects (302) — never returns the file path on
+        disk or any other identifying error."""
+        r = client.get(
+            '/license_plates/download/part2/nonexistent.png',
+            follow_redirects=False,
+        )
+        assert r.status_code == 302
+
+    def test_download_non_png_extension_blocked(self, app, client):
+        """Even an existing file with a non-.png extension must be
+        refused — the route hard-codes the .png extension check."""
+        bad = app.plates_dir / 'sneaky.txt'
+        bad.write_bytes(b'hello')
+        r = client.get(
+            '/license_plates/download/part2/sneaky.txt',
+            follow_redirects=False,
+        )
+        assert r.status_code == 302
+
+    def test_download_invalid_partition_redirects(self, app, client):
+        """Partition name not in USB_PARTITIONS → 302."""
+        r = client.get(
+            '/license_plates/download/bogus/anything.png',
+            follow_redirects=False,
+        )
+        assert r.status_code == 302
+
+    @pytest.mark.skipif(
+        sys.platform == 'win32' and not os.environ.get('TESTS_ALLOW_SYMLINK'),
+        reason='Symlink creation on Windows requires admin or developer mode; '
+               'set TESTS_ALLOW_SYMLINK=1 to run this test there',
+    )
+    def test_download_symlink_outside_plates_dir_blocked(
+            self, app, client, tmp_path):
+        """Defense-in-depth: a symlink under LicensePlate/ pointing
+        OUTSIDE the folder must NOT be served. This is the case the
+        ``os.path.commonpath()`` containment check defends against —
+        ``basename()`` alone would let it through.
+        """
+        # Create a sensitive file outside the plates dir.
+        outside = tmp_path / 'secret.png'
+        outside.write_bytes(b'\x89PNG\r\n\x1a\nSECRET-DATA')
+
+        # Plant a symlink inside the plates dir pointing at it.
+        link = app.plates_dir / 'evil.png'
+        try:
+            os.symlink(str(outside), str(link))
+        except (OSError, NotImplementedError):
+            pytest.skip('Symlink creation not permitted on this platform')
+
+        r = client.get(
+            '/license_plates/download/part2/evil.png',
+            follow_redirects=False,
+        )
+        # The commonpath check rejects it with a flash + 302 redirect.
+        # Crucially, the response must NOT contain the secret payload.
+        assert r.status_code == 302
+        assert b'SECRET-DATA' not in r.data
+
+    def test_download_realpath_outside_blocked_via_mock(
+            self, app, client, monkeypatch):
+        """Portable variant of the symlink test that works on Windows
+        without admin: monkey-patch ``os.path.realpath`` so the
+        resolved path lands outside the plates dir, exercising the
+        ``commonpath()`` rejection branch deterministically.
+        """
+        png = app.plates_dir / 'evil.png'
+        png.write_bytes(b'\x89PNG\r\n\x1a\nSECRET-DATA')
+
+        plates_dir_real = os.path.realpath(str(app.plates_dir))
+        evil_target = os.path.realpath(
+            str(app.mount_path.parent.parent)  # repo-tmp root, definitely outside
+        )
+
+        from blueprints import license_plates as lp_module
+
+        original_realpath = os.path.realpath
+
+        def fake_realpath(p):
+            # The route resolves both the expected dir and the file.
+            # Keep the expected dir honest, but pretend the file
+            # resolves to evil_target (outside the plates folder).
+            if p.endswith('evil.png'):
+                return evil_target
+            return original_realpath(p)
+
+        monkeypatch.setattr(lp_module.os.path, 'realpath', fake_realpath)
+
+        r = client.get(
+            '/license_plates/download/part2/evil.png',
+            follow_redirects=False,
+        )
+        assert r.status_code == 302
+        assert b'SECRET-DATA' not in r.data
+
+    def test_download_no_mount_path_redirects(self, app, client, monkeypatch):
+        """If get_mount_path returns falsy (partition not mounted),
+        route redirects without touching the filesystem."""
+        from blueprints import license_plates as lp_module
+        monkeypatch.setattr(lp_module, 'get_mount_path', lambda part: None)
+        r = client.get(
+            '/license_plates/download/part2/realplate.png',
+            follow_redirects=False,
+        )
+        assert r.status_code == 302
+
+
+# ---------------------------------------------------------------
+# Image gating via before_request
+# ---------------------------------------------------------------
+class TestImageGating:
+
+    def test_routes_blocked_when_image_missing(self, app, client, monkeypatch):
+        from blueprints import license_plates as lp_module
+        monkeypatch.setattr(
+            lp_module, 'IMG_LIGHTSHOW_PATH', '/nonexistent/path.img')
+        r = client.get(
+            '/license_plates/download/part2/realplate.png',
+            follow_redirects=False,
+        )
+        # Browser request → flash + redirect (302).
+        assert r.status_code == 302
+
+    def test_ajax_request_gets_503_json_when_image_missing(
+            self, app, client, monkeypatch):
+        from blueprints import license_plates as lp_module
+        monkeypatch.setattr(
+            lp_module, 'IMG_LIGHTSHOW_PATH', '/nonexistent/path.img')
+        r = client.get(
+            '/license_plates/download/part2/realplate.png',
+            headers={'X-Requested-With': 'XMLHttpRequest'},
+        )
+        assert r.status_code == 503
+        body = r.get_json()
+        assert body == {'error': 'Feature unavailable'}


### PR DESCRIPTION
Closes #55.

## Summary

Adds Custom License Plate management on the LightShow drive (part2). Users
can upload, preview, and delete the PNG files Tesla uses for in-vehicle license-plate
display. Includes a vanilla-JS smart-resize cropper so any image dropped in the page
can be cropped to one of Tesla's exact accepted dimensions (420x200 NA, 420x100 EU).

The implementation mirrors the existing wraps feature (`wrap_service` / `wraps_bp`)
but ships day-one with the count-bypass fix and the USB-rebind fix that
PR #60 added to wraps, so plates never need a follow-up "fix" PR.

## What's new

| File | Purpose |
| --- | --- |
| `scripts/web/services/license_plate_service.py` | Constants, validators, upload/delete with `quick_edit_part2`, mode-aware count, listing that surfaces non-compliant files. Re-exports `safe_rebind_usb_gadget`. |
| `scripts/web/blueprints/license_plates.py` | Flask blueprint with `before_request` guard on `IMG_LIGHTSHOW_PATH` and 5 routes. Multi-upload batches the rebind. |
| `scripts/web/templates/license_plates.html` | Tesla-requirements card, drag-drop multi-file upload, mobile fallback form, per-plate PNG previews, vanilla-canvas smart-resize cropper modal with NA/EU toggle and full touch support. |
| `tests/test_license_plate_service.py` | 55 unit tests across 8 classes (filename, dimensions, size, count, rebind, defer-rebind, path traversal, listing). |

## Edited (7 surgical changes)

| File | Change |
| --- | --- |
| `scripts/web/blueprints/__init__.py` | Export `license_plates_bp`. |
| `scripts/web/web_control.py` | Import + register the blueprint. |
| `scripts/web/services/partition_service.py` | Add `'license_plates_available': lightshow_exists` to `get_feature_availability()`. |
| `scripts/web/templates/base.html` | Extend `media_available` to include `license_plates_available`. |
| `scripts/web/templates/media_hub_nav.html` | New "Plates" pill after Wraps using `#icon-image`. |
| `scripts/web/static/icons/lucide-sprite.svg` | Add `<symbol id="icon-image">` (Lucide image glyph). |
| `scripts/web/blueprints/media.py` | Docstring-only update on `media_home()`; **no behavior change** (chimes already wins as the landing page when LightShow is mounted, which already covers plates). |

## Validation rules (stricter than wraps)

- Filename: `^[A-Za-z0-9]+$` (no `_`, `-`, or space), max 32 chars
- Size: 512 KB max
- Dimensions: exactly `(420, 200)` NA or `(420, 100)` EU
- Count: max 10 plates, **enforced via RO mount in present mode** (count-bypass fix)

## Tests

```
python -m pytest tests/ -q --ignore=tests/test_mapping_service.py --ignore=tests/test_sei_parser.py
```

| | Passing |
| --- | --- |
| Baseline (pre-PR) | **129** |
| After this PR     | **184** (+55, 0 regressions) |

(The two `--ignore`d files fail at *collection* time on the dev machine due to
the missing `services.dashcam_pb2` protobuf module — pre-existing, unrelated to
this PR.)

## UI/UX compliance

- 0 emoji
- 12 Lucide SVG icons (`#icon-image`, `#icon-info`, `#icon-alert-triangle`, etc.)
- 2 `<img>` tags only — both render user-uploaded plate previews via `/download/<partition>/<filename>` (per spec exemption: user content is allowed to be raster)
- Hex colors limited to 4 inside the canvas crop overlay where they MUST stay high-contrast over arbitrary user image content (commented in source); CSS theme tokens used everywhere else
- `min-height: 44px` on all buttons, `touch-action: none` on the cropper canvas
- Bottom-tab + sidebar nav both pick up the new Plates pill via `media_hub_nav.html`
- No "Edit Mode" / "Present Mode" terminology in any new UI text

## Safety / mount semantics

- Reuses `quick_edit_part2()` from `partition_mount_service` — no new mount logic
- Reuses `safe_rebind_usb_gadget()` from `wrap_service` (now public after PR #60) — no duplication
- `os.path.basename()` belt-and-suspenders on every user-supplied filename (even though the validator already rejects non-alphanumerics)
- `before_request` hook returns 503 JSON to AJAX, redirects normal requests to Settings when the LightShow image is missing
- Atomic writes via temp dir → `quick_edit_part2` copy with `fsync` (matches wrap pattern)

## Deployment

```bash
cd /home/pi/TeslaUSB
git pull
sudo ./setup_usb.sh    # picks up new template / blueprint / sprite
sudo systemctl restart gadget_web.service
```

No `config.yaml` changes required. No new dependencies.

## Deviations

- **`media.py`**: the issue body said to "extend the redirect cascade so `LicensePlate` is a valid landing page." Inspecting the existing cascade, it already redirects to `lock_chimes` whenever `IMG_LIGHTSHOW_PATH` is present, and license plates share that same image. So the cascade already covers plates — only a docstring was added to make the intent explicit. **No behavior change in `media.py`.**

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
