### PR TITLE
feat: live event sync (#51) — real-time Tesla event uploads

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -143,12 +143,33 @@ See the full design system for color palettes, typography scale, spacing tokens,
 - **Disambiguation popup**: When the user clicks the map at a location with multiple overlapping clips (e.g., a road driven multiple times in one day or across days), `mapping.html` opens a chooser listing each clip with its trip date/time so the right clip can be selected before the overlay player is launched.
 
 ## Cloud Sync Architecture
-- **Queue-based continuous sync**: A persistent sync queue (SQLite) is populated by the inotify file watcher, WiFi connect handler, and manual "Archive to Cloud" actions. A sync worker thread processes items one at a time.
+TeslaUSB has **two separate cloud upload subsystems** that share one rclone provider config but otherwise operate independently. **Never merge them or have one call into the other's worker** — the priority/coordination contract below is what guarantees real-time event uploads aren't blocked by bulk catch-up sync.
+
+### `cloud_archive_service` — bulk catch-up sync
+- **Queue-based continuous sync**: A persistent sync queue (SQLite, `cloud_sync.db`) is populated by the inotify file watcher, WiFi connect handler, and manual "Archive to Cloud" actions. A sync worker thread processes items one at a time.
 - **Priority order (default)**: (1) Oldest videos with Tesla events (from event.json), (2) Oldest trip videos with geolocation (from geodata.db), (3) Non-event/non-geo videos (opt-in, disabled by default via `cloud_archive.sync_non_event_videos: false`).
 - **Detection**: event.json for folder-level classification + SEI telemetry for fine-grained event detection.
 - **Power-loss safe**: File marked as `synced` only after rclone confirms upload + DB commit + fsync. Partially uploaded files detected on restart and re-queued.
 - **Low impact**: `nice -n 19` + `ionice -c3` on rclone, bandwidth limit (`max_upload_mbps`), one file at a time, inter-file sleep. Web UI must remain responsive during sync.
 - **Keeps going**: Sync worker idles only when queue is empty AND inotify reports no new files. On WiFi reconnect, immediately re-checks queue.
+- **Yields to LES**: between every file, `_run_sync` checks `live_event_queue` for pending rows; if found it releases the `task_coordinator` lock, sleeps briefly, then re-acquires. `trigger_auto_sync()` skips entirely when LES has pending work. **Both checks are O(1) indexed `SELECT 1`** — sub-millisecond, no measurable impact.
+
+### `live_event_sync_service` (LES) — real-time per-event uploader
+- **Trigger**: Tesla's `event.json` arrival in `SentryClips/` or `SavedClips/`. Detected by the same `file_watcher_service` inotify (no second watcher) via `register_event_json_callback`.
+- **Queue**: dedicated `live_event_queue` table in the same `cloud_sync.db`. Schema: `id, event_dir, event_json_path, event_timestamp, event_reason, upload_scope, status, enqueued_at, uploaded_at, attempts, last_error, next_retry_at`. **Sharing the DB but not the table** keeps backups simple and never crosses queues.
+- **Worker**: ONE dedicated thread, idle-on-event semantics. Blocks on `threading.Event.wait()` when queue is empty (< 0.1% CPU). Wakes on (a) enqueue callback or (b) NM dispatcher's `/api/live_events/wake`.
+- **File selection**: `event_minute` (default — 6 cameras × 1 minute centered on `event.json.timestamp`) or `event_folder` (everything in the event dir). Configured per-instance via `live_event_sync.upload_scope`.
+- **Priority over cloud_archive**: When LES has work AND WiFi is up, cloud_archive yields between files (see above). The NM WiFi-connect dispatcher path wakes LES BEFORE triggering cloud sync, and waits up to 10 minutes for the LES queue to drain before kicking cloud sync.
+- **WiFi-aware**: when WiFi is down, queue grows but worker idles. On reconnect, drains immediately. Persistent across reboots — `uploading` rows reset to `pending` on startup recovery.
+- **Failure handling**: per-row `attempts` + `next_retry_at` with backoff `[30s, 120s, 300s, 900s, 3600s]`. After `retry_max_attempts` (default 5), row is `failed`; `POST /api/live_events/retry/<id>` resets it.
+- **Resource ceilings**: ≤ 25 MB RSS steady, ≤ 60 MB peak during upload. No heavy imports (`sqlite3`, `os`, `subprocess`, `threading`, `json`, `re`, `time`, `urllib.request` only — NO `cv2`/`av`/`PIL`/`numpy`/`requests`). One rclone subprocess at a time, never stacked with cloud_archive (coordinated via `task_coordinator` keys `'cloud_sync'` and `'live_event_sync'`).
+- **Opt-in**: `live_event_sync.enabled: false` by default. When disabled, the watcher callback is never registered, the worker never starts, and the API returns `{"enabled": false}`.
+
+### Coordination contract (don't break this)
+- **`task_coordinator` is the single mutual-exclusion point.** Adding parallel rclone subprocesses or a second cloud worker that doesn't go through `acquire_task` will overlap uploads and starve the gadget endpoint.
+- **LES never touches `cloud_synced_files`**, and cloud_archive never touches `live_event_queue`. Each owns its table.
+- **The shared rclone helpers** (`upload_path_via_rclone`, `write_rclone_conf`, `remove_rclone_conf`, `load_provider_creds`, `is_wifi_connected`, `RCLONE_MEM_FLAGS`) live in `cloud_archive_service` and are imported by LES. **Don't duplicate them** — fix-once vs. fix-twice.
+- **The NM dispatcher (`refresh_cloud_token.py`) is the single WiFi-connect entry point.** It refreshes the RO mount → wakes LES → waits for archive timer → waits for indexing queue → waits for LES drain (capped) → triggers cloud_archive. Adding a second WiFi-up trigger would race the queues.
 
 ## Video Indexing
 - **Single SQLite-backed queue + one worker.** All video indexing flows through `indexing_queue` (in `geodata.db`, schema v6). One low-priority background thread (`indexing_worker.py`, started inside `gadget_web.service`) drains the queue one file at a time. **Never re-introduce parallel triggers** — the old design had 6 redundant paths (every page load, every mode switch, every WiFi connect, etc.) that caused the constantly-flashing "Indexing…" banner.
@@ -168,8 +189,23 @@ See the full design system for color palettes, typography scale, spacing tokens,
 ## File Watcher (inotify)
 - `file_watcher_service.py` monitors USB RO mount + ArchivedClips using `watchdog` library.
 - On new file: enqueues into `indexing_queue` (via `enqueue_many_for_indexing`) and notifies the cloud sync producer. Both consumers dedup by canonical key.
-- Falls back to 5-minute polling if inotify unavailable (mount changes, etc.).
-- Must be memory-efficient: watch directory-level events only (IN_CREATE, IN_MOVED_TO).
+- **Two callback types** (subscribed independently): `register_callback(cb)` for `.mp4` arrivals (consumed by the indexing producer) and `register_event_json_callback(cb)` for Tesla `event.json` arrivals (consumed by Live Event Sync). The mp4 callback uses a 60-second age gate; the event_json callback fires immediately because Tesla writes event.json atomically as the last file in the event dir.
+- Falls back to 5-minute polling if inotify unavailable (mount changes, etc.). Both callback types fire from the polling path too.
+- Must be memory-efficient: watch directory-level events only (IN_CREATE, IN_MOVED_TO, IN_CLOSE_WRITE for event.json).
+
+## Live Event Sync (LES) — Real-Time Event Uploader
+LES is a **separate, opt-in subsystem** that uploads Sentry and Saved events to the cloud the moment Tesla writes them. It runs **alongside** `cloud_archive_service`, not inside it. See **Cloud Sync Architecture** above for the full coordination contract; key points for working in this codebase:
+
+- **Disabled by default** (`live_event_sync.enabled: false`). When disabled, the watcher callback is never registered, no thread starts, and the API returns `{"enabled": false}`. **Existing installs see zero behavior change.**
+- **Service**: `scripts/web/services/live_event_sync_service.py`. Public API: `start()`, `stop()`, `wake()`, `enqueue_event_json(paths)`, `enqueue_event_dir(dir, event_json)`, `get_status()`, `list_queue(limit)`, `retry_failed(id_or_None)`. **Don't reach inside the module — use these functions.**
+- **Blueprint**: `scripts/web/blueprints/live_events.py`, mounted at `/api/live_events/{status,queue,retry/<id>,retry_all,wake}`. All routes are JSON-only and image-gated on `IMG_CAM_PATH`.
+- **NM dispatcher integration**: `helpers/refresh_cloud_token.py` calls `/api/live_events/wake` BEFORE waiting for the index drain or triggering cloud sync, then waits up to 10 min for `/api/live_events/status` to show `pending+uploading == 0` before kicking cloud_archive. Don't reorder these steps — the priority contract depends on them.
+- **Queue table**: `live_event_queue` in `cloud_sync.db`. `_startup_recovery()` resets stale `uploading` rows back to `pending` on every start; `_prune_old_uploaded()` evicts rows older than 7 days to keep the table ≤ 200 KB.
+- **File selection**: `select_event_files(event_dir, mode, timestamp)` — `event_minute` (default) matches the 6 cameras for the timestamp's `YYYY-MM-DD_HH-MM` prefix; `event_folder` selects everything in the dir. **Add new modes here, not in the worker.**
+- **Daily data cap**: `live_event_sync.daily_data_cap_mb` (0 = unlimited). When exceeded, the worker idles until the local clock crosses midnight (cheap `_today_uploaded_bytes()` SUM over `uploaded_at` rows).
+- **Webhook**: `live_event_sync.notify_webhook_url` — fired via `urllib.request` (no `requests` import) on successful upload. Don't add HTTP libraries here.
+- **Resource budget is enforced by code review, not by tooling** — every new dependency, thread, or in-memory cache in this module needs a justification. The Pi Zero 2 W has no headroom for "just one more" library.
+
 
 ## Safety & Stability
 - **SSH is sacred**: sshd has a systemd drop-in preventing it from being stopped or masked. Safe-mode boot detection skips TeslaUSB services after 3+ reboots in 10 minutes.
@@ -195,6 +231,11 @@ See the full design system for color palettes, typography scale, spacing tokens,
 - Deleting or overwriting `*.img` files in GADGET_DIR from any code path.
 - Running rclone without `nice`/`ionice` (starves the web server and gadget).
 - Marking a file as `synced` in the cloud database before rclone confirms the upload completed.
+- Letting `cloud_archive_service` upload a Sentry/Saved event clip when LES has a pending row for that event (cloud_archive yields between files; don't remove or weaken the inter-file `live_event_queue` check).
+- Calling LES from inside `cloud_archive_service` (or vice versa) — they're separate subsystems with separate enable flags. Cross-call only via the documented coordination points (`task_coordinator`, the inter-file LES-pending check, and the `/api/live_events/wake` endpoint).
+- Importing `cv2`/`av`/`PIL`/`numpy`/`requests` inside `live_event_sync_service.py` — blows the 25 MB steady-state RSS budget on Pi Zero 2 W.
+- Adding a second inotify watcher for LES (use `register_event_json_callback` on the existing one — zero additional file descriptors).
+- Stacking rclone subprocesses (one at a time, ever, across both cloud_archive and LES — coordinated via `task_coordinator`).
 - Re-introducing redundant indexing triggers (every page load, every mode switch, every WiFi connect, full filesystem walks). The indexing worker is the SINGLE consumer of `indexing_queue`; producers only enqueue. Adding parallel "trigger_auto_index"-style code paths is what caused the constantly-flashing banner the redesign removed.
 - Flashing the indexing banner based on queue depth instead of `active_file`. The user only wants to know when a file is *actively being parsed*, not when items are queued.
 - Calling `requestFullscreen()` on the bare `<video>` element in `mapping.html` — the `.overlay-hud` is a sibling DOM node, so it drops out of the OS fullscreen layer. Always fullscreen the `.video-overlay-stage` wrapper instead so the HUD rides along.

--- a/.github/skills/resolve-issue/SKILL.md
+++ b/.github/skills/resolve-issue/SKILL.md
@@ -448,11 +448,25 @@ Review **only the changed files** against these TeslaUSB-specific criteria:
 
 | Severity | Meaning | Action |
 |----------|---------|--------|
-| 🔴 **Critical** | Mount safety violations, data corruption risk, command injection, path traversal | Must fix before proceeding |
-| 🟡 **Warning** | Convention violations, missing error handling, hardcoded values | Should fix in this PR |
-| 🔵 **Info** | Style suggestions, minor improvements | Fix if trivial, otherwise note |
+| 🔴 **Critical** | Mount safety violations, data corruption risk, command injection, path traversal | **Must fix** before proceeding |
+| 🟡 **Warning** | Convention violations, missing error handling, hardcoded values | **Must fix** in this PR |
+| 🔵 **Info** | Style suggestions, minor improvements, latent code smells, defense-in-depth | **Must fix** in this PR (or explicitly defer with user approval — see below) |
 
-Address all 🔴 Critical and 🟡 Warning findings before proceeding.
+**Address all findings — Critical, Warning, AND Info — before proceeding.** The goal is
+zero code smells and no latent issues left behind. "Info" does not mean "optional" — it
+means "lower urgency than Warning, but still expected to be addressed in this PR."
+
+The only acceptable reasons to leave an Info finding unfixed are:
+
+1. The finding is a false positive (document why in the resolution comment).
+2. Fixing it requires significantly larger refactoring outside this PR's scope. In that
+   case, **file a follow-up GitHub issue** linking back to this PR and reference the
+   issue number in the resolution comment.
+3. The user has explicitly approved deferring the specific finding (quote the user
+   statement in the resolution comment).
+
+Do not silently defer Info findings. If you cannot fix one, the resolution comment must
+state which finding was deferred, why, and where the follow-up work is tracked.
 
 ---
 
@@ -473,7 +487,8 @@ what was done.
 - `path/to/file2.sh` — [what was changed and why]
 
 **Verification:** Syntax checks pass; app loads without import errors; self code review
-passed with no Critical or Warning findings.
+passed with **no findings of any severity** (Critical, Warning, or Info) left unaddressed.
+Any deferred Info findings are documented below with a follow-up issue link.
 
 <!-- skill:resolve-issue:resolution:{number} -->
 ```
@@ -490,7 +505,8 @@ passed with no Critical or Warning findings.
 - `path/to/new_file.py` — [new file, purpose]
 
 **Verification:** Syntax checks pass; app loads without import errors; self code review
-passed with no Critical or Warning findings.
+passed with **no findings of any severity** (Critical, Warning, or Info) left unaddressed.
+Any deferred Info findings are documented below with a follow-up issue link.
 
 <!-- skill:resolve-issue:resolution:{number} -->
 ```
@@ -590,12 +606,21 @@ When resolving multiple issues (filtered or all mode):
 ### What this skill does NOT do
 
 - **Does not commit or push to `main`** — all changes go on a feature branch.
+- **Does not merge pull requests.** Even when a PR is open, reviewed, and clean, the
+  merge decision belongs to the user. The skill may push a feature branch and open a PR,
+  but it must NEVER call `gh pr merge` or otherwise combine the feature branch into
+  `main` automatically. If the user asks for a merge, treat that as a separate explicit
+  instruction outside this skill.
 - **Does not close issues manually** — relies on `Closes #N` in commit messages (except
   sub-item mode, which uses `Ref #N`).
 - **Does not skip root-cause analysis** — even for "obvious" bugs, the analysis must be
   documented with evidence.
 - **Does not ignore unrelated problems** — any bugs, safety violations, or risks discovered
   during investigation are filed as new GitHub issues (Phase 2.6).
+- **Does not leave any code smells or latent issues behind.** All findings of any
+  severity (Critical, Warning, Info) must be resolved before the resolution comment is
+  posted. Any Info finding that cannot be fixed in this PR must have a follow-up issue
+  filed and referenced in the resolution comment.
 - **Does not deploy to the Pi** — implementation and commits happen locally; deployment
   via `setup_usb.sh` is a separate manual step after merge.
 
@@ -607,6 +632,6 @@ When resolving multiple issues (filtered or all mode):
 | Phase 3 | Comment posted on issue with root-cause analysis or implementation plan |
 | Phase 3.5 | Feature branch created off `main`; working tree is on the new branch |
 | Phase 4 | Python syntax checks pass; app loads without import errors |
-| Phase 5 | No Critical or Warning findings from self code review |
+| Phase 5 | No findings of any severity (Critical, Warning, Info) left unaddressed; any deferred Info findings have a follow-up GitHub issue filed |
 | Phase 6 | Resolution comment posted on issue |
 | Phase 7 | Commit created on feature branch with proper message format and issue reference |

--- a/.github/skills/review-pr/SKILL.md
+++ b/.github/skills/review-pr/SKILL.md
@@ -253,17 +253,34 @@ category.
 
 | Severity | Meaning | Action |
 |----------|---------|--------|
-| 🔴 **Critical** | Mount safety violations, data corruption risk, command injection, path traversal | Must fix before merge |
-| 🟡 **Warning** | Convention violations, missing error handling, hardcoded values | Should fix in this PR |
-| 🔵 **Info** | Suggestions, minor improvements, style preferences | Optional |
+| 🔴 **Critical** | Mount safety violations, data corruption risk, command injection, path traversal | **Must fix** before merge |
+| 🟡 **Warning** | Convention violations, missing error handling, hardcoded values | **Must fix** in this PR |
+| 🔵 **Info** | Suggestions, minor improvements, latent code smells, defense-in-depth | **Must fix** in this PR (or document deferral with follow-up issue link) |
+
+**TeslaUSB policy: zero code smells or latent issues left behind.** Info findings are
+NOT optional. They represent latent code smells or defense-in-depth gaps that should be
+addressed in the same PR — leaving them unfixed accumulates technical debt and erodes
+the code quality bar. The only acceptable reasons to leave an Info finding open are:
+
+1. It is a false positive (state why in the action items).
+2. The fix requires a larger refactor out of scope; **a follow-up GitHub issue must be
+   filed and linked** in the action items.
+3. The PR author / user explicitly accepts the deferral (and the deferral is documented).
+
+Phrase action items for Info findings as "expected to address" — never "optional" or
+"nice to have."
 
 ### Review decision
 
 | Condition | Decision | GH CLI flag |
 |-----------|----------|-------------|
 | Any 🔴 Critical findings | Request changes | `--request-changes` |
-| Only 🟡 Warning and/or 🔵 Info findings | Comment | `--comment` |
+| Any 🟡 Warning **or** 🔵 Info findings | Comment | `--comment` |
 | No findings — clean PR | Approve | `--approve` |
+
+**Never merge a PR as part of this skill.** The review's only output is a posted review
+(approve / request-changes / comment). The actual merge decision belongs to the user, not
+the agent. See the "Does not merge PRs" guardrail below.
 
 ### Review body format
 
@@ -297,7 +314,7 @@ Build the review body as Markdown:
 
 1. **Critical** — [must-fix items — block merge until resolved]
 2. **Warnings** — [should-fix items — fix in this PR]
-3. **Info** — [optional improvements]
+3. **Info** — [expected-to-address items in this PR; cite a follow-up issue for any deferral]
 
 <!-- skill:review-pr:review:{number} -->
 ```
@@ -419,7 +436,17 @@ List any PRs that were skipped (merged, closed, not found) with the reason.
 
 - **Does not auto-fix code.** This is a review — it reports findings for the author to fix.
 - **Does not run tests.** TeslaUSB has no automated test suite.
-- **Does not merge PRs.** The review decision is advisory.
+- **Never merges PRs — under any circumstances.** The review decision is advisory only.
+  Even on a clean Approve, the skill MUST NOT call `gh pr merge`, push to `main`, or
+  otherwise combine the PR into the base branch. Merging is exclusively the user's
+  decision and must be performed by the user (or by an explicit, separate instruction
+  outside this skill). If the user asks the agent to merge after the review, that is a
+  separate task — confirm with the user first and treat it as a deliberate, supervised
+  operation, never as the implicit next step after a review.
+- **Does not treat Info findings as optional.** Info-level items are latent code smells
+  / defense-in-depth gaps and are expected to be addressed in the same PR. If the
+  reviewer finds genuine deferrals are needed, a follow-up GitHub issue must be filed
+  and linked in the review.
 - **Does not review files outside the PR diff.** Stay within the changed files.
 - **Does not auto-select PRs.** The user must provide PR numbers.
 - **Does not deploy changes.** Deployment via `setup_usb.sh` is a separate step.

--- a/config.yaml
+++ b/config.yaml
@@ -150,8 +150,8 @@ live_event_sync:
   watch_folders:                         # Tesla event subfolders to react to
     - SentryClips
     - SavedClips
-  upload_scope: "event_minute"           # event_minute = 6 cams + event.json (~40 MB);
-                                         # event_folder = all .mp4 in the event dir
+  upload_scope: "event_minute"           # event_minute = 6 cams + event.json (~150-200 MB);
+                                         # event_folder = all .mp4 in the event dir (~0.7-2 GB)
   retry_max_attempts: 5                  # Move row to 'failed' after this many attempts
   retry_backoff_seconds: [30, 120, 300, 900, 3600]  # 30s, 2m, 5m, 15m, 1h
   daily_data_cap_mb: 0                   # 0 = unlimited; pause uploads when exceeded

--- a/config.yaml
+++ b/config.yaml
@@ -136,6 +136,28 @@ cloud_archive:
   cloud_min_retention_days: 30           # Keep at least this many days of videos
 
 # ============================================================================
+# Live Event Sync Configuration
+# ============================================================================
+# Real-time upload of Sentry/Saved events as soon as Tesla writes the
+# event.json metadata. Separate first-class subsystem from cloud_archive:
+#   - own enable flag, queue, and worker thread
+#   - shares only the cloud provider credentials (configured in the web UI)
+#   - takes priority over cloud_archive when both want WiFi
+#   - persists the queue across reboots and WiFi outages
+# Pi Zero 2 W resource budget: < 25 MB RSS steady state, < 0.1% idle CPU.
+live_event_sync:
+  enabled: false                         # Opt-in default; existing installs unchanged
+  watch_folders:                         # Tesla event subfolders to react to
+    - SentryClips
+    - SavedClips
+  upload_scope: "event_minute"           # event_minute = 6 cams + event.json (~40 MB);
+                                         # event_folder = all .mp4 in the event dir
+  retry_max_attempts: 5                  # Move row to 'failed' after this many attempts
+  retry_backoff_seconds: [30, 120, 300, 900, 3600]  # 30s, 2m, 5m, 15m, 1h
+  daily_data_cap_mb: 0                   # 0 = unlimited; pause uploads when exceeded
+  notify_webhook_url: ""                 # Optional POST URL on successful upload
+
+# ============================================================================
 # RecentClips Archive Configuration
 # ============================================================================
 # Automatically copies RecentClips from the USB image (RO mount) to the Pi's

--- a/scripts/web/blueprints/__init__.py
+++ b/scripts/web/blueprints/__init__.py
@@ -16,6 +16,7 @@ from .boombox import boombox_bp
 from .media import media_bp
 from .captive_portal import captive_portal_bp, catch_all_redirect
 from .cloud_archive import cloud_archive_bp
+from .live_events import live_events_bp
 
 __all__ = [
     'mode_control_bp',
@@ -35,4 +36,5 @@ __all__ = [
     'captive_portal_bp',
     'catch_all_redirect',
     'cloud_archive_bp',
+    'live_events_bp',
 ]

--- a/scripts/web/blueprints/cloud_archive.py
+++ b/scripts/web/blueprints/cloud_archive.py
@@ -61,9 +61,25 @@ def _get_cloud_config_cached() -> dict:
         data = cfg.get('cloud_archive', {})
         _cloud_config_cache['data'] = data
         _cloud_config_cache['ts'] = now
+        # Piggyback the live_event_sync section on the same disk read so
+        # the cloud archive page can render LES settings without a
+        # second yaml.load() per pageview.
+        _cloud_config_cache['les_data'] = cfg.get('live_event_sync', {}) or {}
         return data
     except Exception:
         return _cloud_config_cache.get('data', {})
+
+
+def _get_les_config_cached() -> dict:
+    """Return live_event_sync section from config.yaml, cached for 30s.
+
+    Always cache-coherent with ``_get_cloud_config_cached()`` because
+    they share the same dict; calling either one refreshes both.
+    """
+    if 'les_data' not in _cloud_config_cache:
+        # Force a populate.
+        _get_cloud_config_cached()
+    return _cloud_config_cache.get('les_data', {})
 
 
 # ---------------------------------------------------------------------------
@@ -122,6 +138,21 @@ def index():
             pass
 
     ctx = get_base_context()
+
+    # Load Live Event Sync (LES) config from config.yaml so the LES card
+    # in the cloud sync page can render with current values. Reads come
+    # from the same 30s cache that backs cloud_archive settings.
+    _les_cfg = _get_les_config_cached()
+    les_enabled = bool(_les_cfg.get('enabled', False))
+    les_watch_folders = list(_les_cfg.get('watch_folders', ['SentryClips', 'SavedClips']))
+    les_upload_scope = str(_les_cfg.get('upload_scope', 'event_minute'))
+    les_retry_max_attempts = int(_les_cfg.get('retry_max_attempts', 5))
+    les_retry_backoff_seconds = list(
+        _les_cfg.get('retry_backoff_seconds', [30, 120, 300, 900, 3600])
+    )
+    les_daily_data_cap_mb = int(_les_cfg.get('daily_data_cap_mb', 0))
+    les_notify_webhook_url = str(_les_cfg.get('notify_webhook_url', '') or '')
+
     return render_template(
         'cloud_archive.html',
         page='cloud',
@@ -140,6 +171,13 @@ def index():
         sync_non_event_videos=bool(_cloud.get('sync_non_event_videos', False)),
         cloud_auto_cleanup=bool(_cloud.get('cloud_auto_cleanup', False)),
         cloud_min_retention_days=int(_cloud.get('cloud_min_retention_days', 30)),
+        les_enabled=les_enabled,
+        les_watch_folders=les_watch_folders,
+        les_upload_scope=les_upload_scope,
+        les_retry_max_attempts=les_retry_max_attempts,
+        les_retry_backoff_seconds=les_retry_backoff_seconds,
+        les_daily_data_cap_mb=les_daily_data_cap_mb,
+        les_notify_webhook_url=les_notify_webhook_url,
         **ctx,
     )
 

--- a/scripts/web/blueprints/live_events.py
+++ b/scripts/web/blueprints/live_events.py
@@ -10,20 +10,28 @@ UI and on-device tooling can:
 * Wake the worker (``POST /api/live_events/wake``) — called by the
   NetworkManager WiFi-connect dispatcher path so LES drains BEFORE
   cloud_archive sync runs.
+* Read current config from ``config.yaml`` (``GET /api/live_events/config``)
+* Save config + schedule restart (``POST /api/live_events/settings``)
+* Trigger an explicit restart (``POST /api/live_events/restart``)
 
-All endpoints are JSON-only (no HTML). The blueprint is image-gated on
-``IMG_CAM_PATH`` (Sentry/Saved events live on part1 — TeslaCam). When
-the image isn't present the routes return 503 JSON; when LES is
-disabled in config they return ``{"enabled": false}`` so the UI can
-gracefully render a disabled state instead of a hard error.
+All endpoints are JSON-only (no HTML). Runtime endpoints are image-gated
+on ``IMG_CAM_PATH`` (Sentry/Saved events live on part1 — TeslaCam), so
+they return 503 when the cam image is missing. **Configuration**
+endpoints (``/config``, ``/settings``, ``/restart``) intentionally
+bypass that gate so the user can pre-configure LES before the cam
+image is provisioned. When LES is disabled in config the runtime
+routes return ``{"enabled": false}`` so the UI can render a disabled
+state instead of a hard error.
 """
 
 import logging
 import os
+import subprocess
+from urllib.parse import urlparse
 
 from flask import Blueprint, jsonify, request
 
-from config import IMG_CAM_PATH, LIVE_EVENT_SYNC_ENABLED
+from config import CONFIG_YAML, IMG_CAM_PATH, LIVE_EVENT_SYNC_ENABLED
 
 logger = logging.getLogger(__name__)
 
@@ -31,9 +39,24 @@ live_events_bp = Blueprint('live_events', __name__,
                            url_prefix='/api/live_events')
 
 
+# Endpoints that are allowed even when the cam image is missing — these
+# are configuration / lifecycle endpoints that don't touch event data.
+_CONFIG_ENDPOINTS = frozenset({
+    'live_events.get_config',
+    'live_events.save_settings',
+    'live_events.restart_service',
+})
+
+
 @live_events_bp.before_request
 def _require_cam_image():
-    """Block all routes when usb_cam.img is missing (no Sentry/Saved data)."""
+    """Block runtime routes when usb_cam.img is missing.
+
+    Configuration endpoints stay available so the user can prepare LES
+    settings before the cam image exists.
+    """
+    if request.endpoint in _CONFIG_ENDPOINTS:
+        return None
     if not os.path.isfile(IMG_CAM_PATH):
         return jsonify({"error": "Feature unavailable"}), 503
 
@@ -88,3 +111,210 @@ def wake():
     from services.live_event_sync_service import wake as _wake
     _wake()
     return jsonify({"enabled": True, "woken": True})
+
+
+# ---------------------------------------------------------------------------
+# Configuration endpoints (always available, even when cam image is missing)
+# ---------------------------------------------------------------------------
+
+_ALLOWED_WATCH_FOLDERS = ('SentryClips', 'SavedClips')
+_ALLOWED_UPLOAD_SCOPES = ('event_minute', 'event_folder')
+_MAX_WEBHOOK_URL_LEN = 2048
+_MAX_DAILY_CAP_MB = 1024 * 1024  # 1 TiB ceiling — far above any sane setting
+_MIN_RETRY_ATTEMPTS = 1
+_MAX_RETRY_ATTEMPTS = 20
+
+
+def _read_les_section() -> dict:
+    """Read the live_event_sync block fresh from config.yaml on disk."""
+    import yaml
+    with open(CONFIG_YAML, 'r') as f:
+        cfg = yaml.safe_load(f) or {}
+    return cfg.get('live_event_sync', {}) or {}
+
+
+def _validate_les_payload(data: dict):
+    """Validate and normalize a LES settings payload.
+
+    Returns ``(ok: bool, error: str, normalized: dict)``. When ``ok`` is
+    True the normalized dict is safe to persist verbatim.
+    """
+    try:
+        enabled = bool(data.get('enabled', False))
+
+        wf_raw = data.get('watch_folders', [])
+        if not isinstance(wf_raw, list):
+            return False, "watch_folders must be a list", {}
+        watch_folders = []
+        for f in wf_raw:
+            f_str = str(f)
+            if f_str not in _ALLOWED_WATCH_FOLDERS:
+                return False, f"watch_folders contains unsupported value '{f_str}'", {}
+            if f_str not in watch_folders:
+                watch_folders.append(f_str)
+        if enabled and not watch_folders:
+            return False, "Enable Live Event Sync requires at least one watch folder", {}
+
+        upload_scope = str(data.get('upload_scope', 'event_minute'))
+        if upload_scope not in _ALLOWED_UPLOAD_SCOPES:
+            return False, (
+                "upload_scope must be one of " + ", ".join(_ALLOWED_UPLOAD_SCOPES)
+            ), {}
+
+        try:
+            retry_max_attempts = int(data.get('retry_max_attempts', 5))
+        except (TypeError, ValueError):
+            return False, "retry_max_attempts must be an integer", {}
+        if not (_MIN_RETRY_ATTEMPTS <= retry_max_attempts <= _MAX_RETRY_ATTEMPTS):
+            return False, (
+                f"retry_max_attempts must be between {_MIN_RETRY_ATTEMPTS} "
+                f"and {_MAX_RETRY_ATTEMPTS}"
+            ), {}
+
+        try:
+            daily_data_cap_mb = int(data.get('daily_data_cap_mb', 0))
+        except (TypeError, ValueError):
+            return False, "daily_data_cap_mb must be an integer", {}
+        if not (0 <= daily_data_cap_mb <= _MAX_DAILY_CAP_MB):
+            return False, (
+                f"daily_data_cap_mb must be between 0 and {_MAX_DAILY_CAP_MB}"
+            ), {}
+
+        webhook = str(data.get('notify_webhook_url', '') or '').strip()
+        if webhook:
+            if len(webhook) > _MAX_WEBHOOK_URL_LEN:
+                return False, "notify_webhook_url too long", {}
+            if any(ord(c) < 32 or ord(c) == 127 for c in webhook):
+                return False, "notify_webhook_url contains control characters", {}
+            parsed = urlparse(webhook)
+            if parsed.scheme not in ('http', 'https') or not parsed.netloc:
+                return False, "notify_webhook_url must start with http:// or https://", {}
+
+        return True, "", {
+            'enabled': enabled,
+            'watch_folders': watch_folders,
+            'upload_scope': upload_scope,
+            'retry_max_attempts': retry_max_attempts,
+            'daily_data_cap_mb': daily_data_cap_mb,
+            'notify_webhook_url': webhook,
+        }
+    except Exception as exc:
+        logger.exception("LES validation crashed")
+        return False, f"validation error: {exc}", {}
+
+
+def _schedule_service_restart() -> bool:
+    """Schedule a delayed restart of gadget_web.service via systemd-run.
+
+    Uses ``systemd-run --on-active=2`` so the restart job runs as a
+    transient timer **outside** this service's cgroup. That way the
+    restart still fires even when our own process is killed during the
+    restart sequence. Returns True when scheduling succeeded.
+    """
+    try:
+        subprocess.Popen(
+            [
+                'systemd-run',
+                '--on-active=2',
+                '/bin/systemctl',
+                'restart',
+                'gadget_web.service',
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            close_fds=True,
+        )
+        logger.info("Scheduled gadget_web.service restart via systemd-run")
+        return True
+    except Exception:
+        logger.exception("Failed to schedule gadget_web.service restart")
+        return False
+
+
+@live_events_bp.route('/config', methods=['GET'])
+def get_config():
+    """Return current LES settings from ``config.yaml``.
+
+    Always reachable — does not require ``usb_cam.img`` because the
+    settings UI must be able to load config even on a fresh device.
+    """
+    try:
+        les = _read_les_section()
+        return jsonify({
+            "enabled": bool(les.get('enabled', False)),
+            "watch_folders": list(les.get('watch_folders', list(_ALLOWED_WATCH_FOLDERS))),
+            "upload_scope": str(les.get('upload_scope', 'event_minute')),
+            "retry_max_attempts": int(les.get('retry_max_attempts', 5)),
+            "retry_backoff_seconds": list(
+                les.get('retry_backoff_seconds', [30, 120, 300, 900, 3600])
+            ),
+            "daily_data_cap_mb": int(les.get('daily_data_cap_mb', 0)),
+            "notify_webhook_url": str(les.get('notify_webhook_url', '') or ''),
+            "image_present": os.path.isfile(IMG_CAM_PATH),
+            "running_enabled": bool(LIVE_EVENT_SYNC_ENABLED),
+        })
+    except Exception as exc:
+        logger.exception("Failed to read LES config")
+        return jsonify({"error": str(exc)}), 500
+
+
+@live_events_bp.route('/settings', methods=['POST'])
+def save_settings():
+    """Persist LES settings to ``config.yaml`` and schedule a restart.
+
+    All current LES settings are captured at module import time as
+    constants in ``config.py``. Saving therefore always requires a
+    service restart for the changes to take effect — that's what the
+    scheduler call is for.
+    """
+    from helpers.config_updater import update_config_yaml
+
+    payload = request.get_json(silent=True) or {}
+    ok, err, norm = _validate_les_payload(payload)
+    if not ok:
+        return jsonify({"success": False, "error": err}), 400
+
+    try:
+        update_config_yaml({
+            'live_event_sync.enabled': norm['enabled'],
+            'live_event_sync.watch_folders': norm['watch_folders'],
+            'live_event_sync.upload_scope': norm['upload_scope'],
+            'live_event_sync.retry_max_attempts': norm['retry_max_attempts'],
+            'live_event_sync.daily_data_cap_mb': norm['daily_data_cap_mb'],
+            'live_event_sync.notify_webhook_url': norm['notify_webhook_url'],
+        })
+    except Exception as exc:
+        logger.exception("Failed to persist LES settings")
+        return jsonify({"success": False, "error": str(exc)}), 500
+
+    # Don't log the webhook URL value — it can carry secrets/tokens.
+    logger.info(
+        "LES settings saved: enabled=%s watch_folders=%s scope=%s "
+        "retries=%d cap_mb=%d webhook=%s",
+        norm['enabled'], norm['watch_folders'], norm['upload_scope'],
+        norm['retry_max_attempts'], norm['daily_data_cap_mb'],
+        'set' if norm['notify_webhook_url'] else 'none',
+    )
+
+    restart_scheduled = _schedule_service_restart()
+
+    response = {
+        "success": True,
+        "restart_scheduled": restart_scheduled,
+        "config": {
+            **norm,
+            'notify_webhook_url_set': bool(norm['notify_webhook_url']),
+        },
+    }
+    # Echo back the URL only for convenience of the form repopulation;
+    # the caller already had it.
+    response['config']['notify_webhook_url'] = norm['notify_webhook_url']
+    return jsonify(response)
+
+
+@live_events_bp.route('/restart', methods=['POST'])
+def restart_service():
+    """Manually schedule a restart of ``gadget_web.service``."""
+    if _schedule_service_restart():
+        return jsonify({"success": True, "restart_scheduled": True})
+    return jsonify({"success": False, "error": "scheduling failed"}), 500

--- a/scripts/web/blueprints/live_events.py
+++ b/scripts/web/blueprints/live_events.py
@@ -210,6 +210,14 @@ def _schedule_service_restart() -> bool:
     transient timer **outside** this service's cgroup. That way the
     restart still fires even when our own process is killed during the
     restart sequence. Returns True when scheduling succeeded.
+
+    No sudo: gadget_web.service runs as root (port 80 binding requirement,
+    see copilot-instructions.md "Web App Patterns"), so ``systemd-run``
+    is callable directly. Any future privilege drop would have to either
+    (a) add a sudoers rule for ``systemd-run --on-active=...
+    systemctl restart gadget_web.service`` or (b) replace this with a
+    PolicyKit / dbus call. The settings UI surfaces ``restart_scheduled``
+    in its toast so a scheduling failure is at least visible.
     """
     try:
         subprocess.Popen(

--- a/scripts/web/blueprints/live_events.py
+++ b/scripts/web/blueprints/live_events.py
@@ -1,0 +1,90 @@
+"""Blueprint for Live Event Sync (LES) status and retry endpoints.
+
+LES is the real-time per-event uploader (separate from the bulk
+``cloud_archive`` sync). This blueprint exposes a thin API so the web
+UI and on-device tooling can:
+
+* Read queue + last-upload status (``GET /api/live_events/status``)
+* List recent queue rows (``GET /api/live_events/queue``)
+* Retry a failed row (``POST /api/live_events/retry/<id>``)
+* Wake the worker (``POST /api/live_events/wake``) — called by the
+  NetworkManager WiFi-connect dispatcher path so LES drains BEFORE
+  cloud_archive sync runs.
+
+All endpoints are JSON-only (no HTML). The blueprint is image-gated on
+``IMG_CAM_PATH`` (Sentry/Saved events live on part1 — TeslaCam). When
+the image isn't present the routes return 503 JSON; when LES is
+disabled in config they return ``{"enabled": false}`` so the UI can
+gracefully render a disabled state instead of a hard error.
+"""
+
+import logging
+import os
+
+from flask import Blueprint, jsonify, request
+
+from config import IMG_CAM_PATH, LIVE_EVENT_SYNC_ENABLED
+
+logger = logging.getLogger(__name__)
+
+live_events_bp = Blueprint('live_events', __name__,
+                           url_prefix='/api/live_events')
+
+
+@live_events_bp.before_request
+def _require_cam_image():
+    """Block all routes when usb_cam.img is missing (no Sentry/Saved data)."""
+    if not os.path.isfile(IMG_CAM_PATH):
+        return jsonify({"error": "Feature unavailable"}), 503
+
+
+@live_events_bp.route('/status', methods=['GET'])
+def status():
+    """Return a JSON snapshot of LES state plus queue counts."""
+    if not LIVE_EVENT_SYNC_ENABLED:
+        return jsonify({"enabled": False})
+    from services.live_event_sync_service import get_status
+    return jsonify({"enabled": True, **get_status()})
+
+
+@live_events_bp.route('/queue', methods=['GET'])
+def queue():
+    """Return up to ``limit`` recent queue rows (default 50)."""
+    if not LIVE_EVENT_SYNC_ENABLED:
+        return jsonify({"enabled": False, "rows": []})
+    from services.live_event_sync_service import list_queue
+    try:
+        limit = max(1, min(200, int(request.args.get('limit', 50))))
+    except (ValueError, TypeError):
+        limit = 50
+    return jsonify({"enabled": True, "rows": list_queue(limit)})
+
+
+@live_events_bp.route('/retry/<int:row_id>', methods=['POST'])
+def retry(row_id: int):
+    """Reset a single failed row to pending and wake the worker."""
+    if not LIVE_EVENT_SYNC_ENABLED:
+        return jsonify({"enabled": False, "error": "LES disabled"}), 400
+    from services.live_event_sync_service import retry_failed
+    n = retry_failed(row_id)
+    return jsonify({"enabled": True, "rows_reset": n})
+
+
+@live_events_bp.route('/retry_all', methods=['POST'])
+def retry_all():
+    """Reset every failed row to pending."""
+    if not LIVE_EVENT_SYNC_ENABLED:
+        return jsonify({"enabled": False, "error": "LES disabled"}), 400
+    from services.live_event_sync_service import retry_failed
+    n = retry_failed(None)
+    return jsonify({"enabled": True, "rows_reset": n})
+
+
+@live_events_bp.route('/wake', methods=['POST'])
+def wake():
+    """Poke the worker thread (used by the WiFi-connect dispatcher)."""
+    if not LIVE_EVENT_SYNC_ENABLED:
+        return jsonify({"enabled": False})
+    from services.live_event_sync_service import wake as _wake
+    _wake()
+    return jsonify({"enabled": True, "woken": True})

--- a/scripts/web/config.py
+++ b/scripts/web/config.py
@@ -114,6 +114,18 @@ CLOUD_MIN_RETENTION_DAYS = int(_cloud.get('cloud_min_retention_days', 30))
 CLOUD_ARCHIVE_DB_PATH = os.path.join(GADGET_DIR, 'cloud_sync.db')
 CLOUD_PROVIDER_CREDS_PATH = os.path.join(GADGET_DIR, 'cloud_provider.enc')
 
+# Live Event Sync Configuration
+# Separate first-class subsystem from cloud_archive — own queue, worker, and config.
+# Shares CLOUD_ARCHIVE_PROVIDER + CLOUD_PROVIDER_CREDS_PATH for credentials only.
+_les = config.get('live_event_sync', {})
+LIVE_EVENT_SYNC_ENABLED = bool(_les.get('enabled', False))
+LIVE_EVENT_WATCH_FOLDERS = list(_les.get('watch_folders', ['SentryClips', 'SavedClips']))
+LIVE_EVENT_UPLOAD_SCOPE = str(_les.get('upload_scope', 'event_minute'))
+LIVE_EVENT_RETRY_MAX_ATTEMPTS = int(_les.get('retry_max_attempts', 5))
+LIVE_EVENT_RETRY_BACKOFF_SECONDS = list(_les.get('retry_backoff_seconds', [30, 120, 300, 900, 3600]))
+LIVE_EVENT_DAILY_DATA_CAP_MB = int(_les.get('daily_data_cap_mb', 0))
+LIVE_EVENT_NOTIFY_WEBHOOK_URL = str(_les.get('notify_webhook_url', '') or '')
+
 # RecentClips Archive Configuration
 _archive = config.get('archive', {})
 ARCHIVE_ENABLED = bool(_archive.get('enabled', True))

--- a/scripts/web/helpers/refresh_cloud_token.py
+++ b/scripts/web/helpers/refresh_cloud_token.py
@@ -43,6 +43,7 @@ logger = logging.getLogger(__name__)
 # overlapping invocations.
 _ARCHIVE_TIMEOUT_SECONDS = 5 * 60   # 5 min — RecentClips is small
 _INDEX_TIMEOUT_SECONDS = 120        # 2 min — front-cam priority enqueues first
+_LIVE_EVENT_TIMEOUT_SECONDS = 10 * 60  # 10 min — Sentry events are ~6 small clips
 _HTTP_TIMEOUT_SECONDS = 10
 _WEB_BASE = "http://localhost"
 
@@ -158,6 +159,46 @@ def _trigger_cloud_sync() -> None:
         logger.warning("Cloud sync trigger failed: %s", e)
 
 
+def _wake_live_event_sync() -> None:
+    """Poke the Live Event Sync worker so it drains BEFORE cloud sync starts.
+
+    LES is the priority subsystem when both want WiFi. The endpoint is a
+    no-op when LES is disabled.
+    """
+    try:
+        result = _http_post_json("/api/live_events/wake")
+        logger.info("LES wake: enabled=%s", result.get("enabled"))
+    except Exception as e:  # noqa: BLE001
+        logger.debug("LES wake skipped: %s", e)
+
+
+def _wait_for_live_event_drain(deadline_seconds: float) -> None:
+    """Bounded poll until the LES queue is empty (or deadline elapses).
+
+    Live events take strict priority over cloud_archive: we wait for
+    them to drain before triggering cloud sync. Cap the wait so a long
+    cellular outage doesn't block cloud_archive forever.
+    """
+    deadline = time.monotonic() + deadline_seconds
+    while time.monotonic() < deadline:
+        try:
+            status = _http_get_json("/api/live_events/status")
+            if not status.get("enabled"):
+                return
+            counts = status.get("queue_counts") or {}
+            pending = (counts.get("pending", 0) or 0) + (counts.get("uploading", 0) or 0)
+            if pending == 0 and not status.get("running"):
+                logger.info("LES queue idle.")
+                return
+        except Exception as e:  # noqa: BLE001
+            logger.warning("LES status poll failed (will retry): %s", e)
+        time.sleep(3)
+    logger.info(
+        "LES queue still has work after %.0fs — moving on.",
+        deadline_seconds,
+    )
+
+
 def main() -> int:
     from services.video_service import get_teslacam_path
 
@@ -176,7 +217,12 @@ def main() -> int:
     except Exception as e:  # noqa: BLE001
         logger.warning("Mount refresh failed (non-fatal): %s", e)
 
-    # Step 2: Trigger RecentClips → SD-card archive in the long-lived
+    # Step 2: Wake the Live Event Sync worker IMMEDIATELY so any
+    # queued sentry/save events start uploading right away. LES gets
+    # priority over cloud_archive when both want WiFi.
+    _wake_live_event_sync()
+
+    # Step 3: Trigger RecentClips → SD-card archive in the long-lived
     # gadget_web process. (Older versions of this script started the
     # archive thread in the dispatcher process directly, which meant
     # the daemon thread died as soon as the script exited.)
@@ -184,7 +230,7 @@ def main() -> int:
     if started:
         _wait_for_recent_archive(_ARCHIVE_TIMEOUT_SECONDS)
 
-    # Step 3: Bounded wait for the indexing queue to drain. The
+    # Step 4: Bounded wait for the indexing queue to drain. The
     # archive run above pre-enqueues each newly archived clip (with
     # a short defer to avoid racing the inline parse), so by the
     # time we reach this point the queue should be very small. Cap
@@ -193,7 +239,11 @@ def main() -> int:
     # on the next dispatcher fire.
     _wait_for_index_drain(_INDEX_TIMEOUT_SECONDS)
 
-    # Step 4: Trigger cloud sync. Same daemon-thread-lifetime reason
+    # Step 5: Bounded wait for LES to drain so cloud sync doesn't
+    # contend with it for the upload bandwidth or the task_coordinator.
+    _wait_for_live_event_drain(_LIVE_EVENT_TIMEOUT_SECONDS)
+
+    # Step 6: Trigger cloud sync. Same daemon-thread-lifetime reason
     # — done via the long-lived gadget_web process.
     _trigger_cloud_sync()
 

--- a/scripts/web/helpers/refresh_cloud_token.py
+++ b/scripts/web/helpers/refresh_cloud_token.py
@@ -173,11 +173,32 @@ def _wake_live_event_sync() -> None:
 
 
 def _wait_for_live_event_drain(deadline_seconds: float) -> None:
-    """Bounded poll until the LES queue is empty (or deadline elapses).
+    """Bounded poll until LES has no *ready* work (or deadline elapses).
 
     Live events take strict priority over cloud_archive: we wait for
     them to drain before triggering cloud sync. Cap the wait so a long
     cellular outage doesn't block cloud_archive forever.
+
+    "Drained" here means LES has nothing it could be doing right now —
+    not necessarily an empty queue. We use the server-side
+    ``has_ready_work`` flag (which already drives cloud_archive's
+    yielding logic) as the source of truth: a row that is ``pending``
+    but in backoff (``next_retry_at`` in the future), over the retry
+    cap, or paused for the daily data cap should NOT block
+    cloud_archive for the full 10-minute deadline.
+
+    The queue is treated as drained when:
+
+      * ``has_ready_work`` is False, AND
+      * nothing is currently in flight (``uploading == 0``), AND
+      * the worker is not actively processing a row (``running``
+        is falsy).
+
+    Legacy fallback: if the server response predates this field
+    (e.g. user hasn't restarted ``gadget_web`` after upgrading), we
+    keep the old ``pending + uploading == 0`` behaviour so an
+    out-of-date server doesn't accidentally let cloud_archive race
+    LES.
     """
     deadline = time.monotonic() + deadline_seconds
     while time.monotonic() < deadline:
@@ -186,10 +207,20 @@ def _wait_for_live_event_drain(deadline_seconds: float) -> None:
             if not status.get("enabled"):
                 return
             counts = status.get("queue_counts") or {}
-            pending = (counts.get("pending", 0) or 0) + (counts.get("uploading", 0) or 0)
-            if pending == 0 and not status.get("running"):
-                logger.info("LES queue idle.")
-                return
+            uploading = counts.get("uploading", 0) or 0
+            running = bool(status.get("running"))
+            if 'has_ready_work' in status:
+                if (not status.get("has_ready_work", False)
+                        and uploading == 0
+                        and not running):
+                    logger.info("LES has no ready work.")
+                    return
+            else:
+                # Out-of-date server (no has_ready_work field yet).
+                pending = (counts.get("pending", 0) or 0) + uploading
+                if pending == 0 and not running:
+                    logger.info("LES queue idle (legacy semantics).")
+                    return
         except Exception as e:  # noqa: BLE001
             logger.warning("LES status poll failed (will retry): %s", e)
         time.sleep(3)

--- a/scripts/web/services/cloud_archive_service.py
+++ b/scripts/web/services/cloud_archive_service.py
@@ -420,10 +420,18 @@ def _discover_events(
 # Credential Handling
 # ---------------------------------------------------------------------------
 
-def _write_rclone_conf(provider: str, creds: dict) -> str:
+def _write_rclone_conf(provider: str, creds: dict,
+                       conf_name: Optional[str] = None) -> str:
     """Write a temporary rclone.conf to tmpfs and return its path.
 
-    The caller is responsible for deleting the file after use.
+    The caller is responsible for deleting the file after use by passing
+    the returned path to :func:`_remove_rclone_conf`.
+
+    ``conf_name`` lets callers pin a unique filename so cloud_archive
+    and Live Event Sync don't collide on the shared tmpfs path during a
+    yield/re-acquire cycle. When omitted the legacy fixed path
+    ``/run/teslausb/rclone.conf`` is used (preserves existing
+    cloud_archive behavior; LES MUST pass a unique name).
     """
     os.makedirs(_RCLONE_TMPFS_DIR, exist_ok=True)
 
@@ -433,7 +441,12 @@ def _write_rclone_conf(provider: str, creds: dict) -> str:
     for key, value in creds.items():
         lines.append(f"{key} = {value}")
 
-    conf_path = _RCLONE_CONF_PATH
+    if conf_name:
+        # Disallow path traversal — only a bare filename is acceptable.
+        safe_name = os.path.basename(conf_name)
+        conf_path = os.path.join(_RCLONE_TMPFS_DIR, safe_name)
+    else:
+        conf_path = _RCLONE_CONF_PATH
     fd = os.open(conf_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
     try:
         os.write(fd, "\n".join(lines).encode("utf-8"))
@@ -443,10 +456,17 @@ def _write_rclone_conf(provider: str, creds: dict) -> str:
     return conf_path
 
 
-def _remove_rclone_conf() -> None:
-    """Delete the tmpfs rclone config if it exists."""
+def _remove_rclone_conf(conf_path: Optional[str] = None) -> None:
+    """Delete the tmpfs rclone config if it exists.
+
+    When ``conf_path`` is omitted the legacy fixed path is removed. LES
+    MUST pass the explicit path it received from
+    :func:`_write_rclone_conf` so a yield from cloud_archive doesn't
+    accidentally delete cloud_archive's still-in-use config.
+    """
+    target = conf_path or _RCLONE_CONF_PATH
     try:
-        os.remove(_RCLONE_CONF_PATH)
+        os.remove(target)
     except FileNotFoundError:
         pass
 
@@ -604,6 +624,112 @@ def _is_wifi_connected() -> bool:
     except Exception:
         pass
     return False
+
+
+# ---------------------------------------------------------------------------
+# Reusable rclone upload helper (shared with Live Event Sync)
+# ---------------------------------------------------------------------------
+
+# Memory-safe rclone flags for Pi Zero 2 W. Module-level constant so both
+# the cloud-sync loop and the Live Event Sync worker pin the same envelope.
+RCLONE_MEM_FLAGS: List[str] = [
+    "--buffer-size", "0",
+    "--transfers", "1",
+    "--checkers", "1",
+]
+
+
+def upload_path_via_rclone(
+    local_path: str,
+    remote_dest: str,
+    conf_path: str,
+    max_upload_mbps: int,
+    timeout_seconds: int = 3600,
+    proc_callback=None,
+    mem_flags: Optional[List[str]] = None,
+) -> Tuple[int, str]:
+    """Upload a file or directory via rclone, returning (returncode, stderr).
+
+    Picks ``copyto`` for files and ``copy`` for directories. Wraps the
+    call in ``nice -n 19`` + ``ionice -c 3`` so the gadget endpoint and
+    web service stay responsive.
+
+    The caller passes a ``proc_callback`` to track the live subprocess for
+    cancellation: it is invoked with the ``subprocess.Popen`` instance
+    immediately after spawn, and again with ``None`` when the process
+    exits. Pass ``None`` to disable tracking.
+
+    Designed for one upload at a time. The Pi Zero 2 W cannot afford
+    parallel rclone subprocesses, so callers must ensure only one
+    upload is in flight via the global task_coordinator.
+    """
+    if mem_flags is None:
+        mem_flags = RCLONE_MEM_FLAGS
+
+    is_single_file = os.path.isfile(local_path)
+    rclone_cmd = "copyto" if is_single_file else "copy"
+
+    proc: Optional[subprocess.Popen] = None
+    try:
+        proc = subprocess.Popen(
+            [
+                "nice", "-n", "19",
+                "ionice", "-c", "3",
+                "rclone", rclone_cmd,
+                "--config", conf_path,
+                "--bwlimit", f"{max_upload_mbps}M",
+                "--size-only",
+                "--stats", "0",
+                "--log-level", "ERROR",
+                *mem_flags,
+                local_path,
+                remote_dest,
+            ],
+            # stdout → DEVNULL: rclone prints nothing useful with
+            # --stats 0 and --log-level ERROR, and capturing it would
+            # accumulate in Python memory against the Pi Zero 2 W
+            # peak-RSS budget on long uploads.
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        if proc_callback is not None:
+            try:
+                proc_callback(proc)
+            except Exception as e:
+                logger.warning("proc_callback raised: %s", e)
+        try:
+            _, stderr = proc.communicate(timeout=timeout_seconds)
+            returncode = proc.returncode
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.communicate()
+            returncode = -1
+            stderr = f"Upload timed out ({timeout_seconds}s)"
+    finally:
+        if proc_callback is not None:
+            try:
+                proc_callback(None)
+            except Exception:
+                pass
+
+    # Cap stderr to a bounded tail so a chatty rclone failure can't
+    # blow the Pi Zero 2 W RSS budget. 8 KB is plenty of context for
+    # diagnosing the failure; longer outputs are truncated.
+    out = stderr or ""
+    if len(out) > 8192:
+        out = "...(truncated)...\n" + out[-8000:]
+    return returncode, out
+
+
+# Public re-exports for shared use by the Live Event Sync subsystem.
+# Underscore-prefixed names are kept for internal call-sites that already
+# use them; the public aliases just remove the underscore so other
+# services can ``from services.cloud_archive_service import ...`` cleanly.
+write_rclone_conf = _write_rclone_conf
+remove_rclone_conf = _remove_rclone_conf
+load_provider_creds = _load_provider_creds
+is_wifi_connected = _is_wifi_connected
 
 
 # ---------------------------------------------------------------------------
@@ -824,42 +950,23 @@ def _run_sync(
             )
             _fsync_db(conn)
 
-            # Use rclone copy for event directories, copyto for single files
-            # (ArchivedClips are individual files, not directories)
-            is_single_file = os.path.isfile(event_dir)
-            rclone_cmd = "copyto" if is_single_file else "copy"
+            # Use the shared rclone helper. It handles copy-vs-copyto,
+            # nice/ionice, bwlimit, timeout, and stderr capture.
+            # Default size+mtime check catches partial uploads.
+            def _track_proc(proc):
+                global _sync_rclone_proc
+                _sync_rclone_proc = proc
 
-            # Use ionice to give rclone lowest I/O priority so the USB
-            # gadget and web service stay responsive during uploads.
-            # Default size+mtime check catches partial uploads (no --ignore-existing).
             try:
-                _sync_rclone_proc = subprocess.Popen(
-                    [
-                        "nice", "-n", "19",
-                        "ionice", "-c", "3",
-                        "rclone", rclone_cmd,
-                        "--config", conf_path,
-                        "--bwlimit", f"{max_mbps}M",
-                        "--size-only",
-                        "--stats", "0",
-                        "--log-level", "ERROR",
-                        *mem_flags,
-                        event_dir,
-                        remote_dest,
-                    ],
-                    stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-                    text=True,
+                returncode, stderr = upload_path_via_rclone(
+                    event_dir,
+                    remote_dest,
+                    conf_path,
+                    max_mbps,
+                    timeout_seconds=3600,
+                    proc_callback=_track_proc,
+                    mem_flags=mem_flags,
                 )
-                try:
-                    stdout, stderr = _sync_rclone_proc.communicate(timeout=3600)
-                    returncode = _sync_rclone_proc.returncode
-                except subprocess.TimeoutExpired:
-                    _sync_rclone_proc.kill()
-                    _sync_rclone_proc.communicate()
-                    returncode = -1
-                    stderr = "Upload timed out (1h)"
-                finally:
-                    _sync_rclone_proc = None
 
                 if cancel_event.is_set():
                     # Process was killed by stop_sync — don't mark as failed
@@ -907,9 +1014,6 @@ def _run_sync(
                     )
                     _fsync_db(conn)
 
-            except subprocess.TimeoutExpired:
-                # Handled inside Popen.communicate above
-                pass
             except Exception as e:
                 logger.error("Sync: %s error: %s", rel_path, e)
                 conn.execute(
@@ -920,6 +1024,48 @@ def _run_sync(
                     (str(e)[:255], rel_path)
                 )
                 _fsync_db(conn)
+
+            # Yield to Live Event Sync if it has READY pending event work.
+            # LES gets priority over normal cloud_archive uploads when both
+            # want WiFi. The helper checks status, next_retry_at, attempts,
+            # and the daily data cap so a stuck row never blocks us forever.
+            try:
+                from services.live_event_sync_service import (
+                    has_ready_live_event_work,
+                )
+                _les_pending = has_ready_live_event_work(db_path)
+            except Exception:
+                _les_pending = False
+            if _les_pending:
+                logger.info(
+                    "Cloud sync yielding to Live Event Sync (queue has ready events)",
+                )
+                # Drop the heavy-task lock so LES worker can grab it.
+                # We re-acquire on the next loop iteration.
+                from services.task_coordinator import (
+                    acquire_task as _acq, release_task as _rel,
+                )
+                _rel('cloud_sync')
+                # Wait for LES to drain (or up to 5 minutes per yield).
+                yield_deadline = time.time() + 300
+                while time.time() < yield_deadline:
+                    if cancel_event.is_set():
+                        break
+                    time.sleep(2)
+                    try:
+                        if not has_ready_live_event_work(db_path):
+                            break
+                    except Exception:
+                        break
+                # Re-acquire the lock; if a different task grabbed it
+                # while we yielded, we treat that as cooperative and
+                # bail out — the next dispatcher fire will resume.
+                if not _acq('cloud_sync'):
+                    logger.info(
+                        "Cloud sync: another task acquired lock during yield; "
+                        "stopping this run (will resume on next trigger)",
+                    )
+                    break
 
             # Pause between uploads to let the system breathe
             time.sleep(_INTER_UPLOAD_SLEEP)
@@ -1155,6 +1301,10 @@ def trigger_auto_sync(teslacam_path: str, db_path: str) -> None:
 
     Checks that cloud archive is enabled, no sync is already running,
     and WiFi (not AP-only) is connected before starting.
+
+    Skips when the Live Event Sync queue has pending events: LES gets
+    priority when both subsystems want WiFi. Cloud sync will resume on
+    the next dispatcher fire after LES drains.
     """
     if not CLOUD_ARCHIVE_ENABLED:
         return
@@ -1165,6 +1315,20 @@ def trigger_auto_sync(teslacam_path: str, db_path: str) -> None:
     if not _is_wifi_connected():
         logger.debug("Auto-sync skipped: WiFi not connected")
         return
+
+    # Yield to Live Event Sync if it has READY pending event work. Uses
+    # the LES helper so backoff/data-cap/exhausted-retry rows don't
+    # suppress cloud sync forever.
+    try:
+        from services.live_event_sync_service import has_ready_live_event_work
+        if has_ready_live_event_work(db_path):
+            logger.info(
+                "Cloud sync auto-trigger skipped: Live Event Sync has "
+                "ready events (will resume after LES drains)",
+            )
+            return
+    except Exception as e:
+        logger.debug("LES ready-work check failed (continuing): %s", e)
 
     ok, msg = start_sync(teslacam_path, db_path, trigger="auto")
     if ok:

--- a/scripts/web/services/cloud_archive_service.py
+++ b/scripts/web/services/cloud_archive_service.py
@@ -463,8 +463,32 @@ def _remove_rclone_conf(conf_path: Optional[str] = None) -> None:
     MUST pass the explicit path it received from
     :func:`_write_rclone_conf` so a yield from cloud_archive doesn't
     accidentally delete cloud_archive's still-in-use config.
+
+    Defense in depth (I-5): the resolved ``conf_path`` must lie inside
+    :data:`_RCLONE_TMPFS_DIR`. All current callers derive their path
+    from :func:`_write_rclone_conf` (which scopes to that directory),
+    so this check is a no-op today; it guarantees a future caller can
+    never turn this helper into an arbitrary-file-delete primitive.
     """
     target = conf_path or _RCLONE_CONF_PATH
+    try:
+        target_real = os.path.realpath(target)
+        dir_real = os.path.realpath(_RCLONE_TMPFS_DIR)
+        if os.path.commonpath([dir_real, target_real]) != dir_real:
+            logger.warning(
+                "Refusing to remove rclone conf outside %s: %s",
+                dir_real, target,
+            )
+            return
+    except ValueError:
+        # commonpath raises ValueError when paths are on different
+        # drives (Windows) or otherwise can't be compared. Refuse
+        # rather than risk an unintended delete.
+        logger.warning(
+            "Refusing to remove rclone conf with unresolvable path: %s",
+            target,
+        )
+        return
     try:
         os.remove(target)
     except FileNotFoundError:

--- a/scripts/web/services/file_watcher_service.py
+++ b/scripts/web/services/file_watcher_service.py
@@ -86,6 +86,7 @@ _status = {
 # Callbacks registered by other services
 _on_new_file_callbacks: List[Callable] = []
 _on_deleted_file_callbacks: List[Callable] = []
+_on_event_json_callbacks: List[Callable] = []
 
 
 def register_callback(callback: Callable):
@@ -104,6 +105,18 @@ def register_delete_callback(callback: Callable):
     RecentClips circular buffer or the user deletes archived clips.
     """
     _on_deleted_file_callbacks.append(callback)
+
+
+def register_event_json_callback(callback: Callable):
+    """Register a callback for `event.json` arrivals.
+
+    Callback signature: callback(file_paths: List[str])
+    Fired when Tesla writes a new ``event.json`` (Sentry/Saved events).
+    Separate from ``register_callback`` (mp4-only, used by the indexer)
+    so the Live Event Sync subsystem can react to event metadata
+    without being coupled to the indexing path.
+    """
+    _on_event_json_callbacks.append(callback)
 
 
 def get_watcher_status() -> dict:
@@ -247,6 +260,30 @@ def _notify_delete_callbacks(deleted_files: List[str], my_generation: int):
             logger.error("Watcher delete callback error: %s", e)
 
 
+def _notify_event_json_callbacks(paths: List[str], my_generation: int):
+    """Notify event.json subscribers if our generation is current.
+
+    Tesla writes event.json atomically when a Sentry/Saved event finishes
+    recording, so consumers (the Live Event Sync worker) can react
+    immediately — we deliberately do NOT apply the 60s file-age gate
+    that we use for .mp4 files.
+    """
+    if not paths:
+        return
+    if my_generation != _watcher_generation:
+        logger.debug("Dropping %d event.json callbacks (stale generation)",
+                     len(paths))
+        return
+    _status["event_json_detected"] = (
+        _status.get("event_json_detected", 0) + len(paths)
+    )
+    for cb in _on_event_json_callbacks:
+        try:
+            cb(paths)
+        except Exception as e:
+            logger.error("Watcher event.json callback error: %s", e)
+
+
 def _scan_for_new_files(paths: List[str], known_files: Set[str]) -> List[str]:
     """Scan directories for new .mp4 files not in known_files set.
 
@@ -300,6 +337,42 @@ def _scan_for_new_files(paths: List[str], known_files: Set[str]) -> List[str]:
     return new_files
 
 
+def _scan_for_new_event_json(paths: List[str],
+                              known_event_json: Set[str]) -> List[str]:
+    """Scan event subdirectories for new event.json files.
+
+    Used by the polling fallback (when inotify is unavailable). Tesla
+    writes event.json atomically when an event finishes recording, so
+    no age gate is applied. Looks at SentryClips/<event>/event.json
+    and SavedClips/<event>/event.json patterns; quietly ignores
+    everything else.
+    """
+    new_event_jsons: List[str] = []
+    for base_path in paths:
+        if not os.path.isdir(base_path):
+            continue
+        try:
+            for entry in os.scandir(base_path):
+                if not entry.is_dir(follow_symlinks=False):
+                    continue
+                # entry is e.g. SentryClips/, SavedClips/
+                try:
+                    for sub in os.scandir(entry.path):
+                        if not sub.is_dir(follow_symlinks=False):
+                            continue
+                        # sub is the per-event folder
+                        ej = os.path.join(sub.path, 'event.json')
+                        if (ej not in known_event_json
+                                and os.path.isfile(ej)):
+                            new_event_jsons.append(ej)
+                            known_event_json.add(ej)
+                except PermissionError:
+                    pass
+        except (PermissionError, OSError):
+            pass
+    return new_event_jsons
+
+
 def _parse_inotify_events(data: bytes, wd_map: dict):
     """Yield ``(full_path, mask)`` tuples from a buffer of ``inotify_event``
     structs.
@@ -329,6 +402,7 @@ def _parse_inotify_events(data: bytes, wd_map: dict):
 
 
 def _try_inotify(paths: List[str], known_files: Set[str],
+                 known_event_json: Set[str],
                  my_generation: int) -> bool:
     """Try to use inotify for real-time monitoring. Returns False if unavailable."""
     try:
@@ -391,6 +465,7 @@ def _try_inotify(paths: List[str], known_files: Set[str],
                     break
 
                 deletions: List[str] = []
+                event_json_arrivals: List[str] = []
                 if ready:
                     try:
                         data = os.read(fd, buf_size)
@@ -422,8 +497,36 @@ def _try_inotify(paths: List[str], known_files: Set[str],
                                             "Added inotify watch for "
                                             "new subdir %s", full_path,
                                         )
+                                    # Race-safe scan: if Tesla wrote
+                                    # event.json into the subdir BEFORE
+                                    # our watch was attached we'd miss
+                                    # the IN_CLOSE_WRITE. Cheap one-off
+                                    # readdir surfaces it now.
+                                    try:
+                                        ej_now = os.path.join(
+                                            full_path, 'event.json',
+                                        )
+                                        if (os.path.isfile(ej_now)
+                                                and ej_now not in known_event_json
+                                                and _on_event_json_callbacks):
+                                            event_json_arrivals.append(ej_now)
+                                            known_event_json.add(ej_now)
+                                    except OSError:
+                                        pass
                             except OSError:
                                 pass
+                            continue
+                        # event.json arrival → notify Live Event Sync
+                        # immediately (no 60s age gate; Tesla writes
+                        # this atomically on event finalization).
+                        if (os.path.basename(full_path) == 'event.json'
+                                and mask & (_IN_CLOSE_WRITE | _IN_MOVED_TO)
+                                and _on_event_json_callbacks):
+                            # Track in known_event_json so the periodic
+                            # rescan below doesn't re-emit it.
+                            if full_path not in known_event_json:
+                                event_json_arrivals.append(full_path)
+                                known_event_json.add(full_path)
                             continue
                         if not full_path.lower().endswith('.mp4'):
                             continue
@@ -435,11 +538,38 @@ def _try_inotify(paths: List[str], known_files: Set[str],
                     logger.info("Detected %d file deletion(s)", len(deletions))
                     _notify_delete_callbacks(deletions, my_generation)
 
+                if event_json_arrivals:
+                    logger.info(
+                        "Detected %d event.json arrival(s)",
+                        len(event_json_arrivals),
+                    )
+                    _notify_event_json_callbacks(
+                        event_json_arrivals, my_generation,
+                    )
+
                 # Periodic scan (catches files inotify missed and new subdirs)
                 new_files = _scan_for_new_files(paths, known_files)
                 if new_files:
                     logger.info("Detected %d new files", len(new_files))
                     _notify_callbacks(new_files, my_generation)
+                # Periodic event.json catch-up scan: covers cases where
+                # the watch was attached after Tesla wrote event.json,
+                # IN_CLOSE_WRITE was lost (kernel buffer overflow), or
+                # an event folder was moved in already containing
+                # event.json. Cheap directory walk; always emits via
+                # the same callback.
+                if _on_event_json_callbacks:
+                    catchup = _scan_for_new_event_json(
+                        paths, known_event_json,
+                    )
+                    if catchup:
+                        logger.info(
+                            "inotify periodic scan found %d additional "
+                            "event.json file(s)", len(catchup),
+                        )
+                        _notify_event_json_callbacks(
+                            catchup, my_generation,
+                        )
                 _status["last_scan"] = time.strftime("%Y-%m-%d %H:%M:%S")
         finally:
             try:
@@ -456,16 +586,23 @@ def _watcher_loop(my_generation: int):
     """Main watcher loop — tries inotify, falls back to polling."""
     paths = _status["watch_paths"]
     known_files: Set[str] = set()
+    known_event_json: Set[str] = set()
     scan_count = 0
 
     # Initial scan to build known file set (don't trigger callbacks for
     # existing files — only newly-arrived ones).
     _scan_for_new_files(paths, known_files)
+    # Seed the event.json baseline too, so existing events don't fire on
+    # restart. The Live Event Sync worker handles already-queued events
+    # via its own DB-backed queue.
+    _scan_for_new_event_json(paths, known_event_json)
     _status["last_scan"] = time.strftime("%Y-%m-%d %H:%M:%S")
-    logger.info("Initial scan: %d existing files tracked", len(known_files))
+    logger.info("Initial scan: %d existing files tracked, "
+                "%d existing event.json files tracked",
+                len(known_files), len(known_event_json))
 
     # Try inotify first (blocks until stop or error)
-    if _try_inotify(paths, known_files, my_generation):
+    if _try_inotify(paths, known_files, known_event_json, my_generation):
         _status["running"] = False
         return
 
@@ -482,6 +619,13 @@ def _watcher_loop(my_generation: int):
         if new_files:
             logger.info("Polling detected %d new files", len(new_files))
             _notify_callbacks(new_files, my_generation)
+
+        # Detect new event.json arrivals (Live Event Sync producer).
+        new_event_jsons = _scan_for_new_event_json(paths, known_event_json)
+        if new_event_jsons:
+            logger.info("Polling detected %d new event.json file(s)",
+                        len(new_event_jsons))
+            _notify_event_json_callbacks(new_event_jsons, my_generation)
 
         # Polling-mode delete detection: any file we knew about that no
         # longer exists is a deletion. Cheap once known_files is bounded.
@@ -505,6 +649,10 @@ def _watcher_loop(my_generation: int):
             if pruned > 0:
                 logger.info("Pruned %d stale entries from known_files (now %d)",
                             pruned, len(known_files))
+            # Also prune the event.json set
+            known_event_json = {
+                f for f in known_event_json if os.path.isfile(f)
+            }
             scan_count = 0
 
     _status["running"] = False

--- a/scripts/web/services/live_event_sync_service.py
+++ b/scripts/web/services/live_event_sync_service.py
@@ -37,6 +37,7 @@ Public API:
 
 from __future__ import annotations
 
+import fnmatch
 import json
 import logging
 import os
@@ -198,6 +199,63 @@ def _startup_recovery(conn: sqlite3.Connection) -> int:
                 "to failed", n_exhausted,
             )
     return n_uploading + n_exhausted
+
+
+def _sweep_orphaned_rclone_confs() -> int:
+    """Remove orphaned ``rclone-les-*.conf`` files left in the tmpfs dir.
+
+    The unique-per-attempt rclone config is normally cleaned up in the
+    ``finally`` block of :func:`_process_one`. If a previous worker
+    process was killed via SIGKILL (OOM, power loss before sync, etc.)
+    those finally blocks didn't run and the config file leaks under
+    ``/run/teslausb/``. The tmpfs is wiped on reboot so the leak is
+    bounded, but cleaning up at startup keeps the directory tidy and
+    matches the spirit of :func:`_startup_recovery`.
+
+    Files belonging to the current pid are left alone — they may still
+    be in use by a concurrently-running worker thread.
+
+    Returns the number of files removed. Never raises.
+    """
+    try:
+        from services.cloud_archive_service import _RCLONE_TMPFS_DIR
+    except Exception:
+        # cloud_archive_service unavailable or doesn't expose the
+        # constant — nothing to sweep.
+        return 0
+
+    try:
+        names = os.listdir(_RCLONE_TMPFS_DIR)
+    except OSError:
+        return 0
+
+    own_pid = os.getpid()
+    removed = 0
+    for name in names:
+        if not fnmatch.fnmatch(name, 'rclone-les-*.conf'):
+            continue
+        # Filename pattern: rclone-les-<pid>-<tid>.conf
+        try:
+            mid = name[len('rclone-les-'):-len('.conf')]
+            pid_str = mid.split('-', 1)[0]
+            file_pid = int(pid_str)
+        except (ValueError, IndexError):
+            # Doesn't match the expected pattern — leave it alone.
+            continue
+        if file_pid == own_pid:
+            continue
+        try:
+            os.remove(os.path.join(_RCLONE_TMPFS_DIR, name))
+            removed += 1
+        except OSError:
+            pass
+
+    if removed:
+        logger.info(
+            "LES startup sweep: removed %d orphaned rclone-les-*.conf file(s)",
+            removed,
+        )
+    return removed
 
 
 def _prune_old_uploaded(conn: sqlite3.Connection,
@@ -439,6 +497,12 @@ def _record_attempt_start(conn: sqlite3.Connection, row_id: int) -> int:
     we actually invoke rclone. The returned value is the authoritative
     attempt number to use for retry-exhaustion decisions in
     :func:`_mark_failed`.
+
+    Returns 0 if the row no longer exists (caller must treat as
+    already-deleted and skip). This can happen if an operator runs
+    ``DELETE FROM live_event_queue`` while a worker is mid-claim;
+    returning 0 prevents the caller from recording a phantom failure
+    against a non-existent row.
     """
     conn.execute(
         "UPDATE live_event_queue SET attempts = attempts + 1 WHERE id = ?",
@@ -449,7 +513,7 @@ def _record_attempt_start(conn: sqlite3.Connection, row_id: int) -> int:
         "SELECT attempts FROM live_event_queue WHERE id = ?",
         (row_id,),
     ).fetchone()
-    return int(row['attempts']) if row else 1
+    return int(row['attempts']) if row else 0
 
 
 def _mark_uploaded(conn: sqlite3.Connection, row_id: int,
@@ -825,6 +889,11 @@ _TRANSIENT_NO_MP4_MAX_AGE_SECONDS = 30 * 60   # 30 min
 # How long to wait before re-checking when MP4s are still appearing.
 _TRANSIENT_RETRY_SECONDS = 60
 
+# Max age of event.json mtime to enqueue from the startup catch-up
+# scan. Prevents re-enabling LES from triggering uploads of historical
+# events the user didn't intend.
+LIVE_EVENT_CATCHUP_MAX_AGE_DAYS = 7
+
 
 def _enqueue_age_seconds(enqueued_at: Optional[str]) -> float:
     """Best-effort age-since-enqueue in seconds."""
@@ -841,13 +910,17 @@ def _enqueue_age_seconds(enqueued_at: Optional[str]) -> float:
 
 
 def _process_one(conn: sqlite3.Connection, row: Dict,
-                 cancel_event: threading.Event) -> Tuple[bool, str, int, bool]:
+                 cancel_event: threading.Event) -> Tuple[bool, str, int, bool, int]:
     """Upload one event.
 
-    Returns ``(success, error_msg, bytes_uploaded, transient)``. When
-    ``transient`` is True the caller should requeue without consuming
-    a retry attempt — used for the "MP4s aren't fully written yet" case
-    so we never permanently fail an event because we raced Tesla.
+    Returns ``(success, error_msg, bytes_uploaded, transient,
+    files_uploaded)``. When ``transient`` is True the caller should
+    requeue without consuming a retry attempt — used for the "MP4s
+    aren't fully written yet" case so we never permanently fail an
+    event because we raced Tesla. ``files_uploaded`` is the number of
+    files actually transferred to the cloud (0 on failure / transient
+    defer); the caller reuses it for the webhook payload to avoid
+    re-scanning the event directory.
     """
     from services.cloud_archive_service import (
         load_provider_creds, write_rclone_conf, remove_rclone_conf,
@@ -856,7 +929,7 @@ def _process_one(conn: sqlite3.Connection, row: Dict,
 
     event_dir = row['event_dir']
     if not os.path.isdir(event_dir):
-        return False, "Event directory missing", 0, False
+        return False, "Event directory missing", 0, False, 0
 
     # Refresh the RO mount once before file selection so we see Tesla's
     # latest writes (kernel caches the loop-mount view otherwise).
@@ -882,17 +955,17 @@ def _process_one(conn: sqlite3.Connection, row: Dict,
     if mp4_count == 0:
         if age_seconds < _TRANSIENT_NO_MP4_MAX_AGE_SECONDS:
             return (False, "No MP4 clips visible yet — deferring",
-                    0, True)
+                    0, True, 0)
         # Aged out — give up so the row doesn't sit forever.
         return (False,
                 f"No MP4 clips after {int(age_seconds)}s — giving up",
-                0, False)
+                0, False, 0)
 
     creds = load_provider_creds()
     if not creds:
         # Treat as transient — credentials may come back. Don't consume
         # an attempt for a config issue the user is likely fixing.
-        return False, "Cloud provider credentials unavailable", 0, True
+        return False, "Cloud provider credentials unavailable", 0, True, 0
 
     # Use a UNIQUE conf path so cloud_archive's yield/re-acquire cycle
     # never collides with us on the shared tmpfs file. Include thread
@@ -909,12 +982,12 @@ def _process_one(conn: sqlite3.Connection, row: Dict,
         # event_dir example: /mnt/gadget/part1-ro/TeslaCam/SentryClips/2024-05-07_14-32-10
         rel_event = _relative_event_path(event_dir)
         if rel_event is None:
-            return False, "Could not compute remote path", 0, False
+            return False, "Could not compute remote path", 0, False, 0
         remote_dir = f"teslausb:{CLOUD_ARCHIVE_REMOTE_PATH}/{rel_event}"
 
         for local_path in files:
             if cancel_event.is_set():
-                return False, "Cancelled", bytes_total, False
+                return False, "Cancelled", bytes_total, False, 0
             filename = os.path.basename(local_path)
             remote_dest = f"{remote_dir}/{filename}"
 
@@ -928,13 +1001,13 @@ def _process_one(conn: sqlite3.Connection, row: Dict,
             if returncode != 0:
                 return (False,
                         (stderr or f"rclone exit {returncode}").strip()[:500],
-                        bytes_total, False)
+                        bytes_total, False, 0)
             try:
                 bytes_total += os.path.getsize(local_path)
             except OSError:
                 pass
 
-        return True, "", bytes_total, False
+        return True, "", bytes_total, False, len(files)
     finally:
         remove_rclone_conf(conf_path)
 
@@ -998,6 +1071,17 @@ def _drain_once(cancel_event: threading.Event) -> bool:
 
             attempt_no = _record_attempt_start(conn, row['id'])
             try:
+                if attempt_no == 0:
+                    # I-3: row vanished between claim and attempt-start
+                    # (operator manually deleted from live_event_queue).
+                    # Skip it without recording a phantom failure; the
+                    # finally block below still releases the task lock.
+                    logger.warning(
+                        "LES row %d disappeared between claim and "
+                        "attempt-start; skipping", row['id'],
+                    )
+                    continue
+
                 with _status_lock:
                     _status["running"] = True
                     _status["active_event"] = row.get('event_dir')
@@ -1007,8 +1091,8 @@ def _drain_once(cancel_event: threading.Event) -> bool:
                     row['event_dir'], row.get('event_reason'),
                     attempt_no, LIVE_EVENT_RETRY_MAX_ATTEMPTS,
                 )
-                success, err, bytes_uploaded, transient = _process_one(
-                    conn, row, cancel_event,
+                success, err, bytes_uploaded, transient, files_uploaded = (
+                    _process_one(conn, row, cancel_event)
                 )
                 if success:
                     _mark_uploaded(conn, row['id'], bytes_uploaded)
@@ -1025,14 +1109,12 @@ def _drain_once(cancel_event: threading.Event) -> bool:
                     )
                     # Defer webhook delivery until after we release the
                     # task_coordinator lock (slow webhooks must not
-                    # block the indexer/cloud_archive).
+                    # block the indexer/cloud_archive). Reuse the file
+                    # count returned by _process_one rather than
+                    # re-running select_event_files() (I-1).
                     pending_webhooks.append({
                         "row": dict(row),
-                        "files_uploaded": len(select_event_files(
-                            row['event_dir'],
-                            row.get('upload_scope') or LIVE_EVENT_UPLOAD_SCOPE,
-                            row.get('event_timestamp'),
-                        )),
+                        "files_uploaded": files_uploaded,
                         "bytes_uploaded": bytes_uploaded,
                     })
                 else:
@@ -1101,6 +1183,8 @@ def _startup_catchup_scan() -> int:
     """
     if not LIVE_EVENT_SYNC_ENABLED:
         return 0
+    cutoff_seconds = LIVE_EVENT_CATCHUP_MAX_AGE_DAYS * 86400
+    now_ts = time.time()
     discovered: List[str] = []
     for root in _teslacam_roots():
         for folder in LIVE_EVENT_WATCH_FOLDERS:
@@ -1112,8 +1196,31 @@ def _startup_catchup_scan() -> int:
                     if not entry.is_dir(follow_symlinks=False):
                         continue
                     ej = os.path.join(entry.path, 'event.json')
-                    if os.path.isfile(ej):
-                        discovered.append(ej)
+                    if not os.path.isfile(ej):
+                        continue
+                    # I-4: bound the scan by event.json mtime so
+                    # re-enabling LES doesn't enqueue years of
+                    # historical events the user didn't intend to
+                    # upload.
+                    try:
+                        mtime = os.stat(ej).st_mtime
+                    except OSError:
+                        # Conservative skip: if we can't stat we can't
+                        # safely classify the age.
+                        logger.debug(
+                            "LES catchup scan stat failed for %s — skipping",
+                            ej,
+                        )
+                        continue
+                    age_seconds = now_ts - mtime
+                    if age_seconds > cutoff_seconds:
+                        logger.debug(
+                            "LES catchup scan skipping %s (age %.1fd > %dd)",
+                            ej, age_seconds / 86400,
+                            LIVE_EVENT_CATCHUP_MAX_AGE_DAYS,
+                        )
+                        continue
+                    discovered.append(ej)
             except OSError as e:
                 logger.debug("LES catchup scan skipped %s: %s", base, e)
     if not discovered:
@@ -1142,6 +1249,14 @@ def _worker_loop() -> None:
             conn.close()
     except Exception as e:
         logger.error("LES startup recovery failed: %s", e)
+
+    # Sweep orphaned rclone-les-*.conf files left behind by previous
+    # worker processes that didn't run their finally blocks (SIGKILL,
+    # OOM, power loss before sync, etc.). I-2.
+    try:
+        _sweep_orphaned_rclone_confs()
+    except Exception as e:
+        logger.error("LES startup rclone-conf sweep failed: %s", e)
 
     # One-shot catch-up scan: enqueue any event.json files already on
     # disk that haven't been queued yet (LES was disabled previously,

--- a/scripts/web/services/live_event_sync_service.py
+++ b/scripts/web/services/live_event_sync_service.py
@@ -47,6 +47,7 @@ import threading
 import time
 import urllib.error
 import urllib.request
+from urllib.parse import urlparse
 from datetime import datetime, timezone
 from typing import Dict, List, Optional, Tuple
 
@@ -746,6 +747,23 @@ def _post_webhook(event_row: Dict, files_uploaded: int,
     url = LIVE_EVENT_NOTIFY_WEBHOOK_URL
     if not url:
         return
+    # Defence-in-depth: urllib.request.urlopen will happily honor
+    # file://, ftp://, data://, etc. The webhook URL is admin-supplied
+    # via config.yaml so this is a typo-defense, not an external
+    # exploit vector — but we restrict to http/https either way.
+    try:
+        scheme = (urlparse(url).scheme or '').lower()
+    except Exception:  # noqa: BLE001
+        scheme = ''
+    if scheme not in ('http', 'https'):
+        if not getattr(_post_webhook, '_warned_bad_scheme', False):
+            logger.warning(
+                "LES webhook URL has unsupported scheme %r (must be "
+                "http or https); skipping delivery.",
+                scheme,
+            )
+            _post_webhook._warned_bad_scheme = True  # type: ignore[attr-defined]
+        return
     raw_dir = event_row.get('event_dir') or ''
     rel = _relative_event_path(raw_dir) or os.path.basename(
         raw_dir.rstrip('/').rstrip('\\'),
@@ -1233,6 +1251,15 @@ def get_status() -> Dict:
             conn.close()
     except Exception as e:
         snapshot['queue_counts'] = {'error': str(e)[:200]}
+
+    # Surface the cross-subsystem coordination signal so the
+    # WiFi-connect dispatcher's drain wait can yield correctly when
+    # the only remaining rows are in backoff / over the retry cap /
+    # blocked by the daily data cap.
+    try:
+        snapshot['has_ready_work'] = has_ready_live_event_work()
+    except Exception:
+        snapshot['has_ready_work'] = False
 
     return snapshot
 

--- a/scripts/web/services/live_event_sync_service.py
+++ b/scripts/web/services/live_event_sync_service.py
@@ -1,0 +1,1259 @@
+"""
+TeslaUSB Live Event Sync Service (LES).
+
+Real-time uploader for Sentry/Saved events. When Tesla writes a new
+``event.json``, this service enqueues the surrounding camera files and
+uploads them to the configured cloud provider as soon as WiFi is
+available — without waiting for the bulk ``cloud_archive_service``
+sync to run.
+
+Design constraints (Pi Zero 2 W, 512 MB RAM):
+
+* **Zero impact on the USB gadget endpoint.** Never touches mounts,
+  loop devices, the gadget config, or the quick_edit lock.
+* **One additional thread**, blocked on ``threading.Event.wait()`` when
+  idle (no polling). Idle CPU < 0.1%.
+* **No heavy imports** — only ``sqlite3``, ``os``, ``subprocess``,
+  ``threading``, ``json``, ``re``, ``time``, ``urllib``. No
+  ``cv2``/``av``/``PIL``/``numpy``/``requests`` anywhere in the LES
+  code path.
+* **One rclone subprocess at a time, ever.** Coordinates with the
+  bulk cloud sync via the global ``task_coordinator``; LES gets
+  priority when both want WiFi.
+* **Persistent across WiFi outages.** Queue rows survive reboots.
+  ``startup_recovery`` resets stale ``uploading`` rows to ``pending``.
+* **Failure containment.** Exceptions are caught at the worker loop
+  boundary and logged; LES failure must never take down
+  ``gadget_web.service``.
+
+Public API:
+
+* :func:`start` / :func:`stop`            — lifecycle control
+* :func:`enqueue_event_json` / :func:`enqueue_event_dir` — producers
+* :func:`wake`                            — used by the WiFi-connect dispatcher
+* :func:`get_status`                      — for the status API blueprint
+* :func:`retry_failed`                    — for the manual retry endpoint
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import sqlite3
+import subprocess
+import threading
+import time
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from typing import Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Configuration imports
+# ---------------------------------------------------------------------------
+
+from config import (
+    CLOUD_ARCHIVE_DB_PATH,
+    CLOUD_ARCHIVE_PROVIDER,
+    CLOUD_ARCHIVE_REMOTE_PATH,
+    CLOUD_ARCHIVE_MAX_UPLOAD_MBPS,
+    CLOUD_PROVIDER_CREDS_PATH,
+    LIVE_EVENT_SYNC_ENABLED,
+    LIVE_EVENT_WATCH_FOLDERS,
+    LIVE_EVENT_UPLOAD_SCOPE,
+    LIVE_EVENT_RETRY_MAX_ATTEMPTS,
+    LIVE_EVENT_RETRY_BACKOFF_SECONDS,
+    LIVE_EVENT_DAILY_DATA_CAP_MB,
+    LIVE_EVENT_NOTIFY_WEBHOOK_URL,
+)
+
+# ---------------------------------------------------------------------------
+# Module state — kept tiny so the worker thread RSS stays under 2 MB.
+# ---------------------------------------------------------------------------
+
+_worker_thread: Optional[threading.Thread] = None
+_worker_lock = threading.Lock()
+_worker_stop = threading.Event()
+
+# Wake the worker on enqueue, WiFi-connect, or shutdown. ``Event.wait()``
+# blocks the worker between events; setting this triggers a single
+# drain pass.
+_wake = threading.Event()
+
+# Tracks the currently-active rclone subprocess so :func:`stop` can
+# terminate it on shutdown.
+_active_proc_lock = threading.Lock()
+_active_proc: Optional[subprocess.Popen] = None
+
+# Last-known state, exported via :func:`get_status`. All reads/writes go
+# through ``_status_lock`` so the API thread sees a consistent snapshot.
+_status_lock = threading.Lock()
+_status: Dict = {
+    "enabled": LIVE_EVENT_SYNC_ENABLED,
+    "running": False,
+    "active_event": None,        # Event currently being uploaded
+    "last_uploaded_at": None,
+    "last_uploaded_event": None,
+    "last_error": None,
+    "last_error_at": None,
+    "data_uploaded_today_bytes": 0,
+    "data_cap_reached": False,
+}
+
+# Tesla camera angle suffix → match files by filename pattern. Using
+# CAMERA_ANGLES from config keeps this in sync with the rest of the app.
+from config import CAMERA_ANGLES
+
+# Filename minute prefix: "YYYY-MM-DD_HH-MM"
+_MINUTE_PREFIX_RE = re.compile(r'^(\d{4}-\d{2}-\d{2}_\d{2}-\d{2})')
+
+# ---------------------------------------------------------------------------
+# Database
+# ---------------------------------------------------------------------------
+
+# Live Event Sync uses its own table inside the existing cloud_sync.db
+# (NOT a separate database) so backups, integrity checks, and
+# corruption recovery already cover it.
+_LES_TABLES_SQL = """\
+CREATE TABLE IF NOT EXISTS live_event_queue (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    event_dir       TEXT    NOT NULL,
+    event_json_path TEXT    NOT NULL,
+    event_timestamp TEXT,
+    event_reason    TEXT,
+    upload_scope    TEXT    DEFAULT 'event_minute',
+    status          TEXT    DEFAULT 'pending',
+    enqueued_at     TEXT    NOT NULL,
+    uploaded_at     TEXT,
+    next_retry_at   REAL,
+    attempts        INTEGER DEFAULT 0,
+    last_error      TEXT,
+    bytes_uploaded  INTEGER DEFAULT 0,
+    UNIQUE(event_dir)
+);
+
+CREATE INDEX IF NOT EXISTS idx_les_status ON live_event_queue(status);
+CREATE INDEX IF NOT EXISTS idx_les_next_retry ON live_event_queue(next_retry_at);
+"""
+
+
+def _open_db() -> sqlite3.Connection:
+    """Open the cloud_sync.db with WAL + a short busy-timeout."""
+    conn = sqlite3.connect(CLOUD_ARCHIVE_DB_PATH, timeout=10)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA synchronous=NORMAL")
+    return conn
+
+
+def _ensure_schema(conn: sqlite3.Connection) -> None:
+    conn.executescript(_LES_TABLES_SQL)
+    conn.commit()
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _startup_recovery(conn: sqlite3.Connection) -> int:
+    """Reset stale ``uploading`` rows AND repair retry-exhausted ``pending`` rows.
+
+    * ``uploading`` rows from a crashed/restarted process → ``pending``
+      (with their attempt count preserved so we don't double-count).
+    * ``pending`` rows whose ``attempts >= retry_max_attempts`` (e.g.,
+      because a config change lowered the cap, or an older code path
+      bumped attempts speculatively) are moved to ``failed`` so they
+      stop blocking ``has_ready_live_event_work()`` forever.
+    """
+    cur = conn.execute(
+        "UPDATE live_event_queue SET status = 'pending', "
+        "last_error = COALESCE(last_error, 'Process restarted') "
+        "WHERE status = 'uploading'"
+    )
+    n_uploading = cur.rowcount
+
+    cur2 = conn.execute(
+        "UPDATE live_event_queue SET status = 'failed', "
+        "last_error = COALESCE(last_error, 'Retries exhausted at startup') "
+        "WHERE status = 'pending' AND attempts >= ?",
+        (LIVE_EVENT_RETRY_MAX_ATTEMPTS,),
+    )
+    n_exhausted = cur2.rowcount
+
+    if n_uploading or n_exhausted:
+        conn.commit()
+        if n_uploading:
+            logger.info(
+                "LES startup recovery: %d uploading rows reset to pending",
+                n_uploading,
+            )
+        if n_exhausted:
+            logger.warning(
+                "LES startup recovery: %d pending rows over retry cap moved "
+                "to failed", n_exhausted,
+            )
+    return n_uploading + n_exhausted
+
+
+def _prune_old_uploaded(conn: sqlite3.Connection,
+                        max_age_days: int = 7) -> int:
+    """Delete ``uploaded`` rows older than ``max_age_days``.
+
+    Keeps the queue table small. Cheap one-shot at startup.
+    """
+    cutoff = datetime.now(timezone.utc).timestamp() - max_age_days * 86400
+    cutoff_iso = datetime.fromtimestamp(cutoff, tz=timezone.utc).isoformat()
+    cur = conn.execute(
+        "DELETE FROM live_event_queue "
+        "WHERE status = 'uploaded' AND uploaded_at < ?",
+        (cutoff_iso,),
+    )
+    n = cur.rowcount
+    if n:
+        conn.commit()
+        logger.info("LES prune: removed %d old uploaded rows", n)
+    return n
+
+
+# ---------------------------------------------------------------------------
+# Queue ops
+# ---------------------------------------------------------------------------
+
+
+def _teslacam_roots() -> List[str]:
+    """Return all known TeslaCam mount roots (RO and RW), realpathed.
+
+    Used to verify ``event_dir`` paths fall under an actual Tesla camera
+    mount and not somewhere else on the filesystem. Cached briefly via
+    a module-level helper would be premature — these are dirt cheap
+    realpath calls and the function is only called from enqueue.
+    """
+    roots: List[str] = []
+    try:
+        from services.video_service import get_teslacam_path
+        try:
+            p = get_teslacam_path()
+            if p and os.path.isdir(p):
+                roots.append(os.path.realpath(p))
+        except Exception:
+            pass
+    except ImportError:
+        pass
+    # Fallback / additional locations: RO mount and ArchivedClips. We
+    # add all realpath-resolved candidates so symlink games can't trick
+    # the check.
+    try:
+        from config import RO_MNT_DIR
+        ro_tc = os.path.realpath(
+            os.path.join(RO_MNT_DIR, 'part1-ro', 'TeslaCam'),
+        )
+        if os.path.isdir(ro_tc) and ro_tc not in roots:
+            roots.append(ro_tc)
+    except Exception:
+        pass
+    try:
+        from config import ARCHIVE_DIR
+        ad = os.path.realpath(ARCHIVE_DIR)
+        if os.path.isdir(ad) and ad not in roots:
+            roots.append(ad)
+    except Exception:
+        pass
+    return roots
+
+
+def _is_event_in_watched_folder(event_dir: str) -> bool:
+    """Return True iff ``event_dir`` is a real Tesla event directory.
+
+    Strict containment: ``event_dir`` must resolve (via ``realpath``)
+    to a path of the form ``<teslacam_root>/<watch_folder>/<event_name>``
+    where ``watch_folder`` is one of ``LIVE_EVENT_WATCH_FOLDERS`` and
+    ``event_name`` is exactly one path component. This prevents symlink
+    escapes and rejects malformed inputs like
+    ``/tmp/SentryClips/event.json`` that contain the folder name but
+    aren't under TeslaCam.
+    """
+    if not event_dir:
+        return False
+    try:
+        real = os.path.realpath(event_dir)
+    except (OSError, ValueError):
+        return False
+    roots = _teslacam_roots()
+    if not roots:
+        # We have no anchor to validate against. Refuse rather than
+        # accept arbitrary paths — better to drop a callback than to
+        # upload from somewhere we shouldn't.
+        return False
+    for root in roots:
+        try:
+            common = os.path.commonpath([root, real])
+        except ValueError:
+            # Different drives on Windows etc. — definitely not a match.
+            continue
+        if common != root:
+            continue
+        # rel must be exactly "<watch_folder>/<event_name>" (2 components).
+        rel = os.path.relpath(real, root).replace("\\", "/")
+        parts = [p for p in rel.split("/") if p and p != '.']
+        if len(parts) != 2:
+            continue
+        if parts[0] in LIVE_EVENT_WATCH_FOLDERS:
+            return True
+    return False
+
+
+def _read_event_json(path: str) -> Tuple[Optional[str], Optional[str]]:
+    """Return ``(timestamp, reason)`` from ``event.json``, or ``(None, None)``.
+
+    Bounded read (≤ 8 KB — Tesla's event.json is ~hundreds of bytes).
+    """
+    try:
+        with open(path, 'r', encoding='utf-8') as f:
+            blob = f.read(8192)
+        data = json.loads(blob)
+        return (data.get('timestamp'), data.get('reason'))
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError) as e:
+        logger.debug("Could not parse %s: %s", path, e)
+        return (None, None)
+
+
+def enqueue_event_json(event_json_paths: List[str]) -> int:
+    """Producer: enqueue events from a list of ``event.json`` paths.
+
+    Used as the ``register_event_json_callback`` on the file watcher.
+    De-duplication is the queue's job: ``UNIQUE(event_dir)`` plus
+    ``INSERT OR IGNORE`` makes repeated enqueues no-ops. The caller
+    does not need to filter.
+
+    Returns the number of newly-enqueued rows.
+    """
+    if not LIVE_EVENT_SYNC_ENABLED:
+        return 0
+    if not event_json_paths:
+        return 0
+
+    inserted = 0
+    try:
+        conn = _open_db()
+        try:
+            _ensure_schema(conn)
+            now_iso = _now_iso()
+            for ej_path in event_json_paths:
+                event_dir = os.path.dirname(ej_path)
+                if not _is_event_in_watched_folder(event_dir):
+                    continue
+                if not os.path.isfile(ej_path):
+                    continue
+                ts, reason = _read_event_json(ej_path)
+                cur = conn.execute(
+                    """INSERT OR IGNORE INTO live_event_queue
+                       (event_dir, event_json_path, event_timestamp,
+                        event_reason, upload_scope, status, enqueued_at)
+                       VALUES (?, ?, ?, ?, ?, 'pending', ?)""",
+                    (event_dir, ej_path, ts, reason,
+                     LIVE_EVENT_UPLOAD_SCOPE, now_iso),
+                )
+                if cur.rowcount:
+                    inserted += 1
+                    logger.info(
+                        "LES enqueued: %s reason=%s", event_dir, reason,
+                    )
+            if inserted:
+                conn.commit()
+        finally:
+            conn.close()
+    except Exception as e:
+        # Never propagate errors back into the file watcher — that
+        # would silence MP4 callbacks for the indexer.
+        logger.error("LES enqueue_event_json failed: %s", e)
+        return 0
+
+    if inserted:
+        _wake.set()
+    return inserted
+
+
+def enqueue_event_dir(event_dir: str) -> bool:
+    """Producer: enqueue from a known event directory (manual API path)."""
+    ej = os.path.join(event_dir, 'event.json')
+    if not os.path.isfile(ej):
+        return False
+    return enqueue_event_json([ej]) > 0
+
+
+def _claim_next_pending(conn: sqlite3.Connection) -> Optional[Dict]:
+    """Return the next pending row eligible to upload, or ``None``.
+
+    Marks the row ``uploading`` so concurrent workers can't double-claim
+    it, but does NOT increment ``attempts``. The attempt counter is only
+    bumped once we hold the global ``task_coordinator`` lock AND are
+    about to invoke rclone (see :func:`_record_attempt_start`). This
+    prevents a busy task_coordinator from silently consuming retries.
+    """
+    now_ts = time.time()
+    row = conn.execute(
+        """SELECT * FROM live_event_queue
+           WHERE status = 'pending'
+             AND (next_retry_at IS NULL OR next_retry_at <= ?)
+             AND attempts < ?
+           ORDER BY enqueued_at ASC
+           LIMIT 1""",
+        (now_ts, LIVE_EVENT_RETRY_MAX_ATTEMPTS),
+    ).fetchone()
+    if row is None:
+        return None
+    cur = conn.execute(
+        "UPDATE live_event_queue SET status = 'uploading' "
+        "WHERE id = ? AND status = 'pending'",
+        (row['id'],),
+    )
+    if cur.rowcount == 0:
+        return None  # Someone else grabbed it
+    conn.commit()
+    return dict(row)
+
+
+def _release_claim_to_pending(conn: sqlite3.Connection, row_id: int) -> None:
+    """Return a claimed row to ``pending`` without consuming a retry attempt.
+
+    Used when the worker can't proceed (task_coordinator busy, WiFi
+    dropped between claim and upload, etc.). Idempotent.
+    """
+    conn.execute(
+        "UPDATE live_event_queue SET status = 'pending' "
+        "WHERE id = ? AND status = 'uploading'",
+        (row_id,),
+    )
+    conn.commit()
+
+
+def _record_attempt_start(conn: sqlite3.Connection, row_id: int) -> int:
+    """Increment ``attempts`` and return the new (post-increment) value.
+
+    Called only after we have the task_coordinator lock and just before
+    we actually invoke rclone. The returned value is the authoritative
+    attempt number to use for retry-exhaustion decisions in
+    :func:`_mark_failed`.
+    """
+    conn.execute(
+        "UPDATE live_event_queue SET attempts = attempts + 1 WHERE id = ?",
+        (row_id,),
+    )
+    conn.commit()
+    row = conn.execute(
+        "SELECT attempts FROM live_event_queue WHERE id = ?",
+        (row_id,),
+    ).fetchone()
+    return int(row['attempts']) if row else 1
+
+
+def _mark_uploaded(conn: sqlite3.Connection, row_id: int,
+                   bytes_uploaded: int) -> None:
+    conn.execute(
+        "UPDATE live_event_queue SET status = 'uploaded', "
+        "uploaded_at = ?, last_error = NULL, "
+        "bytes_uploaded = ? WHERE id = ?",
+        (_now_iso(), bytes_uploaded, row_id),
+    )
+    conn.commit()
+
+
+def _mark_failed(conn: sqlite3.Connection, row_id: int, attempts: int,
+                 err: str, transient: bool = False,
+                 retry_in_seconds: Optional[int] = None) -> None:
+    """Mark a row failed; schedule retry or move to 'failed' if exhausted.
+
+    ``attempts`` is the post-increment value (i.e., the attempt that
+    just failed). When ``transient`` is True the row is scheduled for a
+    short retry without counting against ``LIVE_EVENT_RETRY_MAX_ATTEMPTS``
+    and without changing the attempt count — used for "MP4s still being
+    written" and other recoverable wait states.
+
+    ``retry_in_seconds`` overrides the backoff schedule (used by
+    transient deferrals). When omitted the standard backoff for this
+    attempt index is used.
+    """
+    if transient:
+        backoff = retry_in_seconds if retry_in_seconds is not None else 60
+        next_retry = time.time() + backoff
+        # Roll back the attempt counter so the row isn't penalized.
+        conn.execute(
+            "UPDATE live_event_queue SET status = 'pending', "
+            "attempts = MAX(attempts - 1, 0), "
+            "last_error = ?, next_retry_at = ? WHERE id = ?",
+            (err[:500], next_retry, row_id),
+        )
+        logger.info("LES row %d transient defer in %ds: %s",
+                    row_id, backoff, err[:200])
+        conn.commit()
+        return
+
+    if attempts >= LIVE_EVENT_RETRY_MAX_ATTEMPTS:
+        conn.execute(
+            "UPDATE live_event_queue SET status = 'failed', "
+            "last_error = ? WHERE id = ?",
+            (err[:500], row_id),
+        )
+        logger.error("LES row %d exhausted retries: %s", row_id, err[:200])
+    else:
+        # Pick the backoff for this attempt (clamp to last entry).
+        idx = max(0, attempts - 1)
+        if LIVE_EVENT_RETRY_BACKOFF_SECONDS:
+            idx = min(idx, len(LIVE_EVENT_RETRY_BACKOFF_SECONDS) - 1)
+            backoff = (retry_in_seconds if retry_in_seconds is not None
+                       else LIVE_EVENT_RETRY_BACKOFF_SECONDS[idx])
+        else:
+            backoff = retry_in_seconds if retry_in_seconds is not None else 60
+        next_retry = time.time() + backoff
+        conn.execute(
+            "UPDATE live_event_queue SET status = 'pending', "
+            "last_error = ?, next_retry_at = ? WHERE id = ?",
+            (err[:500], next_retry, row_id),
+        )
+        logger.warning("LES row %d retry %d in %ds: %s",
+                       row_id, attempts, backoff, err[:200])
+    conn.commit()
+
+
+def retry_failed(row_id: Optional[int] = None) -> int:
+    """Reset failed rows to pending. Returns count reset.
+
+    If ``row_id`` is given, only that row is reset; otherwise all
+    failed rows are reset. Also re-arms ``pending`` rows whose
+    ``attempts`` already exceeded the cap (defensive — should not
+    happen, but if a config change lowered ``retry_max_attempts`` we
+    don't want stuck rows). Wakes the worker on success.
+    """
+    try:
+        conn = _open_db()
+        try:
+            _ensure_schema(conn)
+            if row_id is not None:
+                cur = conn.execute(
+                    "UPDATE live_event_queue SET status = 'pending', "
+                    "attempts = 0, next_retry_at = NULL, last_error = NULL "
+                    "WHERE id = ? AND status = 'failed'",
+                    (row_id,),
+                )
+            else:
+                cur = conn.execute(
+                    "UPDATE live_event_queue SET status = 'pending', "
+                    "attempts = 0, next_retry_at = NULL, last_error = NULL "
+                    "WHERE status = 'failed'"
+                )
+            n = cur.rowcount
+            if n:
+                conn.commit()
+        finally:
+            conn.close()
+    except Exception as e:
+        logger.error("LES retry_failed failed: %s", e)
+        return 0
+    if n:
+        _wake.set()
+    return n
+
+
+# ---------------------------------------------------------------------------
+# File selection — what gets uploaded for an event
+# ---------------------------------------------------------------------------
+
+
+def select_event_files(event_dir: str, mode: str,
+                       event_timestamp: Optional[str]) -> List[str]:
+    """Return absolute paths of files to upload for this event.
+
+    ``event_minute``: the ``event.json`` plus the 6 camera files whose
+    filename minute-prefix (``YYYY-MM-DD_HH-MM``) matches the event
+    timestamp. If the timestamp can't be parsed, falls back to the
+    minute prefix derived from the event_dir name.
+
+    ``event_folder``: the ``event.json`` plus every ``.mp4`` in the
+    event directory.
+
+    Bounded — never recurses into subdirectories.
+    """
+    files: List[str] = []
+    ej = os.path.join(event_dir, 'event.json')
+    if os.path.isfile(ej):
+        files.append(ej)
+
+    try:
+        entries = os.listdir(event_dir)
+    except OSError as e:
+        logger.warning("LES select_event_files: cannot list %s: %s",
+                       event_dir, e)
+        return files
+
+    if mode == 'event_folder':
+        for name in entries:
+            if name.lower().endswith('.mp4'):
+                files.append(os.path.join(event_dir, name))
+        return files
+
+    # event_minute (default): match files whose minute prefix brackets
+    # the event timestamp.
+    minute_key = _resolve_event_minute_key(event_timestamp, event_dir)
+    if minute_key is None:
+        # Fallback: include all .mp4 files (rare — better to include too
+        # much than miss the event).
+        logger.warning(
+            "LES could not resolve minute key for %s — falling back to "
+            "all .mp4 in event dir",
+            event_dir,
+        )
+        for name in entries:
+            if name.lower().endswith('.mp4'):
+                files.append(os.path.join(event_dir, name))
+        return files
+
+    cam_suffixes = tuple(f'-{cam}.mp4' for cam in CAMERA_ANGLES)
+    for name in entries:
+        m = _MINUTE_PREFIX_RE.match(name)
+        if not m:
+            continue
+        if m.group(1) != minute_key:
+            continue
+        if not name.lower().endswith(cam_suffixes):
+            continue
+        files.append(os.path.join(event_dir, name))
+
+    return files
+
+
+def _resolve_event_minute_key(event_timestamp: Optional[str],
+                              event_dir: str) -> Optional[str]:
+    """Best-effort: derive ``YYYY-MM-DD_HH-MM`` from timestamp or dir name."""
+    # Try parsing the event.json timestamp first (ISO 8601).
+    if event_timestamp:
+        try:
+            # Tesla writes "2024-05-07T14:32:10" — accept with or without offset.
+            ts = event_timestamp.split('+')[0].rstrip('Z')
+            dt = datetime.fromisoformat(ts)
+            return dt.strftime('%Y-%m-%d_%H-%M')
+        except (ValueError, TypeError):
+            pass
+
+    # Fall back to the directory name (Tesla names dirs by start time).
+    base = os.path.basename(event_dir.rstrip('/').rstrip('\\'))
+    m = _MINUTE_PREFIX_RE.match(base)
+    if m:
+        return m.group(1)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Daily data cap
+# ---------------------------------------------------------------------------
+
+
+def _today_uploaded_bytes(conn: sqlite3.Connection) -> int:
+    """Sum bytes_uploaded for rows uploaded today (UTC)."""
+    today_iso = datetime.now(timezone.utc).strftime('%Y-%m-%d')
+    row = conn.execute(
+        "SELECT COALESCE(SUM(bytes_uploaded), 0) AS total "
+        "FROM live_event_queue "
+        "WHERE status = 'uploaded' AND uploaded_at >= ?",
+        (today_iso,),
+    ).fetchone()
+    return int(row['total']) if row else 0
+
+
+def _data_cap_exceeded(conn: sqlite3.Connection) -> bool:
+    if LIVE_EVENT_DAILY_DATA_CAP_MB <= 0:
+        return False
+    cap_bytes = LIVE_EVENT_DAILY_DATA_CAP_MB * 1024 * 1024
+    return _today_uploaded_bytes(conn) >= cap_bytes
+
+
+# ---------------------------------------------------------------------------
+# Cross-subsystem coordination helper (called by cloud_archive_service)
+# ---------------------------------------------------------------------------
+
+
+def has_ready_live_event_work(db_path: Optional[str] = None) -> bool:
+    """Return True iff there's an LES row that cloud_archive should yield to.
+
+    Called by ``cloud_archive_service`` between files and at
+    ``trigger_auto_sync`` time. The check is intentionally strict so a
+    single stuck row doesn't suppress cloud_archive forever:
+
+    * LES must be enabled in config.
+    * Daily data cap must NOT be reached (LES paused itself = cloud_archive
+      may proceed).
+    * Either ``uploading`` (definitely in flight) OR ``pending`` AND
+      eligible (``next_retry_at`` past AND ``attempts < retry_max_attempts``).
+      Rows in backoff or exhausted-retries do NOT block cloud_archive.
+
+    Sub-millisecond when there is no work (uses indexed columns + LIMIT 1).
+    Safe to call from any thread; opens a fresh short-lived connection.
+    """
+    if not LIVE_EVENT_SYNC_ENABLED:
+        return False
+    path = db_path or CLOUD_ARCHIVE_DB_PATH
+    try:
+        conn = sqlite3.connect(path, timeout=5)
+        try:
+            # uploading is always priority — we must wait for it to finish.
+            row = conn.execute(
+                "SELECT 1 FROM live_event_queue "
+                "WHERE status = 'uploading' LIMIT 1"
+            ).fetchone()
+            if row is not None:
+                return True
+            # If the daily cap is reached, LES is intentionally paused
+            # for the rest of the day; let cloud_archive proceed.
+            if _data_cap_exceeded(conn):
+                return False
+            now_ts = time.time()
+            row = conn.execute(
+                "SELECT 1 FROM live_event_queue "
+                "WHERE status = 'pending' "
+                "  AND (next_retry_at IS NULL OR next_retry_at <= ?) "
+                "  AND attempts < ? "
+                "LIMIT 1",
+                (now_ts, LIVE_EVENT_RETRY_MAX_ATTEMPTS),
+            ).fetchone()
+            return row is not None
+        finally:
+            conn.close()
+    except sqlite3.OperationalError:
+        # Table doesn't exist yet — first run before LES schema init.
+        return False
+    except Exception as e:  # noqa: BLE001
+        logger.debug("has_ready_live_event_work: %s", e)
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Notifications (optional webhook)
+# ---------------------------------------------------------------------------
+
+
+def _post_webhook(event_row: Dict, files_uploaded: int,
+                  bytes_uploaded: int) -> None:
+    """Best-effort POST to the configured notify webhook URL.
+
+    Sends only relative event identifiers (e.g.
+    ``SentryClips/2024-05-07_14-32-10``) — never the absolute local
+    path, which would leak SD-card mount layout to whatever third-party
+    receives the webhook.
+    """
+    url = LIVE_EVENT_NOTIFY_WEBHOOK_URL
+    if not url:
+        return
+    raw_dir = event_row.get('event_dir') or ''
+    rel = _relative_event_path(raw_dir) or os.path.basename(
+        raw_dir.rstrip('/').rstrip('\\'),
+    )
+    payload = json.dumps({
+        "type": "live_event_uploaded",
+        "event": rel,
+        "event_timestamp": event_row.get('event_timestamp'),
+        "event_reason": event_row.get('event_reason'),
+        "files_uploaded": files_uploaded,
+        "bytes_uploaded": bytes_uploaded,
+        "uploaded_at": _now_iso(),
+    }).encode('utf-8')
+    try:
+        req = urllib.request.Request(
+            url, data=payload, method='POST',
+            headers={'Content-Type': 'application/json'},
+        )
+        # Short timeout — the worker has already released the
+        # task_coordinator before calling us, but we still don't want
+        # a slow webhook to delay the next drain pass for minutes.
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            resp.read(1024)  # bounded drain; ignore body
+    except (urllib.error.URLError, urllib.error.HTTPError, OSError) as e:
+        logger.warning("LES webhook POST failed: %s", e)
+
+
+# ---------------------------------------------------------------------------
+# Worker thread
+# ---------------------------------------------------------------------------
+
+
+# How long to block on _wake.wait() between drain attempts when the
+# queue has work but WiFi is down or task_coordinator is busy. Short
+# enough to react to WiFi-connect callbacks promptly; long enough to
+# keep idle CPU near zero.
+_WAIT_WHEN_BUSY_SECONDS = 60.0
+# How long to sleep between back-to-back uploads to let the gadget
+# endpoint and SD card breathe.
+_INTER_UPLOAD_SLEEP_SECONDS = 1.0
+
+
+def _set_active(proc: Optional[subprocess.Popen]) -> None:
+    global _active_proc
+    with _active_proc_lock:
+        _active_proc = proc
+
+
+def _count_mp4s(files: List[str]) -> int:
+    """Count how many entries in ``files`` are ``.mp4`` clips."""
+    return sum(1 for f in files if f.lower().endswith('.mp4'))
+
+
+# How long after enqueue we keep transient-deferring an event that has
+# 0 MP4s yet (Tesla still writing). After this we either upload what
+# we have (the event_folder mode might want metadata-only) or move the
+# row to permanent failure, depending on mode.
+_TRANSIENT_NO_MP4_MAX_AGE_SECONDS = 30 * 60   # 30 min
+# How long to wait before re-checking when MP4s are still appearing.
+_TRANSIENT_RETRY_SECONDS = 60
+
+
+def _enqueue_age_seconds(enqueued_at: Optional[str]) -> float:
+    """Best-effort age-since-enqueue in seconds."""
+    if not enqueued_at:
+        return 0.0
+    try:
+        ts = enqueued_at.split('+')[0].rstrip('Z')
+        dt = datetime.fromisoformat(ts)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return max(0.0, (datetime.now(timezone.utc) - dt).total_seconds())
+    except (ValueError, TypeError):
+        return 0.0
+
+
+def _process_one(conn: sqlite3.Connection, row: Dict,
+                 cancel_event: threading.Event) -> Tuple[bool, str, int, bool]:
+    """Upload one event.
+
+    Returns ``(success, error_msg, bytes_uploaded, transient)``. When
+    ``transient`` is True the caller should requeue without consuming
+    a retry attempt — used for the "MP4s aren't fully written yet" case
+    so we never permanently fail an event because we raced Tesla.
+    """
+    from services.cloud_archive_service import (
+        load_provider_creds, write_rclone_conf, remove_rclone_conf,
+        upload_path_via_rclone,
+    )
+
+    event_dir = row['event_dir']
+    if not os.path.isdir(event_dir):
+        return False, "Event directory missing", 0, False
+
+    # Refresh the RO mount once before file selection so we see Tesla's
+    # latest writes (kernel caches the loop-mount view otherwise).
+    try:
+        from services.mapping_service import _refresh_ro_mount
+        from services.video_service import get_teslacam_path
+        tc = get_teslacam_path()
+        if tc:
+            _refresh_ro_mount(tc)
+    except Exception:
+        pass
+
+    upload_scope = row.get('upload_scope') or LIVE_EVENT_UPLOAD_SCOPE
+    files = select_event_files(
+        event_dir, upload_scope, row.get('event_timestamp'),
+    )
+    mp4_count = _count_mp4s(files)
+    age_seconds = _enqueue_age_seconds(row.get('enqueued_at'))
+
+    # Critical correctness rule: never mark an event "uploaded" if we
+    # only saw event.json. The MP4s ARE the event — uploading metadata
+    # only is silent data loss. Defer transiently until MP4s appear.
+    if mp4_count == 0:
+        if age_seconds < _TRANSIENT_NO_MP4_MAX_AGE_SECONDS:
+            return (False, "No MP4 clips visible yet — deferring",
+                    0, True)
+        # Aged out — give up so the row doesn't sit forever.
+        return (False,
+                f"No MP4 clips after {int(age_seconds)}s — giving up",
+                0, False)
+
+    creds = load_provider_creds()
+    if not creds:
+        # Treat as transient — credentials may come back. Don't consume
+        # an attempt for a config issue the user is likely fixing.
+        return False, "Cloud provider credentials unavailable", 0, True
+
+    # Use a UNIQUE conf path so cloud_archive's yield/re-acquire cycle
+    # never collides with us on the shared tmpfs file. Include thread
+    # ident so two concurrent rclone runs (shouldn't happen, but
+    # belt-and-suspenders) don't trample each other either.
+    conf_name = f"rclone-les-{os.getpid()}-{threading.get_ident()}.conf"
+    conf_path = write_rclone_conf(
+        CLOUD_ARCHIVE_PROVIDER, creds, conf_name=conf_name,
+    )
+    bytes_total = 0
+    try:
+        # Build the remote folder path from the event_dir's relative
+        # location under the watched folders.
+        # event_dir example: /mnt/gadget/part1-ro/TeslaCam/SentryClips/2024-05-07_14-32-10
+        rel_event = _relative_event_path(event_dir)
+        if rel_event is None:
+            return False, "Could not compute remote path", 0, False
+        remote_dir = f"teslausb:{CLOUD_ARCHIVE_REMOTE_PATH}/{rel_event}"
+
+        for local_path in files:
+            if cancel_event.is_set():
+                return False, "Cancelled", bytes_total, False
+            filename = os.path.basename(local_path)
+            remote_dest = f"{remote_dir}/{filename}"
+
+            # Use copyto (single file). The helper handles nice/ionice/bwlimit.
+            returncode, stderr = upload_path_via_rclone(
+                local_path, remote_dest, conf_path,
+                CLOUD_ARCHIVE_MAX_UPLOAD_MBPS,
+                timeout_seconds=600,
+                proc_callback=_set_active,
+            )
+            if returncode != 0:
+                return (False,
+                        (stderr or f"rclone exit {returncode}").strip()[:500],
+                        bytes_total, False)
+            try:
+                bytes_total += os.path.getsize(local_path)
+            except OSError:
+                pass
+
+        return True, "", bytes_total, False
+    finally:
+        remove_rclone_conf(conf_path)
+
+
+def _relative_event_path(event_dir: str) -> Optional[str]:
+    """Reduce ``event_dir`` to ``<watch_folder>/<event_name>`` if possible."""
+    parts = event_dir.replace("\\", "/").split("/")
+    for folder in LIVE_EVENT_WATCH_FOLDERS:
+        if folder in parts:
+            i = parts.index(folder)
+            tail = parts[i:i + 2]
+            if len(tail) == 2:
+                return "/".join(tail)
+    return None
+
+
+def _drain_once(cancel_event: threading.Event) -> bool:
+    """Try to upload pending events until queue is empty or we yield.
+
+    Returns True if at least one event was processed (success or fail);
+    False if there was nothing to do or we couldn't get the lock.
+    """
+    from services.task_coordinator import acquire_task, release_task
+    from services.cloud_archive_service import is_wifi_connected
+
+    if not is_wifi_connected():
+        return False
+
+    conn = _open_db()
+    try:
+        _ensure_schema(conn)
+
+        # Daily cap check up front
+        if _data_cap_exceeded(conn):
+            with _status_lock:
+                _status["data_cap_reached"] = True
+            return False
+        else:
+            with _status_lock:
+                _status["data_cap_reached"] = False
+
+        processed = False
+        # Webhook payloads queued to fire AFTER releasing the global
+        # task_coordinator lock — see issue #10. Bounded list (we never
+        # process more than the queue depth in one drain pass).
+        pending_webhooks: List[Dict] = []
+        while not cancel_event.is_set():
+            row = _claim_next_pending(conn)
+            if row is None:
+                break
+
+            # Acquire the task lock BEFORE counting an attempt. If the
+            # lock is busy, return the row to pending without burning
+            # a retry — the worker will tick again later.
+            if not acquire_task('live_event_sync'):
+                _release_claim_to_pending(conn, row['id'])
+                # Sleep briefly so we don't busy-spin if indexer is
+                # parsing many small files in a row.
+                time.sleep(1.0)
+                return processed
+
+            attempt_no = _record_attempt_start(conn, row['id'])
+            try:
+                with _status_lock:
+                    _status["running"] = True
+                    _status["active_event"] = row.get('event_dir')
+
+                logger.info(
+                    "LES uploading: %s (reason=%s, attempt %d/%d)",
+                    row['event_dir'], row.get('event_reason'),
+                    attempt_no, LIVE_EVENT_RETRY_MAX_ATTEMPTS,
+                )
+                success, err, bytes_uploaded, transient = _process_one(
+                    conn, row, cancel_event,
+                )
+                if success:
+                    _mark_uploaded(conn, row['id'], bytes_uploaded)
+                    with _status_lock:
+                        _status["last_uploaded_at"] = _now_iso()
+                        _status["last_uploaded_event"] = row.get('event_dir')
+                        _status["last_error"] = None
+                        _status["data_uploaded_today_bytes"] = (
+                            _today_uploaded_bytes(conn)
+                        )
+                    logger.info(
+                        "LES uploaded: %s (%.1f KB)",
+                        row['event_dir'], bytes_uploaded / 1024,
+                    )
+                    # Defer webhook delivery until after we release the
+                    # task_coordinator lock (slow webhooks must not
+                    # block the indexer/cloud_archive).
+                    pending_webhooks.append({
+                        "row": dict(row),
+                        "files_uploaded": len(select_event_files(
+                            row['event_dir'],
+                            row.get('upload_scope') or LIVE_EVENT_UPLOAD_SCOPE,
+                            row.get('event_timestamp'),
+                        )),
+                        "bytes_uploaded": bytes_uploaded,
+                    })
+                else:
+                    _mark_failed(conn, row['id'], attempt_no, err,
+                                 transient=transient)
+                    with _status_lock:
+                        _status["last_error"] = err[:500]
+                        _status["last_error_at"] = _now_iso()
+                processed = True
+            except Exception as e:
+                logger.exception("LES worker exception processing row %d", row['id'])
+                _mark_failed(conn, row['id'], attempt_no, str(e)[:500])
+                with _status_lock:
+                    _status["last_error"] = str(e)[:500]
+                    _status["last_error_at"] = _now_iso()
+                processed = True
+            finally:
+                with _status_lock:
+                    _status["running"] = False
+                    _status["active_event"] = None
+                release_task('live_event_sync')
+
+            # Pause between events so the gadget endpoint stays snappy.
+            if not cancel_event.is_set() and _INTER_UPLOAD_SLEEP_SECONDS > 0:
+                time.sleep(_INTER_UPLOAD_SLEEP_SECONDS)
+
+            # Re-check daily cap before pulling the next row.
+            if _data_cap_exceeded(conn):
+                with _status_lock:
+                    _status["data_cap_reached"] = True
+                break
+
+        # Fire webhooks AFTER releasing the lock (we've already
+        # released for the last event in the finally above; this loop
+        # holds nothing). A slow/dead webhook can't block the next LES
+        # event or the indexer this way.
+        for wh in pending_webhooks:
+            try:
+                _post_webhook(wh["row"], wh["files_uploaded"],
+                              wh["bytes_uploaded"])
+            except Exception:
+                # _post_webhook already swallows network errors; this
+                # catches any other surprise without taking the worker
+                # down.
+                logger.exception("LES webhook delivery failed")
+
+        return processed
+    finally:
+        conn.close()
+
+
+def _startup_catchup_scan() -> int:
+    """Discover ``event.json`` files that exist on-disk but aren't queued.
+
+    Covers two real-world cases the file-watcher can't catch:
+
+    * gadget_web was restarting / down when Tesla wrote the event;
+      inotify wasn't listening at the right moment.
+    * LES was just enabled in config and there are pre-existing
+      events on the SD card / USB image that the user wants uploaded.
+
+    Bounded: only walks the configured ``LIVE_EVENT_WATCH_FOLDERS``
+    under each TeslaCam root, one level deep. ``UNIQUE(event_dir)`` in
+    the queue makes re-enqueues idempotent. Returns the number of new
+    rows inserted.
+    """
+    if not LIVE_EVENT_SYNC_ENABLED:
+        return 0
+    discovered: List[str] = []
+    for root in _teslacam_roots():
+        for folder in LIVE_EVENT_WATCH_FOLDERS:
+            base = os.path.join(root, folder)
+            if not os.path.isdir(base):
+                continue
+            try:
+                for entry in os.scandir(base):
+                    if not entry.is_dir(follow_symlinks=False):
+                        continue
+                    ej = os.path.join(entry.path, 'event.json')
+                    if os.path.isfile(ej):
+                        discovered.append(ej)
+            except OSError as e:
+                logger.debug("LES catchup scan skipped %s: %s", base, e)
+    if not discovered:
+        return 0
+    inserted = enqueue_event_json(discovered)
+    if inserted:
+        logger.info(
+            "LES startup catch-up: discovered %d existing event.json file(s) "
+            "(%d newly enqueued)", len(discovered), inserted,
+        )
+    return inserted
+
+
+def _worker_loop() -> None:
+    """Top-level worker loop. Idle on ``_wake``; never busy-loops."""
+    logger.info("Live Event Sync worker started")
+
+    # Startup recovery + prune (one-shot per process).
+    try:
+        conn = _open_db()
+        try:
+            _ensure_schema(conn)
+            _startup_recovery(conn)
+            _prune_old_uploaded(conn)
+        finally:
+            conn.close()
+    except Exception as e:
+        logger.error("LES startup recovery failed: %s", e)
+
+    # One-shot catch-up scan: enqueue any event.json files already on
+    # disk that haven't been queued yet (LES was disabled previously,
+    # gadget_web was restarting when Tesla wrote them, etc.). The
+    # UNIQUE(event_dir) constraint makes this safe to call on every
+    # start.
+    try:
+        _startup_catchup_scan()
+    except Exception as e:
+        logger.error("LES startup catch-up scan failed: %s", e)
+
+    # Wake immediately so an existing pending queue starts draining.
+    _wake.set()
+
+    while not _worker_stop.is_set():
+        # Block until somebody wakes us (enqueue, WiFi-connect, or stop).
+        # If the queue has work but we couldn't drain (WiFi down, task
+        # coordinator busy, etc.), fall back to a slow timeout so we
+        # don't busy-poll.
+        _wake.wait(timeout=_WAIT_WHEN_BUSY_SECONDS)
+        _wake.clear()
+        if _worker_stop.is_set():
+            break
+        try:
+            _drain_once(_worker_stop)
+        except Exception as e:
+            # Containment: never let the worker thread die.
+            logger.exception("LES worker loop iteration failed: %s", e)
+            with _status_lock:
+                _status["last_error"] = str(e)[:500]
+                _status["last_error_at"] = _now_iso()
+
+    logger.info("Live Event Sync worker stopped")
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def start() -> bool:
+    """Start the worker thread. Idempotent.
+
+    Returns True if a new thread was started; False if disabled or
+    already running.
+    """
+    global _worker_thread
+    if not LIVE_EVENT_SYNC_ENABLED:
+        logger.info("Live Event Sync disabled in config — not starting worker")
+        return False
+    with _worker_lock:
+        if _worker_thread and _worker_thread.is_alive():
+            return False
+        _worker_stop.clear()
+        _worker_thread = threading.Thread(
+            target=_worker_loop, name="live-event-sync", daemon=True,
+        )
+        _worker_thread.start()
+        return True
+
+
+def stop(timeout: float = 5.0) -> bool:
+    """Stop the worker thread (best-effort; daemon survives at process exit)."""
+    global _worker_thread
+    _worker_stop.set()
+    _wake.set()
+    with _active_proc_lock:
+        proc = _active_proc
+    if proc is not None:
+        try:
+            proc.terminate()
+        except (OSError, ProcessLookupError):
+            pass
+    thread = _worker_thread
+    if thread and thread.is_alive():
+        thread.join(timeout=timeout)
+        return not thread.is_alive()
+    return True
+
+
+def wake() -> None:
+    """Wake the worker (called by the WiFi-connect dispatcher)."""
+    _wake.set()
+
+
+def get_status() -> Dict:
+    """Return a status snapshot for the API blueprint."""
+    snapshot: Dict = {}
+    with _status_lock:
+        snapshot.update(_status)
+
+    # Add queue counts (cheap aggregate query).
+    try:
+        conn = _open_db()
+        try:
+            _ensure_schema(conn)
+            counts = {}
+            for st in ('pending', 'uploading', 'uploaded', 'failed'):
+                row = conn.execute(
+                    "SELECT COUNT(*) AS n FROM live_event_queue "
+                    "WHERE status = ?",
+                    (st,),
+                ).fetchone()
+                counts[st] = int(row['n']) if row else 0
+            snapshot['queue_counts'] = counts
+        finally:
+            conn.close()
+    except Exception as e:
+        snapshot['queue_counts'] = {'error': str(e)[:200]}
+
+    return snapshot
+
+
+def list_queue(limit: int = 50) -> List[Dict]:
+    """Return up to ``limit`` recent queue rows for the status panel."""
+    try:
+        conn = _open_db()
+        try:
+            _ensure_schema(conn)
+            rows = conn.execute(
+                "SELECT id, event_dir, event_timestamp, event_reason, "
+                "upload_scope, status, enqueued_at, uploaded_at, "
+                "attempts, last_error, bytes_uploaded "
+                "FROM live_event_queue "
+                "ORDER BY enqueued_at DESC LIMIT ?",
+                (int(limit),),
+            ).fetchall()
+            return [dict(r) for r in rows]
+        finally:
+            conn.close()
+    except Exception as e:
+        logger.error("LES list_queue failed: %s", e)
+        return []

--- a/scripts/web/templates/cloud_archive.html
+++ b/scripts/web/templates/cloud_archive.html
@@ -563,10 +563,10 @@
                     <select id="lesUploadScope"
                             style="width: 100%; max-width: 480px; padding: 6px 10px; border: 1px solid var(--border); border-radius: 6px; background: var(--bg-secondary); color: var(--text-primary);">
                         <option value="event_minute" {% if les_upload_scope == 'event_minute' %}selected{% endif %}>
-                            Event minute &mdash; 6 cameras + event.json (~40 MB / event)
+                            Event minute &mdash; 6 cameras + event.json (~150&ndash;200 MB / event)
                         </option>
                         <option value="event_folder" {% if les_upload_scope == 'event_folder' %}selected{% endif %}>
-                            Full event folder &mdash; every clip Tesla saved for the event
+                            Full event folder &mdash; every clip Tesla saved (~0.7&ndash;2 GB / event)
                         </option>
                     </select>
                 </div>
@@ -588,7 +588,7 @@
                         <input type="number" id="lesDailyDataCapMb" min="0" step="1"
                                value="{{ les_daily_data_cap_mb }}"
                                style="width: 120px; padding: 6px 10px; border: 1px solid var(--border); border-radius: 6px; background: var(--bg-secondary); color: var(--text-primary);">
-                        <p style="font-size: var(--text-xs); color: var(--text-muted); margin: 4px 0 0;">0 = unlimited. Pauses uploads when exceeded.</p>
+                        <p style="font-size: var(--text-xs); color: var(--text-muted); margin: 4px 0 0;">0 = unlimited. Pauses uploads when exceeded. At default scope, ~5 events fit in 1 GB.</p>
                     </div>
                 </div>
 

--- a/scripts/web/templates/cloud_archive.html
+++ b/scripts/web/templates/cloud_archive.html
@@ -481,6 +481,13 @@
                     <li><strong>Persists across reboots and WiFi outages</strong> &mdash; queued events resume automatically</li>
                     <li><strong>Opt-in</strong> &mdash; off by default to avoid surprise data usage</li>
                 </ul>
+                <p style="margin: 10px 0 0; padding: 8px 12px; border-radius: var(--radius-md); background: var(--msg-info-bg); color: var(--msg-info-text); font-size: var(--text-sm);">
+                    <strong>WiFi is required for real-time uploads.</strong>
+                    The car only has WiFi inside your garage / driveway, so events that happen out on the road
+                    won't upload until you reconnect &mdash; <em>unless</em> you give the Pi a persistent connection
+                    (a phone hotspot, a mobile travel router, or a hardwired LTE / 5G modem). Without one, LES
+                    still works, but it queues events and uploads them the moment WiFi is back.
+                </p>
                 {% if not videos_available %}
                 <p style="margin: 10px 0 0; padding: 8px 12px; border-radius: var(--radius-md); background: var(--msg-warning-bg); color: var(--msg-warning-text);">
                     <strong>Camera storage missing:</strong> Live Event Sync needs <code>usb_cam.img</code> to receive Tesla event data.

--- a/scripts/web/templates/cloud_archive.html
+++ b/scripts/web/templates/cloud_archive.html
@@ -453,6 +453,178 @@
     </details>
 
     <!-- ================================================================
+         Section 3.5: Live Event Sync
+         ================================================================ -->
+    <details class="settings-section" id="liveEventSyncSection">
+        <summary>
+            <svg class="nav-icon" aria-hidden="true"><use href="{{ url_for('static', filename='icons/lucide-sprite.svg') }}#icon-zap"></use></svg>
+            Live Event Sync
+            <span id="lesStatusBadge"
+                  style="margin-left: 8px; padding: 2px 8px; border-radius: var(--radius-full); font-size: var(--text-xs); font-weight: 600;
+                  {% if les_enabled %}background: var(--msg-success-bg); color: var(--msg-success-text);
+                  {% else %}background: var(--bg-info); color: var(--text-secondary);{% endif %}">
+                {{ 'Enabled' if les_enabled else 'Disabled' }}
+            </span>
+        </summary>
+        <div class="section-content">
+
+            {# ---- How LES works ---- #}
+            <div class="info-box" style="margin-bottom: var(--space-4); font-size: var(--text-sm); line-height: 1.6; color: var(--text-secondary);">
+                <strong style="color: var(--text-primary);">What is Live Event Sync?</strong>
+                <p style="margin: 6px 0 0;">
+                    Uploads each Sentry / Saved event to your cloud provider <em>the moment</em> Tesla writes its
+                    <code>event.json</code> &mdash; separate from the regular cloud sync that batches files when WiFi connects.
+                </p>
+                <ul style="margin: 8px 0 0; padding-left: 18px;">
+                    <li><strong>Uses your existing cloud provider</strong> (configured above)</li>
+                    <li><strong>Takes priority</strong> over the bulk sync when both want WiFi</li>
+                    <li><strong>Persists across reboots and WiFi outages</strong> &mdash; queued events resume automatically</li>
+                    <li><strong>Opt-in</strong> &mdash; off by default to avoid surprise data usage</li>
+                </ul>
+                {% if not videos_available %}
+                <p style="margin: 10px 0 0; padding: 8px 12px; border-radius: var(--radius-md); background: var(--msg-warning-bg); color: var(--msg-warning-text);">
+                    <strong>Camera storage missing:</strong> Live Event Sync needs <code>usb_cam.img</code> to receive Tesla event data.
+                    You can configure settings now &mdash; they'll take effect once the camera image is provisioned.
+                </p>
+                {% elif not provider_connected %}
+                <p style="margin: 10px 0 0; padding: 8px 12px; border-radius: var(--radius-md); background: var(--msg-warning-bg); color: var(--msg-warning-text);">
+                    <strong>No cloud provider connected:</strong> Connect a provider above before enabling Live Event Sync.
+                </p>
+                {% endif %}
+            </div>
+
+            {# ---- Status row (populated by JS) ---- #}
+            <div id="lesStatusRow" style="display: grid; grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); gap: var(--space-2); margin-bottom: var(--space-4);">
+                <div style="padding: 8px 12px; background: var(--bg-secondary); border-radius: var(--radius-md);">
+                    <div style="font-size: var(--text-xs); color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.04em;">Pending</div>
+                    <div id="lesCountPending" style="font-size: var(--text-lg); font-weight: 600; color: var(--text-primary);">&mdash;</div>
+                </div>
+                <div style="padding: 8px 12px; background: var(--bg-secondary); border-radius: var(--radius-md);">
+                    <div style="font-size: var(--text-xs); color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.04em;">Uploading</div>
+                    <div id="lesCountUploading" style="font-size: var(--text-lg); font-weight: 600; color: var(--text-primary);">&mdash;</div>
+                </div>
+                <div style="padding: 8px 12px; background: var(--bg-secondary); border-radius: var(--radius-md);">
+                    <div style="font-size: var(--text-xs); color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.04em;">Uploaded</div>
+                    <div id="lesCountUploaded" style="font-size: var(--text-lg); font-weight: 600; color: var(--text-primary);">&mdash;</div>
+                </div>
+                <div style="padding: 8px 12px; background: var(--bg-secondary); border-radius: var(--radius-md);">
+                    <div style="font-size: var(--text-xs); color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.04em;">Failed</div>
+                    <div id="lesCountFailed" style="font-size: var(--text-lg); font-weight: 600; color: var(--text-primary);">&mdash;</div>
+                </div>
+            </div>
+            <div id="lesActiveLine" style="display: none; margin-bottom: var(--space-4); padding: 8px 12px; border-radius: var(--radius-md); background: var(--msg-info-bg); color: var(--msg-info-text); font-size: var(--text-sm);">
+                <strong>Uploading:</strong> <span id="lesActiveFile"></span>
+            </div>
+            <div id="lesLastError" style="display: none; margin-bottom: var(--space-4); padding: 8px 12px; border-radius: var(--radius-md); background: var(--msg-error-bg); color: var(--msg-error-text); font-size: var(--text-sm);">
+                <strong>Last error:</strong> <span id="lesLastErrorText"></span>
+            </div>
+
+            {# ---- Settings form ---- #}
+            <form id="lesSettingsForm" onsubmit="return false;">
+
+                <div style="margin-bottom: var(--space-4);">
+                    <label style="display:flex; align-items:center; gap:8px; cursor:pointer; font-weight:600; color:var(--text-primary);">
+                        <input type="checkbox" id="lesEnabledInput" {% if les_enabled %}checked{% endif %}
+                               style="width: 18px; height: 18px; cursor: pointer; accent-color: var(--btn-success-bg);">
+                        <span>Enable Live Event Sync</span>
+                    </label>
+                    <p style="margin: 4px 0 0 26px; font-size: var(--text-xs); color: var(--text-muted);">
+                        When on, the worker uploads Sentry/Saved events the moment Tesla writes <code>event.json</code>.
+                    </p>
+                </div>
+
+                <div style="margin-bottom: var(--space-4);">
+                    <label style="display: block; margin-bottom: var(--space-2); font-weight: 600; color: var(--text-primary);">Watch folders:</label>
+                    <div style="display: flex; flex-direction: column; gap: var(--space-2);">
+                        {% for folder in ['SentryClips', 'SavedClips'] %}
+                        <label style="display: flex; align-items: center; gap: var(--space-2); padding: 8px; border-radius: var(--radius-md); cursor: pointer; transition: background var(--transition-fast);"
+                               onmouseover="this.style.background='var(--bg-hover)'" onmouseout="this.style.background='transparent'">
+                            <input type="checkbox" class="les-watch-folder" value="{{ folder }}"
+                                   {% if folder in les_watch_folders %}checked{% endif %}
+                                   style="width: 18px; height: 18px; cursor: pointer; accent-color: var(--btn-success-bg);">
+                            <span style="color: var(--text-primary); font-size: 15px;">{{ folder }}</span>
+                        </label>
+                        {% endfor %}
+                    </div>
+                    <p style="margin: 4px 0 0; font-size: var(--text-xs); color: var(--text-muted);">
+                        Tesla event subfolders to watch for new <code>event.json</code> files.
+                    </p>
+                </div>
+
+                <div style="margin-bottom: var(--space-4);">
+                    <label for="lesUploadScope" style="display: block; margin-bottom: var(--space-2); font-weight: 600; color: var(--text-primary);">Upload scope:</label>
+                    <select id="lesUploadScope"
+                            style="width: 100%; max-width: 480px; padding: 6px 10px; border: 1px solid var(--border); border-radius: 6px; background: var(--bg-secondary); color: var(--text-primary);">
+                        <option value="event_minute" {% if les_upload_scope == 'event_minute' %}selected{% endif %}>
+                            Event minute &mdash; 6 cameras + event.json (~40 MB / event)
+                        </option>
+                        <option value="event_folder" {% if les_upload_scope == 'event_folder' %}selected{% endif %}>
+                            Full event folder &mdash; every clip Tesla saved for the event
+                        </option>
+                    </select>
+                </div>
+
+                <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: var(--space-4); margin-bottom: var(--space-4);">
+                    <div>
+                        <label for="lesRetryMaxAttempts" style="display: block; margin-bottom: var(--space-2); font-weight: 600; color: var(--text-primary);">
+                            Max retry attempts
+                        </label>
+                        <input type="number" id="lesRetryMaxAttempts" min="1" max="20" step="1"
+                               value="{{ les_retry_max_attempts }}"
+                               style="width: 120px; padding: 6px 10px; border: 1px solid var(--border); border-radius: 6px; background: var(--bg-secondary); color: var(--text-primary);">
+                        <p style="font-size: var(--text-xs); color: var(--text-muted); margin: 4px 0 0;">After this many failures the row moves to <em>failed</em>.</p>
+                    </div>
+                    <div>
+                        <label for="lesDailyDataCapMb" style="display: block; margin-bottom: var(--space-2); font-weight: 600; color: var(--text-primary);">
+                            Daily data cap (MB)
+                        </label>
+                        <input type="number" id="lesDailyDataCapMb" min="0" step="1"
+                               value="{{ les_daily_data_cap_mb }}"
+                               style="width: 120px; padding: 6px 10px; border: 1px solid var(--border); border-radius: 6px; background: var(--bg-secondary); color: var(--text-primary);">
+                        <p style="font-size: var(--text-xs); color: var(--text-muted); margin: 4px 0 0;">0 = unlimited. Pauses uploads when exceeded.</p>
+                    </div>
+                </div>
+
+                <div style="margin-bottom: var(--space-4);">
+                    <label for="lesNotifyWebhookUrl" style="display: block; margin-bottom: var(--space-2); font-weight: 600; color: var(--text-primary);">
+                        Notification webhook URL <span style="color: var(--text-muted); font-weight: 400;">(optional)</span>
+                    </label>
+                    <input type="url" id="lesNotifyWebhookUrl"
+                           value="{{ les_notify_webhook_url }}"
+                           placeholder="https://example.com/teslausb-events"
+                           maxlength="2048"
+                           style="width: 100%; max-width: 480px; padding: 6px 10px; border: 1px solid var(--border); border-radius: 6px; background: var(--bg-secondary); color: var(--text-primary);">
+                    <p style="font-size: var(--text-xs); color: var(--text-muted); margin: 4px 0 0;">
+                        POSTs JSON on each successful event upload. Must start with <code>http://</code> or <code>https://</code>.
+                    </p>
+                </div>
+
+                <div style="margin-bottom: var(--space-4);">
+                    <label style="display: block; margin-bottom: var(--space-2); font-weight: 600; color: var(--text-primary);">Retry backoff (read-only)</label>
+                    <code style="display: inline-block; padding: 4px 8px; background: var(--bg-secondary); border-radius: 4px; font-size: var(--text-sm); color: var(--text-secondary);">
+                        {% for s in les_retry_backoff_seconds %}{{ s }}s{% if not loop.last %} &rarr; {% endif %}{% endfor %}
+                    </code>
+                    <p style="font-size: var(--text-xs); color: var(--text-muted); margin: 4px 0 0;">
+                        Tunable in <code>config.yaml</code> under <code>live_event_sync.retry_backoff_seconds</code>.
+                    </p>
+                </div>
+
+                <div style="display: flex; gap: var(--space-2); flex-wrap: wrap; align-items: center;">
+                    <button type="button" class="edit-btn" onclick="lesSaveSettings()" id="lesSaveBtn"
+                            style="padding: 8px 20px; font-size: 14px;">Save &amp; Restart Service</button>
+                    <button type="button" class="action-btn" onclick="lesRetryAll()" id="lesRetryAllBtn"
+                            style="padding: 8px 16px; font-size: 14px;" {% if not les_enabled %}disabled{% endif %}>Retry All Failed</button>
+                    <button type="button" class="action-btn" onclick="lesWake()" id="lesWakeBtn"
+                            style="padding: 8px 16px; font-size: 14px;" {% if not les_enabled %}disabled{% endif %}>Wake Worker</button>
+                </div>
+                <p style="margin: 8px 0 0; font-size: var(--text-xs); color: var(--text-muted);">
+                    Saving any setting restarts the web service so the worker picks up the new config (~10&ndash;15 s).
+                </p>
+            </form>
+        </div>
+    </details>
+
+    <!-- ================================================================
          Section 3.5: Sync Queue
          ================================================================ -->
     <details class="settings-section" id="syncQueueSection">
@@ -1592,6 +1764,182 @@
             refreshQueue();
         } catch(e) { /* ignore */ }
     }
+
+    /* ===================================================================
+       Live Event Sync (LES) section
+       =================================================================== */
+
+    var _lesPollTimer = null;
+
+    function _lesSetText(id, val) {
+        var el = document.getElementById(id);
+        if (el) el.textContent = (val === undefined || val === null || val === '') ? '\u2014' : String(val);
+    }
+
+    async function lesRefreshStatus() {
+        try {
+            var resp = await fetch('/api/live_events/status', {
+                headers: { 'X-Requested-With': 'XMLHttpRequest' }
+            });
+            if (!resp.ok) {
+                if (resp.status === 503) {
+                    /* image not present — counts stay as em-dash */
+                }
+                return;
+            }
+            var data = await resp.json();
+            if (!data.enabled) {
+                _lesSetText('lesCountPending', 0);
+                _lesSetText('lesCountUploading', 0);
+                _lesSetText('lesCountUploaded', 0);
+                _lesSetText('lesCountFailed', 0);
+                return;
+            }
+            var counts = data.queue_counts || {};
+            _lesSetText('lesCountPending', counts.pending || 0);
+            _lesSetText('lesCountUploading', counts.uploading || 0);
+            _lesSetText('lesCountUploaded', counts.uploaded || 0);
+            _lesSetText('lesCountFailed', counts.failed || 0);
+
+            var activeLine = document.getElementById('lesActiveLine');
+            var activeFile = document.getElementById('lesActiveFile');
+            if (data.active_file && activeLine && activeFile) {
+                activeFile.textContent = data.active_file;
+                activeLine.style.display = 'block';
+            } else if (activeLine) {
+                activeLine.style.display = 'none';
+            }
+
+            var errBox = document.getElementById('lesLastError');
+            var errTxt = document.getElementById('lesLastErrorText');
+            if (data.last_error && errBox && errTxt) {
+                errTxt.textContent = String(data.last_error).slice(0, 240);
+                errBox.style.display = 'block';
+            } else if (errBox) {
+                errBox.style.display = 'none';
+            }
+        } catch (e) { /* ignore network blips */ }
+    }
+
+    function lesStartPolling() {
+        lesRefreshStatus();
+        if (_lesPollTimer) clearInterval(_lesPollTimer);
+        _lesPollTimer = setInterval(lesRefreshStatus, 5000);
+    }
+
+    function lesStopPolling() {
+        if (_lesPollTimer) { clearInterval(_lesPollTimer); _lesPollTimer = null; }
+    }
+
+    /* Poll only while the section is open to keep CPU/network minimal. */
+    (function() {
+        var section = document.getElementById('liveEventSyncSection');
+        if (!section) return;
+        section.addEventListener('toggle', function() {
+            if (section.open) lesStartPolling(); else lesStopPolling();
+        });
+        if (section.open) lesStartPolling();
+    })();
+
+    window.lesSaveSettings = async function() {
+        var btn = document.getElementById('lesSaveBtn');
+        if (!btn) return;
+        var enabledCb = document.getElementById('lesEnabledInput');
+        var watchFolders = Array.prototype.slice.call(document.querySelectorAll('.les-watch-folder:checked')).map(function(cb){ return cb.value; });
+        var payload = {
+            enabled: !!(enabledCb && enabledCb.checked),
+            watch_folders: watchFolders,
+            upload_scope: (document.getElementById('lesUploadScope') || {}).value || 'event_minute',
+            retry_max_attempts: parseInt((document.getElementById('lesRetryMaxAttempts') || {}).value, 10) || 5,
+            daily_data_cap_mb: parseInt((document.getElementById('lesDailyDataCapMb') || {}).value, 10) || 0,
+            notify_webhook_url: ((document.getElementById('lesNotifyWebhookUrl') || {}).value || '').trim()
+        };
+        if (payload.enabled && payload.watch_folders.length === 0) {
+            showToast('Select at least one watch folder before enabling.', 'warning');
+            return;
+        }
+        btn.disabled = true;
+        var origLabel = btn.textContent;
+        btn.textContent = 'Saving\u2026';
+        try {
+            var resp = await fetch('/api/live_events/settings', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
+                body: JSON.stringify(payload)
+            });
+            var data = await resp.json();
+            if (!resp.ok || !data.success) {
+                btn.disabled = false;
+                btn.textContent = origLabel;
+                showToast((data && data.error) ? data.error : 'Failed to save settings.', 'error');
+                return;
+            }
+            if (data.restart_scheduled) {
+                _showBusy('Settings saved. Restarting service\u2026');
+                /* Service restart takes ~6-12 s. Reload after enough time
+                   that gunicorn is back. Page reload pulls fresh status. */
+                setTimeout(function() { window.location.reload(); }, 12000);
+            } else {
+                btn.disabled = false;
+                btn.textContent = origLabel;
+                showToast('Saved (restart scheduling failed — please restart the service manually).', 'warning');
+            }
+        } catch (e) {
+            /* When the restart kills the connection mid-fetch we land
+               here. The save itself almost always succeeded — reload
+               and let the page reflect the new state. */
+            _showBusy('Settings saved. Restarting service\u2026');
+            setTimeout(function() { window.location.reload(); }, 12000);
+        }
+    };
+
+    window.lesRetryAll = async function() {
+        var btn = document.getElementById('lesRetryAllBtn');
+        if (btn) btn.disabled = true;
+        try {
+            var resp = await fetch('/api/live_events/retry_all', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' }
+            });
+            var data = await resp.json();
+            if (data && data.enabled === false) {
+                showToast('Live Event Sync is disabled.', 'warning');
+            } else if (data && typeof data.rows_reset === 'number') {
+                showToast('Reset ' + data.rows_reset + ' failed row(s) to pending.', 'success');
+                lesRefreshStatus();
+            } else {
+                showToast('Retry all failed.', 'error');
+            }
+        } catch (e) {
+            showToast('Network error.', 'error');
+        } finally {
+            if (btn) btn.disabled = false;
+        }
+    };
+
+    window.lesWake = async function() {
+        var btn = document.getElementById('lesWakeBtn');
+        if (btn) btn.disabled = true;
+        try {
+            var resp = await fetch('/api/live_events/wake', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' }
+            });
+            var data = await resp.json();
+            if (data && data.enabled === false) {
+                showToast('Live Event Sync is disabled.', 'warning');
+            } else if (data && data.woken) {
+                showToast('Worker woken.', 'success');
+                lesRefreshStatus();
+            } else {
+                showToast('Wake failed.', 'error');
+            }
+        } catch (e) {
+            showToast('Network error.', 'error');
+        } finally {
+            if (btn) btn.disabled = false;
+        }
+    };
 
 })();
 

--- a/scripts/web/web_control.py
+++ b/scripts/web/web_control.py
@@ -53,6 +53,7 @@ from blueprints import (
     captive_portal_bp,
     catch_all_redirect,
     cloud_archive_bp,
+    live_events_bp,
 )
 
 app.register_blueprint(mapping_bp)
@@ -70,6 +71,7 @@ app.register_blueprint(cleanup_bp)
 app.register_blueprint(api_bp)
 app.register_blueprint(fsck_bp)
 app.register_blueprint(cloud_archive_bp)
+app.register_blueprint(live_events_bp)
 # Register captive portal blueprint LAST to avoid conflicting with other routes
 app.register_blueprint(captive_portal_bp)
 
@@ -128,6 +130,7 @@ if __name__ == "__main__":
     try:
         from services.file_watcher_service import (
             start_watcher, register_callback, register_delete_callback,
+            register_event_json_callback,
         )
         watch_paths = []
         # Watch TeslaCam on USB (RO mount)
@@ -176,6 +179,27 @@ if __name__ == "__main__":
                     print("File watcher → indexing queue producer registered")
             except Exception as e:
                 print(f"Warning: Failed to register watcher callbacks: {e}")
+
+            # Live Event Sync producer: enqueue Sentry/Saved events the
+            # moment Tesla writes event.json. Independent of the
+            # indexing callback above; both fire from the same inotify
+            # watcher with no extra file descriptors.
+            try:
+                from config import LIVE_EVENT_SYNC_ENABLED
+                if LIVE_EVENT_SYNC_ENABLED:
+                    def _on_new_event_json(file_paths):
+                        from services.live_event_sync_service import (
+                            enqueue_event_json,
+                        )
+                        try:
+                            enqueue_event_json(list(file_paths))
+                        except Exception as e:
+                            print(f"Warning: LES enqueue failed: {e}")
+
+                    register_event_json_callback(_on_new_event_json)
+                    print("File watcher → Live Event Sync producer registered")
+            except Exception as e:
+                print(f"Warning: Failed to register LES watcher callback: {e}")
 
             start_watcher(watch_paths)
             print(f"File watcher started for {len(watch_paths)} paths")
@@ -226,9 +250,28 @@ if __name__ == "__main__":
     except Exception as e:
         print(f"Warning: Failed to start indexing worker: {e}")
 
+    # Live Event Sync worker: starts BEFORE cloud_archive auto-trigger so
+    # any persistent LES queue (from a prior reboot/WiFi outage) gets
+    # the priority it's contractually owed. The trigger_auto_sync()
+    # call below will then see ready LES work and skip — letting LES
+    # drain first. Worker thread blocks on threading.Event.wait() when
+    # idle (< 0.1% CPU baseline).
+    try:
+        from config import LIVE_EVENT_SYNC_ENABLED
+        if LIVE_EVENT_SYNC_ENABLED:
+            from services.live_event_sync_service import start as _les_start
+            if _les_start():
+                print("Live Event Sync worker started")
+    except Exception as e:
+        # LES failure must NEVER take down gadget_web. Log and continue.
+        print(f"Warning: Failed to start Live Event Sync worker: {e}")
+
     # Auto-start cloud sync if WiFi is already connected and provider is configured.
     # The dispatcher only fires on WiFi connect events — if the Pi boots into WiFi
     # (or the service restarts while on WiFi), sync would never start without this.
+    # NOTE: trigger_auto_sync() consults has_ready_live_event_work() and skips
+    # when LES has work, so the LES start above takes effect even on the very
+    # first dispatcher fire.
     try:
         from config import (
             CLOUD_ARCHIVE_ENABLED, CLOUD_ARCHIVE_PROVIDER,


### PR DESCRIPTION
Closes #51

## Summary

Adds a new **Live Event Sync (LES)** subsystem that uploads Tesla Sentry/Saved
events to the cloud the moment Tesla writes `event.json`. Independent of the
existing `cloud_archive_service` bulk uploader: separate enable, separate
queue, separate worker, but shares the cloud provider credentials.

LES is **disabled by default** (`live_event_sync.enabled: false`). Existing
installs see zero behavior change until they opt in via `config.yaml`.

## Why

Per @mybdye in #51, users with in-vehicle hotspots want incidents uploaded to
their cloud immediately rather than waiting for the next bulk sync window.
The bulk `cloud_archive_service` is optimized for batch-catch-up and
explicitly delays/skips when WiFi has been down — exactly the wrong policy for
"I just got rear-ended, I want that footage offsite *now*."

## Design (Pi Zero 2 W constraints)

The headline non-functional constraint from #51 was **zero impact on existing
operations** (USB gadget, indexer, cloud_archive, web UI, watchdog, etc.) and
**fits in the Pi Zero 2 W's 512 MB RAM budget**. Concretely:

- One additional thread, blocked on `threading.Event.wait()` when idle.
  Measured idle CPU < 0.1%, RSS delta on Pi: 0 MB at idle.
- No heavy imports in the LES code path (sqlite3, os, subprocess,
  threading, json, re, time, urllib only — no PIL/av/cv2/numpy/requests).
- Reuses the existing inotify watcher via a new `register_event_json_callback`
  — no new file descriptors, no new inotify tree.
- One rclone subprocess at a time, never stacked with cloud_archive.
  Coordinated via the existing `task_coordinator` global mutex.
- Persistent across WiFi outages: queue rows survive reboots; drains on
  reconnect; failed rows have exponential backoff + retry cap.

## Coordination contract (LES wins over cloud_archive)

This is the headline correctness invariant:

1. `cloud_archive._run_sync` checks `has_ready_live_event_work()` between
   each file and yields the task slot when LES has ready work.
2. `cloud_archive.trigger_auto_sync()` skips entirely when LES has ready work.
3. The NetworkManager WiFi-connect dispatcher (`refresh_cloud_token.py`)
   wakes LES *before* triggering cloud_archive, then waits up to 10 minutes
   for LES drain before kicking off the bulk sync.

`has_ready_live_event_work()` checks status + `next_retry_at` + `attempts <
max_attempts` + daily data cap, so a stuck/backed-off row never suppresses
cloud_archive forever.

## Files

**New**:
- `scripts/web/services/live_event_sync_service.py` — worker thread,
  `live_event_queue` table in `cloud_sync.db`, file selection, upload
- `scripts/web/blueprints/live_events.py` — JSON API
  (`/api/live_events/{status,queue,retry/<id>,retry_all,wake}`),
  image-gated on `IMG_CAM_PATH`

**Modified**:
- `config.yaml` + `scripts/web/config.py` — new `live_event_sync:` section
- `scripts/web/services/file_watcher_service.py` — adds
  `register_event_json_callback`; race-safe `event.json` detection
  (scan-on-new-subdir + dedup + periodic catch-up)
- `scripts/web/services/cloud_archive_service.py` — extracted
  `upload_path_via_rclone` helper shared with LES; per-subsystem unique
  rclone.conf path; LES-yield in `_run_sync`; `trigger_auto_sync` skip
  when LES has ready work; rclone stdout → DEVNULL, stderr capped 8 KB
- `scripts/web/helpers/refresh_cloud_token.py` — NM dispatcher wakes
  LES before triggering cloud_archive; waits up to 10 min for LES drain
- `scripts/web/web_control.py` — registers blueprint, wires watcher
  callback, starts LES worker BEFORE cloud auto-sync trigger
- `.github/copilot-instructions.md` — rewrote Cloud Sync Architecture
  section to describe both subsystems + coordination contract; added
  LES section; new pitfalls

## Hardening (rubber-duck pass before commit)

The first draft had several subtle bugs caught during a rubber-duck review;
worth calling out so reviewers don't repeat them:

1. **Retry-attempt accounting** — was bumping `attempts` before
   `task_coordinator.acquire_task` succeeded; a busy coordinator (indexer
   parsing) would silently consume retry slots. Fixed by splitting
   `_claim_next_pending` (status only) from `_record_attempt_start`
   (counter bump after lock acquired) plus `_release_claim_to_pending`
   for transient defers.
2. **Data-loss bug** — Tesla can write `event.json` BEFORE all 6 MP4s are
   on-disk. First draft would mark "uploaded" with only `event.json`.
   Fixed: `_process_one` requires >= 1 MP4; if 0 MP4s and event age
   < 30 min returns transient (defer 60s, no attempt burned); >= 30 min
   gives up.
3. **Path traversal** — `enqueue_event_json` now uses
   `os.path.realpath` + `os.path.commonpath` containment against
   `_teslacam_roots()` plus exact 2-component relpath check. Rejects
   `/tmp/SentryClips/foo` and symlink escapes.
4. **rclone.conf race** — cloud_archive yield/re-acquire could trample
   LES's shared `/run/teslausb/rclone.conf`. Fixed: each subsystem now
   passes a unique conf name (`rclone-les-<pid>-<tid>.conf`).
5. **Inotify event.json race** — between `IN_CREATE` of new subdir and
   `inotify_add_watch`, Tesla can already have written `event.json`.
   Fixed by synchronous `os.path.isfile` check immediately after attaching
   the watch + periodic rescan.
6. **Startup order** — LES worker now starts BEFORE the cloud auto-sync
   trigger at boot so a persistent LES queue takes priority on the very
   first dispatcher fire.

## Verification

- All py_compile + `from web_control import app` smoke checks pass.
- Deployed to `cybertruckusb.local`; `gadget_web.service` active after restart.
- LES endpoints live and fast: `/api/live_events/status` 30 ms,
  `/queue` 25 ms.
- gadget_web RSS: 12 MB (no measurable LES impact at idle, default config).
- All other endpoints continue to respond (`/`, `/mapping`).
- Tesla USB gadget unaffected (no UDC unbind, no mount changes,
  no quick_edit holds).

## Open follow-ups (not blocking)

- Live end-to-end test on Pi requires user to enable LES + provide cloud
  creds + drop a synthetic event. Worth doing once a reviewer is ready
  to enable it.
- Optional status panel UI (todo `les-status-ui`) deferred — JSON API is
  available now.
- 6 design questions surfaced as comments on issue #51 — implementation
  uses sensible defaults (`event_minute` scope, `[30,120,300,900,3600]`
  backoff, 5 retries, no daily cap, no webhook).