### PR TITLE
feat(#77): hide ghost trips from map disambiguation chooser

### DIFF
--- a/scripts/web/blueprints/mapping.py
+++ b/scripts/web/blueprints/mapping.py
@@ -355,6 +355,69 @@ def api_day_routes(date):
         return jsonify({'error': str(e)}), 500
 
 
+@mapping_bp.route("/api/trips/playable")
+def api_trips_playable():
+    """Return which trips on a given day still have playable video on disk.
+
+    Powers the disambiguation popup's ghost-trip filter (issue #77):
+    a trip whose ``waypoints.video_path`` rows reference clips that
+    Tesla has rotated out of RecentClips (and that the archive job
+    didn't copy in time) should not appear in the chooser, because
+    picking one yields an unhelpful "No video available" toast.
+
+    The check is per-trip — a trip is "playable" iff at least one of
+    its waypoints' video paths resolves to a real file on disk via
+    the same fallback rules :func:`videos.stream_video` uses
+    (RecentClips → ArchivedClips). Per-day results are cached
+    server-side for 60 s; subsequent calls within that window are
+    served from memory.
+
+    Query params:
+      * ``date`` — ISO ``YYYY-MM-DD`` (required).
+
+    Response shape::
+
+        {
+          "date": "2026-05-07",
+          "trips": {"62": false, "63": true, ...}
+        }
+
+    Trip ids are JSON-stringified because JSON object keys must be
+    strings; the client coerces them back to numbers.
+    """
+    from services.mapping_service import playable_trips_for_date
+
+    date = request.args.get('date', '')
+    if not _DATE_RE.match(date):
+        return jsonify({'error': 'date must be YYYY-MM-DD'}), 400
+
+    try:
+        from config import ARCHIVE_DIR, ARCHIVE_ENABLED
+        archive_dir = ARCHIVE_DIR if ARCHIVE_ENABLED else None
+    except ImportError:
+        archive_dir = None
+
+    teslacam_path = get_teslacam_path()
+
+    try:
+        result = playable_trips_for_date(
+            MAPPING_DB_PATH, date,
+            teslacam_path=teslacam_path,
+            archive_dir=archive_dir,
+        )
+    except Exception as e:  # noqa: BLE001
+        logger.error("Failed to compute playable trips for %s: %s",
+                     date, e)
+        return jsonify({'error': str(e)}), 500
+
+    # Stringify keys for JSON compatibility; the client expects this
+    # and coerces them back via Number() / parseInt().
+    return jsonify({
+        'date': date,
+        'trips': {str(k): v for k, v in result.items()},
+    })
+
+
 # Maximum simplified waypoints per trip in /api/all-routes. With
 # RDP-based simplification (the default for query_all_routes_simplified)
 # this is a safety cap that pathological zigzag trips would hit;

--- a/scripts/web/services/mapping_service.py
+++ b/scripts/web/services/mapping_service.py
@@ -3673,6 +3673,223 @@ def query_day_routes(db_path: str, date_str: str,
         conn.close()
 
 
+# ---------------------------------------------------------------------------
+# Trip-playability check (Issue #77)
+# ---------------------------------------------------------------------------
+#
+# The map's disambiguation popup needs to know whether a trip's videos still
+# exist on disk so it can hide "ghost" trips whose RecentClips footage Tesla
+# has overwritten. The check is filesystem-bound, so we cache the per-day
+# result for 60 s — clip rotation by Tesla is on the order of hours, and the
+# stale-scan / file-watcher subsystems publish authoritative state changes
+# inside that window anyway.
+#
+# Cache shape: ``{date_str: (computed_at_monotonic, {trip_id: bool})}``.
+# Thread-safe so concurrent Flask request handlers can share results.
+
+_PLAYABLE_TRIPS_CACHE: Dict[str, Tuple[float, Dict[int, bool]]] = {}
+_PLAYABLE_TRIPS_CACHE_LOCK = threading.Lock()
+_PLAYABLE_TRIPS_TTL_SECONDS = 60.0
+
+
+def _resolve_video_path_on_disk(video_path: str,
+                                teslacam_path: Optional[str],
+                                archive_dir: Optional[str]) -> bool:
+    """Return ``True`` if ``video_path`` resolves to a real file on disk.
+
+    Mirrors the resolution that ``videos.stream_video`` performs at
+    playback time, so this check matches what playback would actually
+    serve. Order:
+
+      1. If the path begins with ``ArchivedClips/``, look in
+         ``archive_dir`` (the SD-card archive root).
+      2. Else, look at ``<teslacam_path>/<relative path>`` (handles
+         ``RecentClips/foo.mp4``, ``SavedClips/<event>/foo.mp4``,
+         ``SentryClips/<event>/foo.mp4``, and bare basenames).
+      3. Fall back to ``<archive_dir>/<basename>`` so a clip that was
+         rotated out of RecentClips but copied to ArchivedClips by the
+         archive job is still considered playable.
+
+    Args:
+        video_path: Relative ``waypoints.video_path`` value from the DB.
+            Must be a non-empty string.
+        teslacam_path: TeslaCam mount root (RO in present mode, RW in
+            edit mode), or ``None`` if the gadget is mid-transition.
+        archive_dir: ARCHIVE_DIR from config when ARCHIVE_ENABLED is
+            true, else ``None``.
+
+    Returns:
+        ``True`` iff at least one candidate file exists.
+    """
+    if not video_path:
+        return False
+
+    norm = video_path.replace('\\', '/').lstrip('/')
+    parts = [p for p in norm.split('/') if p]
+    if not parts:
+        return False
+
+    # Defense-in-depth: ``waypoints.video_path`` is written by our own
+    # indexer and is always one of the canonical relative shapes
+    # (``RecentClips/<basename>``, ``ArchivedClips/<basename>``,
+    # ``SavedClips/<event>/<basename>``, ``SentryClips/<event>/<basename>``,
+    # or a bare basename). A path with ``..`` segments or an absolute
+    # form would only appear from a corrupt row or a legacy path —
+    # reject the natural-location lookup in that case to keep this
+    # function from probing arbitrary filesystem locations. The archive
+    # basename fallback below still finds genuinely-archived clips.
+    if any(p == '..' for p in parts):
+        if archive_dir:
+            archive_path = os.path.join(archive_dir, parts[-1])
+            if os.path.isfile(archive_path):
+                return True
+        return False
+
+    # Direct ArchivedClips reference: serve from SD-card archive root.
+    if parts[0] == 'ArchivedClips':
+        if archive_dir:
+            archive_path = os.path.join(archive_dir, parts[-1])
+            if os.path.isfile(archive_path):
+                return True
+        return False
+
+    # Natural location under the TeslaCam mount.
+    if teslacam_path:
+        candidate = os.path.join(teslacam_path, *parts)
+        if os.path.isfile(candidate):
+            return True
+
+    # ArchivedClips fallback: a RecentClips clip that was rotated out
+    # may still exist as an archived copy on the SD card.
+    if archive_dir:
+        archive_path = os.path.join(archive_dir, parts[-1])
+        if os.path.isfile(archive_path):
+            return True
+
+    return False
+
+
+def playable_trips_for_date(db_path: str, date_str: str,
+                            teslacam_path: Optional[str],
+                            archive_dir: Optional[str],
+                            ttl_seconds: float = (
+                                _PLAYABLE_TRIPS_TTL_SECONDS),
+                            ) -> Dict[int, bool]:
+    """Return ``{trip_id: has_playable_video}`` for every trip on ``date_str``.
+
+    A trip is considered playable iff at least one of its waypoints'
+    ``video_path`` values resolves to a real file on disk (see
+    :func:`_resolve_video_path_on_disk` for the resolution rules).
+
+    Results are cached per-date for ``ttl_seconds`` (default 60 s)
+    behind a module-level lock so concurrent Flask request handlers
+    share the work. Within a trip, unique ``video_path`` values are
+    stat'd at most once and the iteration short-circuits on the first
+    hit — a typical trip has a single video referenced by all its
+    waypoints, so the average cost is one ``isfile`` per trip.
+
+    Args:
+        db_path: Path to the geodata.db.
+        date_str: ISO ``YYYY-MM-DD`` day to evaluate. Caller must
+            validate format before calling.
+        teslacam_path: TeslaCam mount root, or ``None`` if unavailable.
+        archive_dir: ARCHIVE_DIR or ``None`` when archive is disabled.
+        ttl_seconds: Cache TTL. Tests can pass a smaller value.
+
+    Returns:
+        Dict mapping ``trip_id`` (int) → ``bool``. Trips with no
+        ``video_path`` waypoints are reported as ``False``. Empty dict
+        when no trips exist on the given date.
+    """
+    now = time.monotonic()
+    with _PLAYABLE_TRIPS_CACHE_LOCK:
+        cached = _PLAYABLE_TRIPS_CACHE.get(date_str)
+        if cached is not None:
+            computed_at, payload = cached
+            if (now - computed_at) < ttl_seconds:
+                return dict(payload)
+
+    conn = _init_db(db_path)
+    try:
+        # Single LEFT JOIN: every trip on the date appears at least
+        # once. Trips with no video_path waypoints come back as a
+        # single row with video_path NULL — we'll surface them as
+        # ``False`` in the result map. This avoids a second round
+        # trip and keeps the iteration order stable.
+        rows = conn.execute(
+            """
+            SELECT t.id AS trip_id,
+                   w.video_path AS video_path
+              FROM trips t
+              LEFT JOIN waypoints w
+                ON w.trip_id = t.id
+               AND w.video_path IS NOT NULL
+               AND w.video_path != ''
+             WHERE substr(t.start_time, 1, 10) = ?
+            """,
+            (date_str,),
+        ).fetchall()
+    finally:
+        conn.close()
+
+    # Group unique video_paths per trip so we stat each clip at most
+    # once. The LEFT JOIN guarantees every qualifying trip has at
+    # least one row, even if all its waypoints had a NULL video_path
+    # (those rows have ``video_path == None`` which we drop here).
+    by_trip: Dict[int, set] = {}
+    for row in rows:
+        trip_id = row['trip_id']
+        if trip_id not in by_trip:
+            by_trip[trip_id] = set()
+        vp = row['video_path']
+        if vp:
+            by_trip[trip_id].add(vp)
+
+    # Per-clip stat cache scoped to this call so two trips referencing
+    # the same clip (rare but possible after a v3 trip merge) don't
+    # double-stat.
+    file_cache: Dict[str, bool] = {}
+
+    def _is_playable(p: str) -> bool:
+        v = file_cache.get(p)
+        if v is None:
+            v = _resolve_video_path_on_disk(
+                p, teslacam_path, archive_dir,
+            )
+            file_cache[p] = v
+        return v
+
+    result: Dict[int, bool] = {}
+    for trip_id, paths in by_trip.items():
+        playable = False
+        for p in paths:
+            if _is_playable(p):
+                playable = True
+                break
+        result[trip_id] = playable
+
+    with _PLAYABLE_TRIPS_CACHE_LOCK:
+        _PLAYABLE_TRIPS_CACHE[date_str] = (time.monotonic(), result)
+        # Bound cache growth: a single device only ever has a few
+        # hundred days of history, but stale entries are pure ballast.
+        if len(_PLAYABLE_TRIPS_CACHE) > 64:
+            # Drop the oldest entries; cheap heuristic, no LRU needed.
+            oldest = sorted(
+                _PLAYABLE_TRIPS_CACHE.items(),
+                key=lambda kv: kv[1][0],
+            )[: len(_PLAYABLE_TRIPS_CACHE) - 32]
+            for k, _ in oldest:
+                _PLAYABLE_TRIPS_CACHE.pop(k, None)
+
+    return dict(result)
+
+
+def _reset_playable_trips_cache_for_tests() -> None:
+    """Clear the playable-trips cache. Intended for unit tests only."""
+    with _PLAYABLE_TRIPS_CACHE_LOCK:
+        _PLAYABLE_TRIPS_CACHE.clear()
+
+
 @_with_db_retry
 def query_all_routes_simplified(
     db_path: str,

--- a/scripts/web/services/mapping_service.py
+++ b/scripts/web/services/mapping_service.py
@@ -3739,7 +3739,12 @@ def _resolve_video_path_on_disk(video_path: str,
     # function from probing arbitrary filesystem locations. The archive
     # basename fallback below still finds genuinely-archived clips.
     if any(p == '..' for p in parts):
-        if archive_dir:
+        # Only probe the archive when the basename is a real filename;
+        # ``parts[-1]`` of ``..`` (e.g. ``foo/..``) would otherwise
+        # cause ``os.path.join`` to probe ``archive_dir``'s parent.
+        # ``os.path.isfile`` on a directory returns False so this is
+        # not exploitable, but the probe pattern is sketchy — gate it.
+        if archive_dir and parts[-1] not in ('..', ''):
             archive_path = os.path.join(archive_dir, parts[-1])
             if os.path.isfile(archive_path):
                 return True
@@ -3868,18 +3873,25 @@ def playable_trips_for_date(db_path: str, date_str: str,
                 break
         result[trip_id] = playable
 
-    with _PLAYABLE_TRIPS_CACHE_LOCK:
-        _PLAYABLE_TRIPS_CACHE[date_str] = (time.monotonic(), result)
-        # Bound cache growth: a single device only ever has a few
-        # hundred days of history, but stale entries are pure ballast.
-        if len(_PLAYABLE_TRIPS_CACHE) > 64:
-            # Drop the oldest entries; cheap heuristic, no LRU needed.
-            oldest = sorted(
-                _PLAYABLE_TRIPS_CACHE.items(),
-                key=lambda kv: kv[1][0],
-            )[: len(_PLAYABLE_TRIPS_CACHE) - 32]
-            for k, _ in oldest:
-                _PLAYABLE_TRIPS_CACHE.pop(k, None)
+    # Skip caching when ``teslacam_path`` is None (mid-mode-transition):
+    # every recent-only RecentClips trip would resolve to ``False`` here,
+    # and caching that all-False payload would hide real trips from the
+    # disambiguation chooser for the full TTL even after the mount is
+    # back up. Recompute on the next call instead — the work is cheap
+    # (single LEFT JOIN + already-cached stats).
+    if teslacam_path is not None:
+        with _PLAYABLE_TRIPS_CACHE_LOCK:
+            _PLAYABLE_TRIPS_CACHE[date_str] = (time.monotonic(), result)
+            # Bound cache growth: a single device only ever has a few
+            # hundred days of history, but stale entries are pure ballast.
+            if len(_PLAYABLE_TRIPS_CACHE) > 64:
+                # Drop the oldest entries; cheap heuristic, no LRU needed.
+                oldest = sorted(
+                    _PLAYABLE_TRIPS_CACHE.items(),
+                    key=lambda kv: kv[1][0],
+                )[: len(_PLAYABLE_TRIPS_CACHE) - 32]
+                for k, _ in oldest:
+                    _PLAYABLE_TRIPS_CACHE.pop(k, None)
 
     return dict(result)
 

--- a/scripts/web/templates/mapping.html
+++ b/scripts/web/templates/mapping.html
@@ -990,6 +990,17 @@ let showingAllTime = false;
 // rendered All time layers — never let it outlive them.
 let allTimeTrips = [];
 
+// Per-day playability snapshot for the disambiguation chooser.
+// Shape: { date: 'YYYY-MM-DD', trips: { <trip_id>: <bool> } }.
+// Populated by loadPlayableTripsForCurrentDay() after each loadDay()
+// fetch lands. Read by filterPlayableCandidates() to drop ghost trips
+// (waypoints reference video files Tesla has overwritten) before the
+// disambiguation popup is built (issue #77). Null until the first
+// load completes — filtering fails-open in that window so a slow
+// network never hides real trips. Cleared whenever we leave the
+// per-day view so stale state can't bleed into a subsequent day.
+let playableTripsForDay = null;
+
 // Highlight overlay used by the disambiguation popup to flash a
 // candidate trip's polyline on row hover. Drawn into a dedicated
 // layer group (not tripLayer) so we never have to "restore" the
@@ -1193,6 +1204,78 @@ function pickPlayableWaypointForTrip(trip, clickLatLng) {
         if (d2 < bestDist2) { bestDist2 = d2; best = wp; }
     }
     return best;
+}
+
+function filterPlayableCandidates(candidates) {
+    // Drop candidates whose trip is a "ghost" — its waypoints'
+    // video_path values still point at clips Tesla has overwritten,
+    // so the disambiguation popup would offer them and the user's
+    // pick would yield a "No video available" toast. The server's
+    // /api/trips/playable endpoint authoritatively answers this via
+    // os.path.isfile() on the canonical paths (issue #77).
+    //
+    // Fail-open: if the playability snapshot hasn't arrived yet
+    // (slow network, fetch errored, or All time view), pass the
+    // candidate list through unchanged so we never hide a real trip
+    // because of a metadata fetch hiccup. Worst case: the user sees
+    // the same toast they would have seen pre-fix.
+    if (!candidates || !candidates.length) return candidates || [];
+    if (!playableTripsForDay
+        || playableTripsForDay.date !== currentDate
+        || !playableTripsForDay.trips) {
+        return candidates;
+    }
+    const known = playableTripsForDay.trips;
+    const filtered = [];
+    for (const c of candidates) {
+        const tid = c && c.trip && c.trip.trip_id;
+        if (tid == null) {
+            // Trip without an id (defensive) — keep it; we have no
+            // basis to filter.
+            filtered.push(c);
+            continue;
+        }
+        // The server JSON-stringifies trip ids (object keys must be
+        // strings). Look up by string form; treat unknown trips as
+        // playable to avoid hiding any trip the snapshot missed.
+        const entry = known[String(tid)];
+        if (entry === false) continue;
+        filtered.push(c);
+    }
+    return filtered;
+}
+
+async function loadPlayableTripsForCurrentDay(date, seq) {
+    // Fetch /api/trips/playable for ``date`` and stash the result in
+    // playableTripsForDay so the disambiguation chooser can hide
+    // ghost trips (issue #77). Race-guarded against rapid day
+    // navigation: the caller passes the same dayLoadSeq token used
+    // by loadDay(), and we only commit if it's still current.
+    //
+    // The endpoint is cached server-side for 60 s, so repeated
+    // navigation back to the same day is essentially free.
+    if (!date) return;
+    let data;
+    try {
+        const resp = await fetch(
+            `/api/trips/playable?date=${encodeURIComponent(date)}`,
+        );
+        if (!resp.ok) {
+            // Non-200 (e.g. 503 when image is missing or 400 on bad
+            // date) — leave snapshot null so filtering fails-open.
+            return;
+        }
+        data = await resp.json();
+    } catch (e) {
+        // Network error — same fail-open behavior.
+        console.warn('Failed to load playable-trips snapshot:', e);
+        return;
+    }
+    if (seq !== dayLoadSeq || date !== currentDate) return;
+    if (data && data.date === date && data.trips
+            && typeof data.trips === 'object') {
+        playableTripsForDay = { date: date, trips: data.trips };
+    }
 }
 
 function highlightCandidateTrip(trip) {
@@ -1527,6 +1610,10 @@ async function loadDay(date, options) {
     // and the All time waypoints would be stale anyway after a
     // re-render.
     allTimeTrips = [];
+    // Drop the previous day's playability snapshot so a stale
+    // entry can never filter out a real trip on the new day.
+    // loadPlayableTripsForCurrentDay() repopulates this below.
+    playableTripsForDay = null;
     showingAllTime = false;
     currentDate = date;
     writeUrlState({ date: date }, {
@@ -1562,6 +1649,12 @@ async function loadDay(date, options) {
         currentDayData = routesData && routesData.trips ? routesData : { trips: [] };
         allEvents = eventsData.events || [];
         rebuildEventFilterPills();
+        // Kick off the playability snapshot in parallel with
+        // renderDay() — the disambiguation popup only needs it on
+        // user click, and renderDay() doesn't depend on it. A late
+        // arrival is fine; filterPlayableCandidates() fails-open
+        // until the snapshot lands. Race-guarded by ``seq``.
+        loadPlayableTripsForCurrentDay(date, seq);
         await renderDay();
     } catch (e) {
         console.error('Failed to load day routes/events:', e);
@@ -2017,19 +2110,42 @@ function renderTripOnDay(trip, bounds) {
             // picks whichever trip's clickTarget happens to be on top
             // and the user can't choose the drive they wanted.
             const candidates = findCandidatesNearClick(e.latlng);
-            if (candidates.length >= 2) {
-                showDisambigPopup(e.latlng, candidates);
+            // Drop "ghost" trips whose video files no longer exist on
+            // disk so the popup never offers them and the user never
+            // hits a "No video available" toast (issue #77). Filter
+            // fails-open while the playability snapshot is loading.
+            const playableCandidates = filterPlayableCandidates(candidates);
+            if (playableCandidates.length >= 2) {
+                showDisambigPopup(e.latlng, playableCandidates);
                 return;
             }
-            // Single-candidate (or zero) fast path — preserve the
-            // pre-disambiguation behavior of opening the nearest
-            // playable waypoint immediately. Pass the full trip's
-            // valid waypoints (not just this chunk) so the overlay
-            // can navigate the entire trip's video timeline.
-            const trip = (candidates[0] && candidates[0].trip) || { waypoints: valid };
-            const playable = pickPlayableWaypointForTrip(trip, e.latlng);
-            if (playable) {
-                openVideoOverlay(playable, e.containerPoint, trip.waypoints || valid);
+            if (playableCandidates.length === 1) {
+                // Exactly one trip survived the filter — skip the
+                // popup and play directly. Use the original click
+                // latlng (not the candidate's seed) so we pick the
+                // same point the user actually tapped.
+                const trip = playableCandidates[0].trip;
+                const playable = pickPlayableWaypointForTrip(trip, e.latlng);
+                if (playable) {
+                    openVideoOverlay(playable, e.containerPoint, trip.waypoints || valid);
+                }
+                return;
+            }
+            // Zero playable candidates. If the spatial search did
+            // find something but every match was a ghost, tell the
+            // user. Otherwise (no spatial match at all) fall through
+            // to the legacy per-chunk fallback — try this trip's
+            // nearest playable waypoint.
+            if (candidates.length > 0) {
+                if (typeof showToast === 'function') {
+                    showToast('No clips available for this location.', 'warning');
+                }
+                return;
+            }
+            const fallbackTrip = { waypoints: valid };
+            const fallbackPlayable = pickPlayableWaypointForTrip(fallbackTrip, e.latlng);
+            if (fallbackPlayable) {
+                openVideoOverlay(fallbackPlayable, e.containerPoint, valid);
             }
         });
     }
@@ -2108,6 +2224,12 @@ async function renderAllTime() {
     // the fetch doesn't search a half-stale trip set, and so a
     // failed load doesn't leave the previous trips searchable.
     allTimeTrips = [];
+    // All-time view doesn't apply the per-day playable-trips filter
+    // (its candidates resolve to a "go to that day" navigation, not
+    // a video open), but clear the snapshot anyway so a click on
+    // an All-time polyline followed by quick navigation back to a
+    // per-day view can't reuse a stale snapshot from a different day.
+    playableTripsForDay = null;
     tripLayer.clearLayers();
     fsdLayer.clearLayers();
     eventCluster.clearLayers();


### PR DESCRIPTION
## Summary

Implements the server-side filter described in the issue: a new lightweight, 60s-cached endpoint reports `has_playable_video` per trip per day, and the map page filters disambiguation candidates by it **before** building the popup. Trips whose video files Tesla has overwritten never appear in the chooser, so the user can no longer pick a row and get a useless "No video available" toast.

Closes #77.

## Approach

Server-side endpoint (Option 1 from the issue). Three changes, blueprint/service-separated:

- **`scripts/web/services/mapping_service.py`** — new `playable_trips_for_date()` with thread-safe TTL cache (60 s, bounded to 64 entries). Single LEFT JOIN fetches every trip on the date plus its waypoints' `video_path` rows; per-trip dedup + per-call file stat cache + first-hit short-circuit means the average cost is ~one `os.path.isfile` per trip. New helper `_resolve_video_path_on_disk()` mirrors `videos.stream_video`'s resolution rules (TeslaCam relative path → ArchivedClips basename fallback) so "playable" matches what playback would actually serve. Includes a `..`-traversal guard for defense-in-depth against corrupt DB rows.

- **`scripts/web/blueprints/mapping.py`** — `GET /api/trips/playable?date=YYYY-MM-DD`. Reuses the existing `_DATE_RE` validator and inherits the blueprint's `IMG_CAM_PATH` `before_request` image-gate (so feature-gating Just Works). Returns `{date, trips: {trip_id: bool}}` with stringified trip ids for JSON object-key compatibility.

- **`scripts/web/templates/mapping.html`** — adds per-day playability state cleared on every `loadDay()` and on entering All-time view; `loadPlayableTripsForCurrentDay()` race-guarded by `dayLoadSeq` and kicked off in parallel with `renderDay()`; `filterPlayableCandidates()` applied in the per-day click handler. Logic now: **≥2 filtered candidates → popup**; **==1 → play directly**; **==0 with prior spatial matches → "No clips available for this location." toast**; **==0 with no spatial matches → legacy per-chunk fallback** (preserves existing behavior for clicks that didn't actually hit any trip's segments). All-time click path unchanged because it navigates to a day rather than playing a video — the filter applies the next time the day loads.

## Key design decisions

- **Fail-open on stale/missing playability data:** if the snapshot hasn't arrived (slow network, fetch errored), don't filter. Worst case: same toast users got pre-fix. We never hide a real trip because of a metadata fetch hiccup.
- **No mount/UDC churn:** pure VFS reads. Safe to call freely on a presenting Pi while Tesla is recording.
- **Cache-key is the date string:** `get_teslacam_path()` may be momentarily None during a mode switch — captured at compute time so a None-result doesn't poison the cache.
- **No new UI elements:** existing disambiguation popup CSS already uses design tokens and works in dark/light mode; this PR only filters the row list.

## Testing performed

- `python -m py_compile scripts/web/services/mapping_service.py` ✅
- `python -m py_compile scripts/web/blueprints/mapping.py` ✅
- `cd scripts/web && python -c "from web_control import app; print('App loads OK')"` ✅
- Endpoint registration: `app.url_map` shows `/api/trips/playable → mapping.api_trips_playable` (GET/HEAD/OPTIONS). ✅
- End-to-end via Flask `app.test_client()` with patched `IMG_CAM_PATH`:
  - No `date` → `400 {'error': 'date must be YYYY-MM-DD'}`
  - Bad `date` → `400 {'error': 'date must be YYYY-MM-DD'}`
  - Valid `date` → `200 {'date': '2026-05-07', 'trips': {}}`
  - Without the `IMG_CAM_PATH` gate satisfied → `503 {'error': 'Feature unavailable — TeslaCam image not found'}`
- A throwaway smoke test (not committed) exercised `_resolve_video_path_on_disk` (RecentClips, SavedClips/event, SentryClips/event, ArchivedClips, basename fallback, missing-everywhere, traversal-rejection, basename-only, backslash-normalization, None-args) and `playable_trips_for_date` (mixed real/ghost trips, cache hit, NULL-`video_path` trip, multi-day isolation, `ttl_seconds=0` re-stat after the file is removed). All pass.
- Inline JavaScript in `mapping.html` extracted and validated with `node --check` → no syntax errors.
- Jinja template parses cleanly via `env.parse()` from the live Flask app context.

## Pre-merge UI/UX checklist

- [x] **No emoji icons** — no new icons added; existing Lucide chevron unchanged.
- [x] **Color tokens only** — no hardcoded hex; existing disambig popup uses `var(--bg-secondary)`, `var(--text-primary)`, `var(--border-color)`, etc.
- [x] **Dark and light mode** — no new visual surfaces; existing token-based styles cover both.
- [x] **Touch targets ≥44×44px** — existing `.disambig-row` already enforces `min-height: 44px`.
- [x] **Mobile-first** — no layout changes; popup `max-width: calc(100vw - 32px)` already handles 375px viewport.
- [x] **No "Edit Mode" / "Present Mode" strings** — no user-facing copy added beyond a single "No clips available for this location." toast that uses neutral language.
- [x] **No JS frameworks / external CDN** — pure DOM + existing `fetch`.
- [x] **Accessibility** — no new interactive elements; `showToast` is the existing announcement channel.
- [x] **Performance on Pi Zero 2 W** — single SQL round-trip per date, cached 60 s, stat per unique clip per call, short-circuit on first hit.

## Deployment

This change touches files under `scripts/`. After merge on the Pi:

```bash
sudo ./setup_usb.sh
sudo systemctl restart gadget_web.service
```

Or, for a faster targeted deploy (no template placeholders are touched), copy the three changed files in place and `sudo systemctl restart gadget_web.service`.

## Files changed

| File | Change |
|------|--------|
| `scripts/web/services/mapping_service.py` | +217 lines — new `playable_trips_for_date`, `_resolve_video_path_on_disk`, cache + lock + reset helper |
| `scripts/web/blueprints/mapping.py` | +63 lines — new `/api/trips/playable` route |
| `scripts/web/templates/mapping.html` | +144 / -11 lines — state, fetch helper, filter, click-handler wiring |
| **Total** | **+413 / -11** |

---

**Generated by GitHub Copilot CLI working with the `resolve-issue` skill.**
