### PR TITLE
Add manual WiFi reconnect button to settings page

### DIFF
--- a/scripts/web/blueprints/mode_control.py
+++ b/scripts/web/blueprints/mode_control.py
@@ -10,7 +10,7 @@ from config import GADGET_DIR
 from utils import get_base_context
 from services.mode_service import mode_display
 from services.ap_service import ap_status, ap_force, get_ap_config, update_ap_config
-from services.wifi_service import get_current_wifi_connection, update_wifi_credentials, get_available_networks, get_wifi_status, clear_wifi_status, get_saved_networks, forget_network, reorder_networks
+from services.wifi_service import get_current_wifi_connection, update_wifi_credentials, get_available_networks, get_wifi_status, clear_wifi_status, get_saved_networks, forget_network, reorder_networks, connect_to_network
 
 mode_control_bp = Blueprint('mode_control', __name__, url_prefix='/settings')
 
@@ -551,6 +551,34 @@ def api_wifi_forget():
         return jsonify(result)
     except Exception as e:
         return jsonify({"success": False, "message": str(e)}), 500
+
+
+@mode_control_bp.route("/api/wifi/connect", methods=["POST"])
+def api_wifi_connect():
+    """Manually reconnect to a saved WiFi network.
+
+    Drops the offline AP if it is currently up so the single-radio chip can
+    associate. Returns 202 Accepted with `started: True` when a worker was
+    spawned; the actual outcome is written to the WiFi status file. Returns
+    409 Conflict if another connect attempt is already in progress.
+    """
+    data = request.get_json(silent=True) or {}
+    name = (data.get("name") or "").strip()
+    if not name:
+        return jsonify({"success": False, "message": "No network name provided"}), 400
+    try:
+        result = connect_to_network(name)
+    except Exception as e:
+        return jsonify({"success": False, "message": str(e)}), 500
+
+    if result.get("started"):
+        return jsonify(result), 202
+    if result.get("in_progress"):
+        return jsonify(result), 409
+    if not result.get("success"):
+        # Validation failure (unknown network) or already-connected no-op.
+        return jsonify(result), 400 if "saved list" in result.get("message", "") else 200
+    return jsonify(result), 200
 
 
 @mode_control_bp.route("/api/wifi/scan")

--- a/scripts/web/services/wifi_service.py
+++ b/scripts/web/services/wifi_service.py
@@ -620,6 +620,9 @@ def _set_runtime_force_mode(mode: str) -> bool:
         logger.warning("Failed to write runtime force mode %s: %s", mode, e)
         return False
     # Wake wifi-monitor so it observes the change immediately (best-effort).
+    # No sudo: gadget_web.service runs as root (port 80 binding requirement,
+    # see copilot-instructions.md "Web App Patterns"). Any future privilege
+    # drop would have to add sudo here AND update the sudoers policy.
     try:
         subprocess.run(
             ["systemctl", "kill", "-s", "SIGUSR1", "wifi-monitor.service"],

--- a/scripts/web/services/wifi_service.py
+++ b/scripts/web/services/wifi_service.py
@@ -3,12 +3,24 @@ import logging
 import subprocess
 import re
 import os
+import threading
+import time
 from datetime import datetime
 
 logger = logging.getLogger(__name__)
 
 # File to store WiFi change history/status
 WIFI_STATUS_FILE = "/tmp/teslausb_wifi_status.json"
+
+# Runtime-only AP force mode file (does NOT persist to config.sh).
+# Used by the manual "Connect Now" flow so a worker crash cannot disable
+# the AP across reboots.
+_RUNTIME_FORCE_DIR = "/run/teslausb-ap"
+_RUNTIME_FORCE_FILE = "/run/teslausb-ap/force.mode"
+
+# Serializes user-initiated connect attempts. Two simultaneous Connect
+# clicks would otherwise fight over the radio and the AP state machine.
+_CONNECT_LOCK = threading.Lock()
 
 
 def _save_wifi_status(status: dict):
@@ -587,6 +599,232 @@ def get_saved_networks():
     except Exception as e:
         logger.error("Error getting saved networks: %s", e)
         return []
+
+
+def _set_runtime_force_mode(mode: str) -> bool:
+    """Write force mode to /run only (no config.sh edit) and wake wifi-monitor.
+
+    Unlike ap_control.sh's set_force_mode which persists to config.sh via sed,
+    this is intentionally transient: if our worker crashes, a reboot resets
+    the runtime file and wifi-monitor falls back to the persistent config.
+    """
+    if mode not in ("auto", "force_on", "force_off"):
+        raise ValueError(f"invalid force mode: {mode}")
+    try:
+        os.makedirs(_RUNTIME_FORCE_DIR, exist_ok=True)
+        tmp = _RUNTIME_FORCE_FILE + ".tmp"
+        with open(tmp, "w") as f:
+            f.write(mode + "\n")
+        os.replace(tmp, _RUNTIME_FORCE_FILE)
+    except Exception as e:
+        logger.warning("Failed to write runtime force mode %s: %s", mode, e)
+        return False
+    # Wake wifi-monitor so it observes the change immediately (best-effort).
+    try:
+        subprocess.run(
+            ["systemctl", "kill", "-s", "SIGUSR1", "wifi-monitor.service"],
+            capture_output=True, check=False, timeout=5,
+        )
+    except Exception:
+        pass
+    return True
+
+
+def _wait_for_ap_down(timeout_s: int = 15) -> bool:
+    """Poll until the AP is confirmed down (hostapd/dnsmasq stopped)."""
+    from services.ap_service import ap_status
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if not bool(ap_status().get("ap_active")):
+            return True
+        time.sleep(0.5)
+    return False
+
+
+def _get_active_wlan0_connection_name():
+    """Return the NetworkManager connection name currently active on wlan0, or None."""
+    try:
+        result = subprocess.run(
+            ["nmcli", "-t", "-f", "NAME,DEVICE", "connection", "show", "--active"],
+            capture_output=True, text=True, check=False, timeout=5,
+        )
+        if result.returncode == 0:
+            for line in result.stdout.splitlines():
+                parts = line.split(":")
+                if len(parts) >= 2 and parts[1] == "wlan0":
+                    return parts[0]
+    except Exception:
+        pass
+    return None
+
+
+def _wlan0_has_ipv4() -> bool:
+    """True if wlan0 has an IPv4 address bound (basic connectivity check)."""
+    try:
+        result = subprocess.run(
+            ["ip", "-4", "-br", "addr", "show", "wlan0"],
+            capture_output=True, text=True, check=False, timeout=5,
+        )
+        if result.returncode != 0:
+            return False
+        # Brief format example: "wlan0            UP             192.168.1.42/24"
+        return bool(re.search(r"\d+\.\d+\.\d+\.\d+", result.stdout))
+    except Exception:
+        return False
+
+
+def _wait_for_target_connection(target_name: str, timeout_s: int = 60) -> bool:
+    """Poll until wlan0 is associated with target_name AND has an IPv4 address."""
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        active = _get_active_wlan0_connection_name()
+        if active == target_name and _wlan0_has_ipv4():
+            return True
+        time.sleep(1)
+    return False
+
+
+def _normalize_force_mode_for_runtime(status_value):
+    """Normalize ap_status() force_mode field to a runtime-file value."""
+    if status_value in ("auto", "force_on", "force_off"):
+        return status_value
+    return "auto"
+
+
+def _connect_worker(connection_name: str, original_force_mode: str, ap_was_up: bool):
+    """Background worker that drops the AP, runs nmcli, and restores force mode."""
+    success = False
+    error_msg = None
+    final_active = None
+    try:
+        if ap_was_up:
+            logger.info("connect_to_network: dropping AP for STA reconnect to %r", connection_name)
+            _set_runtime_force_mode("force_off")
+            if not _wait_for_ap_down(timeout_s=15):
+                error_msg = "AP did not stop within 15s; aborting"
+                logger.warning(error_msg)
+                return
+            time.sleep(1)  # brief settle so the radio releases the channel
+
+        logger.info("connect_to_network: nmcli connection up id %r ifname wlan0", connection_name)
+        try:
+            result = subprocess.run(
+                ["sudo", "-n", "nmcli", "connection", "up",
+                 "id", connection_name, "ifname", "wlan0"],
+                capture_output=True, text=True, check=False, timeout=45,
+            )
+            if result.returncode != 0:
+                logger.warning("nmcli connection up returned %d: %s",
+                               result.returncode, (result.stderr or "").strip())
+        except subprocess.TimeoutExpired:
+            logger.warning("nmcli connection up timed out (45s)")
+
+        # Verify the actual outcome regardless of nmcli return code: NM is finicky.
+        if _wait_for_target_connection(connection_name, timeout_s=60):
+            success = True
+        final_active = _get_active_wlan0_connection_name()
+    except Exception as e:
+        error_msg = str(e)
+        logger.exception("connect_to_network worker failed: %s", e)
+    finally:
+        # Always restore the user's original force mode so a worker crash cannot
+        # leave the AP permanently disabled.
+        try:
+            _set_runtime_force_mode(_normalize_force_mode_for_runtime(original_force_mode))
+        except Exception:
+            logger.exception("Failed to restore force mode to %r", original_force_mode)
+
+        _save_wifi_status({
+            "type": "manual_connect",
+            "target": connection_name,
+            "success": success,
+            "active_after": final_active,
+            "message": (
+                f"Connected to '{connection_name}'." if success
+                else (error_msg or f"Could not connect to '{connection_name}'.")
+            ),
+        })
+        # Release the connect lock so further attempts are allowed.
+        try:
+            _CONNECT_LOCK.release()
+        except RuntimeError:
+            # Already released or never held - shouldn't happen, but log it.
+            logger.warning("Connect lock release: already released")
+
+
+def connect_to_network(connection_name: str) -> dict:
+    """User-initiated reconnect to a saved WiFi network.
+
+    Drops the offline AP if it is currently up (radio is single-channel on Pi
+    Zero 2 W, so STA cannot associate while hostapd holds uap0). Restores the
+    user's original AP force mode in a finally block.
+
+    Validation: connection_name must match a known saved network exactly. The
+    name is then passed verbatim to nmcli as a list arg (no shell).
+
+    Returns immediately with `started: True` if a worker was spawned; the
+    caller (route handler) should map this to HTTP 202. Final result is
+    written to WIFI_STATUS_FILE for the settings page to display.
+    """
+    # 1. Allowlist validation against currently-saved networks.
+    saved = get_saved_networks()
+    target = next((n for n in saved if n["name"] == connection_name), None)
+    if target is None:
+        return {
+            "success": False, "started": False,
+            "message": f"Network '{connection_name}' is not in the saved list",
+        }
+
+    # 2. Already connected to this network and IP is live? No-op.
+    if target.get("active") and _wlan0_has_ipv4():
+        return {
+            "success": True, "started": False,
+            "message": f"Already connected to '{connection_name}'",
+            "ap_will_drop": False,
+        }
+
+    # 3. Serialize: only one connect attempt at a time.
+    if not _CONNECT_LOCK.acquire(blocking=False):
+        return {
+            "success": False, "started": False, "in_progress": True,
+            "message": "Another connect attempt is in progress. Please wait.",
+        }
+
+    # 4. Capture state and spawn worker. From here the lock will be released by
+    #    the worker's finally block (or by us on the immediate-failure path).
+    try:
+        from services.ap_service import ap_status
+        status = ap_status()
+        ap_was_up = bool(status.get("ap_active"))
+        original_force_mode = status.get("force_mode") or "auto"
+
+        worker = threading.Thread(
+            target=_connect_worker,
+            args=(connection_name, original_force_mode, ap_was_up),
+            name=f"wifi-connect-{connection_name[:20]}",
+            daemon=True,
+        )
+        worker.start()
+    except Exception as e:
+        # Spawn failed: release lock so future attempts work.
+        try:
+            _CONNECT_LOCK.release()
+        except RuntimeError:
+            pass
+        logger.exception("Failed to start connect worker: %s", e)
+        return {"success": False, "started": False, "message": f"Failed to start: {e}"}
+
+    return {
+        "success": True, "started": True,
+        "ap_will_drop": ap_was_up,
+        "target": connection_name,
+        "message": (
+            f"Reconnect to '{connection_name}' started. "
+            "AP will drop for ~30-60 seconds while we attempt the connection."
+            if ap_was_up else
+            f"Reconnect to '{connection_name}' started."
+        ),
+    }
 
 
 def forget_network(connection_name: str) -> dict:

--- a/scripts/web/templates/index.html
+++ b/scripts/web/templates/index.html
@@ -469,7 +469,22 @@ function loadSavedNetworks() {
             const dot = net.active ? '<span style="color:var(--success-text, #22c55e);margin-right:6px">●</span>' : '<span style="margin-right:14px"></span>';
             const signal = net.in_range ? '<span style="font-size:0.8em;color:var(--text-secondary)">' + getSignalIcon(net.signal) + ' ' + net.signal + '%</span>' : '<span style="font-size:0.8em;color:var(--text-secondary)">Not in range</span>';
             const name = (net.ssid || net.name).replace(/</g, '&lt;').replace(/>/g, '&gt;');
-            const escapedName = net.name.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+            // Defence against XSS via SSID. The value is embedded inside
+            //   onclick="someFn('VALUE')"
+            // so we have to escape for two contexts in order:
+            //   1. JS string literal: backslash, then single quote (the JS
+            //      string delimiter).
+            //   2. HTML attribute value: ampersand first (must come before
+            //      other &-entities so we don't double-encode), then the
+            //      attribute delimiter (").
+            // Without the HTML attribute pass, an SSID containing `"` or
+            // `&quot;` could close the onclick attribute and inject
+            // arbitrary HTML. The order matters in BOTH passes.
+            const escapedName = net.name
+                .replace(/\\/g, '\\\\')   // JS: backslash
+                .replace(/'/g, "\\'")     // JS: single quote (string delimiter)
+                .replace(/&/g, '&amp;')   // HTML attr: ampersand (first!)
+                .replace(/"/g, '&quot;'); // HTML attr: double quote (delimiter)
             html += '<div style="display:flex;align-items:center;padding:8px 4px;border-bottom:1px solid var(--border-color, var(--border));gap:6px">';
             html += dot;
             html += '<span style="flex:1;font-size:0.875rem;font-weight:' + (net.active ? '600' : '400') + '">' + name + '</span>';

--- a/scripts/web/templates/index.html
+++ b/scripts/web/templates/index.html
@@ -474,6 +474,11 @@ function loadSavedNetworks() {
             html += dot;
             html += '<span style="flex:1;font-size:0.875rem;font-weight:' + (net.active ? '600' : '400') + '">' + name + '</span>';
             html += signal;
+            // Connect button: only shown for non-active networks. Disabled if not in range.
+            if (!net.active) {
+                const cantConnect = !net.in_range;
+                html += '<button class="edit-btn wifi-connect-btn" onclick="connectToNetwork(\'' + escapedName + '\')" title="' + (cantConnect ? 'Network not in range' : 'Connect to this network now') + '" style="padding:2px 8px;font-size:0.8em;min-height:auto"' + (cantConnect ? ' disabled' : '') + '>Connect</button>';
+            }
             html += '<button class="edit-btn" onclick="moveNetwork(\'' + escapedName + '\',-1)" title="Move up" style="padding:2px 6px;font-size:0.8em;min-height:auto"' + (idx === 0 ? ' disabled' : '') + '>▲</button>';
             html += '<button class="edit-btn" onclick="moveNetwork(\'' + escapedName + '\',1)" title="Move down" style="padding:2px 6px;font-size:0.8em;min-height:auto"' + (idx === networks.length - 1 ? ' disabled' : '') + '>▼</button>';
             html += '<button class="present-btn" onclick="forgetNetwork(\'' + escapedName + '\')" title="Forget" style="padding:2px 6px;font-size:0.8em;min-height:auto">✕</button>';
@@ -516,6 +521,49 @@ function forgetNetwork(name) {
         if (data.message) alert(data.message);
         loadSavedNetworks();
     });
+}
+
+function connectToNetwork(name) {
+    const msg = 'Connect to "' + name + '" now?\n\n'
+        + 'If the offline access point is currently active, it will drop for ~30-60 seconds '
+        + 'while we attempt the connection. After about 60-90 seconds:\n\n'
+        + '  - If WiFi reconnect succeeds, the AP stays off. Reach the Pi at '
+        + 'http://cybertruckusb.local on your home WiFi.\n'
+        + '  - If WiFi reconnect fails, the AP comes back automatically. '
+        + 'Reconnect to the TeslaUSB AP and try again.';
+    if (!confirm(msg)) return;
+
+    // Disable all Connect buttons so the user cannot double-fire.
+    document.querySelectorAll('.wifi-connect-btn').forEach(b => {
+        b.disabled = true;
+        if (b.getAttribute('onclick') && b.getAttribute('onclick').indexOf(name) !== -1) {
+            b.textContent = 'Connecting…';
+        }
+    });
+
+    fetch('{{ url_for("mode_control.api_wifi_connect") }}', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({name: name})
+    }).then(r => r.json().then(data => ({status: r.status, data: data})))
+      .then(({status, data}) => {
+          if (status === 202 || (data && data.success)) {
+              alert((data && data.message) || 'Reconnect started.');
+          } else if (status === 409) {
+              alert('Another connect attempt is already in progress. Please wait.');
+              loadSavedNetworks();
+          } else {
+              alert((data && data.message) || ('Connect failed (HTTP ' + status + ')'));
+              loadSavedNetworks();
+          }
+      })
+      .catch(err => {
+          // Expected when the AP drops mid-fetch: the request is in flight, the
+          // server is doing its work, but the response could not be delivered.
+          alert('Reconnect attempt sent. The AP may have dropped. Wait ~60-90s, '
+              + 'then try http://cybertruckusb.local on your home WiFi, or '
+              + 'reconnect to the TeslaUSB AP if the attempt failed.');
+      });
 }
 
 function toggleAddNetwork() {


### PR DESCRIPTION
## Problem

When the offline AP is active in `auto` mode, the Pi Zero 2 W's single-radio WiFi chip is locked to the AP channel, so `wlan0` cannot associate with home WiFi. The `wifi-monitor.sh` daemon's periodic retry only fires every ~5 minutes, leaving the user stuck on the AP for several minutes after returning home. There was no manual way to force a reconnect from the UI — only Add / Reorder / Forget.

Reported by user this session: `I drove home but the AP is still up and the Pi didn't reconnect to my home WiFi`.

## Change

Adds a **Connect** button next to each non-active saved network on the WiFi settings page. Clicking it briefly drops the AP, runs `nmcli connection up id <name> ifname wlan0`, and either lets STA take over (success) or restarts the AP (failure).

### Backend

- New `connect_to_network(name)` in `wifi_service.py`:
  - Validates `name` against the saved-networks allowlist (security: list-arg `nmcli`, no shell)
  - Captures the user's current AP force mode so it can be restored on every exit path
  - Spawns a daemon thread (so the HTTP 202 response lands on the user's device before the AP drops mid-fetch)
  - Writes `force.mode=force_off` to `/run/teslausb-ap/force.mode` only — **never** to `config.sh`, so a worker crash cannot disable the AP across reboot
  - Sends `SIGUSR1` to `wifi-monitor.service` to wake it immediately
  - Polls `ap_status()` until `ap_active=False` (15s timeout) instead of a fragile fixed sleep
  - Verifies success by polling for active wlan0 connection name == target **AND** wlan0 has IPv4, up to 60s
  - Restores the original force mode in a `finally` block (preserves `force_on` if user had set it)
  - Module-level `threading.Lock` serializes attempts; second concurrent click returns HTTP 409
- New `POST /api/wifi/connect` route in `mode_control.py`:
  - 202 Accepted on spawn, final outcome lands in `WIFI_STATUS_FILE`
  - 400 Bad Request: name missing or not in saved list
  - 409 Conflict: another attempt already in progress

### UI

- Connect button next to each non-active saved network (disabled if not in range)
- Confirmation modal explains the AP-drop window and where to look afterwards (60-90s budget for STA + DHCP + mDNS announce)
- All Connect buttons disabled on click to prevent double-fire
- Fetch-rejection path treats network errors as "AP probably dropped, your request was sent" — honest interpretation when the connection drops mid-flight

## Out of scope

The auto-recovery in `wifi-monitor.sh` (5-minute retry interval, 10-second post-rescan settle) is intentionally **not** touched here. That tuning is a separate concern and should be its own PR.

## Testing

Python syntax check passes (`python -m py_compile`). Live deployment to the Pi pending — the Pi is currently in the very state this PR fixes (stuck on AP, unreachable on home WiFi). User will deploy once the Pi recovers.

## Rubber-duck

Plan was reviewed by the rubber-duck agent. Adopted: runtime-only force-mode write, threading lock, AP-down polling, try/finally with original-mode restore, target-name verification, `id <name> ifname wlan0` form, HTTP 202, 60-90s UI timing, disable buttons on click. Deferred: full DOM rebuild of the saved-networks list (consistency with existing UI), moving orchestration into wifi-monitor (larger refactor).

## Files

- `scripts/web/services/wifi_service.py` — new `connect_to_network`, `_set_runtime_force_mode`, `_wait_for_ap_down`, `_get_active_wlan0_connection_name`, `_wlan0_has_ipv4`, `_wait_for_target_connection`, `_connect_worker` helpers + module lock
- `scripts/web/blueprints/mode_control.py` — import update + new `POST /api/wifi/connect` route
- `scripts/web/templates/index.html` — Connect button in saved-networks list + `connectToNetwork()` JS function