### PR TITLE
fix(#67): cloud sync queue items deletable when provider unconfigured

### DIFF
--- a/scripts/web/services/cloud_archive_service.py
+++ b/scripts/web/services/cloud_archive_service.py
@@ -1456,7 +1456,15 @@ def queue_event_for_sync(folder: str, event_name: str, priority: bool = False) -
 
 
 def get_sync_queue() -> dict:
-    """Return the current sync queue (queued/pending/uploading files)."""
+    """Return the current sync queue (queued/pending/uploading files).
+
+    Note:
+        Rows in ``failed`` state are intentionally excluded from this view —
+        the UI surfaces only the active pipeline (queued / pending /
+        uploading). To scrub historical failures from the underlying
+        table, use :func:`remove_from_queue` or :func:`clear_queue`,
+        both of which match every non-``synced`` row.
+    """
     conn = _init_cloud_tables(CLOUD_ARCHIVE_DB_PATH)
     try:
         rows = conn.execute(

--- a/scripts/web/services/cloud_archive_service.py
+++ b/scripts/web/services/cloud_archive_service.py
@@ -1470,25 +1470,44 @@ def get_sync_queue() -> dict:
 
 
 def remove_from_queue(file_path: str) -> Tuple[bool, str]:
-    """Remove a single item from the sync queue."""
+    """Remove a single item from the sync queue.
+
+    Deletes any non-``synced`` row matching ``file_path``.  The local queue
+    is local data that the user owns, so deletion is allowed regardless of
+    cloud provider configuration, sync worker state, or row status — including
+    rows stuck in ``uploading`` (e.g. when the sync was interrupted before the
+    worker could reset the row back to ``pending``) and ``failed`` rows.
+
+    ``synced`` rows are preserved so deleting from the queue cannot wipe the
+    historical record of files already uploaded; those rows are not exposed
+    via :func:`get_sync_queue` anyway.
+    """
     conn = _init_cloud_tables(CLOUD_ARCHIVE_DB_PATH)
     try:
-        conn.execute(
-            "DELETE FROM cloud_synced_files WHERE file_path = ? AND status IN ('queued', 'pending')",
+        result = conn.execute(
+            "DELETE FROM cloud_synced_files WHERE file_path = ? AND status != 'synced'",
             (file_path,),
         )
         conn.commit()
-        return True, "Removed from queue"
+        if result.rowcount:
+            return True, "Removed from queue"
+        return True, "Not in queue"
     finally:
         conn.close()
 
 
 def clear_queue() -> Tuple[bool, str]:
-    """Clear all queued/pending items from the sync queue."""
+    """Clear every non-``synced`` item from the sync queue.
+
+    Includes ``queued``, ``pending``, ``uploading`` and ``failed`` rows so the
+    user can always reset the queue — even after stopping the sync worker or
+    disconnecting the cloud provider, both of which can leave rows stuck in
+    ``uploading`` state.  ``synced`` history rows are preserved.
+    """
     conn = _init_cloud_tables(CLOUD_ARCHIVE_DB_PATH)
     try:
         result = conn.execute(
-            "DELETE FROM cloud_synced_files WHERE status IN ('queued', 'pending')"
+            "DELETE FROM cloud_synced_files WHERE status != 'synced'"
         )
         conn.commit()
         return True, "Cleared {} items from queue".format(result.rowcount)

--- a/scripts/web/templates/cloud_archive.html
+++ b/scripts/web/templates/cloud_archive.html
@@ -1735,10 +1735,9 @@
                         '<div style="font-size: var(--text-xs); color: var(--text-muted);">' + size + ' &middot; <span style="color:' + statusColor + ';">' + statusLabel + '</span>' +
                         (item.retry_count > 0 ? ' &middot; retries: ' + item.retry_count : '') + '</div>' +
                     '</div>';
-                if (statusLabel === 'queued' || statusLabel === 'pending') {
-                    html += '<button type="button" class="action-btn danger" style="padding: 4px 10px; font-size: 12px; flex-shrink: 0;" ' +
-                        'onclick="removeFromQueue(\'' + item.file_path.replace(/'/g, "\\'") + '\')">&times;</button>';
-                }
+                html += '<button type="button" class="action-btn danger" style="padding: 4px 10px; font-size: 12px; flex-shrink: 0;" ' +
+                    'aria-label="Remove from queue" ' +
+                    'onclick="removeFromQueue(\'' + item.file_path.replace(/'/g, "\\'") + '\')">&times;</button>';
                 html += '</div>';
             });
             html += '</div>';

--- a/tests/test_cloud_archive_queue.py
+++ b/tests/test_cloud_archive_queue.py
@@ -1,0 +1,212 @@
+"""Tests for cloud_archive_service queue management — issue #67.
+
+Focuses on queue deletion behaviour: items in the local queue must be
+removable by the user regardless of cloud provider configuration, sync
+worker state, or row status (queued / pending / uploading / failed).
+The local SQLite queue is local data the user owns.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from services import cloud_archive_service as svc
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def db(tmp_path, monkeypatch):
+    """Initialise an isolated cloud_sync.db and point the service at it.
+
+    Resets ``_startup_recovery_done`` so each test gets fresh recovery
+    semantics, and patches the module-level ``CLOUD_ARCHIVE_DB_PATH`` so
+    helpers that read it directly use the test database.
+    """
+    db_path = str(tmp_path / "cloud_sync.db")
+    monkeypatch.setattr(svc, "CLOUD_ARCHIVE_DB_PATH", db_path)
+    monkeypatch.setattr(svc, "_startup_recovery_done", False)
+    # Materialise the schema once.
+    conn = svc._init_cloud_tables(db_path)
+    conn.close()
+    return db_path
+
+
+def _insert_row(db_path, file_path, status, file_size=1024):
+    """Insert a single row into cloud_synced_files with the given status."""
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "INSERT INTO cloud_synced_files "
+        "(file_path, file_size, file_mtime, status, retry_count) "
+        "VALUES (?, ?, ?, ?, 0)",
+        (file_path, file_size, 1700000000.0, status),
+    )
+    conn.commit()
+    conn.close()
+
+
+def _row_count(db_path, status=None):
+    conn = sqlite3.connect(db_path)
+    if status is None:
+        row = conn.execute(
+            "SELECT COUNT(*) FROM cloud_synced_files"
+        ).fetchone()
+    else:
+        row = conn.execute(
+            "SELECT COUNT(*) FROM cloud_synced_files WHERE status = ?",
+            (status,),
+        ).fetchone()
+    conn.close()
+    return row[0]
+
+
+# ---------------------------------------------------------------------------
+# remove_from_queue — single-item delete
+# ---------------------------------------------------------------------------
+
+class TestRemoveFromQueue:
+    """remove_from_queue must succeed for any non-synced row."""
+
+    def test_removes_queued_row(self, db):
+        _insert_row(db, "/path/clip.mp4", "queued")
+        ok, _ = svc.remove_from_queue("/path/clip.mp4")
+        assert ok is True
+        assert _row_count(db) == 0
+
+    def test_removes_pending_row(self, db):
+        _insert_row(db, "/path/clip.mp4", "pending")
+        ok, _ = svc.remove_from_queue("/path/clip.mp4")
+        assert ok is True
+        assert _row_count(db) == 0
+
+    def test_removes_uploading_row(self, db):
+        """Reproduction for issue #67: 'uploading' rows stuck after
+        ``stop_sync`` + provider disconnect must still be deletable."""
+        _insert_row(db, "/path/clip.mp4", "uploading")
+        ok, _ = svc.remove_from_queue("/path/clip.mp4")
+        assert ok is True
+        assert _row_count(db) == 0
+
+    def test_removes_failed_row(self, db):
+        """Failed rows from a disconnected/unreachable provider must be
+        deletable."""
+        _insert_row(db, "/path/clip.mp4", "failed")
+        ok, _ = svc.remove_from_queue("/path/clip.mp4")
+        assert ok is True
+        assert _row_count(db) == 0
+
+    def test_preserves_synced_row(self, db):
+        """Synced rows are historical records and must NOT be deletable
+        through the queue API (they're not exposed via get_sync_queue
+        either)."""
+        _insert_row(db, "/path/clip.mp4", "synced")
+        ok, _ = svc.remove_from_queue("/path/clip.mp4")
+        # Returns success ("not in queue") but the synced row stays.
+        assert ok is True
+        assert _row_count(db, "synced") == 1
+
+    def test_missing_path_is_not_an_error(self, db):
+        """Removing a path that isn't in the queue is a no-op success —
+        the UI should never see an error for a row that was already
+        cleaned up by the worker."""
+        ok, msg = svc.remove_from_queue("/never/queued.mp4")
+        assert ok is True
+        assert "queue" in msg.lower()
+
+    def test_provider_unconfigured_does_not_block_delete(self, db, monkeypatch):
+        """The local queue is local data — clearing the cloud provider
+        from config.yaml must not prevent deletion."""
+        monkeypatch.setattr(svc, "CLOUD_ARCHIVE_PROVIDER", "")
+        _insert_row(db, "/path/clip.mp4", "uploading")
+        ok, _ = svc.remove_from_queue("/path/clip.mp4")
+        assert ok is True
+        assert _row_count(db) == 0
+
+    def test_only_targets_named_path(self, db):
+        """remove_from_queue must not touch other rows."""
+        _insert_row(db, "/a/clip.mp4", "uploading")
+        _insert_row(db, "/b/clip.mp4", "uploading")
+        ok, _ = svc.remove_from_queue("/a/clip.mp4")
+        assert ok is True
+        assert _row_count(db) == 1
+        conn = sqlite3.connect(db)
+        row = conn.execute(
+            "SELECT file_path FROM cloud_synced_files"
+        ).fetchone()
+        conn.close()
+        assert row[0] == "/b/clip.mp4"
+
+
+# ---------------------------------------------------------------------------
+# clear_queue — bulk delete
+# ---------------------------------------------------------------------------
+
+class TestClearQueue:
+    """clear_queue must drain every non-synced row in one call."""
+
+    def test_clears_mixed_statuses(self, db):
+        """All four queue statuses must be cleared in a single call."""
+        _insert_row(db, "/a.mp4", "queued")
+        _insert_row(db, "/b.mp4", "pending")
+        _insert_row(db, "/c.mp4", "uploading")
+        _insert_row(db, "/d.mp4", "failed")
+        ok, msg = svc.clear_queue()
+        assert ok is True
+        assert "4" in msg
+        assert _row_count(db) == 0
+
+    def test_preserves_synced_history(self, db):
+        """Synced rows are historical records — clear_queue must leave
+        them alone so the dashboard's 'total synced' counter stays
+        accurate."""
+        _insert_row(db, "/a.mp4", "queued")
+        _insert_row(db, "/b.mp4", "uploading")
+        _insert_row(db, "/c.mp4", "synced")
+        ok, _ = svc.clear_queue()
+        assert ok is True
+        assert _row_count(db) == 1
+        assert _row_count(db, "synced") == 1
+
+    def test_provider_unconfigured_does_not_block_clear(self, db, monkeypatch):
+        """Reproduction for issue #67: clearing the queue must work even
+        after the cloud provider has been disconnected."""
+        monkeypatch.setattr(svc, "CLOUD_ARCHIVE_PROVIDER", "")
+        _insert_row(db, "/a.mp4", "uploading")
+        _insert_row(db, "/b.mp4", "queued")
+        ok, _ = svc.clear_queue()
+        assert ok is True
+        assert _row_count(db) == 0
+
+    def test_empty_queue_returns_zero(self, db):
+        ok, msg = svc.clear_queue()
+        assert ok is True
+        assert "0" in msg
+
+
+# ---------------------------------------------------------------------------
+# get_sync_queue interaction
+# ---------------------------------------------------------------------------
+
+class TestGetSyncQueueAfterDelete:
+    """End-to-end: after delete, the row must be gone from get_sync_queue."""
+
+    def test_uploading_row_disappears_from_queue_after_delete(self, db):
+        """The original bug from issue #67: an 'uploading' row was
+        visible in get_sync_queue but invisible to the delete API."""
+        _insert_row(db, "/stuck.mp4", "uploading")
+
+        before = svc.get_sync_queue()
+        assert before["total"] == 1
+        assert before["queue"][0]["file_path"] == "/stuck.mp4"
+        assert before["queue"][0]["status"] == "uploading"
+
+        ok, _ = svc.remove_from_queue("/stuck.mp4")
+        assert ok is True
+
+        after = svc.get_sync_queue()
+        assert after["total"] == 0
+        assert after["queue"] == []


### PR DESCRIPTION
## Summary

Fixes #67 — items in the cloud sync queue could become "stuck" and undeletable after stopping the cloud sync worker and disconnecting the cloud provider. The local SQLite queue is local data the user owns; deletion must succeed regardless of worker state, provider configuration, or rclone reachability.

## Root cause

`get_sync_queue()` returns rows with status in `('queued', 'pending', 'uploading')`, but `remove_from_queue()` and `clear_queue()` only DELETEd rows with status in `('queued', 'pending')`. A row stuck in `uploading` (e.g. when `stop_sync` killed rclone before the worker thread could reset the row to `pending`, or when a hard process exit beat the cleanup path) was therefore visible in the queue but undeletable from either the API or the bulk **Clear Queue** button.

The UI compounded the problem: the per-row "×" delete button in `cloud_archive.html` was only rendered when `statusLabel` was `queued` or `pending`, so for stuck `uploading` rows the user had no affordance to remove them at all.

## Fix

- **`remove_from_queue(file_path)`** (`scripts/web/services/cloud_archive_service.py`): drop the `status IN ('queued', 'pending')` filter; delete any non-`synced` row matching the path. Returns success even when no row was deleted (a worker may have just cleaned it up) so the UI never shows a spurious error.
- **`clear_queue()`**: same widening — clear every non-`synced` row, including `uploading` and `failed`.
- **`scripts/web/templates/cloud_archive.html`**: render the "×" delete button for every queue row, not only `queued`/`pending`. Adds an `aria-label` for accessibility.
- `synced` rows are still preserved (they're the historical record and aren't exposed via `get_sync_queue` anyway, so this preserves the dashboard's "total synced" counter).

## Files modified

- `scripts/web/services/cloud_archive_service.py` — widen the DELETE filter in `remove_from_queue` and `clear_queue`.
- `scripts/web/templates/cloud_archive.html` — always render the delete button.
- `tests/test_cloud_archive_queue.py` — **new file**, 13 tests.

## Tests added

`tests/test_cloud_archive_queue.py` (13 tests):

**`TestRemoveFromQueue`** — single-item delete:
- `test_removes_queued_row`
- `test_removes_pending_row`
- `test_removes_uploading_row` ← reproduction for #67
- `test_removes_failed_row`
- `test_preserves_synced_row` (historical records protected)
- `test_missing_path_is_not_an_error`
- `test_provider_unconfigured_does_not_block_delete` ← reproduction for #67
- `test_only_targets_named_path`

**`TestClearQueue`** — bulk delete:
- `test_clears_mixed_statuses` (all four non-synced statuses in one call)
- `test_preserves_synced_history`
- `test_provider_unconfigured_does_not_block_clear` ← reproduction for #67
- `test_empty_queue_returns_zero`

**`TestGetSyncQueueAfterDelete`** — end-to-end:
- `test_uploading_row_disappears_from_queue_after_delete`

## Test results

| | Pass | Skipped |
|---|---|---|
| Before | 467 | 1 |
| After | **480** | 1 |

```
$ python -m pytest tests\ --no-header -q
480 passed, 1 skipped in 24.27s
```

## Constraints honored

- No mount/umount/loop/gadget operations touched.
- No new dependencies added.
- No unrelated fixes.
- All existing tests still pass.

Closes #67
