### PR TITLE
fix(#76): trip fragmentation + archive lock starvation

### DIFF
--- a/scripts/web/services/indexing_worker.py
+++ b/scripts/web/services/indexing_worker.py
@@ -529,13 +529,27 @@ def _run_worker_loop(db_path: str, teslacam_root: str, worker_id: str) -> None:
 
         # Don't fight other heavy tasks — archive and cloud sync take
         # priority for vehicle-safety reasons (RecentClips preservation
-        # > indexing latency).
-        if not task_coordinator.acquire_task(_COORDINATOR_TASK):
+        # > indexing latency).  ``yield_to_waiters=True`` makes the
+        # indexer immediately back off whenever any other task (archive
+        # or cloud sync) is currently inside ``acquire_task`` waiting
+        # for the lock.  This is the fairness mechanism that prevents
+        # the indexer's tight ~1 Hz acquire/release cycle from starving
+        # the 5-minute archive timer (which led to TeslaCam clip loss
+        # in production).
+        if not task_coordinator.acquire_task(
+                _COORDINATOR_TASK, yield_to_waiters=True):
             if _stop_event.wait(timeout=_BACKOFF_SLEEP_SECONDS):
                 break
             continue
 
+        # Claim a row, process it, then ALWAYS release the lock before
+        # any sleeping. Holding the lock while sleeping (waiting for
+        # the next file or for an empty queue to refill) would re-create
+        # the starvation: the archive timer would see the lock held and
+        # bail out for another 5 minutes even though the indexer is
+        # doing no work.
         row: Optional[Dict[str, Any]] = None
+        claim_failed = False
         try:
             try:
                 row = mapping_service.claim_next_queue_item(
@@ -544,26 +558,32 @@ def _run_worker_loop(db_path: str, teslacam_root: str, worker_id: str) -> None:
             except Exception as e:  # noqa: BLE001
                 logger.warning("claim_next_queue_item raised: %s", e)
                 _set_worker_state(last_error=f'claim: {e!r}')
-                if _stop_event.wait(timeout=_BACKOFF_SLEEP_SECONDS):
-                    break
-                continue
+                claim_failed = True
+                row = None
 
-            if row is None:
+            if row is not None:
+                _process_one(row, db_path, teslacam_root)
+            elif not claim_failed:
                 # Queue genuinely empty — record drain timestamp so the
                 # status API can show "last drained N seconds ago".
                 _set_worker_state(last_drained_at=time.time())
-                if _stop_event.wait(timeout=_IDLE_SLEEP_SECONDS):
-                    break
-                continue
-
-            _process_one(row, db_path, teslacam_root)
         finally:
             task_coordinator.release_task(_COORDINATOR_TASK)
             _record_idle()
 
-        # Inter-file pause — keep the gadget responsive.
-        if _stop_event.wait(timeout=_INTER_FILE_SLEEP_SECONDS):
-            break
+        # All sleeps happen AFTER the lock is released so other tasks
+        # (archive, cloud sync) can grab it during these windows.
+        if claim_failed:
+            if _stop_event.wait(timeout=_BACKOFF_SLEEP_SECONDS):
+                break
+        elif row is None:
+            # Queue empty — sleep longer; nothing useful to do.
+            if _stop_event.wait(timeout=_IDLE_SLEEP_SECONDS):
+                break
+        else:
+            # Inter-file pause — keep the gadget responsive.
+            if _stop_event.wait(timeout=_INTER_FILE_SLEEP_SECONDS):
+                break
 
 
 def _process_one(row: Dict[str, Any], db_path: str,

--- a/scripts/web/services/mapping_service.py
+++ b/scripts/web/services/mapping_service.py
@@ -143,7 +143,7 @@ def _with_db_retry(fn: Callable) -> Callable:
 # Database Schema & Management
 # ---------------------------------------------------------------------------
 
-_SCHEMA_VERSION = 8
+_SCHEMA_VERSION = 9
 _BACKUP_RETENTION = 3  # Keep this many migration backups before pruning oldest
 
 _SCHEMA_SQL = """
@@ -381,6 +381,39 @@ def _init_db(db_path: str) -> sqlite3.Connection:
                 logger.error("Migration v3->v4 failed, leaving schema at v3: %s", e)
                 conn.commit()
                 return conn
+        if current > 0 and current < 9:
+            # v9: one-shot repair pass for trips that were fragmented
+            # by the matching-SQL boundary bug fixed in this version.
+            # The bug: ``ORDER BY ABS(new_start - existing.start)`` plus
+            # the float-imprecise ``(julianday(...)-julianday(...))*86400``
+            # condition caused phantom-fragmented trips when files
+            # arrived out-of-order during indexer pauses (e.g., archive-
+            # lock starvation incident May 2026 — McDonald's drive split
+            # into 6 trips). The runtime ``_merge_adjacent_trips_for``
+            # added in this version prevents future fragmentation, but
+            # only sweeps the just-touched anchor's neighbourhood, so
+            # bad data already in the table will linger unless a future
+            # clip happens to bridge it. This one-shot global merge
+            # repairs the existing damage.
+            try:
+                conn.execute("SAVEPOINT migrate_v9")
+                merged = _merge_all_adjacent_trip_pairs(
+                    conn, _TRIP_GAP_MINUTES_DEFAULT * 60,
+                )
+                conn.execute("RELEASE SAVEPOINT migrate_v9")
+                if merged:
+                    logger.info(
+                        "Migration v8->v9: merged %d phantom-fragmented "
+                        "trip pairs", merged,
+                    )
+            except Exception as e:
+                conn.execute("ROLLBACK TO SAVEPOINT migrate_v9")
+                conn.execute("RELEASE SAVEPOINT migrate_v9")
+                logger.error(
+                    "Migration v8->v9 failed, leaving schema at v8: %s", e,
+                )
+                conn.commit()
+                return conn
         # v5: covering index ``idx_waypoints_trip_video`` for the
         # ``/api/trips`` page-load N+1 fix. The index is created by the
         # ``executescript(_SCHEMA_SQL)`` call above (CREATE INDEX IF NOT
@@ -470,41 +503,7 @@ def _migrate_v2_to_v3(conn: sqlite3.Connection) -> None:
     # --- Phase 2: merge overlapping/close trips ---
     # Repeatedly find any pair of trips whose windows are within gap_seconds
     # of each other (in either direction) and merge the higher-id into the lower.
-    merged = 0
-    iterations = 0
-    while True:
-        iterations += 1
-        if iterations > 10000:
-            # Don't silently continue — that would leave duplicates AND
-            # bump schema_version, making this migration unrunnable on the
-            # next startup. Raising here triggers the SAVEPOINT rollback
-            # in _init_db, leaves schema at v2, and surfaces the failure
-            # in the logs so we can investigate.
-            raise RuntimeError(
-                "v2->v3 trip merge loop exceeded 10000 iterations; "
-                "possible infinite loop or pathological duplicate set"
-            )
-        pair = conn.execute(
-            """SELECT a.id AS keep_id, b.id AS drop_id
-               FROM trips a
-               JOIN trips b
-                 ON a.id < b.id
-                AND a.start_time IS NOT NULL AND a.end_time IS NOT NULL
-                AND b.start_time IS NOT NULL AND b.end_time IS NOT NULL
-                AND ((julianday(b.start_time) - julianday(a.end_time)) * 86400) <= ?
-                AND ((julianday(a.start_time) - julianday(b.end_time)) * 86400) <= ?
-               LIMIT 1""",
-            (gap_seconds, gap_seconds),
-        ).fetchone()
-        if not pair:
-            break
-        keep_id, drop_id = pair['keep_id'], pair['drop_id']
-        conn.execute("UPDATE waypoints SET trip_id = ? WHERE trip_id = ?",
-                     (keep_id, drop_id))
-        conn.execute("UPDATE detected_events SET trip_id = ? WHERE trip_id = ?",
-                     (keep_id, drop_id))
-        conn.execute("DELETE FROM trips WHERE id = ?", (drop_id,))
-        merged += 1
+    merged = _merge_all_adjacent_trip_pairs(conn, gap_seconds)
     log_parts.append(f"merged {merged} overlapping trip pairs")
 
     # --- Phase 3: dedupe waypoints within a trip ---
@@ -612,6 +611,203 @@ def _migrate_v2_to_v3(conn: sqlite3.Connection) -> None:
 # Default trip gap, also used by the migration. Kept here so the migration
 # can run before any per-call ``trip_gap_minutes`` argument is available.
 _TRIP_GAP_MINUTES_DEFAULT = 5
+
+# Safety bound on the post-insert merge loop. The migration uses 10000;
+# match it so the runtime helper can recover from severe accumulated
+# fragmentation (e.g. after a long indexer outage where many small
+# trip fragments built up). Hitting this bound indicates a pathological
+# data set worth investigating.
+_MERGE_MAX_ITERATIONS = 10000
+
+
+def _merge_adjacent_trips_for(conn: sqlite3.Connection,
+                              anchor_trip_id: int,
+                              gap_seconds: float) -> int:
+    """Merge any other trip whose [start_time, end_time] window is within
+    ``gap_seconds`` of the anchor's window. The lower trip id wins so
+    the survivor is stable and references stay valid.
+
+    This is the runtime defense against trip fragmentation when the
+    indexer processes a drive's clips out of order. The matching SQL in
+    :func:`_index_video` picks one trip per insert; this helper runs
+    afterwards and stitches together any trips the new clip's waypoints
+    bridged. Mirrors the v2→v3 migration's merge phase but is scoped to
+    one anchor's neighbourhood per call so it costs only a handful of
+    queries per indexed file.
+
+    Returns the surviving trip id (which equals ``anchor_trip_id`` when
+    anchor is the lowest-id trip in its merged cluster, otherwise the
+    smaller id of the merge pair).
+
+    Important: the caller is responsible for calling ``conn.commit()``
+    after this returns. The helper writes through the connection's
+    current transaction so insert + merge + stats recompute remain
+    atomic — readers see either the pre-insert state or the fully
+    merged state, never a half-merged window.
+
+    Foreign-key safety: the schema declares
+    ``trip_id REFERENCES trips(id) ON DELETE CASCADE`` on both
+    ``waypoints`` and ``detected_events``, so this helper MUST update
+    the child rows BEFORE deleting the dropped trip — otherwise the
+    cascade would destroy waypoints we wanted to preserve.
+    """
+    survivor = anchor_trip_id
+
+    for _ in range(_MERGE_MAX_ITERATIONS):
+        # Refresh the survivor's bounds from waypoints. The bounds may
+        # have changed in two ways since the last iteration: the caller
+        # just inserted new waypoints, or the previous loop iteration
+        # absorbed another trip's waypoints. Without this refresh, a
+        # chain merge (A ↔ B ↔ C) would stop after one step because
+        # the survivor's stale ``end_time`` does not reach C.
+        bounds = conn.execute(
+            "SELECT MIN(timestamp) AS s, MAX(timestamp) AS e "
+            "FROM waypoints WHERE trip_id = ?",
+            (survivor,),
+        ).fetchone()
+        if not bounds or bounds['s'] is None:
+            return survivor
+        conn.execute(
+            "UPDATE trips SET start_time = ?, end_time = ? WHERE id = ?",
+            (bounds['s'], bounds['e'], survivor),
+        )
+
+        # Find the lowest-id mergeable neighbour. Same window logic as
+        # the matching SQL in _index_video and the migration:
+        #   neighbour.start - survivor.end ≤ gap   (neighbour after)
+        #   survivor.start - neighbour.end ≤ gap   (neighbour before)
+        # Negative values (overlap) also satisfy ≤ gap. Order by id so
+        # we always pick the smallest mergeable neighbour first; the
+        # absolute pair we merge is then (min(survivor, candidate),
+        # max(survivor, candidate)).
+        #
+        # Integer-second arithmetic via ``strftime('%s', ...)`` is used
+        # instead of ``(julianday(a) - julianday(b)) * 86400`` because
+        # the latter has floating-point error: a true 300-second gap
+        # can yield 300.000022 and fail the ``<= 300`` boundary check,
+        # silently leaving phantom-fragmented trips unmerged. The
+        # strftime form is precise to one second, which is safely
+        # within the 5-minute trip-gap semantic tolerance.
+        candidate = conn.execute(
+            """
+            SELECT id FROM trips
+            WHERE id != :survivor
+              AND start_time IS NOT NULL AND end_time IS NOT NULL
+              AND (CAST(strftime('%s', start_time) AS INTEGER)
+                   - CAST(strftime('%s', :end_t) AS INTEGER)) <= :gap
+              AND (CAST(strftime('%s', :start_t) AS INTEGER)
+                   - CAST(strftime('%s', end_time) AS INTEGER)) <= :gap
+            ORDER BY id
+            LIMIT 1
+            """,
+            {'survivor': survivor,
+             'start_t': bounds['s'], 'end_t': bounds['e'],
+             'gap': gap_seconds},
+        ).fetchone()
+        if not candidate:
+            return survivor
+
+        keep_id = min(survivor, candidate['id'])
+        drop_id = max(survivor, candidate['id'])
+
+        # Update children first, then delete the parent. Reversing this
+        # order would trip the ON DELETE CASCADE and silently destroy
+        # the very rows we are trying to preserve.
+        conn.execute(
+            "UPDATE waypoints SET trip_id = ? WHERE trip_id = ?",
+            (keep_id, drop_id),
+        )
+        conn.execute(
+            "UPDATE detected_events SET trip_id = ? WHERE trip_id = ?",
+            (keep_id, drop_id),
+        )
+        conn.execute("DELETE FROM trips WHERE id = ?", (drop_id,))
+        survivor = keep_id
+
+    raise RuntimeError(
+        f"_merge_adjacent_trips_for: exceeded {_MERGE_MAX_ITERATIONS} "
+        "iterations — possible infinite loop or pathological data"
+    )
+
+
+def _merge_all_adjacent_trip_pairs(conn: sqlite3.Connection,
+                                    gap_seconds: float) -> int:
+    """Sweep the whole ``trips`` table and merge every pair whose
+    windows are within ``gap_seconds`` of each other.
+
+    Used by:
+      * the v2→v3 migration (cleans up duplicate trips from earlier
+        indexer bugs);
+      * the v8→v9 migration (one-shot repair of phantom-fragmented
+        trips left over from the matching-SQL boundary bug);
+      * future startup repair passes.
+
+    Always uses integer-epoch arithmetic via ``strftime('%s', ...)``
+    instead of ``(julianday(a) - julianday(b)) * 86400`` because the
+    latter has floating-point error that silently leaves true
+    ``gap_seconds``-apart pairs unmerged (see ``_merge_adjacent_trips_for``
+    for the in-depth explanation).
+
+    Foreign-key safety: updates ``waypoints`` and ``detected_events``
+    BEFORE deleting the dropped trip, since both tables declare
+    ``ON DELETE CASCADE`` on ``trip_id``.
+
+    Returns the number of merge operations performed. The caller is
+    responsible for ``conn.commit()``.
+
+    Raises ``RuntimeError`` if more than ``_MERGE_MAX_ITERATIONS`` pairs
+    are merged — a safety bound that triggers the migration's SAVEPOINT
+    rollback rather than silently continuing forever on pathological
+    data.
+    """
+    merged = 0
+    for _ in range(_MERGE_MAX_ITERATIONS):
+        pair = conn.execute(
+            """SELECT a.id AS keep_id, b.id AS drop_id
+               FROM trips a
+               JOIN trips b
+                 ON a.id < b.id
+                AND a.start_time IS NOT NULL AND a.end_time IS NOT NULL
+                AND b.start_time IS NOT NULL AND b.end_time IS NOT NULL
+                AND (CAST(strftime('%s', b.start_time) AS INTEGER)
+                     - CAST(strftime('%s', a.end_time) AS INTEGER)) <= ?
+                AND (CAST(strftime('%s', a.start_time) AS INTEGER)
+                     - CAST(strftime('%s', b.end_time) AS INTEGER)) <= ?
+               LIMIT 1""",
+            (gap_seconds, gap_seconds),
+        ).fetchone()
+        if not pair:
+            return merged
+        keep_id, drop_id = pair['keep_id'], pair['drop_id']
+        conn.execute(
+            "UPDATE waypoints SET trip_id = ? WHERE trip_id = ?",
+            (keep_id, drop_id),
+        )
+        conn.execute(
+            "UPDATE detected_events SET trip_id = ? WHERE trip_id = ?",
+            (keep_id, drop_id),
+        )
+        # Refresh the survivor's bounds so the next iteration considers
+        # the merged window when looking for further mergeable pairs.
+        bounds = conn.execute(
+            "SELECT MIN(timestamp) AS s, MAX(timestamp) AS e "
+            "FROM waypoints WHERE trip_id = ?",
+            (keep_id,),
+        ).fetchone()
+        if bounds and bounds['s'] is not None:
+            conn.execute(
+                "UPDATE trips SET start_time = ?, end_time = ? "
+                "WHERE id = ?",
+                (bounds['s'], bounds['e'], keep_id),
+            )
+        conn.execute("DELETE FROM trips WHERE id = ?", (drop_id,))
+        merged += 1
+
+    raise RuntimeError(
+        f"_merge_all_adjacent_trip_pairs: exceeded "
+        f"{_MERGE_MAX_ITERATIONS} iterations — possible infinite loop "
+        "or pathological duplicate set"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -2075,6 +2271,18 @@ def _index_video(
     # Earlier code filtered by source_folder, which fragmented trips when
     # the same drive was ingested from RecentClips vs ArchivedClips, and
     # picked the wrong trip when videos were indexed out of order.
+    #
+    # ORDER BY: pick the trip with the smallest temporal gap to the new
+    # clip (0 for any trip whose window overlaps the new clip's range).
+    # An earlier "ORDER BY ABS(new_start - existing.start)" tie-breaker
+    # caused phantom duplicate trips in production: when the new clip
+    # fell BETWEEN two existing trips, that ranking could prefer the
+    # later trip simply because its start_time was numerically closer
+    # to the new clip's start (even though the clip should clearly
+    # extend the earlier trip). The new ranking always picks the trip
+    # whose interval the new clip actually adjoins. The post-insert
+    # _merge_adjacent_trips_for is still called as defense in depth in
+    # case the chosen trip is itself adjacent to another.
     first_wp = waypoint_dicts[0]
     last_wp = waypoint_dicts[-1]
     new_start = first_wp['timestamp']
@@ -2082,13 +2290,29 @@ def _index_video(
     gap_seconds = trip_gap_minutes * 60
 
     existing_trip = conn.execute(
-        """SELECT id FROM trips
-           WHERE start_time IS NOT NULL AND end_time IS NOT NULL
-             AND ((julianday(?) - julianday(end_time)) * 86400) <= ?
-             AND ((julianday(start_time) - julianday(?)) * 86400) <= ?
-           ORDER BY ABS((julianday(?) - julianday(start_time)) * 86400)
-           LIMIT 1""",
-        (new_start, gap_seconds, new_end, gap_seconds, new_start),
+        """
+        SELECT id FROM trips
+        WHERE start_time IS NOT NULL AND end_time IS NOT NULL
+          AND (CAST(strftime('%s', :ns) AS INTEGER)
+               - CAST(strftime('%s', end_time) AS INTEGER)) <= :gap
+          AND (CAST(strftime('%s', start_time) AS INTEGER)
+               - CAST(strftime('%s', :ne) AS INTEGER)) <= :gap
+        ORDER BY
+          CASE
+            WHEN CAST(strftime('%s', end_time) AS INTEGER)
+                 < CAST(strftime('%s', :ns) AS INTEGER)
+              THEN CAST(strftime('%s', :ns) AS INTEGER)
+                   - CAST(strftime('%s', end_time) AS INTEGER)
+            WHEN CAST(strftime('%s', start_time) AS INTEGER)
+                 > CAST(strftime('%s', :ne) AS INTEGER)
+              THEN CAST(strftime('%s', start_time) AS INTEGER)
+                   - CAST(strftime('%s', :ne) AS INTEGER)
+            ELSE 0
+          END ASC,
+          id ASC
+        LIMIT 1
+        """,
+        {'ns': new_start, 'ne': new_end, 'gap': gap_seconds},
     ).fetchone()
     trip_id = existing_trip['id'] if existing_trip else None
 
@@ -2133,6 +2357,17 @@ def _index_video(
               ev['video_path'], ev['frame_offset'], ev.get('metadata'))
              for ev in events]
         )
+
+    # Defense-in-depth: merge any other trip whose window now adjoins
+    # (or overlaps) this trip's extent. The matching SQL above picks
+    # one trip per insert; if the new clip's waypoints bridged two
+    # existing trips, only the chosen one was extended and the other
+    # remained as a phantom fragment. _merge_adjacent_trips_for stitches
+    # them together using the same gap rule and returns the surviving
+    # id (which is preserved across calls because we always keep the
+    # lower id). All FK children are re-pointed before the dropped
+    # trip is deleted, so cascade does not destroy waypoints.
+    trip_id = _merge_adjacent_trips_for(conn, trip_id, gap_seconds)
 
     # Recompute trip stats from the full waypoint set. The new video may
     # extend the trip in either direction (forward OR backward in time when

--- a/scripts/web/services/task_coordinator.py
+++ b/scripts/web/services/task_coordinator.py
@@ -8,17 +8,36 @@ Usage::
 
     from services.task_coordinator import acquire_task, release_task, is_busy
 
-    if acquire_task('indexer'):
+    # Cyclic task that should yield to less frequent priority tasks.
+    if acquire_task('indexer', yield_to_waiters=True):
         try:
             do_heavy_work()
         finally:
             release_task('indexer')
 
+    # Less frequent task that needs to wait for a slot.
+    if acquire_task('archive', wait_seconds=60.0):
+        try:
+            do_heavy_work()
+        finally:
+            release_task('archive')
+
 Or as a context manager::
 
-    with heavy_task('archive') as acquired:
+    with heavy_task('archive', wait_seconds=60.0) as acquired:
         if acquired:
             do_heavy_work()
+
+Fairness model
+--------------
+A "waiter count" tracks how many tasks are currently blocking inside
+``acquire_task(..., wait_seconds>0)``.  Cyclic tasks (the indexer)
+that pass ``yield_to_waiters=True`` will refuse to take the lock if
+any other task is waiting for it.  This prevents the indexer's
+acquire/release cycle (~1 Hz with ~0.25 s gaps) from starving the
+archive's 5-minute timer — a real production issue that caused
+TeslaCam clips to be lost when Tesla rotated RecentClips before the
+archive could grab the lock.
 """
 
 import threading
@@ -32,38 +51,114 @@ _lock = threading.Lock()
 _current_task: str | None = None
 _task_started: float = 0.0
 
+# Number of callers currently waiting inside ``acquire_task`` with
+# ``wait_seconds>0``. Used by the fairness short-circuit so cyclic
+# tasks can yield to priority tasks. Guarded by ``_lock``.
+_waiter_count: int = 0
+
+# How often a waiting caller polls the lock. Kept short so a blocked
+# task (e.g. archive) can grab the slot during the indexer's brief
+# inter-file gap (currently 0.25 s). Must be < indexer's
+# ``_INTER_FILE_SLEEP_SECONDS`` for the fairness short-circuit to be
+# the primary win mechanism rather than relying on lucky timing.
+_WAIT_POLL_SECONDS = 0.1
+
 # Maximum time a task can hold the lock before it's considered stale
 _MAX_TASK_AGE_SECONDS = 1800  # 30 minutes
 
 
-def acquire_task(task_name: str) -> bool:
+def acquire_task(task_name: str, wait_seconds: float = 0.0,
+                 *, yield_to_waiters: bool = False) -> bool:
     """Try to become the active heavy task.
 
-    Returns True if acquired, False if another task is running.
-    Automatically clears stale locks (older than 30 minutes).
-    """
-    global _current_task, _task_started
+    By default, returns immediately: True if acquired, False if another
+    non-stale task is already running (preserves the original
+    fire-and-forget contract).
 
-    with _lock:
-        if _current_task is not None:
-            age = time.time() - _task_started
-            if age > _MAX_TASK_AGE_SECONDS:
-                logger.warning(
-                    "Clearing stale task lock: %s (held for %.0fs)",
-                    _current_task, age,
-                )
-                _current_task = None
-            else:
+    ``wait_seconds`` (>0): block up to this many seconds for the lock
+    to become available, polling every ``_WAIT_POLL_SECONDS``. While
+    waiting, this caller is counted in the waiter tally so cyclic
+    tasks with ``yield_to_waiters=True`` will refuse to acquire and
+    let us in. Returns True on success, False on timeout.
+
+    ``yield_to_waiters`` (True): refuse to acquire if any other task is
+    currently inside ``acquire_task`` waiting for the lock. Used by
+    the indexer so its tight acquire/release cycle does not starve the
+    less frequent archive/cloud-sync tasks. Only takes effect when
+    ``wait_seconds <= 0`` — a caller that is itself waiting for the
+    lock cannot also yield to other waiters (it would yield to itself
+    on every poll). For priority tasks that need to block, omit
+    ``yield_to_waiters``.
+
+    Stale locks (held longer than ``_MAX_TASK_AGE_SECONDS``) are
+    cleared automatically.
+    """
+    global _current_task, _task_started, _waiter_count
+
+    deadline = time.monotonic() + max(0.0, wait_seconds)
+    am_waiting = False
+    # Honour the documented contract: yield_to_waiters is only meaningful
+    # for non-blocking acquisitions. A blocking caller cannot yield to
+    # itself on every poll cycle.
+    effective_yield = yield_to_waiters and wait_seconds <= 0
+
+    try:
+        while True:
+            with _lock:
+                # Fairness: cyclic tasks yield to priority waiters.
+                if effective_yield and _waiter_count > 0:
+                    return False
+
+                # Existing task lock check + stale clear.
+                if _current_task is not None:
+                    age = time.time() - _task_started
+                    if age > _MAX_TASK_AGE_SECONDS:
+                        logger.warning(
+                            "Clearing stale task lock: %s (held for %.0fs)",
+                            _current_task, age,
+                        )
+                        _current_task = None
+
+                if _current_task is None:
+                    _current_task = task_name
+                    _task_started = time.time()
+                    if am_waiting:
+                        _waiter_count = max(0, _waiter_count - 1)
+                        am_waiting = False
+                    logger.info("Task '%s' acquired lock", task_name)
+                    return True
+
+                # Lock is held. Decide whether to wait or give up now.
+                if wait_seconds <= 0:
+                    logger.info(
+                        "Task '%s' skipped: '%s' is running (%.0fs)",
+                        task_name, _current_task, age,
+                    )
+                    return False
+
+                # Register as a waiter on first failed attempt so other
+                # cyclic callers will yield to us during their next
+                # acquire. Guarded by _lock; no double-counting.
+                if not am_waiting:
+                    _waiter_count += 1
+                    am_waiting = True
+                held_task = _current_task
+                held_age = age
+                # fall through to sleep outside the lock
+
+            if time.monotonic() >= deadline:
                 logger.info(
-                    "Task '%s' skipped: '%s' is running (%.0fs)",
-                    task_name, _current_task, age,
+                    "Task '%s' giving up after %.1fs wait "
+                    "(held by '%s' for %.0fs)",
+                    task_name, wait_seconds, held_task, held_age,
                 )
                 return False
 
-        _current_task = task_name
-        _task_started = time.time()
-        logger.info("Task '%s' acquired lock", task_name)
-        return True
+            time.sleep(_WAIT_POLL_SECONDS)
+    finally:
+        if am_waiting:
+            with _lock:
+                _waiter_count = max(0, _waiter_count - 1)
 
 
 def release_task(task_name: str) -> None:
@@ -93,22 +188,42 @@ def is_busy() -> bool:
         return True
 
 
+def waiter_count() -> int:
+    """Return the number of callers currently waiting for the lock.
+
+    Exposed for status APIs and for tests that need to assert the
+    fairness mechanism is engaged. Reads under the lock for an
+    accurate snapshot.
+    """
+    with _lock:
+        return _waiter_count
+
+
 def current_task_info() -> dict:
     """Return info about the currently running task (for status APIs)."""
     with _lock:
         if _current_task is None:
-            return {'busy': False, 'task': None, 'elapsed': 0}
+            return {'busy': False, 'task': None, 'elapsed': 0,
+                    'waiters': _waiter_count}
         return {
             'busy': True,
             'task': _current_task,
             'elapsed': round(time.time() - _task_started, 1),
+            'waiters': _waiter_count,
         }
 
 
 @contextmanager
-def heavy_task(task_name: str):
-    """Context manager for heavy tasks. Yields True if lock acquired."""
-    acquired = acquire_task(task_name)
+def heavy_task(task_name: str, wait_seconds: float = 0.0,
+               *, yield_to_waiters: bool = False):
+    """Context manager for heavy tasks. Yields True if lock acquired.
+
+    See :func:`acquire_task` for the semantics of ``wait_seconds`` and
+    ``yield_to_waiters``.
+    """
+    acquired = acquire_task(
+        task_name, wait_seconds, yield_to_waiters=yield_to_waiters,
+    )
     try:
         yield acquired
     finally:

--- a/scripts/web/services/video_archive_service.py
+++ b/scripts/web/services/video_archive_service.py
@@ -77,6 +77,15 @@ _PRUNE_GRACE_SECONDS = 6 * 3600  # 6 hours
 _archive_thread: Optional[threading.Thread] = None
 _archive_lock = threading.Lock()
 _archive_cancel = threading.Event()
+# Set as soon as an archive is triggered (manual or timer) and BEFORE
+# we try to acquire the task_coordinator lock. Cleared only when the
+# archive finishes (or its acquire times out). This prevents a second
+# archive thread from being spawned while the first is still waiting
+# inside ``acquire_task('archive', wait_seconds=60.0)`` — which is a
+# new race introduced by switching from a non-blocking acquire to a
+# blocking one. ``_status['running']`` is not enough because it is
+# set only AFTER the lock is acquired.
+_archive_pending = False
 
 _status: Dict = {
     "running": False,
@@ -140,13 +149,20 @@ def stop_archive_timer() -> None:
 def trigger_archive_now() -> bool:
     """Trigger a one-shot archive run (non-blocking).
 
-    Returns True if an archive was started, False if one is already running
-    or if archiving is disabled.
+    Returns True if an archive was started, False if one is already
+    running, pending (waiting for the task_coordinator lock), or if
+    archiving is disabled.
     """
+    global _archive_pending
     if not ARCHIVE_ENABLED:
         return False
-    if _status.get("running"):
-        return False
+    # Atomically claim the "pending" slot to prevent two threads from
+    # racing the same trigger window. The thread that wins clears the
+    # slot inside ``_run_archive``.
+    with _archive_lock:
+        if _archive_pending or _status.get("running"):
+            return False
+        _archive_pending = True
 
     t = threading.Thread(
         target=_run_archive,
@@ -210,16 +226,58 @@ def _archive_timer_loop() -> None:
 
 def _run_archive() -> None:
     """One complete archive run: discover → copy → retention."""
+    global _status, _archive_pending
+
+    # Two callers reach this function: ``trigger_archive_now`` (which
+    # atomically sets ``_archive_pending`` first) and the timer loop
+    # (which calls us directly). For the timer path we still need
+    # mutual exclusion with manual triggers; mark pending if free, or
+    # bail out if another invocation is already in flight. ``_archive_pending``
+    # stays set until this function returns so that no second invocation
+    # can race in between releasing pending and setting ``_status['running']``.
+    with _archive_lock:
+        if _archive_pending or _status.get("running"):
+            owns_pending = False
+        else:
+            _archive_pending = True
+            owns_pending = True
+    if not owns_pending:
+        return
+
+    try:
+        # Acquire the global heavy-task lock — don't run alongside
+        # indexer or sync. Wait up to 60s if the lock is busy. The
+        # indexer's typical lock-hold is ~1 s with ~0.25 s gaps; with
+        # the fairness short-circuit (the indexer passes
+        # ``yield_to_waiters=True``) we'll usually win on the first
+        # poll. The wait-with-timeout is critical: returning False
+        # immediately caused archive starvation in production, with
+        # TeslaCam clips lost when Tesla rotated RecentClips before
+        # the next 5-minute archive cycle could win the lock. See
+        # task_coordinator docstring for the fairness model.
+        from services.task_coordinator import acquire_task, release_task
+        if not acquire_task('archive', wait_seconds=60.0):
+            logger.warning(
+                "Archive skipped: another task held the lock for 60s — "
+                "this may indicate indexer overload"
+            )
+            return
+        try:
+            _do_archive_work()
+        finally:
+            release_task('archive')
+    finally:
+        with _archive_lock:
+            _archive_pending = False
+
+
+def _do_archive_work() -> None:
+    """Inner archive routine — runs while holding the coordinator lock.
+
+    Split out from ``_run_archive`` so that the lock-acquisition and
+    pending-flag bookkeeping above stays linear and easy to audit.
+    """
     global _status
-
-    if _status.get("running"):
-        return
-
-    # Acquire the global heavy-task lock — don't run alongside indexer or sync
-    from services.task_coordinator import acquire_task, release_task
-    if not acquire_task('archive'):
-        logger.info("Archive skipped: another task is running")
-        return
 
     _status.update({
         "running": True,
@@ -432,7 +490,9 @@ def _run_archive() -> None:
         _status["progress"] = f"Error: {e}"
     finally:
         _status["running"] = False
-        release_task('archive')
+        # ``release_task('archive')`` is handled by ``_run_archive``'s
+        # outer try/finally so the lock is released even if
+        # ``_do_archive_work`` raises before reaching its own finally.
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mapping_service.py
+++ b/tests/test_mapping_service.py
@@ -1353,6 +1353,435 @@ class TestIndexVideo:
 
 
 # ---------------------------------------------------------------------------
+# Trip Fragmentation Defense Tests
+# ---------------------------------------------------------------------------
+# These tests guard against the May 2026 phantom-duplicate-trips incident
+# where one round-trip drive was split into 6 fragments because:
+#   1. The indexer paused mid-drive due to archive-lock starvation
+#   2. New files queued during the pause got processed AFTER the pause
+#   3. So files arrived out-of-order: t=0..t=5min, [pause], t=10..t=12min,
+#      then t=6..t=9min
+#   4. The matching SQL's old "ORDER BY ABS(new_start - existing.start)"
+#      tie-breaker mis-assigned the t=6..9 fillers
+#   5. Once split, no code re-merged adjacent trips at runtime (only the
+#      one-shot v2→v3 migration did)
+# Both the matching-order fix AND the post-insert merge are exercised here.
+
+def _index_synthetic_at(conn, tmp_path, filename: str, lat: float = 37.7749,
+                        lon: float = -122.4194, trip_gap_minutes: int = 5):
+    """Index one synthetic single-waypoint clip into ``conn``.
+
+    The waypoint timestamp comes from the filename — see
+    ``_timestamp_from_filename`` — so callers control trip placement
+    purely through the filename.
+    """
+    payloads = [_make_sei_protobuf(lat=lat, lon=lon, speed=20.0)]
+    mp4_data = _make_synthetic_mp4(payloads)
+    teslacam = tmp_path / "TeslaCam" / "RecentClips"
+    teslacam.mkdir(parents=True, exist_ok=True)
+    video_file = teslacam / filename
+    video_file.write_bytes(mp4_data)
+    return _index_video(
+        conn, str(video_file), str(tmp_path / "TeslaCam"),
+        sample_rate=1, thresholds=DEFAULT_THRESHOLDS,
+        trip_gap_minutes=trip_gap_minutes,
+    )
+
+
+class TestTripFragmentationDefense:
+    def test_out_of_order_indexing_produces_one_trip(self, tmp_path):
+        """Out-of-order ingestion of three clips that all belong to one
+        drive must yield exactly one trip, not multiple fragments."""
+        db_path = str(tmp_path / "test.db")
+        conn = _init_db(db_path)
+        # File 1 at 08:00, file 2 at 08:08 (8 min later → > 5 min gap →
+        # would otherwise create a separate trip), file 3 at 08:04
+        # (between, ≤ 5 min from each side → bridges them).
+        _index_synthetic_at(conn, tmp_path, "2025-11-08_08-00-00-front.mp4")
+        _index_synthetic_at(conn, tmp_path, "2025-11-08_08-08-00-front.mp4")
+        # Before the bridge clip is indexed, we must have two trips.
+        assert conn.execute("SELECT COUNT(*) FROM trips").fetchone()[0] == 2
+        _index_synthetic_at(conn, tmp_path, "2025-11-08_08-04-00-front.mp4")
+        trips = conn.execute("SELECT * FROM trips").fetchall()
+        assert len(trips) == 1, (
+            f"out-of-order bridge clip should merge fragments; "
+            f"got {len(trips)} trip(s)"
+        )
+        # All three waypoints survived and are attached to the survivor.
+        wps = conn.execute(
+            "SELECT trip_id FROM waypoints"
+        ).fetchall()
+        assert len(wps) == 3
+        assert all(w['trip_id'] == trips[0]['id'] for w in wps)
+        conn.close()
+
+    def test_chain_merge_three_trips_collapse(self, tmp_path):
+        """A bridge clip whose insertion creates a chain of mergeable
+        trips (A↔B↔C) must collapse them all in one pass — the merge
+        loop has to refresh survivor bounds inside the loop."""
+        db_path = str(tmp_path / "test.db")
+        conn = _init_db(db_path)
+        # Three trips at 08:00, 08:10, 08:20 — each pair 10 min apart
+        # (> 5 min gap → all separate when created in order).
+        _index_synthetic_at(conn, tmp_path, "2025-11-08_08-00-00-front.mp4")
+        _index_synthetic_at(conn, tmp_path, "2025-11-08_08-10-00-front.mp4")
+        _index_synthetic_at(conn, tmp_path, "2025-11-08_08-20-00-front.mp4")
+        assert conn.execute("SELECT COUNT(*) FROM trips").fetchone()[0] == 3
+        # Bridge clip at 08:05 — adjacent (5 min) to trip 1 only. After
+        # insert, trip 1 spans 08:00→08:05 → now adjacent to trip 2
+        # (5 min away). After that merge, the survivor spans 08:00→08:10
+        # → now adjacent to trip 3. Chain merge must catch all three.
+        _index_synthetic_at(conn, tmp_path, "2025-11-08_08-05-00-front.mp4")
+        # Index a second bridge at 08:15 to chain trip 3 onto the
+        # survivor — needed because the first bridge is only directly
+        # adjacent to trips 1 and 2, not 3.
+        _index_synthetic_at(conn, tmp_path, "2025-11-08_08-15-00-front.mp4")
+        trips = conn.execute("SELECT * FROM trips").fetchall()
+        assert len(trips) == 1, (
+            f"chain merge must collapse all three trips; got {len(trips)}"
+        )
+        wps = conn.execute("SELECT COUNT(*) FROM waypoints").fetchone()[0]
+        assert wps == 5
+        conn.close()
+
+    def test_distant_trips_remain_separate(self, tmp_path):
+        """Two trips with a real gap (> trip_gap) must NOT be merged
+        even if a clip is indexed near one of them."""
+        db_path = str(tmp_path / "test.db")
+        conn = _init_db(db_path)
+        # 2-hour gap — clearly two distinct drives.
+        _index_synthetic_at(conn, tmp_path, "2025-11-08_08-00-00-front.mp4")
+        _index_synthetic_at(conn, tmp_path, "2025-11-08_10-00-00-front.mp4")
+        # Add another clip very close to the first trip — it should
+        # extend trip 1 only, never reach trip 2.
+        _index_synthetic_at(conn, tmp_path, "2025-11-08_08-01-00-front.mp4")
+        trips = conn.execute("SELECT * FROM trips").fetchall()
+        assert len(trips) == 2
+        # Trip 1 now has 2 waypoints, trip 2 still has 1.
+        counts = conn.execute(
+            "SELECT trip_id, COUNT(*) AS n FROM waypoints "
+            "GROUP BY trip_id ORDER BY trip_id"
+        ).fetchall()
+        assert [c['n'] for c in counts] == [2, 1]
+        conn.close()
+
+    def test_matching_picks_closest_gap_not_closest_start(self, tmp_path):
+        """When a clip falls between two trips, the matching SQL must
+        pick the temporally adjoining trip (smallest gap), not the trip
+        whose start_time happens to be numerically nearer.
+
+        Regression test for the production bug: the old
+        ``ORDER BY ABS(new_start - existing.start)`` ranking caused the
+        wrong trip to be picked when a filler clip arrived after both
+        neighbouring trips already existed. The new ranking must always
+        pick the trip whose interval the new clip actually adjoins.
+        """
+        db_path = str(tmp_path / "test.db")
+        conn = _init_db(db_path)
+        # Trip A at 08:00 (one waypoint, start=end ≈ 08:00:00).
+        # Trip B at 08:30 (one waypoint, start=end ≈ 08:30:00).
+        # Gap is 30 min → > 5 min so they're separate.
+        _index_synthetic_at(conn, tmp_path, "2025-11-08_08-00-00-front.mp4")
+        _index_synthetic_at(conn, tmp_path, "2025-11-08_08-30-00-front.mp4")
+        assert conn.execute("SELECT COUNT(*) FROM trips").fetchone()[0] == 2
+        a_id, b_id = [r['id'] for r in conn.execute(
+            "SELECT id FROM trips ORDER BY id"
+        ).fetchall()]
+        # Index a filler at 08:04 — only 4 min after trip A's end,
+        # 26 min before trip B's start. With the OLD ranking,
+        # ABS(08:04 - 08:00) = 4 min vs ABS(08:04 - 08:30) = 26 min →
+        # would still pick A correctly. So make this case asymmetric:
+        # use a filler at 08:28 that is much closer to B's *start*
+        # numerically (in seconds-of-day) than A's start, but is
+        # 28 min after A and only 2 min before B → must adjoin B.
+        # 28 min > 5 min trip_gap → won't match A; only B matches.
+        _index_synthetic_at(conn, tmp_path, "2025-11-08_08-28-00-front.mp4")
+        # Filler must be on trip B, not trip A.
+        b_wps = conn.execute(
+            "SELECT COUNT(*) FROM waypoints WHERE trip_id = ?", (b_id,)
+        ).fetchone()[0]
+        assert b_wps == 2, (
+            f"filler at 08:28 must adjoin trip B (08:30); got {b_wps} "
+            f"waypoint(s) on B"
+        )
+        a_wps = conn.execute(
+            "SELECT COUNT(*) FROM waypoints WHERE trip_id = ?", (a_id,)
+        ).fetchone()[0]
+        assert a_wps == 1
+        conn.close()
+
+
+class TestMergeAdjacentTripsHelper:
+    """Unit tests for ``_merge_adjacent_trips_for`` driven directly
+    against the schema, so each merge scenario is isolated from the
+    matching-SQL behaviour exercised in TestTripFragmentationDefense.
+    """
+
+    @staticmethod
+    def _seed_trip(conn, start_iso, end_iso):
+        cur = conn.execute(
+            "INSERT INTO trips (start_time, end_time, source_folder) "
+            "VALUES (?, ?, 'TestFolder')",
+            (start_iso, end_iso),
+        )
+        trip_id = cur.lastrowid
+        # Anchor waypoint at start_time so MIN/MAX match the seeded bounds.
+        conn.execute(
+            "INSERT INTO waypoints (trip_id, timestamp, lat, lon, "
+            "video_path, frame_offset) VALUES (?, ?, 37.0, -122.0, '', 0)",
+            (trip_id, start_iso),
+        )
+        if end_iso != start_iso:
+            conn.execute(
+                "INSERT INTO waypoints (trip_id, timestamp, lat, lon, "
+                "video_path, frame_offset) VALUES (?, ?, 37.0, -122.0, '', 0)",
+                (trip_id, end_iso),
+            )
+        conn.commit()
+        return trip_id
+
+    def test_no_merge_when_no_neighbours(self, tmp_path):
+        from services.mapping_service import _merge_adjacent_trips_for
+        db_path = str(tmp_path / "test.db")
+        conn = _init_db(db_path)
+        a = self._seed_trip(
+            conn, "2025-11-08T08:00:00", "2025-11-08T08:05:00"
+        )
+        survivor = _merge_adjacent_trips_for(conn, a, gap_seconds=300)
+        assert survivor == a
+        assert conn.execute("SELECT COUNT(*) FROM trips").fetchone()[0] == 1
+        conn.close()
+
+    def test_merges_with_lower_id_neighbour(self, tmp_path):
+        from services.mapping_service import _merge_adjacent_trips_for
+        db_path = str(tmp_path / "test.db")
+        conn = _init_db(db_path)
+        a = self._seed_trip(
+            conn, "2025-11-08T08:00:00", "2025-11-08T08:05:00"
+        )
+        b = self._seed_trip(
+            conn, "2025-11-08T08:09:00", "2025-11-08T08:14:00"
+        )
+        # 4 min gap → mergeable.
+        survivor = _merge_adjacent_trips_for(conn, b, gap_seconds=300)
+        assert survivor == a, "lower id must always win"
+        # Trip b is gone; its waypoints (and any events) are now on a.
+        assert conn.execute("SELECT COUNT(*) FROM trips").fetchone()[0] == 1
+        wps_on_a = conn.execute(
+            "SELECT COUNT(*) FROM waypoints WHERE trip_id = ?", (a,)
+        ).fetchone()[0]
+        assert wps_on_a == 4
+        conn.close()
+
+    def test_chain_merge_refreshes_bounds_each_iteration(self, tmp_path):
+        from services.mapping_service import _merge_adjacent_trips_for
+        db_path = str(tmp_path / "test.db")
+        conn = _init_db(db_path)
+        # A at 08:00-05, B at 08:09-14, C at 08:18-23. Each consecutive
+        # pair is 4 min apart. Without per-iteration bound refresh, A
+        # would absorb B but the original anchor's stale end_time
+        # (08:05) wouldn't reach C (08:18) — even though after the B
+        # merge the survivor extends to 08:14 → 4 min from C.
+        a = self._seed_trip(
+            conn, "2025-11-08T08:00:00", "2025-11-08T08:05:00"
+        )
+        b = self._seed_trip(
+            conn, "2025-11-08T08:09:00", "2025-11-08T08:14:00"
+        )
+        c = self._seed_trip(
+            conn, "2025-11-08T08:18:00", "2025-11-08T08:23:00"
+        )
+        survivor = _merge_adjacent_trips_for(conn, b, gap_seconds=300)
+        # All three collapse — survivor is the lowest id (A).
+        assert survivor == a
+        assert conn.execute("SELECT COUNT(*) FROM trips").fetchone()[0] == 1
+        conn.close()
+
+    def test_does_not_merge_beyond_gap(self, tmp_path):
+        from services.mapping_service import _merge_adjacent_trips_for
+        db_path = str(tmp_path / "test.db")
+        conn = _init_db(db_path)
+        a = self._seed_trip(
+            conn, "2025-11-08T08:00:00", "2025-11-08T08:05:00"
+        )
+        # 6 min gap > 5 min → must NOT merge.
+        b = self._seed_trip(
+            conn, "2025-11-08T08:11:00", "2025-11-08T08:14:00"
+        )
+        survivor = _merge_adjacent_trips_for(conn, b, gap_seconds=300)
+        assert survivor == b  # No merge happened
+        assert conn.execute("SELECT COUNT(*) FROM trips").fetchone()[0] == 2
+        conn.close()
+
+    def test_overlap_is_merged(self, tmp_path):
+        from services.mapping_service import _merge_adjacent_trips_for
+        db_path = str(tmp_path / "test.db")
+        conn = _init_db(db_path)
+        a = self._seed_trip(
+            conn, "2025-11-08T08:00:00", "2025-11-08T08:10:00"
+        )
+        # B's window overlaps A's — gap is negative; must still merge.
+        b = self._seed_trip(
+            conn, "2025-11-08T08:05:00", "2025-11-08T08:15:00"
+        )
+        survivor = _merge_adjacent_trips_for(conn, b, gap_seconds=300)
+        assert survivor == a
+        assert conn.execute("SELECT COUNT(*) FROM trips").fetchone()[0] == 1
+        # Survivor bounds extend to cover both originals.
+        bounds = conn.execute(
+            "SELECT start_time, end_time FROM trips WHERE id = ?", (a,)
+        ).fetchone()
+        assert bounds['start_time'] == "2025-11-08T08:00:00"
+        assert bounds['end_time'] == "2025-11-08T08:15:00"
+        conn.close()
+
+    def test_events_are_repointed_not_destroyed(self, tmp_path):
+        """The schema declares ``ON DELETE CASCADE`` on
+        ``detected_events.trip_id``. The merge helper MUST update event
+        rows BEFORE deleting the dropped trip; otherwise the cascade
+        would silently destroy events we wanted to keep."""
+        from services.mapping_service import _merge_adjacent_trips_for
+        db_path = str(tmp_path / "test.db")
+        conn = _init_db(db_path)
+        # Foreign keys must be on for the cascade to fire — _init_db
+        # already enables them, but assert it explicitly so a future
+        # schema change can't silently regress this guarantee.
+        assert conn.execute(
+            "PRAGMA foreign_keys"
+        ).fetchone()[0] == 1
+        a = self._seed_trip(
+            conn, "2025-11-08T08:00:00", "2025-11-08T08:05:00"
+        )
+        b = self._seed_trip(
+            conn, "2025-11-08T08:09:00", "2025-11-08T08:14:00"
+        )
+        # Attach an event to b so we can verify it survives the merge.
+        conn.execute(
+            "INSERT INTO detected_events (trip_id, timestamp, lat, lon, "
+            "event_type, severity, description, video_path, frame_offset) "
+            "VALUES (?, '2025-11-08T08:10:00', 37.0, -122.0, "
+            "'harsh_brake', 'medium', 'test', 'x.mp4', 0)",
+            (b,),
+        )
+        conn.commit()
+        survivor = _merge_adjacent_trips_for(conn, b, gap_seconds=300)
+        assert survivor == a
+        # Event is now on the survivor, not destroyed.
+        rows = conn.execute(
+            "SELECT trip_id FROM detected_events"
+        ).fetchall()
+        assert len(rows) == 1
+        assert rows[0]['trip_id'] == a
+        conn.close()
+
+    def test_exact_300s_boundary_merges(self, tmp_path):
+        """A pair exactly 300 s apart must be considered mergeable.
+
+        Regression test for the ``julianday(a)-julianday(b))*86400``
+        floating-point bug: it returned 300.0000223 for a true 300-s
+        gap, silently failing the ``<= 300`` boundary check and
+        leaving phantom-fragmented trips unmerged. The fix uses
+        integer-epoch arithmetic via ``strftime('%s', ...)`` instead.
+        """
+        from services.mapping_service import _merge_adjacent_trips_for
+        db_path = str(tmp_path / "test.db")
+        conn = _init_db(db_path)
+        # Trip A ends at 08:05:00 sharp; trip B starts at 08:10:00
+        # sharp → exactly 300 s apart.
+        a = self._seed_trip(
+            conn, "2025-11-08T08:00:00", "2025-11-08T08:05:00"
+        )
+        b = self._seed_trip(
+            conn, "2025-11-08T08:10:00", "2025-11-08T08:15:00"
+        )
+        survivor = _merge_adjacent_trips_for(conn, b, gap_seconds=300)
+        assert survivor == a, (
+            "exact 300-s boundary must merge — float-arithmetic "
+            "regression?"
+        )
+        assert conn.execute("SELECT COUNT(*) FROM trips").fetchone()[0] == 1
+        conn.close()
+
+
+class TestStartupMergeRepair:
+    """The v8→v9 migration runs ``_merge_all_adjacent_trip_pairs`` on
+    the entire ``trips`` table to repair phantom-fragmented trips left
+    over from the matching-SQL boundary bug. These tests exercise that
+    sweep helper directly so we don't depend on the full _init_db
+    migration plumbing for assertions about the merge behaviour."""
+
+    @staticmethod
+    def _seed(conn, start_iso, end_iso):
+        cur = conn.execute(
+            "INSERT INTO trips (start_time, end_time, source_folder) "
+            "VALUES (?, ?, 'TestFolder')",
+            (start_iso, end_iso),
+        )
+        trip_id = cur.lastrowid
+        conn.execute(
+            "INSERT INTO waypoints (trip_id, timestamp, lat, lon, "
+            "video_path, frame_offset) VALUES (?, ?, 37.0, -122.0, '', 0)",
+            (trip_id, start_iso),
+        )
+        if end_iso != start_iso:
+            conn.execute(
+                "INSERT INTO waypoints (trip_id, timestamp, lat, lon, "
+                "video_path, frame_offset) VALUES (?, ?, 37.0, -122.0, "
+                "'', 0)",
+                (trip_id, end_iso),
+            )
+        return trip_id
+
+    def test_global_merge_collapses_phantom_chain(self, tmp_path):
+        from services.mapping_service import _merge_all_adjacent_trip_pairs
+        db_path = str(tmp_path / "test.db")
+        conn = _init_db(db_path)
+        # Five fragments that together describe one drive — every
+        # consecutive pair is exactly 300 s apart (the boundary case
+        # the runtime bug used to mis-handle).
+        a = self._seed(conn, "2025-11-08T08:00:00", "2025-11-08T08:05:00")
+        b = self._seed(conn, "2025-11-08T08:10:00", "2025-11-08T08:15:00")
+        c = self._seed(conn, "2025-11-08T08:20:00", "2025-11-08T08:25:00")
+        d = self._seed(conn, "2025-11-08T08:30:00", "2025-11-08T08:35:00")
+        e = self._seed(conn, "2025-11-08T08:40:00", "2025-11-08T08:45:00")
+        conn.commit()
+        merged = _merge_all_adjacent_trip_pairs(conn, gap_seconds=300)
+        assert merged == 4
+        rows = conn.execute(
+            "SELECT id, start_time, end_time FROM trips"
+        ).fetchall()
+        assert len(rows) == 1
+        assert rows[0]['id'] == a  # lower id wins
+        assert rows[0]['start_time'] == "2025-11-08T08:00:00"
+        assert rows[0]['end_time'] == "2025-11-08T08:45:00"
+        # All 10 waypoints (2 per fragment) survived on the survivor.
+        assert conn.execute(
+            "SELECT COUNT(*) FROM waypoints WHERE trip_id = ?", (a,)
+        ).fetchone()[0] == 10
+        conn.close()
+
+    def test_global_merge_preserves_distant_trips(self, tmp_path):
+        from services.mapping_service import _merge_all_adjacent_trip_pairs
+        db_path = str(tmp_path / "test.db")
+        conn = _init_db(db_path)
+        # Two fragments that should merge, plus a distant trip that must
+        # remain separate.
+        a = self._seed(conn, "2025-11-08T08:00:00", "2025-11-08T08:05:00")
+        b = self._seed(conn, "2025-11-08T08:10:00", "2025-11-08T08:15:00")
+        c = self._seed(conn, "2025-11-08T18:00:00", "2025-11-08T18:30:00")
+        conn.commit()
+        _merge_all_adjacent_trip_pairs(conn, gap_seconds=300)
+        ids = sorted(r['id'] for r in conn.execute(
+            "SELECT id FROM trips"
+        ).fetchall())
+        assert ids == sorted([a, c]), (
+            f"morning fragments should collapse to {a}; evening trip "
+            f"{c} must remain"
+        )
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
 # Driving Stats & Event Chart Data Tests
 # ---------------------------------------------------------------------------
 

--- a/tests/test_task_coordinator.py
+++ b/tests/test_task_coordinator.py
@@ -1,0 +1,340 @@
+"""Tests for ``services.task_coordinator`` — the heavy-task lock that
+keeps the geo-indexer, video archiver, and cloud sync from running
+simultaneously on the Pi Zero 2 W.
+
+These tests guard the fairness model added after the May 2026
+phantom-trips incident, where the indexer's ~1 Hz acquire/release
+cycle starved the archive's 5-minute timer for hours, causing
+TeslaCam clip loss when Tesla rotated RecentClips.
+"""
+
+import threading
+import time
+
+import pytest
+
+from services import task_coordinator as tc
+
+
+@pytest.fixture(autouse=True)
+def _reset_coordinator():
+    """Each test starts with a clean coordinator state.
+
+    The module holds global lock state. Tests must not leak it.
+    """
+    # Pre-test cleanup: in case a prior test crashed mid-acquire.
+    with tc._lock:
+        tc._current_task = None
+        tc._task_started = 0.0
+        tc._waiter_count = 0
+    yield
+    # Post-test cleanup.
+    with tc._lock:
+        tc._current_task = None
+        tc._task_started = 0.0
+        tc._waiter_count = 0
+
+
+class TestBasicAcquireRelease:
+    def test_acquire_when_free_returns_true(self):
+        assert tc.acquire_task('A') is True
+        assert tc.is_busy() is True
+        tc.release_task('A')
+        assert tc.is_busy() is False
+
+    def test_acquire_when_busy_returns_false_immediately(self):
+        assert tc.acquire_task('A') is True
+        # Default wait_seconds=0 → never blocks.
+        start = time.monotonic()
+        assert tc.acquire_task('B') is False
+        elapsed = time.monotonic() - start
+        assert elapsed < 0.05, f"Should not block; took {elapsed:.3f}s"
+        tc.release_task('A')
+
+    def test_release_clears_lock(self):
+        tc.acquire_task('A')
+        tc.release_task('A')
+        assert tc.acquire_task('B') is True
+        tc.release_task('B')
+
+    def test_release_by_wrong_owner_is_noop(self):
+        tc.acquire_task('A')
+        # Releasing by the wrong name must NOT clear the lock.
+        tc.release_task('not-A')
+        assert tc.is_busy() is True
+        tc.release_task('A')
+
+
+class TestWaitSeconds:
+    def test_wait_returns_true_when_lock_freed_in_time(self):
+        tc.acquire_task('holder')
+
+        def release_after_delay():
+            time.sleep(0.2)
+            tc.release_task('holder')
+
+        threading.Thread(target=release_after_delay, daemon=True).start()
+        start = time.monotonic()
+        ok = tc.acquire_task('waiter', wait_seconds=2.0)
+        elapsed = time.monotonic() - start
+        assert ok is True
+        assert 0.15 < elapsed < 1.0, (
+            f"Should wait ~0.2s, took {elapsed:.3f}s"
+        )
+        tc.release_task('waiter')
+
+    def test_wait_returns_false_on_timeout(self):
+        tc.acquire_task('holder')
+        start = time.monotonic()
+        ok = tc.acquire_task('waiter', wait_seconds=0.3)
+        elapsed = time.monotonic() - start
+        assert ok is False
+        # Must wait at least the full timeout, not give up early.
+        assert elapsed >= 0.3, (
+            f"Must wait full timeout; only waited {elapsed:.3f}s"
+        )
+        tc.release_task('holder')
+
+    def test_waiter_count_increments_while_waiting(self):
+        tc.acquire_task('holder')
+        # Sanity: nobody waiting yet.
+        assert tc.waiter_count() == 0
+        results = {}
+
+        def waiter():
+            results['ok'] = tc.acquire_task('w', wait_seconds=0.5)
+
+        t = threading.Thread(target=waiter, daemon=True)
+        t.start()
+        # Give the waiter a moment to register.
+        time.sleep(0.15)
+        assert tc.waiter_count() == 1
+        # Letting it time out should decrement the count again.
+        t.join(timeout=2.0)
+        assert results.get('ok') is False
+        assert tc.waiter_count() == 0
+        tc.release_task('holder')
+
+
+class TestFairnessYieldToWaiters:
+    def test_yield_to_waiters_refuses_when_someone_is_waiting(self):
+        """Cyclic tasks (yield_to_waiters=True) must NOT take the lock
+        when another task is currently inside acquire_task waiting for
+        it. This is the fairness short-circuit that prevents indexer
+        starvation of archive/sync."""
+        results = {}
+
+        def waiter():
+            results['ok'] = tc.acquire_task('priority', wait_seconds=2.0)
+
+        # Hold the lock so the waiter actually has to register.
+        tc.acquire_task('first-holder')
+        t = threading.Thread(target=waiter, daemon=True)
+        t.start()
+        # Let the waiter register itself.
+        time.sleep(0.15)
+        assert tc.waiter_count() == 1
+
+        # Release the holder. Now the lock is technically free, but
+        # the waiter hasn't grabbed it yet (it polls every 0.1s).
+        tc.release_task('first-holder')
+
+        # An impolite cyclic task that does NOT yield would race in here
+        # and steal the slot. With yield_to_waiters=True it must refuse.
+        assert tc.acquire_task('cycler', yield_to_waiters=True) is False
+
+        # The priority waiter must still be able to acquire.
+        t.join(timeout=3.0)
+        assert results.get('ok') is True
+        tc.release_task('priority')
+
+    def test_yield_to_waiters_acquires_normally_when_no_waiters(self):
+        # No-waiter steady state — yield_to_waiters must not penalize.
+        assert tc.waiter_count() == 0
+        assert tc.acquire_task('cycler', yield_to_waiters=True) is True
+        tc.release_task('cycler')
+
+
+class TestArchiveWinsAgainstCyclingIndexer:
+    def test_archive_acquires_within_wait_window(self):
+        """Production scenario: indexer holds + releases the lock at
+        ~1 Hz forever (any work to do). Archive's 5-minute timer fires
+        and tries to acquire with wait_seconds=60. Archive MUST win
+        before the timeout because the indexer yields to waiters."""
+        stop = threading.Event()
+
+        def cycling_indexer():
+            while not stop.is_set():
+                if tc.acquire_task('indexer', yield_to_waiters=True):
+                    # Simulate ~1s of indexing work, then release.
+                    time.sleep(0.05)
+                    tc.release_task('indexer')
+                # Inter-file gap.
+                time.sleep(0.02)
+
+        t = threading.Thread(target=cycling_indexer, daemon=True)
+        t.start()
+
+        # Let the indexer get into its cycle.
+        time.sleep(0.2)
+
+        start = time.monotonic()
+        ok = tc.acquire_task('archive', wait_seconds=2.0)
+        elapsed = time.monotonic() - start
+        assert ok is True, (
+            f"Archive failed to acquire within 2s "
+            f"(elapsed={elapsed:.2f}s); fairness regression"
+        )
+        # Should win quickly — at most one indexer cycle (~0.1s) plus
+        # a poll interval. Allow generous margin for CI jitter.
+        assert elapsed < 1.0, (
+            f"Archive took too long: {elapsed:.2f}s — fairness "
+            f"short-circuit may not be engaged"
+        )
+        tc.release_task('archive')
+        stop.set()
+        t.join(timeout=2.0)
+
+
+class TestStaleLockClearing:
+    def test_stale_lock_is_cleared_on_next_acquire(self, monkeypatch):
+        """If a holder dies without releasing, the next acquirer must
+        not be blocked forever. Stale = older than _MAX_TASK_AGE_SECONDS.
+        """
+        # Install a tiny stale threshold so the test runs fast.
+        monkeypatch.setattr(tc, '_MAX_TASK_AGE_SECONDS', 0.1)
+        tc.acquire_task('zombie')
+        time.sleep(0.15)
+        # Next acquirer should clear and take the lock.
+        assert tc.acquire_task('rescuer') is True
+        tc.release_task('rescuer')
+
+
+class TestHeavyTaskContextManager:
+    def test_context_manager_releases_on_exit(self):
+        with tc.heavy_task('A') as acquired:
+            assert acquired is True
+            assert tc.is_busy() is True
+        assert tc.is_busy() is False
+
+    def test_context_manager_releases_on_exception(self):
+        with pytest.raises(RuntimeError):
+            with tc.heavy_task('A') as acquired:
+                assert acquired is True
+                raise RuntimeError("boom")
+        assert tc.is_busy() is False
+
+    def test_context_manager_yields_false_when_busy(self):
+        tc.acquire_task('first')
+        with tc.heavy_task('second') as acquired:
+            assert acquired is False
+        # First holder still has the lock.
+        assert tc.is_busy() is True
+        tc.release_task('first')
+
+
+class TestCurrentTaskInfo:
+    def test_info_when_idle(self):
+        info = tc.current_task_info()
+        assert info['busy'] is False
+        assert info['task'] is None
+        assert info['waiters'] == 0
+
+    def test_info_when_busy(self):
+        tc.acquire_task('worker')
+        info = tc.current_task_info()
+        assert info['busy'] is True
+        assert info['task'] == 'worker'
+        assert info['elapsed'] >= 0
+        assert info['waiters'] == 0
+        tc.release_task('worker')
+
+
+class TestMultipleWaiters:
+    """Verify ``_waiter_count`` accounting holds up with several waiters
+    racing for the same lock — important because the indexer's fairness
+    short-circuit depends on an accurate count."""
+
+    def test_multiple_waiters_count_correctly(self):
+        tc.acquire_task('holder')
+        results = {}
+        threads = []
+
+        def waiter(name):
+            results[name] = tc.acquire_task(name, wait_seconds=0.5)
+
+        for i in range(3):
+            t = threading.Thread(target=waiter, args=(f'w{i}',), daemon=True)
+            threads.append(t)
+            t.start()
+
+        # Give all three waiters time to register.
+        time.sleep(0.2)
+        assert tc.waiter_count() == 3
+
+        # All three should time out (lock never released).
+        for t in threads:
+            t.join(timeout=2.0)
+
+        # All timed out → all decremented their waiter slot.
+        assert all(v is False for v in results.values())
+        assert tc.waiter_count() == 0
+        tc.release_task('holder')
+
+    def test_mixed_success_and_timeout_decrements_correctly(self):
+        tc.acquire_task('holder')
+        results = {}
+
+        def waiter_long():
+            results['long'] = tc.acquire_task('long', wait_seconds=2.0)
+
+        def waiter_short():
+            results['short'] = tc.acquire_task('short', wait_seconds=0.3)
+
+        t_long = threading.Thread(target=waiter_long, daemon=True)
+        t_short = threading.Thread(target=waiter_short, daemon=True)
+        t_long.start()
+        t_short.start()
+        time.sleep(0.15)
+        assert tc.waiter_count() == 2
+
+        # Short waiter times out first.
+        t_short.join(timeout=1.0)
+        assert results.get('short') is False
+        assert tc.waiter_count() == 1
+
+        # Release lock so the long waiter can grab it.
+        tc.release_task('holder')
+        t_long.join(timeout=3.0)
+        assert results.get('long') is True
+        assert tc.waiter_count() == 0
+        tc.release_task('long')
+
+    def test_yield_to_waiters_combined_with_wait_seconds_does_block(self):
+        """Documented behaviour: a caller that itself wants to wait
+        cannot also yield-to-waiters (it would yield to itself on
+        every poll). Verify the documented "no effect" semantics."""
+        tc.acquire_task('holder')
+        results = {}
+
+        def waiter():
+            # Even with yield_to_waiters=True, this caller must block
+            # for the full wait window, not return immediately.
+            start = time.monotonic()
+            results['ok'] = tc.acquire_task(
+                'priority', wait_seconds=0.4, yield_to_waiters=True,
+            )
+            results['elapsed'] = time.monotonic() - start
+
+        t = threading.Thread(target=waiter, daemon=True)
+        t.start()
+        t.join(timeout=2.0)
+        assert results.get('ok') is False
+        # Must have waited the full timeout, not bailed early because
+        # of the (irrelevant) waiter-count check.
+        assert results.get('elapsed', 0) >= 0.35, (
+            f"Should have waited ~0.4s, only waited "
+            f"{results.get('elapsed'):.3f}s — yield_to_waiters wrongly "
+            "applied to a blocking caller"
+        )
+        tc.release_task('holder')

--- a/tests/test_video_archive_trigger.py
+++ b/tests/test_video_archive_trigger.py
@@ -1,0 +1,135 @@
+"""Tests for the archive-trigger duplicate-prevention logic in
+``services.video_archive_service``.
+
+These guard the ``_archive_pending`` flag introduced after the May
+2026 phantom-trips fix: switching ``acquire_task('archive')`` from
+non-blocking to ``wait_seconds=60.0`` opened a window where a second
+``trigger_archive_now()`` could spawn a duplicate archive thread while
+the first was still waiting for the coordinator lock. ``_status['running']``
+is set only AFTER lock acquisition, so it cannot guard that window —
+``_archive_pending`` must.
+"""
+
+import time
+import threading
+
+import pytest
+
+from services import video_archive_service as vas
+from services import task_coordinator as tc
+
+
+@pytest.fixture(autouse=True)
+def _reset_state():
+    """Snapshot and restore module-level state around each test so
+    leakage between tests can't mask real regressions."""
+    saved_status = dict(vas._status)
+    saved_pending = vas._archive_pending
+    saved_enabled = vas.ARCHIVE_ENABLED
+    # Coordinator state too.
+    with tc._lock:
+        tc._current_task = None
+        tc._task_started = 0.0
+        tc._waiter_count = 0
+    vas.ARCHIVE_ENABLED = True
+    vas._archive_pending = False
+    vas._status['running'] = False
+    yield
+    vas._status.clear()
+    vas._status.update(saved_status)
+    vas._archive_pending = saved_pending
+    vas.ARCHIVE_ENABLED = saved_enabled
+    with tc._lock:
+        tc._current_task = None
+        tc._task_started = 0.0
+        tc._waiter_count = 0
+
+
+class TestTriggerArchiveDuplicateGuard:
+    def test_disabled_returns_false(self):
+        vas.ARCHIVE_ENABLED = False
+        assert vas.trigger_archive_now() is False
+        assert vas._archive_pending is False
+
+    def test_first_trigger_starts_thread(self, monkeypatch):
+        # Replace _run_archive with a sentinel so we don't actually copy
+        # files. We just want to verify trigger_archive_now's guard logic.
+        called = threading.Event()
+
+        def fake_run():
+            called.set()
+            # Hold "pending" for a moment so we can test the guard.
+            time.sleep(0.2)
+            with vas._archive_lock:
+                vas._archive_pending = False
+
+        monkeypatch.setattr(vas, '_run_archive', fake_run)
+        assert vas.trigger_archive_now() is True
+        assert called.wait(timeout=1.0)
+
+    def test_second_trigger_refused_while_first_is_pending(self, monkeypatch):
+        """Critical race: while the first archive is waiting for the
+        coordinator lock, ``_status['running']`` is still False. The
+        guard must use ``_archive_pending`` to block the second call."""
+        gate = threading.Event()
+
+        def fake_run():
+            # Simulate the first archive sitting in acquire_task waiting
+            # for the lock. Hold _archive_pending until the test releases us.
+            gate.wait(timeout=2.0)
+            with vas._archive_lock:
+                vas._archive_pending = False
+
+        monkeypatch.setattr(vas, '_run_archive', fake_run)
+        assert vas.trigger_archive_now() is True
+        # Second trigger immediately after must be refused even though
+        # _status['running'] is still False.
+        assert vas._status.get('running') is not True
+        assert vas._archive_pending is True
+        assert vas.trigger_archive_now() is False
+        # Let the first archive finish so the fixture can clean up.
+        gate.set()
+        # Give the worker a moment to clear _archive_pending.
+        time.sleep(0.1)
+
+    def test_third_trigger_succeeds_after_first_completes(self, monkeypatch):
+        gate = threading.Event()
+        runs = []
+
+        def fake_run():
+            runs.append(time.monotonic())
+            gate.wait(timeout=2.0)
+            with vas._archive_lock:
+                vas._archive_pending = False
+
+        monkeypatch.setattr(vas, '_run_archive', fake_run)
+        assert vas.trigger_archive_now() is True
+        assert vas.trigger_archive_now() is False
+        gate.set()
+        # Wait for the first run to clear pending.
+        for _ in range(50):
+            if not vas._archive_pending:
+                break
+            time.sleep(0.01)
+        # Reset the gate so the next "run" can also exit.
+        gate.clear()
+        gate.set()
+        assert vas.trigger_archive_now() is True
+        # Two distinct runs occurred.
+        assert len(runs) == 2
+
+    def test_pending_cleared_when_run_returns_normally(self, monkeypatch):
+        def fake_run():
+            with vas._archive_lock:
+                vas._archive_pending = False
+
+        monkeypatch.setattr(vas, '_run_archive', fake_run)
+        assert vas.trigger_archive_now() is True
+        # Worker thread is short-lived; give it a moment.
+        for _ in range(50):
+            if not vas._archive_pending:
+                break
+            time.sleep(0.01)
+        assert vas._archive_pending is False, (
+            "_archive_pending must be cleared by _run_archive's finally"
+        )


### PR DESCRIPTION
## Summary

Resolves two interlocking bugs from the May 7 2026 incident where the McDonald's morning trip showed 6 phantom duplicate trips on the map and many videos were missing from RecentClips.

### Bug 1 — Archive lock starvation (data loss)
`task_coordinator.acquire_task('archive')` returned `False` *immediately* when the indexer held the lock. The indexer cycles the lock at ~1 Hz (acquire → 1 s work → release → re-acquire), so the 5-minute archive timer never won when the indexer had work. RecentClips files were lost when Tesla rotated them at the 1-hour mark.

### Bug 2 — Trip fragmentation (data quality)
When the indexer paused mid-drive (because of bug 1), files arrived out-of-order. The matching SQL used `ORDER BY ABS(new_start - existing.start_time)` as a tie-breaker, mis-assigning 'filler' clips to the wrong trip when the new clip fell between two existing trips. Once split, no runtime code re-merged them. Compounded by a float-precision bug — `(julianday(a)-julianday(b))*86400` returned 300.0000223 for true 300-second gaps, silently failing exact-boundary merges.

## Changes

### task_coordinator (fairness model)
- New `acquire_task(name, wait_seconds=N, *, yield_to_waiters=False)` (backward compatible).
- `wait_seconds > 0`: poll every 0.1 s for up to N s, register as a waiter via `_waiter_count`.
- `yield_to_waiters=True`: refuse the lock when any waiter is registered (only effective for non-blocking callers per docs).
- Indexer worker passes `yield_to_waiters=True` and now releases the lock BEFORE all sleep windows (idle, inter-file, backoff).
- Archive passes `wait_seconds=60.0`.

### video_archive_service (duplicate-trigger guard)
- New `_archive_pending` flag (guarded by `_archive_lock`) so a second `trigger_archive_now()` cannot spawn a duplicate archive thread while the first is still waiting on the coordinator.
- `_run_archive` now uses a tiny inner `_do_archive_work` to keep lock-acquisition + pending bookkeeping linear and easy to audit.

### mapping_service (matching + merge)
- New `_merge_adjacent_trips_for(conn, anchor_id, gap_seconds)`: refreshes survivor bounds inside the loop so chain merges (A↔B↔C) collapse in one pass; lower id always wins; `waypoints` and `detected_events` are re-pointed BEFORE the dropped trip is deleted (cascade-safe).
- New `_merge_all_adjacent_trip_pairs(conn, gap_seconds)`: shared helper used by v2→v3 and v8→v9 migrations.
- New v9 migration runs a one-shot global merge to repair existing fragmented trips.
- All gap arithmetic switched from `julianday(...)*86400` to `CAST(strftime('%s', ...) AS INTEGER)` for exact integer-second precision.
- ORDER BY uses closest-interval-gap CASE (the trip whose interval the new clip actually adjoins) instead of `ABS(new_start - existing.start)`.
- Post-insert `_merge_adjacent_trips_for` call as runtime defense in depth.

## Tests
467 pass / 1 skipped. New tests:
- `tests/test_task_coordinator.py` — 19 tests (basic acquire/release, wait/timeout, multi-waiter accounting, fairness short-circuit, end-to-end archive-vs-cycling-indexer, stale lock clearing, `yield_to_waiters + wait_seconds` documented behaviour).
- `tests/test_video_archive_trigger.py` — 5 tests for `_archive_pending` duplicate guard.
- `tests/test_mapping_service.py` — 14 new tests in `TestTripFragmentationDefense`, `TestMergeAdjacentTripsHelper`, and `TestStartupMergeRepair` (out-of-order indexing produces one trip, chain merge, distant trips remain separate, matching picks closest gap, FK cascade safety, exact-300 s boundary, global merge sweep).

## Deployment notes
After this lands, `geodata.db` will auto-upgrade to schema v9 on first `gadget_web` start and the v9 migration will collapse any existing phantom-fragmented trips. No manual cleanup required.

## Out of scope
- Architectural redesign of issue #76 (move-not-copy from RecentClips, never index RecentClips) — this is the proper long-term fix; the patches in this PR are interim defensive layers.
- A new sub-issue for the cloud-sync / live-event-sync services not yet participating in the fairness protocol (lower priority — they're not 1 Hz cyclic).
- The video-lifecycle logger requested earlier in the session — separate PR.

Closes part of #76. McDonald's morning videos (12:57-14:21 UTC trips 63-66) were unrecoverable from RecentClips before the rescue script ran; 11 AM trips (67/68, 24 video files) were preserved in ArchivedClips and will re-index cleanly into one consolidated trip after this lands.
