### PR TITLE
Fix #72: thread-local low-priority for indexer & archive, throttle skip log

### DIFF
--- a/scripts/web/services/indexing_worker.py
+++ b/scripts/web/services/indexing_worker.py
@@ -482,27 +482,61 @@ def _record_idle(last_outcome: Optional[mapping_service.IndexOutcome] = None,
 
 
 def _apply_low_priority() -> None:
-    """Best-effort drop to nice 19 + SCHED_BATCH on Linux.
+    """Best-effort drop the **calling thread** to lowest CPU + I/O priority.
 
-    No-ops on platforms (Windows/macOS) where the syscalls are missing
-    or fail. Any exception is swallowed — priority adjustment is a
-    nice-to-have, not a correctness requirement.
+    Critical: this MUST be thread-local. Earlier versions called
+    ``os.nice(19)``, which on Linux/glibc lowers the WHOLE PROCESS
+    priority — making the Flask request handlers and every other
+    thread in ``gadget_web`` low-priority too. That caused
+    ``/api/index/status`` and ``/`` to time out at 10 s during boot
+    catchup (issue #72).
+
+    What's safe to use from a worker thread:
+
+    * ``os.sched_setscheduler(0, SCHED_IDLE, ...)`` — the ``0`` first
+      argument means "this thread" on Linux (per ``sched_setscheduler(2)``).
+      ``SCHED_IDLE`` (constant 5) only runs when nothing else wants the
+      CPU, which is exactly what we want for indexing.
+    * ``ionice -c 3 -p <native_tid>`` — Linux ``ioprio_set`` is also
+      per-task; we pass ``threading.get_native_id()`` so the I/O-idle
+      class applies to the indexer thread only, not to the Flask
+      handler thread that happens to be processing a request when
+      this gets called.
+
+    No-ops on platforms (Windows/macOS) or Python builds where the
+    syscalls/CLI tools are missing. Any failure is swallowed —
+    priority adjustment is a nice-to-have, not a correctness
+    requirement.
     """
+    if not sys.platform.startswith('linux'):
+        return
+
+    # CPU scheduling — SCHED_IDLE is thread-local with first arg = 0.
     try:
-        os.nice(19)
-    except (OSError, AttributeError, ValueError):
+        SCHED_IDLE = 5
+        if hasattr(os, 'sched_setscheduler') and hasattr(os, 'sched_param'):
+            os.sched_setscheduler(  # type: ignore[attr-defined]
+                0, SCHED_IDLE, os.sched_param(0),  # type: ignore[attr-defined]
+            )
+    except (OSError, PermissionError, AttributeError):
+        # Some kernels/cgroups refuse SCHED_IDLE for non-root; that's
+        # fine — we still get the I/O priority drop below.
         pass
-    if sys.platform.startswith('linux'):
-        try:
-            # SCHED_BATCH = 3 on Linux; not exposed in stdlib for all
-            # Python builds, so we use the raw constant.
-            SCHED_BATCH = 3
-            if hasattr(os, 'sched_setscheduler') and hasattr(os, 'sched_param'):
-                os.sched_setscheduler(  # type: ignore[attr-defined]
-                    0, SCHED_BATCH, os.sched_param(0),  # type: ignore[attr-defined]
-                )
-        except (OSError, PermissionError, AttributeError):
-            pass
+
+    # I/O scheduling — ionice on the calling thread's TID, not the PID.
+    # ``threading.get_native_id()`` returns the kernel TID on Linux
+    # (Python 3.8+); ionice -p accepts a TID transparently because
+    # Linux's ioprio_set syscall operates per-task.
+    try:
+        import subprocess
+        tid = threading.get_native_id()
+        subprocess.run(
+            ["ionice", "-c", "3", "-p", str(tid)],
+            timeout=5, capture_output=True, check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired,
+            OSError, AttributeError):
+        pass
 
 
 def _run_worker_loop(db_path: str, teslacam_root: str, worker_id: str) -> None:

--- a/scripts/web/services/task_coordinator.py
+++ b/scripts/web/services/task_coordinator.py
@@ -66,6 +66,34 @@ _WAIT_POLL_SECONDS = 0.1
 # Maximum time a task can hold the lock before it's considered stale
 _MAX_TASK_AGE_SECONDS = 1800  # 30 minutes
 
+# Throttle window for the "Task X skipped: Y is running" INFO log.
+# A cyclic caller (e.g. the indexer) hits the skip path every
+# ``_BACKOFF_SLEEP_SECONDS`` (≈ 0.5 s); without throttling, a long
+# archive run produced ~2 logs/sec for ~11 min during a production
+# boot catchup (issue #72). One log per (task, blocker) pair per minute
+# is plenty — the log shows you a contention is in progress, not a
+# blow-by-blow account.
+_SKIPPED_LOG_THROTTLE_SECONDS = 60.0
+# Per (task_name, blocker_name) -> monotonic time of last INFO log.
+# Guarded by ``_lock`` so concurrent acquire_task callers can't
+# double-fire the log.
+_skipped_log_last: dict = {}
+
+
+def _should_log_skipped(task_name: str, blocker_name: str) -> bool:
+    """Return True if "skipped" should be logged at INFO level now.
+
+    Throttled to once per ``_SKIPPED_LOG_THROTTLE_SECONDS`` per
+    (task_name, blocker_name) pair. Caller MUST hold ``_lock``.
+    """
+    now = time.monotonic()
+    key = (task_name, blocker_name)
+    last = _skipped_log_last.get(key, 0.0)
+    if now - last >= _SKIPPED_LOG_THROTTLE_SECONDS:
+        _skipped_log_last[key] = now
+        return True
+    return False
+
 
 def acquire_task(task_name: str, wait_seconds: float = 0.0,
                  *, yield_to_waiters: bool = False) -> bool:
@@ -125,15 +153,29 @@ def acquire_task(task_name: str, wait_seconds: float = 0.0,
                     if am_waiting:
                         _waiter_count = max(0, _waiter_count - 1)
                         am_waiting = False
+                    # On successful acquisition, reset the per-blocker
+                    # throttle map. The "skipped" log should fire on the
+                    # FIRST blocked attempt of the next contention
+                    # period, not stay throttled from the previous one.
+                    _skipped_log_last.clear()
                     logger.info("Task '%s' acquired lock", task_name)
                     return True
 
                 # Lock is held. Decide whether to wait or give up now.
                 if wait_seconds <= 0:
-                    logger.info(
-                        "Task '%s' skipped: '%s' is running (%.0fs)",
-                        task_name, _current_task, age,
-                    )
+                    if _should_log_skipped(task_name, _current_task):
+                        logger.info(
+                            "Task '%s' skipped: '%s' is running (%.0fs)",
+                            task_name, _current_task, age,
+                        )
+                    else:
+                        # Throttled — emit at DEBUG so it's available
+                        # via journalctl -p debug if needed without
+                        # spamming default-level logs at 2 lines/sec.
+                        logger.debug(
+                            "Task '%s' skipped: '%s' is running (%.0fs)",
+                            task_name, _current_task, age,
+                        )
                     return False
 
                 # Register as a waiter on first failed attempt so other

--- a/scripts/web/services/video_archive_service.py
+++ b/scripts/web/services/video_archive_service.py
@@ -184,14 +184,27 @@ def _archive_timer_loop() -> None:
 
     # Set lowest I/O priority so archive doesn't starve the USB gadget.
     # The gadget shares the same SD card I/O bus.
+    #
+    # Critical: ionice MUST target this archive thread's kernel TID
+    # (via ``threading.get_native_id()``), NOT ``os.getpid()``. On
+    # Linux, ``ioprio_set`` is per-task, and passing the process PID
+    # only adjusts the main thread's I/O class — leaving the archive
+    # worker thread at default best-effort priority and fully able to
+    # starve Flask/gadget I/O. This was the second half of issue #72
+    # (the first was os.nice() in the indexer being process-wide).
     try:
         import subprocess
+        tid = threading.get_native_id()
         subprocess.run(
-            ["ionice", "-c", "3", "-p", str(os.getpid())],
-            timeout=5, capture_output=True,
+            ["ionice", "-c", "3", "-p", str(tid)],
+            timeout=5, capture_output=True, check=False,
         )
-        logger.info("Archive thread set to idle I/O priority (ionice -c 3)")
-    except Exception:
+        logger.info(
+            "Archive thread set to idle I/O priority "
+            "(ionice -c 3 -p %d)", tid,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired,
+            OSError, AttributeError):
         pass  # ionice not available — rate limiting still protects us
 
     # Initial delay — let boot finish and other services settle

--- a/tests/test_indexing_worker.py
+++ b/tests/test_indexing_worker.py
@@ -457,3 +457,113 @@ class TestStatus:
             finally:
                 gate.set()
                 indexing_worker.stop_worker(timeout=5.0)
+
+
+class TestApplyLowPriority:
+    """Issue #72: ``_apply_low_priority`` was lowering the WHOLE
+    ``gadget_web`` process priority via ``os.nice(19)``, making the
+    Flask request handlers and every other thread low-priority too.
+    The fix uses thread-local SCHED_IDLE + ``ionice`` against the
+    calling thread's TID instead.
+    """
+
+    def test_does_not_call_os_nice(self, monkeypatch):
+        """``os.nice`` is process-wide on Linux — must NOT be used
+        from a worker thread because it lowers Flask priority too.
+        On Windows ``os.nice`` doesn't even exist; on Linux we must
+        guarantee the function never invokes it.
+        """
+        import sys
+        if not sys.platform.startswith('linux'):
+            # Non-Linux: function early-returns and ``os.nice`` is
+            # missing from stdlib, so the regression cannot occur.
+            indexing_worker._apply_low_priority()
+            return
+
+        called = []
+
+        def fake_nice(_):  # pragma: no cover - just records
+            called.append(True)
+            raise AssertionError(
+                "indexing_worker._apply_low_priority must NOT call "
+                "os.nice() — it's process-wide and would lower "
+                "Flask request handlers' priority too (issue #72)"
+            )
+
+        monkeypatch.setattr(os, 'nice', fake_nice)
+        # Should not raise.
+        indexing_worker._apply_low_priority()
+        assert called == []
+
+    def test_uses_native_tid_for_ionice(self, monkeypatch):
+        """``ionice -p`` must receive the calling thread's TID
+        (``threading.get_native_id()``), not the process PID. On
+        Linux, ioprio_set is per-task — passing the PID only adjusts
+        the main thread's I/O class.
+        """
+        import sys
+        if not sys.platform.startswith('linux'):
+            pytest.skip("ionice is Linux-only")
+
+        captured_args = []
+
+        def fake_run(cmd, *a, **kw):
+            captured_args.append(cmd)
+
+            class R:
+                returncode = 0
+                stdout = b''
+                stderr = b''
+            return R()
+
+        import subprocess as sp
+        monkeypatch.setattr(sp, 'run', fake_run)
+
+        expected_tid = threading.get_native_id()
+        indexing_worker._apply_low_priority()
+
+        ionice_calls = [c for c in captured_args if c and c[0] == 'ionice']
+        assert ionice_calls, (
+            f"Expected an ionice call from _apply_low_priority, got: "
+            f"{captured_args}"
+        )
+        # Find the -p arg.
+        cmd = ionice_calls[0]
+        p_idx = cmd.index('-p')
+        tid_arg = int(cmd[p_idx + 1])
+        # The TID we capture inside the test thread IS the same TID
+        # _apply_low_priority sees because we call it synchronously.
+        assert tid_arg == expected_tid, (
+            f"ionice -p got {tid_arg} but the calling thread's "
+            f"native TID is {expected_tid} — must match for I/O "
+            f"priority to apply to the indexer thread, not the main "
+            f"thread (issue #72)"
+        )
+
+    def test_uses_sched_idle_not_sched_batch(self, monkeypatch):
+        """SCHED_IDLE (5) lowers CPU priority more than SCHED_BATCH (3),
+        and is the right choice for "only run when nothing else wants
+        the CPU" semantics. Earlier code used SCHED_BATCH which still
+        competed normally for the CPU."""
+        import sys
+        if not sys.platform.startswith('linux'):
+            pytest.skip("sched_setscheduler is Linux-only")
+        if not hasattr(os, 'sched_setscheduler'):
+            pytest.skip("os.sched_setscheduler missing on this build")
+
+        captured = []
+
+        def fake_setscheduler(pid, policy, param):
+            captured.append((pid, policy))
+
+        monkeypatch.setattr(os, 'sched_setscheduler', fake_setscheduler)
+        indexing_worker._apply_low_priority()
+
+        assert captured, "Expected sched_setscheduler call"
+        pid_arg, policy_arg = captured[0]
+        assert pid_arg == 0, (
+            "First arg must be 0 (= 'this thread'), not a PID"
+        )
+        assert policy_arg == 5, (
+            f"Policy must be SCHED_IDLE (5), got {policy_arg}"
+        )

--- a/tests/test_task_coordinator.py
+++ b/tests/test_task_coordinator.py
@@ -27,12 +27,14 @@ def _reset_coordinator():
         tc._current_task = None
         tc._task_started = 0.0
         tc._waiter_count = 0
+        tc._skipped_log_last.clear()
     yield
     # Post-test cleanup.
     with tc._lock:
         tc._current_task = None
         tc._task_started = 0.0
         tc._waiter_count = 0
+        tc._skipped_log_last.clear()
 
 
 class TestBasicAcquireRelease:
@@ -338,3 +340,118 @@ class TestMultipleWaiters:
             "applied to a blocking caller"
         )
         tc.release_task('holder')
+
+
+class TestSkippedLogThrottling:
+    """Issue #72: the cyclic indexer hits the "skipped" log path every
+    ~0.5 s while the archive holds the lock. A long archive run was
+    producing ~2 INFO log lines/sec for ~11 minutes (~1300 entries) on
+    Pi production, filling the journal and obscuring real events.
+    Throttle the INFO log to once per (task, blocker) pair per
+    ``_SKIPPED_LOG_THROTTLE_SECONDS``; demote subsequent attempts to
+    DEBUG so they remain available via ``journalctl -p debug``.
+    """
+
+    def test_repeated_skips_log_info_only_once(self, caplog):
+        tc.acquire_task('archive')
+        try:
+            with caplog.at_level('INFO', logger='services.task_coordinator'):
+                # Hit the skip path 10 times in quick succession.
+                for _ in range(10):
+                    assert tc.acquire_task('indexer') is False
+
+            info_skips = [
+                r for r in caplog.records
+                if r.levelname == 'INFO' and 'skipped' in r.message
+            ]
+            assert len(info_skips) == 1, (
+                f"Expected exactly 1 INFO 'skipped' log, got "
+                f"{len(info_skips)}: "
+                f"{[r.getMessage() for r in info_skips]}"
+            )
+        finally:
+            tc.release_task('archive')
+
+    def test_repeated_skips_emit_debug_after_first(self, caplog):
+        tc.acquire_task('archive')
+        try:
+            with caplog.at_level('DEBUG', logger='services.task_coordinator'):
+                for _ in range(5):
+                    assert tc.acquire_task('indexer') is False
+
+            info_skips = [
+                r for r in caplog.records
+                if r.levelname == 'INFO' and 'skipped' in r.message
+            ]
+            debug_skips = [
+                r for r in caplog.records
+                if r.levelname == 'DEBUG' and 'skipped' in r.message
+            ]
+            assert len(info_skips) == 1
+            # 4 throttled attempts → 4 DEBUG logs.
+            assert len(debug_skips) == 4
+        finally:
+            tc.release_task('archive')
+
+    def test_throttle_resets_on_lock_acquisition(self, caplog):
+        """When the lock changes hands, the throttle map clears so the
+        first skip of the next contention window logs at INFO again."""
+        # First contention period.
+        tc.acquire_task('archive')
+        try:
+            with caplog.at_level('INFO', logger='services.task_coordinator'):
+                tc.acquire_task('indexer')  # INFO log
+                tc.acquire_task('indexer')  # throttled to DEBUG
+        finally:
+            tc.release_task('archive')
+
+        caplog.clear()
+
+        # Lock is now free → next acquire resets the throttle map.
+        assert tc.acquire_task('cloud_sync') is True
+        try:
+            with caplog.at_level('INFO', logger='services.task_coordinator'):
+                # Second contention period: indexer's first skip vs
+                # the new blocker should fire at INFO again.
+                assert tc.acquire_task('indexer') is False
+
+            info_skips = [
+                r for r in caplog.records
+                if r.levelname == 'INFO' and 'skipped' in r.message
+            ]
+            assert len(info_skips) == 1
+            assert "'cloud_sync' is running" in info_skips[0].getMessage()
+        finally:
+            tc.release_task('cloud_sync')
+
+    def test_different_blocker_pair_logs_independently(self, caplog):
+        """Throttling is per (task, blocker) pair, not global. If the
+        same task is skipped by two different blockers in succession,
+        both first occurrences should log at INFO."""
+        # We can't actually have two blockers at once, but we can simulate
+        # the throttle map directly.
+        tc._skipped_log_last[('indexer', 'archive')] = 0.0  # warm cache
+
+        tc.acquire_task('archive')
+        try:
+            with caplog.at_level('INFO', logger='services.task_coordinator'):
+                tc.acquire_task('indexer')
+        finally:
+            tc.release_task('archive')
+
+        # Lock acquisition cleared the throttle map for next contention.
+        # New blocker (cloud_sync), same skipped task (indexer).
+        caplog.clear()
+        tc.acquire_task('cloud_sync')
+        try:
+            with caplog.at_level('INFO', logger='services.task_coordinator'):
+                tc.acquire_task('indexer')
+
+            info_skips = [
+                r for r in caplog.records
+                if r.levelname == 'INFO' and 'skipped' in r.message
+            ]
+            assert len(info_skips) == 1
+            assert "'cloud_sync' is running" in info_skips[0].getMessage()
+        finally:
+            tc.release_task('cloud_sync')

--- a/tests/test_video_archive_trigger.py
+++ b/tests/test_video_archive_trigger.py
@@ -114,6 +114,9 @@ class TestTriggerArchiveDuplicateGuard:
         # Reset the gate so the next "run" can also exit.
         gate.clear()
         gate.set()
+        assert vas.trigger_archive_now() is True
+        # Two distinct runs occurred.
+        assert len(runs) == 2
 
 
 class TestArchiveIoniceUsesThreadId:
@@ -198,9 +201,6 @@ class TestArchiveIoniceUsesThreadId:
             f"priority must be set on its OWN native TID, not the "
             f"process PID"
         )
-        assert vas.trigger_archive_now() is True
-        # Two distinct runs occurred.
-        assert len(runs) == 2
 
     def test_pending_cleared_when_run_returns_normally(self, monkeypatch):
         def fake_run():

--- a/tests/test_video_archive_trigger.py
+++ b/tests/test_video_archive_trigger.py
@@ -114,6 +114,90 @@ class TestTriggerArchiveDuplicateGuard:
         # Reset the gate so the next "run" can also exit.
         gate.clear()
         gate.set()
+
+
+class TestArchiveIoniceUsesThreadId:
+    """Issue #72: ``_archive_timer_loop`` was calling
+    ``ionice -c 3 -p <os.getpid()>`` to drop the archive thread's I/O
+    priority — but on Linux ``ioprio_set`` is per-task. Passing the
+    process PID only adjusts the main thread's I/O class, leaving
+    the archive worker thread at default best-effort priority and
+    fully able to starve the gadget endpoint and Flask. The fix
+    passes ``threading.get_native_id()`` instead.
+    """
+
+    def test_archive_ionice_uses_native_tid_not_pid(self, monkeypatch):
+        import sys
+        if not sys.platform.startswith('linux'):
+            pytest.skip("ionice is Linux-only")
+
+        captured = []
+        # Mock subprocess.run to capture the ionice invocation. Then
+        # raise after capturing so the archive timer loop exits early
+        # without waiting 2 minutes for the initial-delay.
+        gate_event = threading.Event()
+
+        def fake_run(cmd, *a, **kw):
+            captured.append(cmd)
+
+            class R:
+                returncode = 0
+                stdout = b''
+                stderr = b''
+            # Trip the cancel after the first ionice call to exit the
+            # loop quickly.
+            gate_event.set()
+            return R()
+
+        import subprocess as sp
+        monkeypatch.setattr(sp, 'run', fake_run)
+
+        # Stop the loop right after the ionice call by setting the
+        # cancel event — that way the for-loop initial delay exits on
+        # its first iteration.
+        cancel = threading.Event()
+        monkeypatch.setattr(vas, '_archive_cancel', cancel)
+
+        def stop_after_first_run():
+            gate_event.wait(timeout=2.0)
+            cancel.set()
+
+        stopper = threading.Thread(target=stop_after_first_run, daemon=True)
+        stopper.start()
+
+        # Run the timer loop directly. It should ionice-then-exit.
+        loop_thread = threading.Thread(
+            target=vas._archive_timer_loop, daemon=True,
+        )
+        loop_thread.start()
+        # Capture the loop thread's TID — that's what should be passed
+        # to ionice. Native TID is set as soon as the thread starts.
+        # Wait briefly for the thread to register its TID and run
+        # ionice.
+        for _ in range(100):
+            if captured:
+                break
+            time.sleep(0.01)
+        loop_thread.join(timeout=5.0)
+
+        ionice_calls = [c for c in captured if c and c[0] == 'ionice']
+        assert ionice_calls, (
+            f"Expected an ionice call from _archive_timer_loop, got: "
+            f"{captured}"
+        )
+        cmd = ionice_calls[0]
+        p_idx = cmd.index('-p')
+        tid_arg = int(cmd[p_idx + 1])
+
+        import os
+        # The TID must NOT be the process PID — that's the bug being
+        # fixed.
+        assert tid_arg != os.getpid(), (
+            f"ionice -p {tid_arg} matches process PID {os.getpid()} "
+            f"— this is the issue #72 bug; archive thread's I/O "
+            f"priority must be set on its OWN native TID, not the "
+            f"process PID"
+        )
         assert vas.trigger_archive_now() is True
         # Two distinct runs occurred.
         assert len(runs) == 2


### PR DESCRIPTION
## Summary

Fixes #72 — boot-catchup IO storm makes the web UI unresponsive.

Production diagnosis on `cybertruckusb.local` during a recent boot:

- `/api/index/status` took 10 s
- `/` and `/api/days` timed out at 10 s
- The archive worker held the `task_coordinator` heavy lock for **691 seconds (11.5 min)**
- The journal carried ~1300 `Task 'indexer' skipped: 'archive' is running (Ns)` INFO entries during that window — ~2 lines/sec

Three concrete root causes were identified and fixed.

## Root causes & fixes

### 1. `os.nice(19)` was process-wide, not thread-local

`indexing_worker._apply_low_priority()` called `os.nice(19)`. On Linux/glibc that's **process-wide**, not thread-local. It lowered the entire `gadget_web` process — including all Flask request-handler threads — to nice 19, making the UI uncompetitive against the archive worker for CPU.

**Fix:** replaced with `os.sched_setscheduler(0, SCHED_IDLE, ...)` (where `0` = "this thread" per `sched_setscheduler(2)`). `SCHED_IDLE` (constant 5) is strictly lower than `SCHED_BATCH` and only runs when nothing else wants the CPU.

### 2. `ionice -p` was targeting the process, not the worker thread

`video_archive_service._archive_timer_loop()` called `ionice -c 3 -p <os.getpid()>`. On Linux `ioprio_set` is per-task, so passing the PID only adjusts the **main** thread's I/O class — the archive worker thread inherited default best-effort priority and was fully able to starve the gadget endpoint and Flask for SD-card I/O.

**Fix:** both the archive timer loop and the indexer worker now pass `threading.get_native_id()` (Python 3.8+, returns the kernel TID on Linux). `ionice -p <tid>` works transparently with TIDs.

### 3. Cyclic INFO log spam

`task_coordinator.acquire_task()` logged `Task X skipped: Y is running (Ns)` at INFO on **every** failed attempt. The indexer hits this path every ~0.5 s while waiting, producing ~2 logs/sec for the duration of any long-running blocker.

**Fix:** throttle the INFO log to once per minute per `(task, blocker)` pair via a small `_skipped_log_last` dict. Throttled attempts emit at DEBUG (still recoverable via `journalctl -p debug`). The throttle map clears on every successful lock acquisition so the next contention period starts fresh.

## Files changed

- `scripts/web/services/indexing_worker.py` — rewrote `_apply_low_priority` to be thread-local; comprehensive docstring documenting the regression.
- `scripts/web/services/video_archive_service.py` — `_archive_timer_loop` now uses `threading.get_native_id()` for ionice; logs the TID for observability.
- `scripts/web/services/task_coordinator.py` — added `_SKIPPED_LOG_THROTTLE_SECONDS`, `_skipped_log_last`, `_should_log_skipped()`; throttled INFO/DEBUG branching; clears throttle map on successful acquire.
- `tests/test_task_coordinator.py` — `TestSkippedLogThrottling` (4 tests) covering single-INFO-then-DEBUG, throttle reset on lock handover, and per-pair independence.
- `tests/test_indexing_worker.py` — `TestApplyLowPriority` (3 tests) verifying `os.nice` is never called, `sched_setscheduler` uses policy 5 with `pid=0`, and `ionice -p` receives the calling thread's `native_tid`.
- `tests/test_video_archive_trigger.py` — `TestArchiveIoniceUsesThreadId` (1 test) verifying the archive ionice call does NOT receive `os.getpid()`.

## Test results

Full suite: **495 passed, 4 skipped** (was 490 / 1 — 5 new tests, no regressions).

Linux-only tests are conditionally skipped on Windows where `os.nice`, `sched_setscheduler`, and `ionice` are unavailable.

## Safety

- Boot path / `present_usb.sh` / USB gadget binding **untouched** — no changes to startup ordering or systemd services.
- `SCHED_IDLE` and `ionice` failures are swallowed gracefully (existing behavior). Some kernels/cgroups refuse `SCHED_IDLE` for non-root; `gadget_web` runs as root via systemd, so this should always succeed in production.
- The throttle is an INFO-level demotion to DEBUG, not a complete suppression — full detail is still recoverable for debugging.

## Verification on Pi (post-merge)

After deploying:
1. `curl -s -o /dev/null -w "%{time_total}\n" http://cybertruckusb.local/api/index/status` should return ≪ 1 s during archive runs (was 10 s).
2. `journalctl -u gadget_web.service -f` during an archive run should show **at most one** "skipped" INFO line per minute per blocker pair (was ~120/min).
3. Thread-level `ionice` and `chrt -p` checks (if SSH'd in) should confirm the worker threads are at idle class while Flask threads remain at default.

Closes #72.
