### PR TITLE
feat(#76 phase-2a): archive_queue schema, producers, and rescan

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -170,3 +170,18 @@ archive:
   max_size_gb: 0                         # 0 = auto (use all available space minus reserved)
   only_driving: true                     # Only archive clips from active driving trips (skip idle/parked)
   path: ""                               # Archive path (default: ~/ArchivedClips, set by web app)
+
+# ============================================================================
+# Archive Queue Configuration (issue #76 — Phase 2a producer-only)
+# ============================================================================
+# Persistent SQLite-backed queue (in geodata.db) for the upcoming two-queue
+# archive pipeline. Phase 2a populates this queue from three independent
+# producers: the inotify file watcher, a periodic full-directory rescan,
+# and a one-shot boot catch-up scan. **No worker yet** — rows accumulate
+# harmlessly until Phase 2b adds the consumer thread. Disabling this
+# section prevents the producers from running, leaving behavior identical
+# to pre-#76 installs.
+archive_queue:
+  enabled: true                          # Run Phase 2a producers (writers; no worker yet)
+  rescan_interval_seconds: 60            # Cadence of the periodic full-dir rescan
+  boot_catchup_enabled: true             # Run the one-shot scan on producer start

--- a/scripts/config.sh
+++ b/scripts/config.sh
@@ -74,6 +74,9 @@ eval "$(yq -r '
   "SMB_CONF=\"" + .system.samba_conf + "\"",
   "CLOUD_ARCHIVE_ENABLED=\"" + (.cloud_archive.enabled // false | tostring) + "\"",
   "CLOUD_ARCHIVE_PROVIDER=\"" + (.cloud_archive.provider // "") + "\"",
+  "ARCHIVE_QUEUE_ENABLED=\"" + (.archive_queue.enabled // true | tostring) + "\"",
+  "ARCHIVE_QUEUE_RESCAN_INTERVAL_SECONDS=\"" + (.archive_queue.rescan_interval_seconds // 60 | tostring) + "\"",
+  "ARCHIVE_QUEUE_BOOT_CATCHUP_ENABLED=\"" + (.archive_queue.boot_catchup_enabled // true | tostring) + "\"",
   "TESLA_API_CLIENT_ID=\"" + (.tesla_api.client_id // "") + "\""
 ' "$CONFIG_YAML")"
 

--- a/scripts/web/blueprints/__init__.py
+++ b/scripts/web/blueprints/__init__.py
@@ -17,6 +17,7 @@ from .media import media_bp
 from .captive_portal import captive_portal_bp, catch_all_redirect
 from .cloud_archive import cloud_archive_bp
 from .live_events import live_events_bp
+from .archive_queue import archive_queue_bp
 
 __all__ = [
     'mode_control_bp',
@@ -37,4 +38,5 @@ __all__ = [
     'catch_all_redirect',
     'cloud_archive_bp',
     'live_events_bp',
+    'archive_queue_bp',
 ]

--- a/scripts/web/blueprints/archive_queue.py
+++ b/scripts/web/blueprints/archive_queue.py
@@ -1,0 +1,66 @@
+"""Blueprint for the Phase 2a archive_queue observability stub (issue #76).
+
+Exposes a single read-only JSON endpoint:
+
+* ``GET /api/archive_queue/status`` — counts per status plus producer
+  thread state.
+
+This is the minimum surface needed to verify Phase 2a is enqueueing
+correctly during the deployment window. The full per-priority counts,
+dead-letter inspection, and retry endpoints land in Phase 2c.
+
+Image-gated on ``IMG_CAM_PATH`` (the queued clips live on the cam
+image / part1). Returns 503 JSON when the cam image is missing so
+URL routing stays stable on installs without a TeslaCam drive.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+from flask import Blueprint, jsonify
+
+from config import ARCHIVE_QUEUE_ENABLED, IMG_CAM_PATH
+
+logger = logging.getLogger(__name__)
+
+archive_queue_bp = Blueprint(
+    'archive_queue', __name__, url_prefix='/api/archive_queue',
+)
+
+
+@archive_queue_bp.before_request
+def _require_cam_image():
+    if not os.path.isfile(IMG_CAM_PATH):
+        return jsonify({"error": "Feature unavailable"}), 503
+
+
+@archive_queue_bp.route('/status', methods=['GET'])
+def status():
+    """Return queue counts plus producer state.
+
+    When ``archive_queue.enabled`` is False in ``config.yaml`` the
+    queue counts are still returned (rows from a previous enabled
+    install are still visible), but ``producer.running`` will be False
+    because :mod:`web_control` skipped the producer thread startup.
+    """
+    from services import archive_queue, archive_producer
+
+    try:
+        counts = archive_queue.get_queue_status()
+    except Exception:
+        logger.exception("archive_queue.get_queue_status crashed")
+        counts = {}
+
+    try:
+        producer = archive_producer.get_producer_status()
+    except Exception:
+        logger.exception("archive_producer.get_producer_status crashed")
+        producer = {}
+
+    return jsonify({
+        "enabled": bool(ARCHIVE_QUEUE_ENABLED),
+        "counts": counts,
+        "producer": producer,
+    })

--- a/scripts/web/config.py
+++ b/scripts/web/config.py
@@ -139,6 +139,21 @@ ARCHIVE_DIR = _archive_path if _archive_path else os.path.join(
     os.path.expanduser(f"~{TARGET_USER}"), 'ArchivedClips'
 )
 
+# Archive Queue Configuration (issue #76 — Phase 2a producers; worker in 2b)
+# Producer-only at this version: the inotify watcher, the 60-s rescan thread,
+# and the boot catch-up scan all enqueue rows into ``archive_queue`` (in
+# geodata.db). When ``ARCHIVE_QUEUE_ENABLED`` is False the wiring in
+# web_control.py skips both the watcher callback registration and the
+# producer thread, so behavior matches pre-#76 installs exactly.
+_archive_queue = config.get('archive_queue', {})
+ARCHIVE_QUEUE_ENABLED = bool(_archive_queue.get('enabled', True))
+ARCHIVE_QUEUE_RESCAN_INTERVAL_SECONDS = float(
+    _archive_queue.get('rescan_interval_seconds', 60)
+)
+ARCHIVE_QUEUE_BOOT_CATCHUP_ENABLED = bool(
+    _archive_queue.get('boot_catchup_enabled', True)
+)
+
 # ============================================================================
 # ADVANCED SETTINGS - Computed values (don't modify these)
 # ============================================================================

--- a/scripts/web/services/archive_producer.py
+++ b/scripts/web/services/archive_producer.py
@@ -1,0 +1,303 @@
+"""TeslaUSB Archive Queue Producer — Phase 2a (issue #76).
+
+Single daemon thread that periodically walks the TeslaCam RO mount and
+calls :func:`services.archive_queue.enqueue_many_for_archive` for every
+``.mp4`` it finds under ``RecentClips/``, ``SentryClips/`` (event
+subfolders), and ``SavedClips/`` (event subfolders). Idempotent —
+``INSERT OR IGNORE`` on the queue's UNIQUE constraint makes re-walks
+cheap.
+
+This is the "belt and suspenders" half of the Phase 2a producer set. The
+other half is the inotify file watcher (``file_watcher_service``), which
+fires individual paths in real time. The producer thread covers:
+
+1. **Boot catch-up** — anything Tesla wrote while ``gadget_web`` was
+   down (crash, restart, or normal boot lag) gets enqueued on the
+   first iteration.
+2. **Inotify gaps** — kernel buffer overflows, transient mount events,
+   or simply missed events (the watcher's mp4 callback uses a 60-s
+   age gate; the rescan picks up files Tesla finished writing > 60 s
+   ago).
+3. **VFS cache drift** — when Tesla writes via the gadget block layer,
+   the Pi's view of the directory is occasionally stale until the
+   next ``readdir``. The periodic rescan forces that ``readdir``.
+
+**Phase 2a is producer-only.** Rows accumulate in ``archive_queue`` but
+no worker drains them until Phase 2b. The producer thread therefore
+performs zero copy work, no network I/O, and never touches the gadget
+or any mount — pure read-side observer.
+
+Public API:
+
+* :func:`start_producer(teslacam_root, db_path, *, rescan_interval_seconds, boot_catchup_enabled)` — start the thread (idempotent).
+* :func:`stop_producer(timeout)` — signal stop and join. Safe across mode switches.
+* :func:`get_producer_status()` — small dict for the observability stub.
+* :func:`run_boot_catchup_once(teslacam_root, db_path)` — synchronous
+  helper exposed for tests; never call from the request thread.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+from typing import Dict, Iterable, List, Optional
+
+from services import archive_queue
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Tunables (kept module-level so tests can monkeypatch)
+# ---------------------------------------------------------------------------
+
+# Subdirectories of TeslaCam that we walk on every scan. The order is
+# the priority order — RecentClips first because those are the most
+# time-sensitive.
+_WATCH_SUBDIRS = ('RecentClips', 'SentryClips', 'SavedClips')
+
+# Default rescan interval (seconds). Overridable via the
+# ``rescan_interval_seconds`` arg to :func:`start_producer` (which the
+# Flask app pulls from ``config.yaml``).
+_DEFAULT_RESCAN_INTERVAL = 60.0
+
+
+# ---------------------------------------------------------------------------
+# Module state — every read/write through ``_state_lock``
+# ---------------------------------------------------------------------------
+
+_state_lock = threading.Lock()
+_thread: Optional[threading.Thread] = None
+_stop_event = threading.Event()
+_state: Dict = {
+    'running': False,
+    'teslacam_root': None,
+    'db_path': None,
+    'rescan_interval_seconds': _DEFAULT_RESCAN_INTERVAL,
+    'boot_catchup_enabled': True,
+    'iterations': 0,
+    'last_scan_at': None,
+    'last_enqueued': 0,
+    'last_seen': 0,
+    'last_error': None,
+    'started_at': None,
+}
+
+
+def _is_running() -> bool:
+    with _state_lock:
+        t = _thread
+    return t is not None and t.is_alive()
+
+
+# ---------------------------------------------------------------------------
+# Directory walking
+# ---------------------------------------------------------------------------
+
+def _iter_archive_candidates(teslacam_root: str) -> List[str]:
+    """Return every ``.mp4`` under the watched subdirectories.
+
+    Walks one level into ``RecentClips`` (flat files) and two levels
+    into ``SentryClips`` / ``SavedClips`` (event-folder per recording).
+    Uses ``os.scandir`` for memory efficiency.
+
+    Permission errors and missing subdirectories are silently skipped —
+    Phase 2a runs against a possibly-unmounted RO bind so any of the
+    three subdirs can transiently be absent. Returning a partial list
+    is correct: the next iteration (60 s later) will pick them up.
+
+    Returns absolute paths in stable insertion order so logs don't
+    shuffle between scans.
+    """
+    out: List[str] = []
+    if not teslacam_root or not os.path.isdir(teslacam_root):
+        return out
+
+    for sub in _WATCH_SUBDIRS:
+        sub_path = os.path.join(teslacam_root, sub)
+        if not os.path.isdir(sub_path):
+            continue
+        try:
+            entries = list(os.scandir(sub_path))
+        except (PermissionError, OSError):
+            continue
+        for entry in entries:
+            try:
+                if entry.is_file(follow_symlinks=False):
+                    if entry.name.lower().endswith('.mp4'):
+                        out.append(entry.path)
+                elif entry.is_dir(follow_symlinks=False):
+                    # Event subfolder — walk one more level for clip files.
+                    try:
+                        for clip in os.scandir(entry.path):
+                            if (clip.is_file(follow_symlinks=False)
+                                    and clip.name.lower().endswith('.mp4')):
+                                out.append(clip.path)
+                    except (PermissionError, OSError):
+                        continue
+            except OSError:
+                # entry.is_file()/is_dir() can race a delete; skip and
+                # move on. Next scan will see the new state.
+                continue
+    return out
+
+
+def _scan_once(teslacam_root: str, db_path: str) -> Dict[str, int]:
+    """Run one scan iteration. Returns ``{seen, enqueued}``.
+
+    Logs only when something was newly enqueued (avoid log spam from
+    the steady-state every-60-s rescan).
+    """
+    seen = _iter_archive_candidates(teslacam_root)
+    if not seen:
+        return {'seen': 0, 'enqueued': 0}
+    enqueued = archive_queue.enqueue_many_for_archive(seen, db_path=db_path)
+    if enqueued > 0:
+        logger.info(
+            "archive_producer: scan enqueued %d new clip(s) (saw %d total)",
+            enqueued, len(seen),
+        )
+    return {'seen': len(seen), 'enqueued': enqueued}
+
+
+def run_boot_catchup_once(teslacam_root: str,
+                          db_path: Optional[str] = None) -> Dict[str, int]:
+    """Synchronous one-shot scan. Exposed for tests and direct callers.
+
+    Most callers should use :func:`start_producer` and let the thread
+    handle both the boot catch-up and the periodic rescans. This
+    helper exists so unit tests can drive a single scan without
+    spinning up a thread.
+    """
+    return _scan_once(teslacam_root, db_path or '')
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle
+# ---------------------------------------------------------------------------
+
+def start_producer(teslacam_root: str,
+                   db_path: Optional[str] = None,
+                   *,
+                   rescan_interval_seconds: float = _DEFAULT_RESCAN_INTERVAL,
+                   boot_catchup_enabled: bool = True) -> bool:
+    """Start the producer thread. Idempotent.
+
+    Returns True if a new thread was started, False if one was already
+    running.
+
+    Args:
+        teslacam_root: Absolute path to the TeslaCam RO mount root
+            (typically ``/mnt/gadget/part1-ro/TeslaCam``).
+        db_path: Override for the queue DB path. ``None`` resolves
+            via :data:`config.MAPPING_DB_PATH` inside the queue module.
+        rescan_interval_seconds: Seconds between successive scans.
+            The default (60 s) matches the issue spec.
+        boot_catchup_enabled: When True (default) the first iteration
+            runs immediately on startup. When False the thread waits
+            ``rescan_interval_seconds`` before its first scan — useful
+            for tests that want to exercise just the periodic path.
+    """
+    global _thread
+    with _state_lock:
+        if _thread is not None and _thread.is_alive():
+            logger.debug("archive_producer.start_producer: already running")
+            return False
+        _stop_event.clear()
+        _state['running'] = True
+        _state['teslacam_root'] = teslacam_root
+        _state['db_path'] = db_path
+        _state['rescan_interval_seconds'] = float(rescan_interval_seconds)
+        _state['boot_catchup_enabled'] = bool(boot_catchup_enabled)
+        _state['iterations'] = 0
+        _state['last_scan_at'] = None
+        _state['last_enqueued'] = 0
+        _state['last_seen'] = 0
+        _state['last_error'] = None
+        _state['started_at'] = time.time()
+        _thread = threading.Thread(
+            target=_run_loop,
+            args=(teslacam_root, db_path,
+                  float(rescan_interval_seconds),
+                  bool(boot_catchup_enabled)),
+            name='archive-producer',
+            daemon=True,
+        )
+        thread = _thread
+    thread.start()
+    logger.info(
+        "archive_producer started (root=%s, interval=%.1fs, boot_catchup=%s)",
+        teslacam_root, rescan_interval_seconds, boot_catchup_enabled,
+    )
+    return True
+
+
+def stop_producer(timeout: float = 10.0) -> bool:
+    """Signal the producer to stop and wait for it to exit.
+
+    Returns True if the thread exited cleanly (or wasn't running),
+    False on timeout.
+    """
+    global _thread
+    with _state_lock:
+        thread = _thread
+    if thread is None:
+        return True
+    _stop_event.set()
+    thread.join(timeout=timeout)
+    exited = not thread.is_alive()
+    if exited:
+        with _state_lock:
+            if _thread is thread:
+                _thread = None
+            _state['running'] = False
+        logger.info("archive_producer stopped cleanly")
+    else:
+        logger.warning(
+            "archive_producer did not exit within %.1fs", timeout,
+        )
+    return exited
+
+
+def get_producer_status() -> Dict:
+    """Snapshot of producer state for the observability endpoint."""
+    with _state_lock:
+        snap = dict(_state)
+    snap['running'] = _is_running()
+    return snap
+
+
+def _run_loop(teslacam_root: str, db_path: Optional[str],
+              rescan_interval_seconds: float,
+              boot_catchup_enabled: bool) -> None:
+    """Producer thread body. Catches every exception so a single bad
+    scan can't kill the thread.
+    """
+    if not boot_catchup_enabled:
+        # Skip the immediate first-pass; wait the full interval first.
+        if _stop_event.wait(rescan_interval_seconds):
+            with _state_lock:
+                _state['running'] = False
+            return
+
+    while not _stop_event.is_set():
+        try:
+            result = _scan_once(teslacam_root, db_path or '')
+            with _state_lock:
+                _state['iterations'] += 1
+                _state['last_scan_at'] = time.time()
+                _state['last_seen'] = int(result.get('seen', 0))
+                _state['last_enqueued'] = int(result.get('enqueued', 0))
+                _state['last_error'] = None
+        except Exception as e:  # noqa: BLE001  -- never let producer die
+            logger.exception("archive_producer scan iteration failed")
+            with _state_lock:
+                _state['last_error'] = str(e)
+
+        if _stop_event.wait(rescan_interval_seconds):
+            break
+
+    with _state_lock:
+        _state['running'] = False

--- a/scripts/web/services/archive_producer.py
+++ b/scripts/web/services/archive_producer.py
@@ -225,8 +225,12 @@ def start_producer(teslacam_root: str,
             name='archive-producer',
             daemon=True,
         )
-        thread = _thread
-    thread.start()
+        # Start inside the lock so a concurrent stop_producer cannot
+        # observe _thread before .start() and call join() on an
+        # unstarted thread (RuntimeError). Phase 2b will add more
+        # lifecycle entry points (admin endpoint, mode-switch hook),
+        # so making the start atomic now keeps the contract simple.
+        _thread.start()
     logger.info(
         "archive_producer started (root=%s, interval=%.1fs, boot_catchup=%s)",
         teslacam_root, rescan_interval_seconds, boot_catchup_enabled,

--- a/scripts/web/services/archive_queue.py
+++ b/scripts/web/services/archive_queue.py
@@ -14,7 +14,7 @@ endpoints will read the same queue.
 Design constraints (Pi Zero 2 W, 512 MB RAM):
 
 * **Lightweight imports only** — ``os``, ``sqlite3``, ``logging``,
-  ``threading``, ``datetime``. Heavy libraries (cv2/av/PIL/numpy/requests)
+  ``datetime``. Heavy libraries (cv2/av/PIL/numpy/requests)
   must never enter this module.
 * **One connection per call** — every public function opens its own
   SQLite connection so the API is thread-safe by construction. No shared
@@ -50,7 +50,6 @@ from __future__ import annotations
 import logging
 import os
 import sqlite3
-import threading
 from datetime import datetime, timezone
 from typing import Dict, Iterable, List, Optional
 
@@ -151,12 +150,14 @@ def _safe_stat(path: str):
         return None
 
 
-# Module-level lock for the single-row enqueue path. SQLite itself is
-# threadsafe at the connection level, but using a Python lock around
-# the rowcount probe lets us return a precise ``True`` / ``False`` for
-# "newly inserted vs. already present" even under concurrent producers
-# without needing an explicit transaction.
-_enqueue_lock = threading.Lock()
+# SQLite's connection-level threadsafety guarantees that ``cur.rowcount``
+# after ``INSERT OR IGNORE`` reflects only that cursor's own outcome:
+# the winning connection sees ``rowcount == 1``, the losing connection
+# sees ``rowcount == 0``. Each enqueue opens its own connection (via
+# the ``_open_archive_conn`` context manager), so no Python-level lock
+# is needed to make the single-row return value reliable. The bulk
+# path (``enqueue_many_for_archive``) uses ``conn.total_changes`` for
+# the same reason — same guarantee, no lock.
 
 
 # ---------------------------------------------------------------------------
@@ -198,19 +199,18 @@ def enqueue_for_archive(source_path: str, *,
     expected_mtime = st.st_mtime if st is not None else None
     enqueued_at = _iso_now()
     try:
-        with _enqueue_lock:
-            with _open_archive_conn(db_path) as conn:
-                cur = conn.execute(
-                    """
-                    INSERT OR IGNORE INTO archive_queue
-                        (source_path, priority, status,
-                         enqueued_at, expected_size, expected_mtime)
-                    VALUES (?, ?, 'pending', ?, ?, ?)
-                    """,
-                    (source_path, int(priority), enqueued_at,
-                     expected_size, expected_mtime),
-                )
-                inserted = cur.rowcount == 1
+        with _open_archive_conn(db_path) as conn:
+            cur = conn.execute(
+                """
+                INSERT OR IGNORE INTO archive_queue
+                    (source_path, priority, status,
+                     enqueued_at, expected_size, expected_mtime)
+                VALUES (?, ?, 'pending', ?, ?, ?)
+                """,
+                (source_path, int(priority), enqueued_at,
+                 expected_size, expected_mtime),
+            )
+            inserted = cur.rowcount == 1
         return inserted
     except sqlite3.Error as e:
         logger.warning("enqueue_for_archive failed for %s: %s",

--- a/scripts/web/services/archive_queue.py
+++ b/scripts/web/services/archive_queue.py
@@ -1,0 +1,346 @@
+"""TeslaUSB Archive Queue — Phase 2a producer-side API (issue #76).
+
+Persistent SQLite-backed queue of clips waiting to be copied from the
+USB RO mount (RecentClips / SentryClips / SavedClips) to the SD-card
+``ArchivedClips/`` directory. Lives in ``geodata.db`` alongside
+``indexing_queue`` so a single migration / backup story covers both.
+
+**Phase 2a is producer-only.** Three independent producers populate the
+queue (the inotify file watcher, a 60-second full-directory rescan, and
+a boot catch-up scan); nothing drains it yet. Rows accumulate harmlessly
+until the Phase 2b worker lands. The Phase 2c watchdog + observability
+endpoints will read the same queue.
+
+Design constraints (Pi Zero 2 W, 512 MB RAM):
+
+* **Lightweight imports only** — ``os``, ``sqlite3``, ``logging``,
+  ``threading``, ``datetime``. Heavy libraries (cv2/av/PIL/numpy/requests)
+  must never enter this module.
+* **One connection per call** — every public function opens its own
+  SQLite connection so the API is thread-safe by construction. No shared
+  module-level connection.
+* **Idempotent enqueue** — every producer can fire the same path many
+  times; ``INSERT OR IGNORE`` on the ``source_path UNIQUE`` constraint
+  makes this O(1) and lock-free at the application layer.
+* **Best-effort metadata** — ``expected_size`` / ``expected_mtime`` are
+  captured via ``os.stat()``; if the stat fails (file already rotated,
+  permission denied, RO mount transiently gone) the row is still
+  inserted with NULL metadata so the Phase 2b worker can decide what to
+  do (it will detect ``source_gone`` on the actual copy attempt).
+
+Public API
+----------
+
+* :func:`enqueue_for_archive` — single path, returns True iff a new row
+  was inserted.
+* :func:`enqueue_many_for_archive` — batch variant, returns the count
+  of newly-inserted rows.
+* :func:`get_queue_status` — counts per status (used by the Phase 2a
+  observability stub and the Phase 2c watchdog).
+* :func:`list_queue` — inspection helper for tests and Phase 2c UI.
+
+The schema itself lives in :mod:`services.mapping_service` (the
+``archive_queue`` CREATE statement is part of ``_SCHEMA_SQL`` so the
+v9 → v10 migration creates it automatically). This module only reads
+and writes rows.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sqlite3
+import threading
+from datetime import datetime, timezone
+from typing import Dict, Iterable, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Priority inference (from the issue spec)
+# ---------------------------------------------------------------------------
+#
+# Lower number = more urgent. The Phase 2b worker picks rows in
+# (priority ASC, expected_mtime ASC) order — the partial index
+# ``archive_queue_ready`` covers exactly that ORDER BY.
+
+PRIORITY_RECENT_CLIPS = 1     # Tesla rotates these out after ~60 min — highest urgency
+PRIORITY_EVENTS = 2           # SentryClips / SavedClips — user wants these soon
+PRIORITY_OTHER = 3            # Default for anything else (e.g. ArchivedClips back-fill)
+
+# Status values stored in the ``status`` column. Phase 2a only ever
+# writes ``pending``; the rest exist so :func:`get_queue_status` can
+# return zeros for them today and the Phase 2b worker can use them
+# without another migration.
+_KNOWN_STATUSES = (
+    'pending',
+    'claimed',
+    'copied',
+    'source_gone',
+    'error',
+    'dead_letter',
+)
+
+
+def _infer_priority(path: str) -> int:
+    """Map a TeslaCam clip path to its archive priority.
+
+    Uses the same lowercase folder-name heuristic as
+    ``mapping_service.priority_for_path`` so behavior is consistent
+    across the indexing and archive subsystems.
+    """
+    norm = (path or '').replace('\\', '/').lower()
+    if '/recentclips/' in norm:
+        return PRIORITY_RECENT_CLIPS
+    if '/sentryclips/' in norm or '/savedclips/' in norm:
+        return PRIORITY_EVENTS
+    return PRIORITY_OTHER
+
+
+# ---------------------------------------------------------------------------
+# Connection helpers
+# ---------------------------------------------------------------------------
+
+def _resolve_db_path(db_path: Optional[str]) -> str:
+    """Return ``db_path`` if given, otherwise the default mapping DB.
+
+    ``MAPPING_DB_PATH`` is computed from ``GADGET_DIR`` so it's only
+    meaningful inside the Flask app process. We import lazily so this
+    module is still safe to import in unit tests where ``config`` may
+    not be on the path.
+    """
+    if db_path:
+        return db_path
+    from config import MAPPING_DB_PATH
+    return MAPPING_DB_PATH
+
+
+def _open_archive_conn(db_path: str) -> sqlite3.Connection:
+    """Open a tuned SQLite connection for archive_queue ops.
+
+    Mirrors the per-connection pragmas used by
+    ``mapping_service._open_queue_conn`` so producers don't trip over
+    contended locks and the WAL stays small under concurrent writers.
+    """
+    conn = sqlite3.connect(db_path, timeout=15.0, isolation_level=None)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA busy_timeout = 15000")
+    conn.execute("PRAGMA journal_mode = WAL")
+    conn.execute("PRAGMA synchronous = NORMAL")
+    return conn
+
+
+def _iso_now() -> str:
+    """Return an ISO-8601 UTC timestamp string (matches LES / cloud_archive)."""
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _safe_stat(path: str):
+    """Return ``os.stat`` result or None on failure.
+
+    Producers use this so a transient stat failure (file rotated mid-
+    enqueue, RO mount remounted, permission denied) does not raise out
+    of the producer thread. The row is still inserted with NULL
+    ``expected_size`` / ``expected_mtime`` and the Phase 2b worker will
+    re-stat and dispatch (likely to ``source_gone``).
+    """
+    try:
+        return os.stat(path)
+    except OSError:
+        return None
+
+
+# Module-level lock for the single-row enqueue path. SQLite itself is
+# threadsafe at the connection level, but using a Python lock around
+# the rowcount probe lets us return a precise ``True`` / ``False`` for
+# "newly inserted vs. already present" even under concurrent producers
+# without needing an explicit transaction.
+_enqueue_lock = threading.Lock()
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def enqueue_for_archive(source_path: str, *,
+                        priority: Optional[int] = None,
+                        db_path: Optional[str] = None) -> bool:
+    """Idempotently enqueue ``source_path`` for archival.
+
+    Returns ``True`` if a new row was inserted, ``False`` if the path
+    was already in the queue (any status) or was rejected (empty path).
+
+    Args:
+        source_path: Absolute path under the RO USB mount (or a test
+            fixture path). Must be non-empty.
+        priority: Override the inferred priority. ``None`` (default)
+            means infer from the path: 1 for RecentClips, 2 for
+            SentryClips/SavedClips, 3 otherwise.
+        db_path: Override the default ``geodata.db`` path. ``None``
+            (default) resolves via :data:`config.MAPPING_DB_PATH`.
+
+    Behavior on failure:
+      * Empty / falsy ``source_path`` → return False, log nothing.
+      * ``os.stat`` failure → row is still inserted with NULL
+        ``expected_size`` / ``expected_mtime``. The worker's stat
+        gate will catch the missing file later.
+      * SQLite error → return False, log a warning. Producer threads
+        keep running.
+    """
+    if not source_path:
+        return False
+    if priority is None:
+        priority = _infer_priority(source_path)
+    db_path = _resolve_db_path(db_path)
+    st = _safe_stat(source_path)
+    expected_size = st.st_size if st is not None else None
+    expected_mtime = st.st_mtime if st is not None else None
+    enqueued_at = _iso_now()
+    try:
+        with _enqueue_lock:
+            with _open_archive_conn(db_path) as conn:
+                cur = conn.execute(
+                    """
+                    INSERT OR IGNORE INTO archive_queue
+                        (source_path, priority, status,
+                         enqueued_at, expected_size, expected_mtime)
+                    VALUES (?, ?, 'pending', ?, ?, ?)
+                    """,
+                    (source_path, int(priority), enqueued_at,
+                     expected_size, expected_mtime),
+                )
+                inserted = cur.rowcount == 1
+        return inserted
+    except sqlite3.Error as e:
+        logger.warning("enqueue_for_archive failed for %s: %s",
+                       source_path, e)
+        return False
+
+
+def enqueue_many_for_archive(source_paths: Iterable[str], *,
+                             priority: Optional[int] = None,
+                             db_path: Optional[str] = None) -> int:
+    """Batch enqueue. Returns the count of newly-inserted rows.
+
+    Same semantics as :func:`enqueue_for_archive` for each path; uses a
+    single SQLite transaction so a 200-file boot catch-up costs ~10 ms.
+    Empty paths and duplicates within ``source_paths`` are silently
+    skipped (the UNIQUE constraint handles duplicates atomically).
+
+    Args:
+        source_paths: Iterable of absolute paths.
+        priority: Force the same priority for every path. ``None``
+            (default) means infer per-path via :func:`_infer_priority`.
+        db_path: Override the default ``geodata.db`` path.
+    """
+    paths = [p for p in source_paths if p]
+    if not paths:
+        return 0
+    db_path = _resolve_db_path(db_path)
+    enqueued_at = _iso_now()
+    rows = []
+    for p in paths:
+        prio = priority if priority is not None else _infer_priority(p)
+        st = _safe_stat(p)
+        rows.append((
+            p,
+            int(prio),
+            enqueued_at,
+            st.st_size if st is not None else None,
+            st.st_mtime if st is not None else None,
+        ))
+    try:
+        with _open_archive_conn(db_path) as conn:
+            before = conn.total_changes
+            conn.executemany(
+                """
+                INSERT OR IGNORE INTO archive_queue
+                    (source_path, priority, status,
+                     enqueued_at, expected_size, expected_mtime)
+                VALUES (?, ?, 'pending', ?, ?, ?)
+                """,
+                rows,
+            )
+            after = conn.total_changes
+        return max(0, after - before)
+    except sqlite3.Error as e:
+        logger.warning("enqueue_many_for_archive failed: %s", e)
+        return 0
+
+
+def get_queue_status(db_path: Optional[str] = None) -> Dict[str, int]:
+    """Return per-status counts for the queue.
+
+    Always returns every key in :data:`_KNOWN_STATUSES` (zero for
+    statuses that have no rows) plus a ``total`` field. Used by the
+    Phase 2a observability stub and the Phase 2c watchdog.
+    """
+    counts: Dict[str, int] = {s: 0 for s in _KNOWN_STATUSES}
+    counts['total'] = 0
+    db_path = _resolve_db_path(db_path)
+    try:
+        with _open_archive_conn(db_path) as conn:
+            for row in conn.execute(
+                "SELECT status, COUNT(*) AS n FROM archive_queue GROUP BY status"
+            ).fetchall():
+                status = row['status'] or 'pending'
+                n = int(row['n'] or 0)
+                # Fold any unknown status (shouldn't happen, but be
+                # defensive — older rows after a downgrade, manual SQL,
+                # etc.) into the total but not into the named buckets.
+                if status in counts:
+                    counts[status] = n
+                counts['total'] += n
+    except sqlite3.Error as e:
+        logger.warning("get_queue_status failed: %s", e)
+    return counts
+
+
+def list_queue(limit: int = 50,
+               status: Optional[str] = None,
+               db_path: Optional[str] = None) -> List[Dict]:
+    """Return up to ``limit`` rows for inspection.
+
+    Sorted by (priority ASC, expected_mtime ASC NULLS LAST, id ASC) so
+    the head of the list matches the order the worker will pick rows.
+    ``status`` is an optional exact-match filter; when ``None`` every
+    status is returned.
+
+    Returns a list of plain dicts so callers can JSON-serialize without
+    fussing over ``sqlite3.Row``.
+    """
+    if limit <= 0:
+        return []
+    db_path = _resolve_db_path(db_path)
+    try:
+        with _open_archive_conn(db_path) as conn:
+            if status is not None:
+                cursor = conn.execute(
+                    """
+                    SELECT * FROM archive_queue
+                    WHERE status = ?
+                    ORDER BY priority ASC,
+                             expected_mtime IS NULL,
+                             expected_mtime ASC,
+                             id ASC
+                    LIMIT ?
+                    """,
+                    (status, int(limit)),
+                )
+            else:
+                cursor = conn.execute(
+                    """
+                    SELECT * FROM archive_queue
+                    ORDER BY priority ASC,
+                             expected_mtime IS NULL,
+                             expected_mtime ASC,
+                             id ASC
+                    LIMIT ?
+                    """,
+                    (int(limit),),
+                )
+            return [dict(r) for r in cursor.fetchall()]
+    except sqlite3.Error as e:
+        logger.warning("list_queue failed: %s", e)
+        return []

--- a/scripts/web/services/file_watcher_service.py
+++ b/scripts/web/services/file_watcher_service.py
@@ -87,6 +87,7 @@ _status = {
 _on_new_file_callbacks: List[Callable] = []
 _on_deleted_file_callbacks: List[Callable] = []
 _on_event_json_callbacks: List[Callable] = []
+_on_archive_callbacks: List[Callable] = []
 
 
 def register_callback(callback: Callable):
@@ -117,6 +118,25 @@ def register_event_json_callback(callback: Callable):
     without being coupled to the indexing path.
     """
     _on_event_json_callbacks.append(callback)
+
+
+def register_archive_callback(callback: Callable):
+    """Register a callback for the new ``archive_queue`` producer (issue #76).
+
+    Callback signature: callback(file_paths: List[str])
+    Fired with the same path list as the existing mp4 callbacks
+    (:func:`register_callback`) so the archive producer enqueues every
+    clip the indexer enqueues, in the same call. Separate registration
+    keeps the two subsystems independently togglable: the archive
+    producer is opt-in via ``archive_queue.enabled`` in ``config.yaml``,
+    and a disabled producer just never registers a callback (zero cost
+    on the watcher's hot path beyond an empty-list iteration).
+
+    Phase 2a producer-only — see :mod:`services.archive_queue` and
+    :mod:`services.archive_producer`. The Phase 2b worker will drain
+    rows enqueued by these callbacks.
+    """
+    _on_archive_callbacks.append(callback)
 
 
 def get_watcher_status() -> dict:
@@ -242,6 +262,16 @@ def _notify_callbacks(new_files: List[str], my_generation: int):
             cb(new_files)
         except Exception as e:
             logger.error("Watcher new-file callback error: %s", e)
+    # Phase 2a archive_queue producers (issue #76): fire the archive
+    # callbacks with the same paths the indexer just got. The same
+    # generation guard above already protected the batch from a racing
+    # stop, so we skip a second check. Each archive callback handles
+    # its own errors so one bad subscriber can't starve the other.
+    for cb in _on_archive_callbacks:
+        try:
+            cb(new_files)
+        except Exception as e:
+            logger.error("Watcher archive callback error: %s", e)
 
 
 def _notify_delete_callbacks(deleted_files: List[str], my_generation: int):

--- a/scripts/web/services/mapping_service.py
+++ b/scripts/web/services/mapping_service.py
@@ -143,7 +143,7 @@ def _with_db_retry(fn: Callable) -> Callable:
 # Database Schema & Management
 # ---------------------------------------------------------------------------
 
-_SCHEMA_VERSION = 9
+_SCHEMA_VERSION = 10
 _BACKUP_RETENTION = 3  # Keep this many migration backups before pruning oldest
 
 _SCHEMA_SQL = """
@@ -271,6 +271,43 @@ CREATE INDEX IF NOT EXISTS idx_queue_ready
 CREATE INDEX IF NOT EXISTS idx_queue_claimed_at
     ON indexing_queue(claimed_at)
     WHERE claimed_by IS NOT NULL;
+
+-- v10: archive_queue. Producer-only in Phase 2a (issue #76); the worker
+-- that drains it lands in Phase 2b. Rows accumulate harmlessly until
+-- then. Keyed by ``source_path`` (UNIQUE) so the inotify producer, the
+-- 60-s rescan producer, and the boot catch-up scan can all use
+-- ``INSERT OR IGNORE`` for cheap idempotent enqueue. ``priority``
+-- follows the issue spec: 1=RecentClips (Tesla rotates these out
+-- after ~60 min, highest urgency), 2=SentryClips/SavedClips
+-- (event clips the user wants ASAP), 3=anything else. ``status``
+-- transitions through pending → claimed → copied (terminal) or
+-- → source_gone / error / dead_letter (terminal). ``expected_size``
+-- and ``expected_mtime`` are captured at enqueue time so the Phase
+-- 2b worker can detect "Tesla still writing" by re-stat-ing before
+-- the copy.
+CREATE TABLE IF NOT EXISTS archive_queue (
+    id INTEGER PRIMARY KEY,
+    source_path TEXT UNIQUE NOT NULL,
+    dest_path TEXT,
+    priority INTEGER DEFAULT 3,
+    status TEXT DEFAULT 'pending',
+    attempts INTEGER DEFAULT 0,
+    last_error TEXT,
+    enqueued_at TEXT NOT NULL,
+    claimed_at TEXT,
+    claimed_by TEXT,
+    copied_at TEXT,
+    expected_size INTEGER,
+    expected_mtime REAL
+);
+-- Worker pick-next index: partial over only ready rows, ordered by
+-- priority then mtime (closest-to-TTL first within each priority band).
+-- The worker's pick query is ``SELECT ... WHERE status='pending' ORDER
+-- BY priority ASC, expected_mtime ASC LIMIT 1``; this index makes it
+-- O(log n) regardless of queue depth.
+CREATE INDEX IF NOT EXISTS archive_queue_ready
+    ON archive_queue(status, priority, expected_mtime)
+    WHERE status = 'pending';
 """
 
 
@@ -433,6 +470,14 @@ def _init_db(db_path: str) -> sqlite3.Connection:
         # expression indexes are created by the executescript above
         # (CREATE INDEX IF NOT EXISTS is idempotent); no data
         # migration required.
+        # v10: ``archive_queue`` table + ``archive_queue_ready``
+        # partial index for the Phase 2a producers (issue #76).
+        # Producer-only at this version — the boot catch-up scan,
+        # 60-s rescan, and inotify file watcher all enqueue rows but
+        # nothing drains them yet. The Phase 2b worker (separate PR)
+        # will be the consumer. Created by the executescript above
+        # (CREATE TABLE IF NOT EXISTS / CREATE INDEX IF NOT EXISTS
+        # are idempotent); no data migration required.
         conn.execute("DELETE FROM schema_version")
         conn.execute(
             "INSERT INTO schema_version (version) VALUES (?)",

--- a/scripts/web/web_control.py
+++ b/scripts/web/web_control.py
@@ -54,6 +54,7 @@ from blueprints import (
     catch_all_redirect,
     cloud_archive_bp,
     live_events_bp,
+    archive_queue_bp,
 )
 
 app.register_blueprint(mapping_bp)
@@ -72,6 +73,7 @@ app.register_blueprint(api_bp)
 app.register_blueprint(fsck_bp)
 app.register_blueprint(cloud_archive_bp)
 app.register_blueprint(live_events_bp)
+app.register_blueprint(archive_queue_bp)
 # Register captive portal blueprint LAST to avoid conflicting with other routes
 app.register_blueprint(captive_portal_bp)
 
@@ -130,7 +132,7 @@ if __name__ == "__main__":
     try:
         from services.file_watcher_service import (
             start_watcher, register_callback, register_delete_callback,
-            register_event_json_callback,
+            register_event_json_callback, register_archive_callback,
         )
         watch_paths = []
         # Watch TeslaCam on USB (RO mount)
@@ -201,6 +203,34 @@ if __name__ == "__main__":
             except Exception as e:
                 print(f"Warning: Failed to register LES watcher callback: {e}")
 
+            # Archive queue producer (issue #76 Phase 2a): mirror the
+            # mp4 callback into the new archive_queue table. Phase 2a
+            # is producer-only — entries accumulate, no worker drains
+            # them until Phase 2b. Independent enable flag so existing
+            # installs that don't want the queue can disable it cleanly.
+            try:
+                from config import ARCHIVE_QUEUE_ENABLED
+                if ARCHIVE_QUEUE_ENABLED:
+                    def _on_new_videos_for_archive(file_paths):
+                        from services.archive_queue import (
+                            enqueue_many_for_archive,
+                        )
+                        try:
+                            enqueue_many_for_archive(list(file_paths))
+                        except Exception as e:
+                            print(
+                                "Warning: archive_queue enqueue failed: "
+                                f"{e}"
+                            )
+
+                    register_archive_callback(_on_new_videos_for_archive)
+                    print("File watcher → archive_queue producer registered")
+            except Exception as e:
+                print(
+                    "Warning: Failed to register archive_queue watcher "
+                    f"callback: {e}"
+                )
+
             start_watcher(watch_paths)
             print(f"File watcher started for {len(watch_paths)} paths")
     except Exception as e:
@@ -249,6 +279,38 @@ if __name__ == "__main__":
                 print("Daily stale scan scheduled")
     except Exception as e:
         print(f"Warning: Failed to start indexing worker: {e}")
+
+    # Archive queue producer thread (issue #76 Phase 2a). Mirrors the
+    # indexing worker's lifecycle: starts after the watcher is
+    # registered so the boot catch-up scan and the every-60-s rescan
+    # observe the same TeslaCam root. Producer-only — no consumer
+    # exists yet (Phase 2b adds the worker). Failure here must never
+    # take down gadget_web.
+    try:
+        from config import (
+            ARCHIVE_QUEUE_ENABLED,
+            ARCHIVE_QUEUE_RESCAN_INTERVAL_SECONDS,
+            ARCHIVE_QUEUE_BOOT_CATCHUP_ENABLED,
+            MAPPING_DB_PATH as _ARCHIVE_QUEUE_DB,
+        )
+        if ARCHIVE_QUEUE_ENABLED:
+            from services.video_service import get_teslacam_path
+            from services import archive_producer
+            tc = get_teslacam_path()
+            if tc:
+                archive_producer.start_producer(
+                    tc,
+                    db_path=_ARCHIVE_QUEUE_DB,
+                    rescan_interval_seconds=(
+                        ARCHIVE_QUEUE_RESCAN_INTERVAL_SECONDS
+                    ),
+                    boot_catchup_enabled=(
+                        ARCHIVE_QUEUE_BOOT_CATCHUP_ENABLED
+                    ),
+                )
+                print("Archive queue producer started (Phase 2a)")
+    except Exception as e:
+        print(f"Warning: Failed to start archive queue producer: {e}")
 
     # Live Event Sync worker: starts BEFORE cloud_archive auto-trigger so
     # any persistent LES queue (from a prior reboot/WiFi outage) gets

--- a/tests/test_archive_producer.py
+++ b/tests/test_archive_producer.py
@@ -1,0 +1,315 @@
+"""Tests for the archive_queue producer thread (services.archive_producer).
+
+Phase 2a producer for issue #76. These tests cover:
+
+* Directory walk: catches all .mp4 in RecentClips (flat) and event
+  subfolders of SentryClips/SavedClips.
+* Walk handles missing root, missing subdirs, permission errors.
+* Synchronous one-shot scan (run_boot_catchup_once).
+* Producer thread lifecycle: start (idempotent), stop, status snapshot.
+* Producer respects ``boot_catchup_enabled=False`` (no immediate scan).
+* Producer survives an exception inside one scan iteration.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+
+import pytest
+
+from services import archive_producer, archive_queue
+from services.mapping_service import _init_db
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def _stop_any_producer():
+    """Make sure no leftover producer thread is running."""
+    archive_producer.stop_producer(timeout=5.0)
+    yield
+    archive_producer.stop_producer(timeout=5.0)
+
+
+@pytest.fixture
+def db(tmp_path):
+    db_path = str(tmp_path / "geodata.db")
+    _init_db(db_path).close()
+    return db_path
+
+
+@pytest.fixture
+def teslacam(tmp_path):
+    """Synthesize a TeslaCam tree:
+
+    TeslaCam/
+      RecentClips/
+        2026-05-11_09-00-00-front.mp4
+        2026-05-11_09-01-00-front.mp4
+      SentryClips/
+        2026-05-11_09-30-00/
+          front.mp4
+          back.mp4
+      SavedClips/
+        2026-05-11_10-00-00/
+          front.mp4
+    """
+    root = tmp_path / "TeslaCam"
+    recent = root / "RecentClips"; recent.mkdir(parents=True)
+    (recent / "2026-05-11_09-00-00-front.mp4").write_bytes(b"x")
+    (recent / "2026-05-11_09-01-00-front.mp4").write_bytes(b"x")
+    sentry_event = root / "SentryClips" / "2026-05-11_09-30-00"
+    sentry_event.mkdir(parents=True)
+    (sentry_event / "front.mp4").write_bytes(b"x")
+    (sentry_event / "back.mp4").write_bytes(b"x")
+    saved_event = root / "SavedClips" / "2026-05-11_10-00-00"
+    saved_event.mkdir(parents=True)
+    (saved_event / "front.mp4").write_bytes(b"x")
+    return str(root)
+
+
+# ---------------------------------------------------------------------------
+# Directory walk
+# ---------------------------------------------------------------------------
+
+class TestIterArchiveCandidates:
+    def test_collects_all_mp4_under_three_subdirs(self, teslacam):
+        paths = archive_producer._iter_archive_candidates(teslacam)
+        assert len(paths) == 5
+        names = sorted(os.path.basename(p) for p in paths)
+        assert names == [
+            '2026-05-11_09-00-00-front.mp4',
+            '2026-05-11_09-01-00-front.mp4',
+            'back.mp4',
+            'front.mp4',
+            'front.mp4',
+        ]
+
+    def test_missing_root_returns_empty(self, tmp_path):
+        ghost = str(tmp_path / "no_such_dir")
+        assert archive_producer._iter_archive_candidates(ghost) == []
+
+    def test_empty_root_returns_empty(self, tmp_path):
+        empty = tmp_path / "TeslaCam"; empty.mkdir()
+        assert archive_producer._iter_archive_candidates(str(empty)) == []
+
+    def test_partial_tree_does_not_crash(self, tmp_path):
+        # Only RecentClips exists; SentryClips/SavedClips missing.
+        root = tmp_path / "TeslaCam"
+        recent = root / "RecentClips"; recent.mkdir(parents=True)
+        (recent / "a.mp4").write_bytes(b"x")
+        out = archive_producer._iter_archive_candidates(str(root))
+        assert len(out) == 1
+
+    def test_ignores_non_mp4_files(self, teslacam):
+        # Drop a stray non-mp4 file in RecentClips and an event folder
+        recent = os.path.join(teslacam, 'RecentClips')
+        with open(os.path.join(recent, 'thumb.jpg'), 'wb') as f:
+            f.write(b"not a video")
+        with open(os.path.join(teslacam, 'SentryClips',
+                               '2026-05-11_09-30-00', 'event.json'), 'w') as f:
+            f.write('{}')
+        paths = archive_producer._iter_archive_candidates(teslacam)
+        assert all(p.lower().endswith('.mp4') for p in paths)
+        assert len(paths) == 5
+
+    def test_case_insensitive_extension(self, tmp_path):
+        root = tmp_path / "TeslaCam"
+        recent = root / "RecentClips"; recent.mkdir(parents=True)
+        (recent / "x.MP4").write_bytes(b"x")
+        (recent / "y.Mp4").write_bytes(b"x")
+        paths = archive_producer._iter_archive_candidates(str(root))
+        assert len(paths) == 2
+
+    def test_empty_root_arg(self):
+        assert archive_producer._iter_archive_candidates('') == []
+        assert archive_producer._iter_archive_candidates(None) == []  # type: ignore
+
+
+# ---------------------------------------------------------------------------
+# Synchronous scan helper
+# ---------------------------------------------------------------------------
+
+class TestRunBootCatchupOnce:
+    def test_enqueues_all_clips_first_run(self, db, teslacam):
+        result = archive_producer.run_boot_catchup_once(teslacam, db_path=db)
+        assert result == {'seen': 5, 'enqueued': 5}
+        assert archive_queue.get_queue_status(db_path=db)['pending'] == 5
+
+    def test_second_run_enqueues_zero_due_to_dedup(self, db, teslacam):
+        archive_producer.run_boot_catchup_once(teslacam, db_path=db)
+        result = archive_producer.run_boot_catchup_once(teslacam, db_path=db)
+        assert result == {'seen': 5, 'enqueued': 0}
+        assert archive_queue.get_queue_status(db_path=db)['pending'] == 5
+
+    def test_picks_up_new_clip_between_runs(self, db, teslacam):
+        archive_producer.run_boot_catchup_once(teslacam, db_path=db)
+        # Tesla writes a new RecentClips file
+        new_clip = os.path.join(teslacam, 'RecentClips',
+                                '2026-05-11_09-02-00-front.mp4')
+        with open(new_clip, 'wb') as f:
+            f.write(b"new")
+        result = archive_producer.run_boot_catchup_once(teslacam, db_path=db)
+        assert result == {'seen': 6, 'enqueued': 1}
+
+    def test_priorities_are_inferred(self, db, teslacam):
+        archive_producer.run_boot_catchup_once(teslacam, db_path=db)
+        rows = archive_queue.list_queue(limit=100, db_path=db)
+        priorities = sorted(r['priority'] for r in rows)
+        # 2 RecentClips (priority 1), 3 events (priority 2)
+        assert priorities == [1, 1, 2, 2, 2]
+
+
+# ---------------------------------------------------------------------------
+# Producer thread lifecycle
+# ---------------------------------------------------------------------------
+
+class TestProducerLifecycle:
+    def test_start_then_stop(self, db, teslacam):
+        # Use long interval — we just want the boot-catchup pass to run.
+        assert archive_producer.start_producer(
+            teslacam, db_path=db,
+            rescan_interval_seconds=60.0,
+            boot_catchup_enabled=True,
+        ) is True
+
+        # Wait for the boot catch-up to complete (up to 5 s)
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline:
+            if archive_queue.get_queue_status(db_path=db)['pending'] == 5:
+                break
+            time.sleep(0.1)
+
+        status = archive_producer.get_producer_status()
+        assert status['running'] is True
+        assert status['teslacam_root'] == teslacam
+        assert status['iterations'] >= 1
+        assert status['last_seen'] == 5
+
+        assert archive_producer.stop_producer(timeout=5.0) is True
+        assert archive_producer.get_producer_status()['running'] is False
+
+    def test_start_is_idempotent(self, db, teslacam):
+        assert archive_producer.start_producer(
+            teslacam, db_path=db,
+            rescan_interval_seconds=60.0,
+        ) is True
+        # Second call returns False, doesn't spawn a second thread.
+        assert archive_producer.start_producer(
+            teslacam, db_path=db,
+            rescan_interval_seconds=60.0,
+        ) is False
+        archive_producer.stop_producer(timeout=5.0)
+
+    def test_stop_when_not_running_returns_true(self):
+        # No thread alive; stop is a no-op.
+        assert archive_producer.stop_producer(timeout=1.0) is True
+
+    def test_boot_catchup_disabled_skips_first_pass(self, db, teslacam):
+        # With a long interval and boot_catchup off, no scan should
+        # have run by the time we stop.
+        archive_producer.start_producer(
+            teslacam, db_path=db,
+            rescan_interval_seconds=60.0,
+            boot_catchup_enabled=False,
+        )
+        time.sleep(0.5)  # Give the thread a moment to settle
+        status = archive_producer.get_producer_status()
+        # Iterations didn't increment because boot_catchup is gated
+        # off and the first interval is 60 s.
+        assert status['iterations'] == 0
+        assert archive_queue.get_queue_status(db_path=db)['pending'] == 0
+        archive_producer.stop_producer(timeout=5.0)
+
+    def test_periodic_rescan_picks_up_new_files(self, db, teslacam):
+        # Short interval so we can observe two scans
+        archive_producer.start_producer(
+            teslacam, db_path=db,
+            rescan_interval_seconds=0.3,
+            boot_catchup_enabled=True,
+        )
+
+        # Wait for first scan
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline:
+            if archive_queue.get_queue_status(db_path=db)['pending'] == 5:
+                break
+            time.sleep(0.05)
+        assert archive_queue.get_queue_status(db_path=db)['pending'] == 5
+
+        # Drop a new clip; next scan should catch it
+        new_clip = os.path.join(teslacam, 'RecentClips', 'new.mp4')
+        with open(new_clip, 'wb') as f:
+            f.write(b"new")
+
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline:
+            if archive_queue.get_queue_status(db_path=db)['pending'] == 6:
+                break
+            time.sleep(0.1)
+        assert archive_queue.get_queue_status(db_path=db)['pending'] == 6
+
+        archive_producer.stop_producer(timeout=5.0)
+
+    def test_scan_exception_does_not_kill_thread(self, db, teslacam,
+                                                 monkeypatch):
+        # Monkeypatch _scan_once so the first call raises, the second
+        # succeeds. Thread must still be alive after the exception.
+        calls = {'n': 0}
+        original_scan = archive_producer._scan_once
+
+        def failing_scan(root, db_path):
+            calls['n'] += 1
+            if calls['n'] == 1:
+                raise RuntimeError("synthetic scan failure")
+            return original_scan(root, db_path)
+
+        monkeypatch.setattr(archive_producer, '_scan_once', failing_scan)
+
+        archive_producer.start_producer(
+            teslacam, db_path=db,
+            rescan_interval_seconds=0.2,
+            boot_catchup_enabled=True,
+        )
+
+        # Wait for at least 2 iterations (first fails, second succeeds)
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline:
+            if calls['n'] >= 2 and archive_queue.get_queue_status(
+                db_path=db
+            )['pending'] == 5:
+                break
+            time.sleep(0.05)
+
+        status = archive_producer.get_producer_status()
+        assert status['running'] is True
+        assert calls['n'] >= 2
+        # Earlier failure recorded then cleared on success
+        archive_producer.stop_producer(timeout=5.0)
+
+
+# ---------------------------------------------------------------------------
+# Producer status snapshot
+# ---------------------------------------------------------------------------
+
+class TestProducerStatus:
+    def test_status_initial_state(self):
+        # No thread started yet — running=False, no fields populated.
+        status = archive_producer.get_producer_status()
+        assert status['running'] is False
+
+    def test_status_after_start_includes_config(self, db, teslacam):
+        archive_producer.start_producer(
+            teslacam, db_path=db,
+            rescan_interval_seconds=42.0,
+            boot_catchup_enabled=False,
+        )
+        status = archive_producer.get_producer_status()
+        assert status['teslacam_root'] == teslacam
+        assert status['rescan_interval_seconds'] == 42.0
+        assert status['boot_catchup_enabled'] is False
+        archive_producer.stop_producer(timeout=5.0)

--- a/tests/test_archive_queue.py
+++ b/tests/test_archive_queue.py
@@ -1,0 +1,427 @@
+"""Tests for the archive_queue module (services.archive_queue).
+
+Phase 2a producer-side API for issue #76. These tests cover:
+
+* Priority inference for every documented directory pattern.
+* Single enqueue (happy path, idempotent dedup, rejects empty paths).
+* Batch enqueue (happy path, dedup within batch, dedup across calls).
+* Metadata capture (size + mtime for existing files; NULL for missing).
+* Status counts (with rows in multiple statuses including unknown).
+* List queue (sorted, with status filter, with limit).
+* Concurrent enqueue from multiple threads (no exceptions, correct count).
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import threading
+import time
+
+import pytest
+
+from services import archive_queue
+from services.archive_queue import (
+    PRIORITY_EVENTS,
+    PRIORITY_OTHER,
+    PRIORITY_RECENT_CLIPS,
+    _infer_priority,
+    enqueue_for_archive,
+    enqueue_many_for_archive,
+    get_queue_status,
+    list_queue,
+)
+from services.mapping_service import _init_db
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def db(tmp_path):
+    """Initialize a fresh geodata.db with the v10 schema (incl. archive_queue)."""
+    db_path = str(tmp_path / "geodata.db")
+    conn = _init_db(db_path)
+    conn.close()
+    return db_path
+
+
+@pytest.fixture
+def sample_file(tmp_path):
+    """Write a small file we can stat for size/mtime."""
+    f = tmp_path / "clip.mp4"
+    f.write_bytes(b"x" * 1234)
+    return str(f)
+
+
+# ---------------------------------------------------------------------------
+# Priority inference
+# ---------------------------------------------------------------------------
+
+class TestInferPriority:
+    @pytest.mark.parametrize("path,expected", [
+        ('/mnt/gadget/part1-ro/TeslaCam/RecentClips/clip.mp4',
+         PRIORITY_RECENT_CLIPS),
+        ('/mnt/gadget/part1-ro/TeslaCam/recentclips/clip.mp4',
+         PRIORITY_RECENT_CLIPS),
+        # Backslash on Windows
+        (r'C:\TeslaCam\RecentClips\clip.mp4', PRIORITY_RECENT_CLIPS),
+        ('/mnt/gadget/part1-ro/TeslaCam/SentryClips/2026-01-01_12-00-00/'
+         'front.mp4', PRIORITY_EVENTS),
+        ('/mnt/gadget/part1-ro/TeslaCam/SavedClips/2026-01-01_12-00-00/'
+         'back.mp4', PRIORITY_EVENTS),
+        ('/mnt/gadget/part1-ro/TeslaCam/sentryclips/lower/clip.mp4',
+         PRIORITY_EVENTS),
+        ('/home/pi/ArchivedClips/2026-01-01/clip.mp4', PRIORITY_OTHER),
+        ('/somewhere/else/random.mp4', PRIORITY_OTHER),
+        ('', PRIORITY_OTHER),
+    ])
+    def test_infer_priority(self, path, expected):
+        assert _infer_priority(path) == expected
+
+    def test_recent_clips_beats_archive_when_both_present(self):
+        # If both substrings appear (synthetic edge case), RecentClips wins
+        # because it's checked first.
+        path = '/var/ArchivedClips/RecentClips/clip.mp4'
+        assert _infer_priority(path) == PRIORITY_RECENT_CLIPS
+
+
+# ---------------------------------------------------------------------------
+# Single-row enqueue
+# ---------------------------------------------------------------------------
+
+class TestEnqueueForArchive:
+    def test_inserts_new_row(self, db, sample_file):
+        assert enqueue_for_archive(sample_file, db_path=db) is True
+        rows = list_queue(db_path=db)
+        assert len(rows) == 1
+        row = rows[0]
+        assert row['source_path'] == sample_file
+        assert row['status'] == 'pending'
+        assert row['attempts'] == 0
+        assert row['priority'] == PRIORITY_OTHER  # tmp_path isn't under any TeslaCam dir
+        assert row['expected_size'] == 1234
+        assert row['expected_mtime'] is not None
+        assert row['enqueued_at'] is not None
+
+    def test_idempotent_returns_false_on_dupe(self, db, sample_file):
+        assert enqueue_for_archive(sample_file, db_path=db) is True
+        # Second insert — still pending — returns False
+        assert enqueue_for_archive(sample_file, db_path=db) is False
+        rows = list_queue(db_path=db)
+        assert len(rows) == 1
+
+    def test_explicit_priority_overrides_inference(self, db, sample_file):
+        assert enqueue_for_archive(
+            sample_file, priority=1, db_path=db,
+        ) is True
+        rows = list_queue(db_path=db)
+        assert rows[0]['priority'] == 1
+
+    def test_rejects_empty_path(self, db):
+        assert enqueue_for_archive('', db_path=db) is False
+        assert enqueue_for_archive(None, db_path=db) is False  # type: ignore
+        assert get_queue_status(db_path=db)['total'] == 0
+
+    def test_missing_file_still_inserts_with_null_metadata(self, db, tmp_path):
+        ghost = str(tmp_path / "does-not-exist.mp4")
+        assert enqueue_for_archive(ghost, db_path=db) is True
+        rows = list_queue(db_path=db)
+        assert len(rows) == 1
+        assert rows[0]['expected_size'] is None
+        assert rows[0]['expected_mtime'] is None
+
+    def test_priority_inferred_from_recent_clips_path(self, db, tmp_path):
+        # Synthesize a RecentClips path (file doesn't need to exist for
+        # priority inference)
+        recent_dir = tmp_path / "RecentClips"
+        recent_dir.mkdir()
+        clip = recent_dir / "clip.mp4"
+        clip.write_bytes(b"data")
+        assert enqueue_for_archive(str(clip), db_path=db) is True
+        rows = list_queue(db_path=db)
+        assert rows[0]['priority'] == PRIORITY_RECENT_CLIPS
+
+
+# ---------------------------------------------------------------------------
+# Batch enqueue
+# ---------------------------------------------------------------------------
+
+class TestEnqueueManyForArchive:
+    def test_batch_inserts(self, db, tmp_path):
+        files = []
+        for i in range(5):
+            f = tmp_path / f"clip_{i}.mp4"
+            f.write_bytes(b"x" * (100 + i))
+            files.append(str(f))
+        assert enqueue_many_for_archive(files, db_path=db) == 5
+        assert get_queue_status(db_path=db)['pending'] == 5
+
+    def test_batch_dedups_within_call(self, db, tmp_path):
+        f = tmp_path / "clip.mp4"
+        f.write_bytes(b"x")
+        # Same path repeated 3 times — UNIQUE constraint dedups,
+        # only 1 actually inserted.
+        n = enqueue_many_for_archive([str(f), str(f), str(f)], db_path=db)
+        assert n == 1
+        assert get_queue_status(db_path=db)['pending'] == 1
+
+    def test_batch_dedups_across_calls(self, db, tmp_path):
+        f1 = tmp_path / "a.mp4"; f1.write_bytes(b"a")
+        f2 = tmp_path / "b.mp4"; f2.write_bytes(b"b")
+        assert enqueue_many_for_archive([str(f1), str(f2)], db_path=db) == 2
+        # Second batch with one new + one duplicate: only the new one counts.
+        f3 = tmp_path / "c.mp4"; f3.write_bytes(b"c")
+        assert enqueue_many_for_archive([str(f1), str(f3)], db_path=db) == 1
+        assert get_queue_status(db_path=db)['pending'] == 3
+
+    def test_batch_skips_empty_paths(self, db, tmp_path):
+        f = tmp_path / "clip.mp4"; f.write_bytes(b"x")
+        assert enqueue_many_for_archive(
+            ['', None, str(f), ''], db_path=db,  # type: ignore
+        ) == 1
+
+    def test_batch_empty_iterable_returns_zero(self, db):
+        assert enqueue_many_for_archive([], db_path=db) == 0
+        assert enqueue_many_for_archive(iter([]), db_path=db) == 0
+
+    def test_batch_priority_override_applies_to_all(self, db, tmp_path):
+        f1 = tmp_path / "a.mp4"; f1.write_bytes(b"a")
+        f2 = tmp_path / "RecentClips"; f2.mkdir()
+        f2_clip = f2 / "b.mp4"; f2_clip.write_bytes(b"b")
+        # Override forces priority=1 regardless of inference
+        enqueue_many_for_archive([str(f1), str(f2_clip)],
+                                 priority=1, db_path=db)
+        rows = list_queue(db_path=db)
+        assert len(rows) == 2
+        assert all(r['priority'] == 1 for r in rows)
+
+    def test_batch_priority_inferred_when_none(self, db, tmp_path):
+        # Mix of priorities: RecentClips and a generic path
+        recent_dir = tmp_path / "RecentClips"
+        recent_dir.mkdir()
+        recent_clip = recent_dir / "r.mp4"
+        recent_clip.write_bytes(b"r")
+        other = tmp_path / "other.mp4"
+        other.write_bytes(b"o")
+        enqueue_many_for_archive([str(recent_clip), str(other)], db_path=db)
+        # Sorted by priority
+        rows = list_queue(db_path=db)
+        assert rows[0]['priority'] == PRIORITY_RECENT_CLIPS
+        assert rows[0]['source_path'] == str(recent_clip)
+        assert rows[1]['priority'] == PRIORITY_OTHER
+
+
+# ---------------------------------------------------------------------------
+# Status counts
+# ---------------------------------------------------------------------------
+
+class TestGetQueueStatus:
+    def test_empty_returns_zero_for_every_known_status(self, db):
+        counts = get_queue_status(db_path=db)
+        assert counts == {
+            'pending': 0, 'claimed': 0, 'copied': 0,
+            'source_gone': 0, 'error': 0, 'dead_letter': 0,
+            'total': 0,
+        }
+
+    def test_counts_include_all_statuses(self, db, tmp_path):
+        # Insert one row per status by hand
+        conn = sqlite3.connect(db)
+        for i, status in enumerate(
+            ['pending', 'pending', 'claimed', 'copied',
+             'source_gone', 'error', 'dead_letter']
+        ):
+            conn.execute(
+                """
+                INSERT INTO archive_queue
+                    (source_path, status, enqueued_at)
+                VALUES (?, ?, ?)
+                """,
+                (f"/tmp/x_{i}.mp4", status, "2026-05-11T09:00:00+00:00"),
+            )
+        conn.commit()
+        conn.close()
+        counts = get_queue_status(db_path=db)
+        assert counts['pending'] == 2
+        assert counts['claimed'] == 1
+        assert counts['copied'] == 1
+        assert counts['source_gone'] == 1
+        assert counts['error'] == 1
+        assert counts['dead_letter'] == 1
+        assert counts['total'] == 7
+
+    def test_unknown_status_folded_into_total_only(self, db):
+        # Defensive: a stray status value doesn't blow up the API.
+        conn = sqlite3.connect(db)
+        conn.execute(
+            """
+            INSERT INTO archive_queue
+                (source_path, status, enqueued_at)
+            VALUES (?, ?, ?)
+            """,
+            ("/tmp/x.mp4", "weird-status", "2026-05-11T09:00:00+00:00"),
+        )
+        conn.commit()
+        conn.close()
+        counts = get_queue_status(db_path=db)
+        assert counts['pending'] == 0
+        assert counts['total'] == 1
+
+
+# ---------------------------------------------------------------------------
+# list_queue
+# ---------------------------------------------------------------------------
+
+class TestListQueue:
+    def test_empty_returns_empty_list(self, db):
+        assert list_queue(db_path=db) == []
+
+    def test_zero_or_negative_limit_returns_empty(self, db, tmp_path):
+        f = tmp_path / "x.mp4"; f.write_bytes(b"x")
+        enqueue_for_archive(str(f), db_path=db)
+        assert list_queue(limit=0, db_path=db) == []
+        assert list_queue(limit=-1, db_path=db) == []
+
+    def test_status_filter(self, db, tmp_path):
+        # 2 pending, 1 copied
+        for name in ('a', 'b'):
+            f = tmp_path / f"{name}.mp4"; f.write_bytes(b"x")
+            enqueue_for_archive(str(f), db_path=db)
+        conn = sqlite3.connect(db)
+        conn.execute("UPDATE archive_queue SET status='copied' "
+                     "WHERE source_path LIKE '%a.mp4'")
+        conn.commit()
+        conn.close()
+        pending = list_queue(status='pending', db_path=db)
+        copied = list_queue(status='copied', db_path=db)
+        assert len(pending) == 1
+        assert pending[0]['source_path'].endswith('b.mp4')
+        assert len(copied) == 1
+        assert copied[0]['source_path'].endswith('a.mp4')
+
+    def test_sorted_by_priority_then_mtime(self, db, tmp_path):
+        # Three files with controlled priorities
+        recent_dir = tmp_path / "RecentClips"; recent_dir.mkdir()
+        r1 = recent_dir / "r1.mp4"; r1.write_bytes(b"x")
+        time.sleep(0.01)  # mtime ordering
+        r2 = recent_dir / "r2.mp4"; r2.write_bytes(b"x")
+        other = tmp_path / "other.mp4"; other.write_bytes(b"x")
+        enqueue_many_for_archive(
+            [str(other), str(r2), str(r1)], db_path=db,
+        )
+        rows = list_queue(db_path=db)
+        # RecentClips (priority 1) come first, oldest mtime first within tier.
+        assert rows[0]['source_path'] == str(r1)
+        assert rows[1]['source_path'] == str(r2)
+        assert rows[2]['source_path'] == str(other)
+
+    def test_limit_caps_results(self, db, tmp_path):
+        for i in range(10):
+            f = tmp_path / f"c_{i}.mp4"; f.write_bytes(b"x")
+            enqueue_for_archive(str(f), db_path=db)
+        assert len(list_queue(limit=3, db_path=db)) == 3
+        assert len(list_queue(limit=20, db_path=db)) == 10
+
+    def test_null_mtime_sorted_after_real_mtimes(self, db, tmp_path):
+        ghost = str(tmp_path / "ghost.mp4")
+        real = tmp_path / "real.mp4"; real.write_bytes(b"x")
+        # Same priority — ghost has NULL mtime, real has a real mtime
+        enqueue_many_for_archive(
+            [ghost, str(real)], priority=2, db_path=db,
+        )
+        rows = list_queue(db_path=db)
+        # Real comes first (NULLs sorted last)
+        assert rows[0]['source_path'] == str(real)
+        assert rows[1]['source_path'] == ghost
+
+
+# ---------------------------------------------------------------------------
+# Concurrency
+# ---------------------------------------------------------------------------
+
+class TestConcurrentEnqueue:
+    def test_many_threads_no_exceptions_correct_count(self, db, tmp_path):
+        # 10 threads, each enqueueing 50 distinct paths plus 50 shared paths.
+        # Shared paths must dedup; distinct paths must all land.
+        shared = []
+        for i in range(50):
+            f = tmp_path / f"shared_{i}.mp4"; f.write_bytes(b"x")
+            shared.append(str(f))
+
+        results = []
+        errors = []
+
+        def worker(worker_id: int):
+            try:
+                # Distinct paths for this worker
+                distinct = []
+                for i in range(50):
+                    f = tmp_path / f"w{worker_id}_{i}.mp4"
+                    f.write_bytes(b"x")
+                    distinct.append(str(f))
+                count = enqueue_many_for_archive(distinct, db_path=db)
+                count += enqueue_many_for_archive(shared, db_path=db)
+                results.append(count)
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=30)
+
+        assert errors == [], f"Workers raised: {errors}"
+        # Exactly: 10 workers × 50 distinct = 500 + 50 shared = 550 unique rows.
+        assert get_queue_status(db_path=db)['pending'] == 550
+        # Total inserted across all workers' return values: distinct (10×50=500)
+        # + shared (only the first worker to win each row counts; 50 total).
+        assert sum(results) == 550
+
+    def test_concurrent_single_enqueue_dedups_correctly(self, db, tmp_path):
+        f = tmp_path / "race.mp4"; f.write_bytes(b"x")
+        path = str(f)
+        results: list = []
+        errors: list = []
+
+        def worker():
+            try:
+                results.append(enqueue_for_archive(path, db_path=db))
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=worker) for _ in range(20)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+
+        assert errors == []
+        assert results.count(True) == 1
+        assert results.count(False) == 19
+        assert get_queue_status(db_path=db)['pending'] == 1
+
+
+# ---------------------------------------------------------------------------
+# Default db_path resolution (sanity — mocked config import)
+# ---------------------------------------------------------------------------
+
+class TestDefaultDbPath:
+    def test_resolves_via_config_when_not_passed(self, tmp_path, monkeypatch):
+        """When ``db_path`` is omitted, the module reads ``MAPPING_DB_PATH``
+        from ``config``. We patch the import to point at a tmp DB.
+        """
+        db_path = str(tmp_path / "default.db")
+        _init_db(db_path).close()
+
+        # Patch config.MAPPING_DB_PATH
+        import config as _cfg
+        monkeypatch.setattr(_cfg, 'MAPPING_DB_PATH', db_path)
+
+        f = tmp_path / "x.mp4"; f.write_bytes(b"x")
+        # No db_path arg
+        assert enqueue_for_archive(str(f)) is True
+        # Status query also resolves the same way
+        assert get_queue_status()['pending'] == 1

--- a/tests/test_file_watcher_service.py
+++ b/tests/test_file_watcher_service.py
@@ -22,10 +22,12 @@ def _reset_watcher_state():
     # Clear callback lists so callbacks from one test don't leak.
     fws._on_new_file_callbacks.clear()
     fws._on_deleted_file_callbacks.clear()
+    fws._on_archive_callbacks.clear()
     yield
     fws.stop_watcher(timeout=2.0)
     fws._on_new_file_callbacks.clear()
     fws._on_deleted_file_callbacks.clear()
+    fws._on_archive_callbacks.clear()
 
 
 class TestLifecycle:
@@ -198,3 +200,88 @@ class TestPollingDeleteDetection:
             assert any(p.endswith('-front.mp4') for p in deleted_paths)
         finally:
             fws.stop_watcher(timeout=3.0)
+
+
+class TestArchiveCallback:
+    """Phase 2a archive_queue producer (issue #76).
+
+    The archive callback list is parallel to the existing mp4 callback
+    list — both fire on the same ``_notify_callbacks`` invocation with
+    the same paths. These tests exercise the wire-up; the producer's
+    behavior (DB writes, priority inference) is covered separately in
+    ``test_archive_queue.py`` and ``test_archive_producer.py``.
+    """
+
+    def test_register_archive_callback_appends_to_list(self):
+        before = len(fws._on_archive_callbacks)
+        fws.register_archive_callback(lambda paths: None)
+        assert len(fws._on_archive_callbacks) == before + 1
+
+    def test_archive_callback_fires_alongside_mp4_callback(self):
+        mp4_received = []
+        archive_received = []
+        fws.register_callback(lambda paths: mp4_received.extend(paths))
+        fws.register_archive_callback(
+            lambda paths: archive_received.extend(paths)
+        )
+        current = fws._watcher_generation
+        fws._notify_callbacks(['/foo/a.mp4', '/foo/b.mp4'],
+                              my_generation=current)
+        # Both subscribers see exactly the same list.
+        assert mp4_received == ['/foo/a.mp4', '/foo/b.mp4']
+        assert archive_received == ['/foo/a.mp4', '/foo/b.mp4']
+
+    def test_archive_callback_dropped_when_generation_stale(self):
+        # Same generation guard as the mp4 callbacks: a stale batch
+        # must not fire archive callbacks either.
+        archive_received = []
+        fws.register_archive_callback(
+            lambda paths: archive_received.extend(paths)
+        )
+        captured = fws._watcher_generation
+        fws._watcher_generation = captured + 1  # simulate stop_watcher bump
+        try:
+            fws._notify_callbacks(['/x.mp4'], my_generation=captured)
+        finally:
+            fws._watcher_generation = captured
+        assert archive_received == []
+
+    def test_archive_callback_exception_does_not_block_others(self):
+        # One bad archive subscriber can't starve a second one.
+        good_received = []
+
+        def bad_cb(paths):
+            raise RuntimeError("synthetic bad subscriber")
+
+        fws.register_archive_callback(bad_cb)
+        fws.register_archive_callback(
+            lambda paths: good_received.extend(paths)
+        )
+        current = fws._watcher_generation
+        fws._notify_callbacks(['/y.mp4'], my_generation=current)
+        assert good_received == ['/y.mp4']
+
+    def test_no_archive_callback_when_none_registered(self):
+        # Sanity: empty archive list, mp4 callback still fires.
+        mp4_received = []
+        fws.register_callback(lambda paths: mp4_received.extend(paths))
+        current = fws._watcher_generation
+        # Should not raise even though _on_archive_callbacks is empty.
+        fws._notify_callbacks(['/z.mp4'], my_generation=current)
+        assert mp4_received == ['/z.mp4']
+
+    def test_mp4_callback_exception_does_not_block_archive(self):
+        """The two callback lists are independent — one bad mp4
+        subscriber must not prevent the archive callback from firing."""
+        archive_received = []
+
+        def bad_mp4(paths):
+            raise RuntimeError("bad mp4 subscriber")
+
+        fws.register_callback(bad_mp4)
+        fws.register_archive_callback(
+            lambda paths: archive_received.extend(paths)
+        )
+        current = fws._watcher_generation
+        fws._notify_callbacks(['/q.mp4'], my_generation=current)
+        assert archive_received == ['/q.mp4']

--- a/tests/test_mapping_service.py
+++ b/tests/test_mapping_service.py
@@ -195,6 +195,176 @@ class TestDatabase:
         conn.close()
 
 
+class TestArchiveQueueSchema:
+    """v9 → v10 migration adds the ``archive_queue`` table + ready index.
+
+    These tests verify the migration is forward-compatible (creates the
+    new table on a fresh DB), idempotent (re-running ``_init_db`` is a
+    no-op), and non-destructive (existing rows in trips / waypoints /
+    detected_events / indexed_files / indexing_queue survive the
+    migration).
+    """
+
+    def test_archive_queue_table_exists_after_init(self, tmp_path):
+        db_path = str(tmp_path / "test.db")
+        conn = _init_db(db_path)
+        tables = [r[0] for r in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        ).fetchall()]
+        assert 'archive_queue' in tables
+        conn.close()
+
+    def test_archive_queue_ready_index_exists(self, tmp_path):
+        db_path = str(tmp_path / "test.db")
+        conn = _init_db(db_path)
+        indexes = [r[0] for r in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='index'"
+        ).fetchall()]
+        assert 'archive_queue_ready' in indexes
+        conn.close()
+
+    def test_archive_queue_columns_match_spec(self, tmp_path):
+        """All 13 columns from the issue spec must be present with the
+        correct types and defaults."""
+        db_path = str(tmp_path / "test.db")
+        conn = _init_db(db_path)
+        cols = {r[1]: r for r in conn.execute(
+            "PRAGMA table_info(archive_queue)"
+        ).fetchall()}
+        # Column name: (type, notnull, dflt_value, pk)
+        # cid(0), name(1), type(2), notnull(3), dflt_value(4), pk(5)
+        assert 'id' in cols and cols['id'][5] == 1  # PK
+        assert 'source_path' in cols
+        assert cols['source_path'][2] == 'TEXT'
+        assert cols['source_path'][3] == 1  # NOT NULL
+        assert 'dest_path' in cols
+        assert 'priority' in cols
+        assert cols['priority'][4] == '3'  # default 3
+        assert 'status' in cols
+        assert cols['status'][4] == "'pending'"
+        assert 'attempts' in cols
+        assert cols['attempts'][4] == '0'
+        assert 'last_error' in cols
+        assert 'enqueued_at' in cols
+        assert cols['enqueued_at'][3] == 1  # NOT NULL
+        assert 'claimed_at' in cols
+        assert 'claimed_by' in cols
+        assert 'copied_at' in cols
+        assert 'expected_size' in cols
+        assert 'expected_mtime' in cols
+        assert cols['expected_mtime'][2] == 'REAL'
+        conn.close()
+
+    def test_source_path_unique_constraint(self, tmp_path):
+        """``source_path`` must enforce UNIQUE so dedup is automatic."""
+        db_path = str(tmp_path / "test.db")
+        conn = _init_db(db_path)
+        conn.execute(
+            "INSERT INTO archive_queue (source_path, enqueued_at) "
+            "VALUES (?, ?)",
+            ('/a/b.mp4', '2026-05-11T09:00:00+00:00'),
+        )
+        conn.commit()
+        # Second insert with same source_path raises IntegrityError.
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                "INSERT INTO archive_queue (source_path, enqueued_at) "
+                "VALUES (?, ?)",
+                ('/a/b.mp4', '2026-05-11T09:01:00+00:00'),
+            )
+        conn.close()
+
+    def test_schema_version_is_v10(self, tmp_path):
+        from services.mapping_service import _SCHEMA_VERSION
+        # Phase 2a bumps the schema to v10.
+        assert _SCHEMA_VERSION >= 10
+
+    def test_migration_is_idempotent(self, tmp_path):
+        """Running ``_init_db`` twice must not lose archive_queue rows."""
+        db_path = str(tmp_path / "test.db")
+        conn = _init_db(db_path)
+        conn.execute(
+            "INSERT INTO archive_queue (source_path, enqueued_at) "
+            "VALUES (?, ?)",
+            ('/keep/me.mp4', '2026-05-11T09:00:00+00:00'),
+        )
+        conn.commit()
+        conn.close()
+
+        # Re-init the same DB. Must preserve the row.
+        conn2 = _init_db(db_path)
+        n = conn2.execute(
+            "SELECT COUNT(*) FROM archive_queue"
+        ).fetchone()[0]
+        assert n == 1
+        row = conn2.execute(
+            "SELECT source_path FROM archive_queue"
+        ).fetchone()
+        assert row[0] == '/keep/me.mp4'
+        conn2.close()
+
+    def test_migration_preserves_existing_data(self, tmp_path):
+        """Pre-existing trips / waypoints / detected_events / indexed_files
+        must survive the migration to v10 unchanged."""
+        db_path = str(tmp_path / "test.db")
+        conn = _init_db(db_path)
+        # Seed data in the older tables.
+        conn.execute(
+            "INSERT INTO trips (start_time, end_time) VALUES (?, ?)",
+            ('2025-01-01T00:00:00', '2025-01-01T01:00:00'),
+        )
+        trip_id = conn.execute(
+            "SELECT id FROM trips ORDER BY id DESC LIMIT 1"
+        ).fetchone()[0]
+        conn.execute(
+            """INSERT INTO waypoints
+                (trip_id, timestamp, lat, lon)
+               VALUES (?, ?, ?, ?)""",
+            (trip_id, '2025-01-01T00:30:00', 37.7749, -122.4194),
+        )
+        conn.execute(
+            """INSERT INTO indexed_files
+                (file_path, indexed_at)
+               VALUES (?, ?)""",
+            ('/tmp/x.mp4', '2025-01-01T00:00:00'),
+        )
+        conn.commit()
+        conn.close()
+
+        # Re-init (no-op for v10) and verify rows are untouched.
+        conn2 = _init_db(db_path)
+        assert conn2.execute(
+            "SELECT COUNT(*) FROM trips"
+        ).fetchone()[0] == 1
+        assert conn2.execute(
+            "SELECT COUNT(*) FROM waypoints"
+        ).fetchone()[0] == 1
+        assert conn2.execute(
+            "SELECT COUNT(*) FROM indexed_files"
+        ).fetchone()[0] == 1
+        conn2.close()
+
+    def test_indexing_queue_unaffected_by_v10(self, tmp_path):
+        """The Phase 2a migration must not touch indexing_queue rows."""
+        db_path = str(tmp_path / "test.db")
+        conn = _init_db(db_path)
+        conn.execute(
+            """INSERT INTO indexing_queue
+                (canonical_key, file_path, priority, enqueued_at)
+               VALUES (?, ?, ?, ?)""",
+            ('keyA', '/tmp/y.mp4', 50, 1700000000.0),
+        )
+        conn.commit()
+        conn.close()
+
+        conn2 = _init_db(db_path)
+        n = conn2.execute(
+            "SELECT COUNT(*) FROM indexing_queue"
+        ).fetchone()[0]
+        assert n == 1
+        conn2.close()
+
+
 # ---------------------------------------------------------------------------
 # Event Detection Tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Phase 2a — `archive_queue` schema + producers

This is **the first of three PRs** for the archive subsystem rewrite tracked in #76.

> **Phase 2a is purely additive — zero user-observable behavior change.** The existing `_archive_timer_loop` and indexer paths keep working unchanged. The new `archive_queue` table accumulates rows but no worker drains them yet (the worker lands in Phase 2b).

### What lands here

| Component | Detail |
|---|---|
| Schema migration | `_SCHEMA_VERSION` 9 → 10 in `mapping_service.py`. Adds `archive_queue` table + partial index `archive_queue_ready` to `_SCHEMA_SQL` (idempotent via `CREATE TABLE/INDEX IF NOT EXISTS`). |
| Queue API | New `services/archive_queue.py` — `enqueue_for_archive`, `enqueue_many_for_archive`, `get_queue_status`, `list_queue`, `_infer_priority`. Uses `INSERT OR IGNORE` on `source_path UNIQUE` for cheap idempotent enqueue. |
| Producer thread | New `services/archive_producer.py` — single daemon thread, boot catch-up + every-60-s rescan of `RecentClips` / `SentryClips` / `SavedClips`. Lifecycle mirrors `indexing_worker`. |
| Watcher integration | New `register_archive_callback()` in `file_watcher_service.py`; fires alongside the existing mp4 callback in `_notify_callbacks` (no new fd, no new inotify watch, same generation guard). |
| Observability stub | `GET /api/archive_queue/status` → `{enabled, counts, producer}`. Image-gated on `IMG_CAM_PATH`. |
| Config | New `archive_queue:` section in `config.yaml`. Wired through `scripts/web/config.py` and `scripts/config.sh` symmetrically. |
| Wire-up | `web_control.py` registers the watcher callback and starts the producer thread when `ARCHIVE_QUEUE_ENABLED` is true. |

### Behavioral guarantees (verified)

* **Existing `_archive_timer_loop` (`video_archive_service`) untouched.** Still copies clips on its own schedule, still writes directly to `ArchivedClips/`. Phase 2b removes it.
* **Existing `register_callback` mp4 → indexer flow untouched.** Videos still get indexed through the same path during the Phase 2a deployment window.
* **Existing indexer reading from both `ArchivedClips` and the RO USB mount untouched.** Reuses the current `mapping_service.canonical_key` + `index_single_file` outcome model.
* **`v9 → v10` migration is idempotent and non-destructive** — verified via simulation against a synthesized v9 DB with seeded `trips` row: schema bumps to 10, `archive_queue` created, partial index created, original trip preserved. Re-running `_init_db` is a no-op.
* **Disable behavior** — when `archive_queue.enabled: false`, the watcher callback is never registered and the producer thread never starts. Behavior matches pre-#76 installs exactly.

### After deploying just Phase 2a

Users see no difference in archive timing or behavior. The only observable effects are:

1. The one-time `v9 → v10` schema migration (creates an empty `archive_queue` table).
2. Rows accumulating in `archive_queue` (visible via `GET /api/archive_queue/status`) as the inotify watcher and 60-s rescan thread enqueue new clips.

The archive queue is producer-only at this version. The Phase 2b worker is what closes the loop.

### What's NOT in this PR (and why)

* **No archive worker** — explicitly Phase 2b. Rows accumulate harmlessly until then; the issue body says this is intentional.
* **No removal of `_archive_timer_loop`** — also Phase 2b. Removing it now would break the existing pipeline during the deployment window.
* **No indexer change to read only from `ArchivedClips`** — Phase 2b. The indexer still reads from both views during the Phase 2a deployment window.
* **No watchdog / per-priority counts / dead-letter retry endpoint** — Phase 2c.
* **No call from `video_archive_service` into the new queue after copy** — out of scope for 2a; existing archive timer keeps writing directly to `ArchivedClips`. The new queue is fed only by inotify + rescan + boot-catchup.

### Phase 2b (next PR) will

* Add the archive_worker thread that drains `archive_queue` (with task_coordinator key `'archive'`).
* Switch the indexer to read only from `ArchivedClips/` on the SD card (no longer from the RO USB mount).
* Remove the existing `_archive_timer_loop` from `video_archive_service.py`.
* Close #70 and #71 as superseded by the queue-based design.

### Phase 2c (later PR) will

* Add the watchdog endpoint with per-priority counts, claim-age stats, dead-letter inspection.
* Add storage management (free-space-aware deletion of archived RecentClips).
* Add admin endpoints to retry failed/dead-letter rows.

### Tests

**+68 new tests, total 563 passed + 4 skipped** (was 495 + 4 on `main` at `c39a6d3`).

* **`tests/test_archive_queue.py`** (new, 30 cases) — priority inference for every documented directory pattern (incl. Windows backslashes), single + batch enqueue, dedup within and across calls, NULL stat metadata for missing files, status counts (incl. defensive handling of unknown statuses), `list_queue` with sort + filter + limit, multi-thread concurrent enqueue stress test (10 threads × 100 paths), default `db_path` resolution.
* **`tests/test_archive_producer.py`** (new, 15 cases) — directory walk (RecentClips flat + Sentry/Saved event subfolders, missing/empty/partial trees, case-insensitive `.mp4` filter, ignores non-mp4), `run_boot_catchup_once` semantics, full thread lifecycle (start idempotent, stop, status snapshot, periodic rescan picks up new files, scan exception doesn't kill thread, `boot_catchup_enabled=False` skips immediate pass).
* **`tests/test_file_watcher_service.py`** (added `TestArchiveCallback`, 6 cases) — registration, fires alongside mp4, dropped on stale generation, exception isolation in both directions.
* **`tests/test_mapping_service.py`** (added `TestArchiveQueueSchema`, 8 cases) — table + index existence, exact column spec from issue body (types, defaults, NOT NULL), `source_path` UNIQUE constraint, `_SCHEMA_VERSION ≥ 10`, idempotent re-init, non-destructive over existing tables, `indexing_queue` unaffected.

Full suite: `python -m pytest tests/ -q` → **563 passed, 4 skipped in 27.36 s**.

### Verification commands run locally

```
python -m py_compile <every changed Python file>      # OK
python -c "from web_control import app; print('OK')"  # OK
python -c "import yaml; yaml.safe_load(open('config.yaml'))"  # OK
python -m pytest tests/ -q                            # 563 passed, 4 skipped
git status                                            # clean (dashcam_pb2 not tracked)
```

### Sub-task tracking

Resolves Phase 2a of #76. Issue stays open for Phase 2b and Phase 2c.

Ref #76 (Phase 2a)
