### PR TITLE
fix(archive): tighten cadence and refresh vfat cache before scan (#70, #71)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -213,7 +213,7 @@ LES is a **separate, opt-in subsystem** that uploads Sentry and Saved events to 
 ## Safety & Stability
 - **SSH is sacred**: sshd has a systemd drop-in preventing it from being stopped or masked. Safe-mode boot detection skips TeslaUSB services after 3+ reboots in 10 minutes.
 - **IMG files are never deleted**: `is_protected_file()` guard in all code paths that delete files. `*.img` files in GADGET_DIR are always refused deletion.
-- **RecentClips preservation**: Archive timer runs every 5 minutes regardless of WiFi state, copying clips to SD card before Tesla's circular buffer overwrites them.
+- **RecentClips preservation**: Archive timer runs every 2 minutes regardless of WiFi state, copying clips to SD card before Tesla's circular buffer overwrites them.
 - **WiFi always reconnects**: wifi-monitor.sh uses adaptive check intervals (20s when searching, 60s when connected), always tries to rejoin configured SSID even when AP is active.
 
 ## Pitfalls to avoid

--- a/config.yaml
+++ b/config.yaml
@@ -164,7 +164,7 @@ live_event_sync:
 # SD card before Tesla's 1-hour circular buffer deletes them. Zero USB disruption.
 archive:
   enabled: true                          # Enable RecentClips archival
-  interval_minutes: 5                    # How often to check for new clips (tighter = less data loss)
+  interval_minutes: 2                    # How often to check for new clips (tighter = less data loss)
   retention_days: 30                     # Delete archived clips older than this
   min_free_space_gb: 10                  # Hard floor — stop archiving if SD card < this free
   max_size_gb: 0                         # 0 = auto (use all available space minus reserved)

--- a/readme.md
+++ b/readme.md
@@ -62,7 +62,7 @@ TeslaUSB creates a multi-drive USB gadget that appears as **two or three separat
 - **Disambiguation popup**: Tapping the map at a location with multiple overlapping clips (e.g., a road driven multiple times) opens a chooser listing each clip with its trip date/time so the right one can be selected.
 - **Telemetry HUD**: Glassmorphic overlay showing real-time steering wheel angle, brake/gas pedal positions, speed, gear (P/R/N/D), turn signals, and Autopilot status — powered by pre-indexed server-side waypoint data (instant, no full video download needed)
 - **Auto-indexing**: A single low-priority background worker drains a SQLite-backed `indexing_queue` one file at a time. Producers: boot catch-up scan, real-time inotify on new files, the post-WiFi archive run, and manual reindex from the UI. The "Indexing…" banner only appears while a specific file is actively being parsed. Sentry events placed on map using inferred location from nearest trip
-- **RecentClips Archive**: Automatically copies RecentClips to the Pi's SD card every 5 minutes before Tesla's 1-hour circular buffer deletes them — zero USB disruption, videos preserved for 30 days
+- **RecentClips Archive**: Automatically copies RecentClips to the Pi's SD card every 2 minutes before Tesla's 1-hour circular buffer deletes them — zero USB disruption, videos preserved for 30 days
 - **Skeuomorphic event markers**: Balloon-pin map markers — brake pedal, gas pedal, steering wheel, speedometer, eye (sentry) — always visible on the map
 - **Trip navigation**: Floating trip card with prev/next navigation; FSD overlay toggle
 - Download all camera views for an event as a zip file
@@ -396,7 +396,7 @@ web:
 # ============================================================================
 archive:
   enabled: true                      # Enable RecentClips archival to SD card
-  interval_minutes: 5                # How often to check for new clips
+  interval_minutes: 2                # How often to check for new clips
   retention_days: 30                 # Delete archived clips older than this
   min_free_space_gb: 10              # Stop archiving if SD card < this free
   max_size_gb: 50                    # Cap on total archive folder size

--- a/scripts/web/config.py
+++ b/scripts/web/config.py
@@ -129,7 +129,7 @@ LIVE_EVENT_NOTIFY_WEBHOOK_URL = str(_les.get('notify_webhook_url', '') or '')
 # RecentClips Archive Configuration
 _archive = config.get('archive', {})
 ARCHIVE_ENABLED = bool(_archive.get('enabled', True))
-ARCHIVE_INTERVAL_MINUTES = int(_archive.get('interval_minutes', 5))
+ARCHIVE_INTERVAL_MINUTES = int(_archive.get('interval_minutes', 2))
 ARCHIVE_RETENTION_DAYS = int(_archive.get('retention_days', 30))
 ARCHIVE_MIN_FREE_SPACE_GB = int(_archive.get('min_free_space_gb', 10))
 ARCHIVE_MAX_SIZE_GB = int(_archive.get('max_size_gb', 50))

--- a/scripts/web/services/video_archive_service.py
+++ b/scripts/web/services/video_archive_service.py
@@ -13,6 +13,7 @@ monitoring between files.
 import logging
 import os
 import shutil
+import subprocess
 import threading
 import time
 from datetime import datetime, timezone, timedelta
@@ -38,9 +39,14 @@ from config import (
 # Constants
 # ---------------------------------------------------------------------------
 
-# Minimum file age before copying (seconds). Files younger than this may
-# still be actively written by Tesla.
-_MIN_FILE_AGE_SECONDS = 300  # 5 minutes
+# Minimum file age before copying (seconds). Files younger than this are
+# assumed to still be actively written by Tesla and skipped this cycle.
+# Tesla's RecentClips are ~60 s long, so by 90 s the clip is finalized.
+# The real safety net against partial reads is ``_is_complete_mp4`` (the
+# moov-atom check at line 405 / 585) — this age gate is belt-and-suspenders
+# and a cheap fast-path that avoids running the moov scan on actively-rotating
+# files. Lowered from 300 s in #70 (was the dominant source of archive lag).
+_MIN_FILE_AGE_SECONDS = 90  # 1.5 minutes — see comment above
 
 # Buffered copy chunk size — keeps memory usage predictable on Pi Zero 2 W
 _COPY_CHUNK_SIZE = 65536  # 64 KB
@@ -58,7 +64,7 @@ _MIN_MEMORY_BYTES = 50 * 1024 * 1024  # 50 MB
 _INTER_FILE_SLEEP = 2.0  # 2 seconds
 
 # Max files to copy per archive cycle. Prevents a large backlog from
-# monopolising I/O and RAM for the entire 5-minute interval, which can
+# monopolising I/O and RAM for the whole archive interval, which can
 # starve the web server and trigger the hardware watchdog on Pi Zero 2 W.
 # Remaining files are picked up in the next cycle.
 _MAX_FILES_PER_CYCLE = 50
@@ -193,7 +199,6 @@ def _archive_timer_loop() -> None:
     # starve Flask/gadget I/O. This was the second half of issue #72
     # (the first was os.nice() in the indexer being process-wide).
     try:
-        import subprocess
         tid = threading.get_native_id()
         subprocess.run(
             ["ionice", "-c", "3", "-p", str(tid)],
@@ -266,7 +271,7 @@ def _run_archive() -> None:
         # poll. The wait-with-timeout is critical: returning False
         # immediately caused archive starvation in production, with
         # TeslaCam clips lost when Tesla rotated RecentClips before
-        # the next 5-minute archive cycle could win the lock. See
+        # the next archive cycle could win the lock. See
         # task_coordinator docstring for the fairness model.
         from services.task_coordinator import acquire_task, release_task
         if not acquire_task('archive', wait_seconds=60.0):
@@ -331,6 +336,24 @@ def _do_archive_work() -> None:
         _purge_corrupt_archives()
 
         # Discover files to copy
+        # Force vfat to re-read directories — the gadget side may have
+        # written new clips without invalidating our local RO mount's
+        # dentry/inode slab cache. ``echo 2`` drops slabs only (NOT the
+        # page cache that backs the gadget's reads of usb_cam.img), so
+        # this is safe to run concurrently with Tesla recording. Cheap
+        # (~100 ms) and bounded. Run once per archive cycle, not per
+        # file. See issue #71. Requires the matching sudoers entry in
+        # setup_usb.sh; if that entry is missing on an old install the
+        # try/except swallows the failure and the scan still works
+        # against whatever the cache currently holds (no regression).
+        try:
+            subprocess.run(
+                ['sudo', 'sh', '-c', 'echo 2 > /proc/sys/vm/drop_caches'],
+                capture_output=True, check=False, timeout=5,
+            )
+        except Exception as exc:  # pragma: no cover — best-effort, log-only
+            logger.debug("vfat slab cache flush failed (best-effort): %s", exc)
+
         _status["progress"] = "Scanning RecentClips..."
         to_copy = list(_discover_new_files(recent_clips))
 

--- a/scripts/web/templates/index.html
+++ b/scripts/web/templates/index.html
@@ -212,7 +212,7 @@
                         <strong>Enable RecentClips archival</strong>
                     </label>
                     <p style="font-size:0.8rem; color:var(--text-secondary); margin:4px 0 0 26px">
-                        When enabled, clips are automatically copied from the USB drive to the SD card every 5 minutes.
+                        When enabled, clips are automatically copied from the USB drive to the SD card every 2 minutes.
                         Disable this if you don't need local copies of your dashcam footage.
                     </p>
                 </div>

--- a/setup_usb.sh
+++ b/setup_usb.sh
@@ -1439,8 +1439,14 @@ $TARGET_USER ALL=(ALL) NOPASSWD: /usr/bin/pkill
 $TARGET_USER ALL=(ALL) NOPASSWD: /usr/bin/nmcli
 
 # Allow cache dropping for exFAT filesystem sync (required for web lock chime updates)
+# and for vfat slab-cache invalidation on the part1 RO mount before each archive
+# scan (issue #71). ``echo 2`` drops slabs only (dentries+inodes) — preserves the
+# page cache that backs the gadget's reads. ``echo 3`` drops both, used after
+# part2 RW remounts where the page cache is already cold.
 $TARGET_USER ALL=(ALL) NOPASSWD: /usr/bin/sh -c echo 3 > /proc/sys/vm/drop_caches
 $TARGET_USER ALL=(ALL) NOPASSWD: /bin/sh -c echo 3 > /proc/sys/vm/drop_caches
+$TARGET_USER ALL=(ALL) NOPASSWD: /usr/bin/sh -c echo 2 > /proc/sys/vm/drop_caches
+$TARGET_USER ALL=(ALL) NOPASSWD: /bin/sh -c echo 2 > /proc/sys/vm/drop_caches
 EOF
 chmod 440 "$SUDOERS_ENTRY"
 

--- a/templates/99-teslausb-cloud-refresh
+++ b/templates/99-teslausb-cloud-refresh
@@ -35,7 +35,7 @@ GADGET_DIR="__GADGET_DIR__"
 LOCK="/run/teslausb-wifi-handler.lock"
 
 # Prevent multiple concurrent runs. The handler is bounded at
-# ~5 min (archive) + ~2 min (indexer drain) + small overhead, so
+# ~one archive cycle + ~one indexer drain + small overhead, so
 # treat any lock newer than 10 minutes as still-valid and skip
 # this fire.
 if [ -f "$LOCK" ]; then


### PR DESCRIPTION
# fix(archive): tighten cadence and refresh vfat cache before scan

Quick-relief patch resolving **#70** and **#71** as a single PR. Both are tiny tweaks in `scripts/web/services/video_archive_service.py` (and a few doc/config refreshes); both have overlapping rationale (shorten the archive feedback loop); both will be superseded structurally by the two-queue pipeline tracked in **#76 Phase 2**. Combining them avoids two near-identical PRs.

## Problem (combined)

Three stacked delays were making freshly-finalised RecentClips take up to ~11 minutes to appear in `ArchivedClips/`:

1. `_MIN_FILE_AGE_SECONDS = 300` — clip must be at least 5 min old before archive considers it
2. `archive.interval_minutes: 5` — cycle gap can add another 5 min
3. **vfat dentry-cache staleness on the part1 RO mount** — `os.listdir()` may not see clips Tesla just wrote via the gadget block layer (separate, compounding cause)

User report (2026-05-07): *"I just drove the vehicle and returned 30 minutes ago. I am seeing my last trip slowly showing up. I would have expected the indexing to be happening while I was driving."*

## Fix

| Change | File | Old | New |
|---|---|---|---|
| #70 — Skip-young-files gate | `video_archive_service.py:43` | `300` (5 min) | `90` (1.5 min) |
| #70 — Cycle period default | `config.yaml:167` | `5` | `2` |
| #70 — Default in Python wrapper | `scripts/web/config.py:132` | `5` | `2` |
| #71 — vfat dentry flush | `video_archive_service.py` `_do_archive_work` | (none) | `subprocess.run(['sudo','sh','-c','echo 2 > /proc/sys/vm/drop_caches'], ...)` once per cycle, before scan |
| #71 — Sudoers permission | `setup_usb.sh:1441-1448` | only `echo 3` | added `echo 2` entries |

Plus comment refreshes that decouple text from the literal interval value, and doc updates in `readme.md`, `scripts/web/templates/index.html`, `.github/copilot-instructions.md`.

**Combined effect: clips reach `ArchivedClips/` (and become indexable) within ~3 min of Tesla finalising them.**

## Why each change is safe

### #70 cadence

- `_is_complete_mp4` is the **real** safety net. Tesla writes the moov atom last; `_is_complete_mp4` (L828) walks every box header front-to-back and returns `True` only when it finds a `moov` box. The post-copy validation at L405 rejects anything that doesn't pass and retries next cycle. The 90 s age gate is now belt-and-suspenders / fast-path.
- More frequent cycles do **not** increase IO load. `_MAX_FILES_PER_CYCLE = 50`, `_MAX_COPY_BYTES_PER_SEC = 2 MB/s`, `_INTER_FILE_SLEEP = 2.0 s` are unchanged — total instantaneous IO rate is identical, just spread more evenly across the wall clock.
- `task_coordinator` mutex unchanged. Archive still serializes against indexer/cloud-sync via `acquire_task('archive', wait_seconds=60.0)` (PR #78's starvation fix retained).
- User overrides honoured: `config.py:132` is `int(_archive.get('interval_minutes', 2))` — explicit user values win.

### #71 cache flush

- `echo 2` drops **slabs only** (dentries + inodes). It does **not** purge the page cache that backs the gadget's reads of `usb_cam.img`. So Tesla recording is unaffected.
- Cheap (~100 ms), bounded (`timeout=5`), best-effort (`try/except Exception`, `check=False`, log at `debug`).
- Once per cycle (not per file) — single flush invalidates the cache for the whole following `os.listdir(recent_clips)` walk.
- Failure mode if sudoers entry is missing on an old install: `try/except` swallows it, scan still works against current cache — **no regression**, just no improvement until the user re-runs setup.

## Why slabs-only (`echo 2`, not `echo 3`)

Tesla writes blocks via the gadget block layer; those updates are coherent at the page-cache level. What stays stale is the vfat driver's **dentry/inode** cache (slabs) — the in-memory directory listing that `os.listdir()` reads. `echo 2` invalidates exactly that.

The existing `partition_mount_service.py:656/963` calls use `echo 3` only because they run **after** a part2 RW remount where the page cache is already cold; that justification does not apply to the archive scan running concurrently with Tesla recording.

## Testing performed

- `python -m py_compile scripts/web/services/video_archive_service.py` — passes
- `python -c "import yaml; yaml.safe_load(open('config.yaml'))"` — passes; `archive.interval_minutes = 2`
- `bash -n setup_usb.sh` — passes
- `python -c "from web_control import app"` — passes
- `pytest tests/test_video_archive_trigger.py -v` — **5 passed, 1 skipped** (no regressions in the duplicate-trigger guard tests added by PR #78)
- Full test suite (`pytest tests/`) excluding two pre-existing collection errors (`test_mapping_service.py`, `test_sei_parser.py` — `services.dashcam_pb2` not auto-generated; **unrelated**, filed as **#84**): **263 passed, 4 skipped**
- Self code-review against TeslaUSB conventions (subprocess safety, mount safety, error handling, resource efficiency, config usage): no findings of any severity left unaddressed

## Deployment notes (for the merge step)

This PR adds a **new** sudoers entry. After merging, on each Pi:

```bash
sudo ./setup_usb.sh    # regenerates /etc/sudoers.d/teslausb
sudo systemctl restart gadget_web.service
```

Or hand-edit `/etc/sudoers.d/teslausb` to append the two `echo 2` lines.

If neither is done, the new flush call is a no-op (best-effort) — system degrades to today's behaviour, no crash, no log spam (debug-level only).

## Out of scope (intentionally not touched)

- `_MAX_COPY_BYTES_PER_SEC` (2 MB/s throttle) — unchanged
- `task_coordinator` semantics — PR #78 already addressed starvation
- Promoting `_MIN_FILE_AGE_SECONDS` to a config key — out of scope for a quick patch; #76 Phase 2 will revisit
- Any restructuring of the single-mutex archive design — that is **#76's** scope. This PR is intentionally minimal.

## Issue line-number drift

The original issue text cites `config.yaml:145`; the actual line in current `main` is **`config.yaml:167`** (file shifted after recent edits). The key path is unchanged: `archive.interval_minutes`. Verified via `grep` before editing. Same fix applied; the issue remains correct in intent.

## Related issue filed during investigation

- **#84** — `pytest` collection fails on fresh checkout because `services.dashcam_pb2` is gitignored and only generated on first run via `setup_usb.sh` or `sei_parser.py`'s auto-compile (which the test files bypass).

Closes #70.
Closes #71.
