### PR TITLE
feat: add image preview to Custom Wraps page (closes #65)

### DIFF
--- a/scripts/web/templates/wraps.html
+++ b/scripts/web/templates/wraps.html
@@ -82,15 +82,23 @@
         <table class="video-table" style="table-layout: fixed;">
             <thead>
                 <tr>
-                    <th style="width: 35%;">Filename</th>
-                    <th style="width: 20%;">Dimensions</th>
-                    <th style="width: 15%;">Size</th>
-                    <th style="width: 30%;">Actions</th>
+                    <th style="width: 18%;">Preview</th>
+                    <th style="width: 27%;">Filename</th>
+                    <th style="width: 15%;">Dimensions</th>
+                    <th style="width: 12%;">Size</th>
+                    <th style="width: 28%;">Actions</th>
                 </tr>
             </thead>
             <tbody>
                 {% for wrap in wrap_files %}
                 <tr>
+                    <td>
+                        {# User-uploaded PNG rendered as a thumbnail — exempt from the SVG-only rule per design system #}
+                        <img src="{{ url_for('wraps.download_wrap', partition=wrap.partition_key, filename=wrap.filename) }}"
+                             alt="Wrap preview {{ wrap.filename }}"
+                             style="max-width: 120px; max-height: 120px; border: 1px solid var(--border-input); border-radius: 4px; background: var(--bg-secondary);"
+                             loading="lazy">
+                    </td>
                     <td style="word-wrap: break-word; overflow-wrap: break-word;">{{ wrap.filename }}</td>
                     <td>{{ wrap.dimensions }}</td>
                     <td>{{ wrap.size_str }}</td>
@@ -116,6 +124,13 @@
     <div class="mobile-card-container">
         {% for wrap in wrap_files %}
         <div class="mobile-card wrap-card">
+            <div style="text-align: center; margin-bottom: 8px;">
+                {# User-uploaded PNG rendered as a thumbnail — exempt from the SVG-only rule per design system #}
+                <img src="{{ url_for('wraps.download_wrap', partition=wrap.partition_key, filename=wrap.filename) }}"
+                     alt="Wrap preview {{ wrap.filename }}"
+                     style="max-width: 100%; max-height: 200px; border: 1px solid var(--border-input); border-radius: 4px; background: var(--bg-secondary);"
+                     loading="lazy">
+            </div>
             <div class="mobile-card-title">
                 <strong>{{ wrap.filename }}</strong>
             </div>


### PR DESCRIPTION
## Summary

Adds an image preview thumbnail for each PNG in the Custom Wraps page, so users can visually identify each wrap before downloading or deleting it.

Closes #65.

## Changes

- **`scripts/web/templates/wraps.html`** — added a "Preview" column to the desktop table and a thumbnail block to the mobile card layout. Both reference the existing `wraps.download_wrap` endpoint as the image source (browsers ignore `Content-Disposition: attachment` for `<img>` references), and use `loading="lazy"` to defer off-screen image fetches.

## Design notes

- **Reuses the existing download endpoint as the thumbnail source.** Same pattern already used by License Plates (`license_plates.html` L112). No new route, no new service method, no extra disk reads.
- **`loading="lazy"`** keeps the page responsive on the Pi Zero 2 W even at the 10-wrap limit (max 10 MB total, 1 MB each).
- **Square 120×120 thumbnail on desktop, capped 200px height on mobile.** Wraps are 512²–1024² so a square preview cell renders consistently without distortion.
- **No emoji or new icons** — user-uploaded PNG is already an exception to the SVG-only rule per the design system note already used in License Plates.
- **Template-only** — no backend, service, mount, config, image-gating, or cleanup-path changes. Diff is +19/-4.

## Verification

- Jinja template parses cleanly.
- Self code review — no Critical or Warning findings against TeslaUSB conventions (config usage, mount safety, mode awareness, path safety, image gating, atomic writes, quick-edit cleanup, error handling, resource efficiency, design system).
- Deployed and verified live on `cybertruckusb.local`:
  - `gadget_web.service` restarted cleanly, status `active`
  - `GET /wraps/` returns `200`
  - Rendered HTML contains both `Wrap preview` `<img>` tags (desktop + mobile)
