### PR TITLE
feat(#74): boot speed Phase 1 — present USB before multi-user.target

### DIFF
--- a/scripts/edit_usb.sh
+++ b/scripts/edit_usb.sh
@@ -470,8 +470,11 @@ fi
 if systemctl is-active --quiet smbd; then
   sudo smbcontrol all reload-config 2>/dev/null || true
 else
+  # Cold start: smbd is now disabled at boot (see setup_usb.sh / issue #74)
+  # to save ~4s of boot time, so this path runs every time the user enters
+  # edit mode. Allow up to 10s for startup.
   sudo systemctl start smbd nmbd 2>/dev/null || true
-  wait_until "systemctl is-active --quiet smbd" 2 "Samba startup" || true
+  wait_until "systemctl is-active --quiet smbd" 10 "Samba startup" || true
 fi
 log_timing "Samba refreshed"
 # Verify mounts are accessible

--- a/scripts/present_usb.sh
+++ b/scripts/present_usb.sh
@@ -306,68 +306,88 @@ sync
 # Loop devices are only needed for local mounting. If they exist from a previous
 # session, that's fine - the gadget can still access the files.
 
-# Stop conflicting rpi-usb-gadget service if running (Pi OS Bookworm+ default)
-# This service claims the UDC for a USB Ethernet gadget, blocking our mass-storage gadget
-for svc in rpi-usb-gadget.service usb-gadget.service; do
-  if systemctl is-active --quiet "$svc" 2>/dev/null; then
-    echo "Stopping conflicting $svc..."
-    sudo systemctl stop "$svc" 2>/dev/null || true
-    sleep 0.3
-  fi
-done
-
-# Remove legacy gadget module if present
-if lsmod | grep -q '^g_mass_storage'; then
-  echo "Removing existing USB gadget module..."
-  sudo rmmod g_mass_storage || true
-  sleep 1
-fi
-
-# Remove existing gadget configuration if present
+# Path to our configfs gadget (declared up front so the boot-mode skip
+# wrapper below can safely reference it under `set -u`).
 CONFIGFS_GADGET="/sys/kernel/config/usb_gadget/teslausb"
-if [ -d "$CONFIGFS_GADGET" ]; then
-  echo "Removing existing gadget configuration..."
 
-  # Unbind UDC first
-  if [ -f "$CONFIGFS_GADGET/UDC" ]; then
-    echo "" | sudo tee "$CONFIGFS_GADGET/UDC" > /dev/null 2>&1 || true
-    # Brief settle time (reduced from 1s - unbind is synchronous)
-    sleep 0.3
-  fi
-
-  # Clear LUN backing files to release kernel file references
-  for lun in "$CONFIGFS_GADGET"/functions/mass_storage.usb0/lun.*; do
-    if [ -f "$lun/file" ]; then
-      echo "" | sudo tee "$lun/file" > /dev/null 2>&1 || true
+# At boot, the conflicting-service stop loop, the rmmod check, and the
+# configfs cleanup are all dead work — setup_usb.sh masks rpi-usb-gadget
+# unconditionally, g_mass_storage is never loaded, and no prior teslausb
+# gadget exists yet. Skip them unless we're not in boot mode OR an unexpected
+# leftover gadget is actually present (~700ms saved per boot).
+if [ "$BOOT_MODE" -eq 0 ] || [ -d "$CONFIGFS_GADGET" ]; then
+  # Stop conflicting rpi-usb-gadget service if running (Pi OS Bookworm+ default)
+  # This service claims the UDC for a USB Ethernet gadget, blocking our mass-storage gadget
+  for svc in rpi-usb-gadget.service usb-gadget.service; do
+    if systemctl is-active --quiet "$svc" 2>/dev/null; then
+      echo "Stopping conflicting $svc..."
+      sudo systemctl stop "$svc" 2>/dev/null || true
+      sleep 0.3
     fi
   done
-  sleep 0.1
 
-  # Remove function links
-  sudo rm -f "$CONFIGFS_GADGET"/configs/*/mass_storage.* 2>/dev/null || true
+  # Remove legacy gadget module if present
+  if lsmod | grep -q '^g_mass_storage'; then
+    echo "Removing existing USB gadget module..."
+    sudo rmmod g_mass_storage || true
+    sleep 1
+  fi
 
-  # Remove configurations
-  sudo rmdir "$CONFIGFS_GADGET"/configs/*/strings/* 2>/dev/null || true
-  sudo rmdir "$CONFIGFS_GADGET"/configs/* 2>/dev/null || true
+  # Remove existing gadget configuration if present
+  if [ -d "$CONFIGFS_GADGET" ]; then
+    echo "Removing existing gadget configuration..."
 
-  # Remove LUNs from functions
-  sudo rmdir "$CONFIGFS_GADGET"/functions/mass_storage.usb0/lun.* 2>/dev/null || true
+    # Unbind UDC first
+    if [ -f "$CONFIGFS_GADGET/UDC" ]; then
+      echo "" | sudo tee "$CONFIGFS_GADGET/UDC" > /dev/null 2>&1 || true
+      # Brief settle time (reduced from 1s - unbind is synchronous)
+      sleep 0.3
+    fi
 
-  # Remove functions
-  sudo rmdir "$CONFIGFS_GADGET"/functions/* 2>/dev/null || true
+    # Clear LUN backing files to release kernel file references
+    for lun in "$CONFIGFS_GADGET"/functions/mass_storage.usb0/lun.*; do
+      if [ -f "$lun/file" ]; then
+        echo "" | sudo tee "$lun/file" > /dev/null 2>&1 || true
+      fi
+    done
+    sleep 0.1
 
-  # Remove strings
-  sudo rmdir "$CONFIGFS_GADGET"/strings/* 2>/dev/null || true
+    # Remove function links
+    sudo rm -f "$CONFIGFS_GADGET"/configs/*/mass_storage.* 2>/dev/null || true
 
-  # Remove gadget
-  sudo rmdir "$CONFIGFS_GADGET" 2>/dev/null || true
+    # Remove configurations
+    sudo rmdir "$CONFIGFS_GADGET"/configs/*/strings/* 2>/dev/null || true
+    sudo rmdir "$CONFIGFS_GADGET"/configs/* 2>/dev/null || true
+
+    # Remove LUNs from functions
+    sudo rmdir "$CONFIGFS_GADGET"/functions/mass_storage.usb0/lun.* 2>/dev/null || true
+
+    # Remove functions
+    sudo rmdir "$CONFIGFS_GADGET"/functions/* 2>/dev/null || true
+
+    # Remove strings
+    sudo rmdir "$CONFIGFS_GADGET"/strings/* 2>/dev/null || true
+
+    # Remove gadget
+    sudo rmdir "$CONFIGFS_GADGET" 2>/dev/null || true
+  fi
+else
+  echo "Boot mode: skipping dead teardown (no leftover gadget)"
 fi
 
 log_timing "Gadget removed/cleared"
 
-# Mount configfs if not already mounted
+# Mount configfs if not already mounted. Fail loud if we can't — the
+# subsequent gadget setup writes into /sys/kernel/config and would otherwise
+# produce confusing errors.
 if ! mountpoint -q /sys/kernel/config 2>/dev/null; then
-  sudo mount -t configfs none /sys/kernel/config || true
+  sudo modprobe configfs 2>/dev/null || true
+  sudo modprobe libcomposite 2>/dev/null || true
+  sudo mount -t configfs none /sys/kernel/config 2>/dev/null || true
+fi
+if ! mountpoint -q /sys/kernel/config 2>/dev/null; then
+  echo "Error: configfs is not mounted at /sys/kernel/config" >&2
+  exit 1
 fi
 
 # Present dual-LUN gadget using configfs
@@ -430,10 +450,17 @@ fi
 # Link function to configuration
 sudo ln -s functions/mass_storage.usb0 configs/c.1/
 
-# Find and enable UDC
-UDC_DEVICE=$(ls /sys/class/udc | head -n1)
+# Find and enable UDC. We're now scheduled before multi-user.target, so
+# /sys/class/udc may briefly be empty if dwc2's UDC node hasn't appeared yet.
+# Wait up to 5 seconds (50 * 100ms) using integer math (no `bc` dependency).
+UDC_DEVICE=""
+for _ in $(seq 1 50); do
+  UDC_DEVICE="$(ls /sys/class/udc 2>/dev/null | head -n1 || true)"
+  [ -n "$UDC_DEVICE" ] && break
+  sleep 0.1
+done
 if [ -z "$UDC_DEVICE" ]; then
-  echo "Error: No UDC device found. Is dwc2 module loaded?" >&2
+  echo "Error: No UDC device found after 5s. Is dwc2 module loaded?" >&2
   exit 1
 fi
 

--- a/setup_usb.sh
+++ b/setup_usb.sh
@@ -934,6 +934,31 @@ for svc in rpi-usb-gadget.service usb-gadget.service; do
   fi
 done
 
+# ===== Disable cloud-init (issue #74 boot speed) =====
+# cloud-init delays boot by ~6s on Pi OS Bookworm and is unnecessary for a
+# Pi USB gadget appliance — we don't need cloud metadata, datasource probing,
+# or per-instance config. Drop the disabled flag (recognized by every cloud-init
+# version) and mask the units as defense in depth.
+echo "Checking for cloud-init..."
+if [ -d /etc/cloud ] || \
+   systemctl list-unit-files 'cloud-init*' --no-legend 2>/dev/null | grep -q '.' || \
+   systemctl list-unit-files 'cloud-config*' --no-legend 2>/dev/null | grep -q '.' || \
+   systemctl list-unit-files 'cloud-final*' --no-legend 2>/dev/null | grep -q '.'; then
+  echo "Disabling cloud-init (not needed for Pi USB gadget; saves ~6s at boot)..."
+  mkdir -p /etc/cloud
+  touch /etc/cloud/cloud-init.disabled
+  for svc in cloud-init.target cloud-init.service cloud-init-local.service \
+             cloud-init-main.service cloud-init-network.service \
+             cloud-config.service cloud-final.service; do
+    if systemctl list-unit-files "$svc" --no-legend 2>/dev/null | grep -q '.'; then
+      systemctl mask "$svc" 2>/dev/null || true
+    fi
+  done
+  echo "  ✓ cloud-init disabled"
+else
+  echo "  cloud-init not installed; nothing to do"
+fi
+
 # Also clean up any gadget left behind by rpi-usb-gadget in configfs
 # (it typically creates /sys/kernel/config/usb_gadget/g1)
 for other_gadget in /sys/kernel/config/usb_gadget/*/; do
@@ -1291,8 +1316,19 @@ cat >> "$SMB_CONF" <<EOF
 EOF
 fi
 
-# Restart Samba
+# Restart Samba to pick up the new config
 systemctl restart smbd nmbd 2>/dev/null || systemctl restart smbd || true
+
+# ===== Disable Samba auto-start at boot (issue #74) =====
+# Samba is only needed in edit mode. Booting it eagerly costs ~4s
+# (smbd waits on network-online.target). edit_usb.sh starts smbd/nmbd on
+# demand when the user enters edit mode. Disable here so they don't auto-start
+# at the next reboot. We do NOT stop the running daemons — if the operator
+# happens to be in an edit session right now, that session keeps working.
+echo "Disabling Samba auto-start at boot (will start on demand in edit mode)..."
+systemctl disable smbd 2>/dev/null || true
+systemctl disable nmbd 2>/dev/null || true
+echo "  ✓ Samba auto-start disabled"
 
 # ===== Configure scripts (no copying - run in place) =====
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/setup_usb.sh
+++ b/setup_usb.sh
@@ -940,10 +940,10 @@ done
 # or per-instance config. Drop the disabled flag (recognized by every cloud-init
 # version) and mask the units as defense in depth.
 echo "Checking for cloud-init..."
+# One glob is faster than three separate `cloud-init*`/`cloud-config*`/`cloud-final*`
+# probes; the inner masking loop only touches a fixed allowlist of unit names.
 if [ -d /etc/cloud ] || \
-   systemctl list-unit-files 'cloud-init*' --no-legend 2>/dev/null | grep -q '.' || \
-   systemctl list-unit-files 'cloud-config*' --no-legend 2>/dev/null | grep -q '.' || \
-   systemctl list-unit-files 'cloud-final*' --no-legend 2>/dev/null | grep -q '.'; then
+   systemctl list-unit-files 'cloud-*' --no-legend 2>/dev/null | grep -q '.'; then
   echo "Disabling cloud-init (not needed for Pi USB gadget; saves ~6s at boot)..."
   mkdir -p /etc/cloud
   touch /etc/cloud/cloud-init.disabled
@@ -954,7 +954,14 @@ if [ -d /etc/cloud ] || \
       systemctl mask "$svc" 2>/dev/null || true
     fi
   done
-  echo "  ✓ cloud-init disabled"
+  # The disabled flag is the primary mechanism (recognized by every cloud-init
+  # version). Masks are defense in depth. Report status based on the flag,
+  # since mask failures are silently swallowed above.
+  if [ -f /etc/cloud/cloud-init.disabled ]; then
+    echo "  ✓ cloud-init disabled (flag set, units mask-attempted)"
+  else
+    echo "  ⚠ cloud-init disable failed (could not create /etc/cloud/cloud-init.disabled)" >&2
+  fi
 else
   echo "  cloud-init not installed; nothing to do"
 fi
@@ -1328,7 +1335,16 @@ systemctl restart smbd nmbd 2>/dev/null || systemctl restart smbd || true
 echo "Disabling Samba auto-start at boot (will start on demand in edit mode)..."
 systemctl disable smbd 2>/dev/null || true
 systemctl disable nmbd 2>/dev/null || true
-echo "  ✓ Samba auto-start disabled"
+# Verify both services actually disabled — `disable` failures (read-only fs,
+# locked unit, missing perms) are swallowed above so the message must be
+# evidence-based, not blind.
+smbd_state="$(systemctl is-enabled smbd 2>/dev/null || echo unknown)"
+nmbd_state="$(systemctl is-enabled nmbd 2>/dev/null || echo unknown)"
+if [ "$smbd_state" != "enabled" ] && [ "$nmbd_state" != "enabled" ]; then
+  echo "  ✓ Samba auto-start disabled (smbd=$smbd_state nmbd=$nmbd_state)"
+else
+  echo "  ⚠ Samba auto-start not fully disabled (smbd=$smbd_state nmbd=$nmbd_state)" >&2
+fi
 
 # ===== Configure scripts (no copying - run in place) =====
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/templates/present_usb_on_boot.service
+++ b/templates/present_usb_on_boot.service
@@ -1,9 +1,17 @@
 [Unit]
 Description=Present USB gadget at boot
-After=teslausb-safe-mode.service multi-user.target
-Wants=multi-user.target
+# Run as soon as basic.target is up — do NOT wait for multi-user.target,
+# which is gated on cloud-init, NetworkManager-wait-online, smbd, nmbd, etc.
+# (~24s on a Pi Zero 2 W). Issue #74 cuts boot-to-UDC from ~27s to ~10s.
+After=teslausb-safe-mode.service
+Wants=teslausb-safe-mode.service
+Before=multi-user.target
 # Skip in safe mode (3+ reboots in 10 min)
 ConditionPathExists=!/run/teslausb-safe-mode
+
+# Restart policy (StartLimit* live in [Unit] in modern systemd)
+StartLimitBurst=3
+StartLimitIntervalSec=600
 
 [Service]
 Type=oneshot
@@ -12,11 +20,12 @@ ExecStart=/bin/bash __GADGET_DIR__/scripts/present_usb.sh --boot
 RemainAfterExit=yes
 User=root
 
-# Restart policy
 Restart=on-failure
 RestartSec=15
-StartLimitBurst=3
-StartLimitIntervalSec=600
+
+# Bound the worst case: even if the script hangs, systemd kills it after 60s
+# and the restart policy kicks in (3 attempts in 600s window).
+TimeoutStartSec=60
 
 # Memory limit
 MemoryMax=100M


### PR DESCRIPTION
## What

Cuts Pi power-on -> USB gadget bound to UDC from **~27s to ~10s** by removing the four biggest blockers in the boot critical path. Closes #74.

## Why

Tesla starts polling for USB ~3s after ignition-on. With the previous boot ordering, `present_usb_on_boot.service` waited for `multi-user.target` (~24s) before even starting, so the gadget didn't appear until ~27s in. Result: missed early-drive RecentClips. This change delivers Phase 1 of the boot-speed plan.

## Changes

### A. `templates/present_usb_on_boot.service` — re-target to before `multi-user.target`

- Drop `After=multi-user.target` / `Wants=multi-user.target`. `multi-user` is gated on cloud-init-main (~6.4s self time) + NetworkManager-wait-online (~5.2s) + smbd/nmbd (~3s) — none of which the gadget needs.
- Add `Before=multi-user.target` so we run as part of the boot graph but no longer wait for those slow services. Default systemd dependencies stay enabled (`After=basic.target` etc.), so we still get `sysinit.target`, `local-fs.target`, and `modules-load.service` (for dwc2) for free.
- Add `Wants=teslausb-safe-mode.service` so the safe-mode check pulls into the transaction even when `multi-user.target` is bypassed.
- Move `StartLimit*` to `[Unit]` (modern systemd convention).
- Add `TimeoutStartSec=60` so a hung script can't permanently brick boot.

### B. `setup_usb.sh` — disable cloud-init

cloud-init runs DataSource probing every boot for an environment that never has cloud metadata (Pi USB gadget). Touch `/etc/cloud/cloud-init.disabled` and mask the units. Idempotent and safe even if cloud-init isn't installed.

### C. `setup_usb.sh` — disable smbd/nmbd at boot

Samba is only used in edit mode. `edit_usb.sh` already has cold-start logic that runs `systemctl start smbd nmbd` on demand (lines 470-475). Don't auto-start at boot. Bumped the post-cold-start wait from 2s to 10s in `edit_usb.sh` since cold start is now the common path.

### D. `scripts/present_usb.sh` — skip dead teardown at `--boot` + safety waits

- Wrap the conflicting-service stop loop + `g_mass_storage` rmmod check + configfs gadget removal in a guard that skips when `--boot` is set AND no leftover gadget exists (~700ms saved per boot).
- Move `CONFIGFS_GADGET` assignment up so the guard can reference it under `set -u`.
- Add a 5-second bounded UDC readiness wait before binding. With the earlier service ordering, `/sys/class/udc` may briefly be empty if dwc2's UDC node hasn't appeared yet. Uses integer math (no `bc` dependency).
- Make configfs mount fail loudly if it can't be mounted (was: silent `|| true` followed by confusing downstream errors).

## Risks and mitigations

Boot ordering changes are systemd's highest-risk surface area. After rubber-duck review I took the **safer variant** of issue #74's Sub-fix A: kept default dependencies enabled, just removed the `multi-user.target` gate. This still gets most of the speedup (~17s saved) while keeping the implicit boot ordering that protects against subtle dependency surprises.

- `TimeoutStartSec=60` + `Restart=on-failure` (3 attempts in 600s) bound the worst case if the script hangs on a slow Pi.
- safe_mode service ordering preserved via `Wants=` + `After=` on the `teslausb-safe-mode.service` unit.
- Sub-fix E from the issue (batch configfs writes) was deliberately skipped — only ~700ms savings, medium risk of breaking USB present.

## Testing

- `bash -n` passes on all 3 changed shell scripts (`present_usb.sh`, `edit_usb.sh`, `setup_usb.sh`).
- Python test suite: **467 passed, 1 skipped** (no regressions; no Python changes in this PR).
- **Acceptance test runs on the Pi**: after merge + deploy, `systemd-analyze` should show `present_usb_on_boot.service` start time well under 10s. Will verify on cybertruckusb.local.

## Notes

- This is Phase 1 of the boot-speed work. A more aggressive Phase 2 could opt out of default dependencies entirely (`DefaultDependencies=no`), but the rubber-duck review flagged that as significantly riskier for marginal additional savings.
- Existing `ConditionPathExists=!/run/teslausb-safe-mode` is preserved — if 3+ reboots happen within 10 minutes, the safe-mode service still blocks present_usb_on_boot from running.

Closes #74
