### PR TITLE
Phase 2b: archive_worker drains queue, removes legacy timer (Ref #76)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -182,6 +182,9 @@ archive:
 # section prevents the producers from running, leaving behavior identical
 # to pre-#76 installs.
 archive_queue:
-  enabled: true                          # Run Phase 2a producers (writers; no worker yet)
+  enabled: true                          # Run Phase 2a producers + Phase 2b worker
   rescan_interval_seconds: 60            # Cadence of the periodic full-dir rescan
   boot_catchup_enabled: true             # Run the one-shot scan on producer start
+  worker_check_interval_seconds: 5       # Idle/empty-queue sleep between worker iterations
+  retry_max_attempts: 3                  # OSError retries before a row goes to dead_letter
+  copy_chunk_bytes: 1048576              # Chunk size (1 MiB) for the temp+fsync+rename copy

--- a/scripts/config.sh
+++ b/scripts/config.sh
@@ -77,6 +77,9 @@ eval "$(yq -r '
   "ARCHIVE_QUEUE_ENABLED=\"" + (.archive_queue.enabled // true | tostring) + "\"",
   "ARCHIVE_QUEUE_RESCAN_INTERVAL_SECONDS=\"" + (.archive_queue.rescan_interval_seconds // 60 | tostring) + "\"",
   "ARCHIVE_QUEUE_BOOT_CATCHUP_ENABLED=\"" + (.archive_queue.boot_catchup_enabled // true | tostring) + "\"",
+  "ARCHIVE_QUEUE_WORKER_CHECK_INTERVAL_SECONDS=\"" + (.archive_queue.worker_check_interval_seconds // 5 | tostring) + "\"",
+  "ARCHIVE_QUEUE_RETRY_MAX_ATTEMPTS=\"" + (.archive_queue.retry_max_attempts // 3 | tostring) + "\"",
+  "ARCHIVE_QUEUE_COPY_CHUNK_BYTES=\"" + (.archive_queue.copy_chunk_bytes // 1048576 | tostring) + "\"",
   "TESLA_API_CLIENT_ID=\"" + (.tesla_api.client_id // "") + "\""
 ' "$CONFIG_YAML")"
 

--- a/scripts/web/blueprints/mode_control.py
+++ b/scripts/web/blueprints/mode_control.py
@@ -33,6 +33,11 @@ def _pause_worker_for_mode_switch() -> bool:
     keeps making progress instead of staying frozen until the next
     successful mode switch.
 
+    Phase 2b (issue #76): the archive worker is paused with the same
+    contract — its mid-file copies must complete before we can swap
+    the RO USB mount. If either worker fails to pause, the mode switch
+    is refused; both are immediately resumed so neither stays frozen.
+
     Failure semantics: if mapping is enabled and the pause API itself
     raises an unexpected exception, we treat that as a failure and
     refuse the mode switch — better to surface a 503 to the user than
@@ -43,44 +48,60 @@ def _pause_worker_for_mode_switch() -> bool:
         from config import MAPPING_ENABLED
     except ImportError:
         MAPPING_ENABLED = False  # noqa: N806
+
+    indexer_ok = True
+    archive_ok = True
+
     try:
         from services import indexing_worker
-        if not indexing_worker.is_running():
-            return True
-        ok = indexing_worker.pause_worker(timeout=_PAUSE_TIMEOUT_SECONDS)
-        if not ok:
-            # The worker is still mid-file. Clear the pause flag so it
-            # can resume after the current file finishes — otherwise it
-            # would idle forever, breaking all subsequent indexing.
-            indexing_worker.resume_worker()
-        return ok
+        if indexing_worker.is_running():
+            indexer_ok = indexing_worker.pause_worker(
+                timeout=_PAUSE_TIMEOUT_SECONDS,
+            )
+            if not indexer_ok:
+                indexing_worker.resume_worker()
     except ImportError as e:
-        # No worker module available — nothing to pause. Safe to proceed.
         logger.debug("indexing_worker module not available: %s", e)
-        return True
     except Exception as e:  # noqa: BLE001
         if MAPPING_ENABLED:
-            # Worker should be present but pause API failed. Don't
-            # silently let the mode switch proceed — surface the error.
             logger.error(
                 "Pause indexing worker failed (mapping enabled): %s", e,
             )
-            return False
-        logger.warning("Failed to pause indexing worker: %s", e)
-        return True
+            indexer_ok = False
+        else:
+            logger.warning("Failed to pause indexing worker: %s", e)
+
+    try:
+        from services import archive_worker
+        if archive_worker.is_running():
+            archive_ok = archive_worker.pause_worker(
+                timeout=_PAUSE_TIMEOUT_SECONDS,
+            )
+            if not archive_ok:
+                archive_worker.resume_worker()
+    except ImportError as e:
+        logger.debug("archive_worker module not available: %s", e)
+    except Exception as e:  # noqa: BLE001
+        # Archive failure is still a refusal — a mid-copy unmount can
+        # produce a 0-byte ArchivedClips file (we'd lose the source
+        # too if Tesla rotates it before the next archive cycle).
+        logger.error("Pause archive worker failed: %s", e)
+        archive_ok = False
+
+    return indexer_ok and archive_ok
 
 
 def _resume_worker_after_mode_switch() -> None:
-    """Resume the indexing worker (and trigger a catch-up scan).
+    """Resume the indexing + archive workers (and trigger a catch-up scan).
 
     The catch-up scan handles the case where a clip arrived while the
-    worker was paused or while we were swapping mount namespaces — the
+    workers were paused or while we were swapping mount namespaces — the
     file-watcher's inotify subscription is invalidated by the unmount,
     so the watcher alone can't be trusted to notice everything.
 
-    Also lazy-starts the worker if it never started at boot (e.g. the
-    TeslaCam mount wasn't ready when ``web_control.startup`` ran but
-    the user has now switched into present mode).
+    Also lazy-starts both workers if they never started at boot (e.g.
+    the TeslaCam mount wasn't ready when ``web_control.startup`` ran
+    but the user has now switched into present mode).
     """
     try:
         from services import indexing_worker
@@ -104,6 +125,14 @@ def _resume_worker_after_mode_switch() -> None:
         indexing_worker.resume_worker()
     except Exception as e:  # noqa: BLE001
         logger.warning("Failed to resume indexing worker: %s", e)
+    # Resume the archive worker independently so a failure to resume
+    # the indexer doesn't leave the archive frozen (and vice-versa).
+    try:
+        from services import archive_worker
+        archive_worker.ensure_worker_started()
+        archive_worker.resume_worker()
+    except Exception as e:  # noqa: BLE001
+        logger.warning("Failed to resume archive worker: %s", e)
 
 
 def _restart_watcher_after_mode_switch() -> None:

--- a/scripts/web/blueprints/mode_control.py
+++ b/scripts/web/blueprints/mode_control.py
@@ -38,6 +38,14 @@ def _pause_worker_for_mode_switch() -> bool:
     the RO USB mount. If either worker fails to pause, the mode switch
     is refused; both are immediately resumed so neither stays frozen.
 
+    Issue #89: the cleanup is centralized at the end so a partial
+    success — one worker pauses OK but the other fails — fully
+    unwinds the side that did pause. Before this, an indexer pause
+    success followed by an archive pause failure would leave the
+    indexer frozen until the next successful mode switch (and vice
+    versa). For the archive worker this was a bounded data-loss path
+    because Tesla rotates RecentClips after ~60 minutes.
+
     Failure semantics: if mapping is enabled and the pause API itself
     raises an unexpected exception, we treat that as a failure and
     refuse the mode switch — better to surface a 503 to the user than
@@ -51,17 +59,24 @@ def _pause_worker_for_mode_switch() -> bool:
 
     indexer_ok = True
     archive_ok = True
+    indexer_paused = False
+    archive_paused = False
+    indexing_worker = None
+    archive_worker = None
 
     try:
         from services import indexing_worker
         if indexing_worker.is_running():
-            indexer_ok = indexing_worker.pause_worker(
+            if indexing_worker.pause_worker(
                 timeout=_PAUSE_TIMEOUT_SECONDS,
-            )
-            if not indexer_ok:
+            ):
+                indexer_paused = True
+            else:
                 indexing_worker.resume_worker()
+                indexer_ok = False
     except ImportError as e:
         logger.debug("indexing_worker module not available: %s", e)
+        indexing_worker = None
     except Exception as e:  # noqa: BLE001
         if MAPPING_ENABLED:
             logger.error(
@@ -74,13 +89,16 @@ def _pause_worker_for_mode_switch() -> bool:
     try:
         from services import archive_worker
         if archive_worker.is_running():
-            archive_ok = archive_worker.pause_worker(
+            if archive_worker.pause_worker(
                 timeout=_PAUSE_TIMEOUT_SECONDS,
-            )
-            if not archive_ok:
+            ):
+                archive_paused = True
+            else:
                 archive_worker.resume_worker()
+                archive_ok = False
     except ImportError as e:
         logger.debug("archive_worker module not available: %s", e)
+        archive_worker = None
     except Exception as e:  # noqa: BLE001
         # Archive failure is still a refusal — a mid-copy unmount can
         # produce a 0-byte ArchivedClips file (we'd lose the source
@@ -88,7 +106,27 @@ def _pause_worker_for_mode_switch() -> bool:
         logger.error("Pause archive worker failed: %s", e)
         archive_ok = False
 
-    return indexer_ok and archive_ok
+    if not (indexer_ok and archive_ok):
+        # Issue #89: unwind whichever side actually paused so neither
+        # worker stays frozen after a refused mode switch.
+        if indexer_paused and indexing_worker is not None:
+            try:
+                indexing_worker.resume_worker()
+            except Exception as e:  # noqa: BLE001
+                logger.exception(
+                    "Failed to resume indexer after partial pause: %s", e,
+                )
+        if archive_paused and archive_worker is not None:
+            try:
+                archive_worker.resume_worker()
+            except Exception as e:  # noqa: BLE001
+                logger.exception(
+                    "Failed to resume archive worker after partial pause: %s",
+                    e,
+                )
+        return False
+
+    return True
 
 
 def _resume_worker_after_mode_switch() -> None:

--- a/scripts/web/config.py
+++ b/scripts/web/config.py
@@ -139,12 +139,15 @@ ARCHIVE_DIR = _archive_path if _archive_path else os.path.join(
     os.path.expanduser(f"~{TARGET_USER}"), 'ArchivedClips'
 )
 
-# Archive Queue Configuration (issue #76 — Phase 2a producers; worker in 2b)
-# Producer-only at this version: the inotify watcher, the 60-s rescan thread,
-# and the boot catch-up scan all enqueue rows into ``archive_queue`` (in
-# geodata.db). When ``ARCHIVE_QUEUE_ENABLED`` is False the wiring in
-# web_control.py skips both the watcher callback registration and the
-# producer thread, so behavior matches pre-#76 installs exactly.
+# Archive Queue Configuration (issue #76 — Phase 2a producers + Phase 2b worker)
+# Persistent SQLite-backed queue (in geodata.db) for the two-queue
+# archive pipeline. The inotify watcher, the 60-s rescan thread, and the
+# boot catch-up scan all enqueue rows into ``archive_queue``; the Phase
+# 2b worker thread drains them by copying source → ArchivedClips and
+# enqueueing the archived path into ``indexing_queue``. When
+# ``ARCHIVE_QUEUE_ENABLED`` is False the wiring in web_control.py skips
+# the watcher callback registration, the producer thread, and the worker
+# thread, so behavior matches pre-#76 installs exactly.
 _archive_queue = config.get('archive_queue', {})
 ARCHIVE_QUEUE_ENABLED = bool(_archive_queue.get('enabled', True))
 ARCHIVE_QUEUE_RESCAN_INTERVAL_SECONDS = float(
@@ -152,6 +155,15 @@ ARCHIVE_QUEUE_RESCAN_INTERVAL_SECONDS = float(
 )
 ARCHIVE_QUEUE_BOOT_CATCHUP_ENABLED = bool(
     _archive_queue.get('boot_catchup_enabled', True)
+)
+ARCHIVE_QUEUE_WORKER_CHECK_INTERVAL_SECONDS = float(
+    _archive_queue.get('worker_check_interval_seconds', 5)
+)
+ARCHIVE_QUEUE_RETRY_MAX_ATTEMPTS = int(
+    _archive_queue.get('retry_max_attempts', 3)
+)
+ARCHIVE_QUEUE_COPY_CHUNK_BYTES = int(
+    _archive_queue.get('copy_chunk_bytes', 1048576)
 )
 
 # ============================================================================

--- a/scripts/web/services/archive_queue.py
+++ b/scripts/web/services/archive_queue.py
@@ -344,3 +344,332 @@ def list_queue(limit: int = 50,
     except sqlite3.Error as e:
         logger.warning("list_queue failed: %s", e)
         return []
+
+
+# ---------------------------------------------------------------------------
+# Worker-side helpers (Phase 2b — consumed by ``archive_worker``)
+# ---------------------------------------------------------------------------
+#
+# These helpers wrap the state-transition SQL the Phase 2b worker needs
+# so the SQL stays in this module (alongside the producer-side queries)
+# and the worker stays a thin loop.
+#
+# State machine:
+#
+#                 pending  <----release_claim------+
+#                    |                              |
+#                    v                              |
+#               (claim_next_for_worker)             |
+#                    |                              |
+#                    v                              |
+#                 claimed --(error, attempts<max)---+
+#                    |
+#         +----------+----------+--------------------+
+#         |          |          |                    |
+#         v          v          v                    v
+#       copied  source_gone  dead_letter         (retry-able error)
+#       (final)   (final)     (final)
+#
+# All transitions go through these helpers so the worker can be reviewed
+# in isolation without grepping for stray UPDATE statements.
+
+
+def claim_next_for_worker(claimed_by: str, *,
+                          db_path: Optional[str] = None) -> Optional[Dict]:
+    """Atomically claim the next ready row for the worker.
+
+    Returns the claimed row as a plain ``dict`` (so the worker can
+    serialize it without ``sqlite3.Row``), or ``None`` if the queue is
+    empty.
+
+    The pick-and-claim is an atomic ``UPDATE ... WHERE status='pending'``
+    using ``RETURNING *`` (SQLite ≥ 3.35), which lets two workers race
+    safely: only one wins each row. We fall back to the older
+    SELECT-then-UPDATE-with-rowcount pattern if the SQLite build is
+    missing RETURNING.
+
+    The pick order matches the partial index ``archive_queue_ready``:
+    ``priority ASC, expected_mtime ASC NULLS LAST, id ASC``. RecentClips
+    (P1) drains before Sentry/Saved (P2) which drains before everything
+    else (P3); within a priority band, files closer to Tesla's rotation
+    deadline go first (oldest mtime).
+
+    Args:
+        claimed_by: Stamped into ``claimed_by`` for diagnostics
+            (typically a thread-name + PID string).
+        db_path: Override the default ``geodata.db`` path.
+    """
+    db_path = _resolve_db_path(db_path)
+    claimed_at = _iso_now()
+    try:
+        with _open_archive_conn(db_path) as conn:
+            try:
+                cur = conn.execute(
+                    """
+                    UPDATE archive_queue
+                       SET status = 'claimed',
+                           claimed_at = ?,
+                           claimed_by = ?
+                     WHERE id = (
+                        SELECT id FROM archive_queue
+                         WHERE status = 'pending'
+                         ORDER BY priority ASC,
+                                  expected_mtime IS NULL,
+                                  expected_mtime ASC,
+                                  id ASC
+                         LIMIT 1
+                     )
+                       AND status = 'pending'
+                    RETURNING *
+                    """,
+                    (claimed_at, claimed_by),
+                )
+                row = cur.fetchone()
+                if row is not None:
+                    return dict(row)
+                return None
+            except sqlite3.OperationalError:
+                # Older SQLite — no RETURNING clause. Fall back to
+                # SELECT-then-UPDATE; the conditional WHERE keeps the
+                # claim atomic even if another worker raced us.
+                pass
+
+            row = conn.execute(
+                """
+                SELECT * FROM archive_queue
+                 WHERE status = 'pending'
+                 ORDER BY priority ASC,
+                          expected_mtime IS NULL,
+                          expected_mtime ASC,
+                          id ASC
+                 LIMIT 1
+                """
+            ).fetchone()
+            if row is None:
+                return None
+            cur = conn.execute(
+                """
+                UPDATE archive_queue
+                   SET status = 'claimed',
+                       claimed_at = ?,
+                       claimed_by = ?
+                 WHERE id = ? AND status = 'pending'
+                """,
+                (claimed_at, claimed_by, row['id']),
+            )
+            if cur.rowcount != 1:
+                return None
+            claimed = dict(row)
+            claimed['status'] = 'claimed'
+            claimed['claimed_at'] = claimed_at
+            claimed['claimed_by'] = claimed_by
+            return claimed
+    except sqlite3.Error as e:
+        logger.warning("claim_next_for_worker failed: %s", e)
+        return None
+
+
+def mark_copied(row_id: int, dest_path: str, *,
+                db_path: Optional[str] = None) -> bool:
+    """Mark a claimed row as successfully copied.
+
+    Terminal transition. Sets ``status='copied'``, fills ``copied_at``
+    and ``dest_path``, and clears ``last_error``. Returns True iff a
+    row was updated (False on SQLite error or unknown id).
+    """
+    if not row_id:
+        return False
+    db_path = _resolve_db_path(db_path)
+    copied_at = _iso_now()
+    try:
+        with _open_archive_conn(db_path) as conn:
+            cur = conn.execute(
+                """
+                UPDATE archive_queue
+                   SET status = 'copied',
+                       copied_at = ?,
+                       dest_path = ?,
+                       last_error = NULL
+                 WHERE id = ?
+                """,
+                (copied_at, dest_path, int(row_id)),
+            )
+            return cur.rowcount == 1
+    except sqlite3.Error as e:
+        logger.warning("mark_copied failed for id=%s: %s", row_id, e)
+        return False
+
+
+def mark_source_gone(row_id: int, *,
+                     db_path: Optional[str] = None) -> bool:
+    """Mark a row as ``source_gone``.
+
+    Terminal transition for the case where the source file has been
+    rotated out by Tesla before we got to copy it. No retry, no
+    dead-letter sidecar — this is normal behavior on RecentClips after
+    ~60 minutes of no clean shutdown.
+    """
+    if not row_id:
+        return False
+    db_path = _resolve_db_path(db_path)
+    try:
+        with _open_archive_conn(db_path) as conn:
+            cur = conn.execute(
+                """
+                UPDATE archive_queue
+                   SET status = 'source_gone',
+                       last_error = NULL
+                 WHERE id = ?
+                """,
+                (int(row_id),),
+            )
+            return cur.rowcount == 1
+    except sqlite3.Error as e:
+        logger.warning("mark_source_gone failed for id=%s: %s", row_id, e)
+        return False
+
+
+def release_claim(row_id: int, *,
+                  expected_size: Optional[int] = None,
+                  expected_mtime: Optional[float] = None,
+                  db_path: Optional[str] = None) -> bool:
+    """Release a claim back to ``pending`` without burning an attempt.
+
+    Used in three places:
+      * The "fully written" stable-mtime gate — when the source file is
+        still being written by Tesla, we requeue it and try again on
+        the next iteration.
+      * Lock contention — if ``task_coordinator.acquire_task`` times
+        out, we shouldn't penalize the row for our own scheduling.
+      * Pause/stop — when the worker shuts down mid-claim, the row
+        goes back to ``pending`` so the next worker (or restart) can
+        re-claim it cleanly.
+
+    Optionally refreshes ``expected_size`` / ``expected_mtime`` so the
+    next pick-and-claim sees the latest stat() values.
+    """
+    if not row_id:
+        return False
+    db_path = _resolve_db_path(db_path)
+    try:
+        with _open_archive_conn(db_path) as conn:
+            if expected_size is not None or expected_mtime is not None:
+                cur = conn.execute(
+                    """
+                    UPDATE archive_queue
+                       SET status = 'pending',
+                           claimed_at = NULL,
+                           claimed_by = NULL,
+                           expected_size = COALESCE(?, expected_size),
+                           expected_mtime = COALESCE(?, expected_mtime)
+                     WHERE id = ?
+                    """,
+                    (expected_size, expected_mtime, int(row_id)),
+                )
+            else:
+                cur = conn.execute(
+                    """
+                    UPDATE archive_queue
+                       SET status = 'pending',
+                           claimed_at = NULL,
+                           claimed_by = NULL
+                     WHERE id = ?
+                    """,
+                    (int(row_id),),
+                )
+            return cur.rowcount == 1
+    except sqlite3.Error as e:
+        logger.warning("release_claim failed for id=%s: %s", row_id, e)
+        return False
+
+
+def mark_failed(row_id: int, error: str, *,
+                max_attempts: int = 3,
+                db_path: Optional[str] = None) -> str:
+    """Record a failed attempt; transition to dead_letter at the cap.
+
+    Returns the new status (``'pending'`` if attempts remain, or
+    ``'dead_letter'`` once ``attempts >= max_attempts``). On SQLite
+    failure returns ``'error'`` and leaves the row alone — the caller
+    should release the claim and let the next iteration retry.
+
+    ``last_error`` is truncated to 4 KB so a runaway exception trace
+    can't bloat the DB.
+    """
+    if not row_id:
+        return 'error'
+    db_path = _resolve_db_path(db_path)
+    truncated = (error or '')[:4096]
+    try:
+        with _open_archive_conn(db_path) as conn:
+            row = conn.execute(
+                "SELECT attempts FROM archive_queue WHERE id = ?",
+                (int(row_id),),
+            ).fetchone()
+            if row is None:
+                return 'error'
+            new_attempts = int(row['attempts'] or 0) + 1
+            if new_attempts >= int(max_attempts):
+                conn.execute(
+                    """
+                    UPDATE archive_queue
+                       SET status = 'dead_letter',
+                           attempts = ?,
+                           last_error = ?,
+                           claimed_at = NULL,
+                           claimed_by = NULL
+                     WHERE id = ?
+                    """,
+                    (new_attempts, truncated, int(row_id)),
+                )
+                return 'dead_letter'
+            conn.execute(
+                """
+                UPDATE archive_queue
+                   SET status = 'pending',
+                       attempts = ?,
+                       last_error = ?,
+                       claimed_at = NULL,
+                       claimed_by = NULL
+                 WHERE id = ?
+                """,
+                (new_attempts, truncated, int(row_id)),
+            )
+            return 'pending'
+    except sqlite3.Error as e:
+        logger.warning("mark_failed failed for id=%s: %s", row_id, e)
+        return 'error'
+
+
+def recover_stale_claims(*,
+                         max_age_seconds: float = 600.0,
+                         db_path: Optional[str] = None) -> int:
+    """Reset ``claimed`` rows older than ``max_age_seconds`` to pending.
+
+    Run once on worker start so a hard crash mid-copy (gadget_web killed
+    during a quick_edit, OOM, power cut) doesn't leave rows stuck in
+    ``claimed`` forever. Returns the count of rows recovered.
+    """
+    db_path = _resolve_db_path(db_path)
+    try:
+        with _open_archive_conn(db_path) as conn:
+            # Compare ISO-8601 strings lexicographically — works
+            # because they're all UTC and same format.
+            cutoff = datetime.now(timezone.utc).timestamp() - max_age_seconds
+            cutoff_iso = datetime.fromtimestamp(
+                cutoff, tz=timezone.utc).isoformat()
+            cur = conn.execute(
+                """
+                UPDATE archive_queue
+                   SET status = 'pending',
+                       claimed_at = NULL,
+                       claimed_by = NULL
+                 WHERE status = 'claimed'
+                   AND (claimed_at IS NULL OR claimed_at < ?)
+                """,
+                (cutoff_iso,),
+            )
+            return cur.rowcount or 0
+    except sqlite3.Error as e:
+        logger.warning("recover_stale_claims failed: %s", e)
+        return 0

--- a/scripts/web/services/archive_worker.py
+++ b/scripts/web/services/archive_worker.py
@@ -1,0 +1,767 @@
+"""Single-threaded archive worker (issue #76 — Phase 2b).
+
+Drains the ``archive_queue`` table one file at a time. For each row:
+
+1. Pick + claim the next ``pending`` row, ordered ``priority ASC,
+   expected_mtime ASC NULLS LAST`` (RecentClips first, then
+   Sentry/Saved, then everything else; closest-to-Tesla-rotation first
+   within each band).
+2. Run a "fully written" gate: re-stat the source; if the file is
+   younger than 5 s AND its size or mtime drift past the values seen
+   when it was enqueued, release the claim with refreshed metadata and
+   try again on the next iteration. Tesla writes clips in chunks; we
+   never want to copy a half-written clip.
+3. Acquire the ``task_coordinator`` slot. The archive worker is a
+   periodic priority task (per the task_coordinator contract docstring),
+   so it uses the **blocking** ``acquire_task('archive', wait_seconds=N)``
+   form — it waits a bounded time for the indexer to yield, then
+   proceeds. NOT the indexer's ``yield_to_waiters=True`` cyclic form.
+4. Compute the destination under ``ARCHIVE_DIR`` mirroring the
+   ``TeslaCam/<sub>/<file>`` layout.
+5. Atomic copy: write to ``dest_path + '.partial'`` in 1-MiB chunks,
+   ``fsync``, ``rename`` to the final name, verify size matches the
+   source.
+6. On success, mark the row ``copied`` and enqueue the **destination**
+   path into ``indexing_queue`` via ``mapping_service.enqueue_for_indexing``
+   so the indexer picks it up next.
+7. Failure handling:
+   * ``FileNotFoundError`` (source rotated by Tesla mid-flight) → mark
+     ``source_gone``. No retry, no dead-letter.
+   * Any other ``OSError`` / ``shutil.Error`` / ``sqlite3.Error`` →
+     bump ``attempts``; at ``attempts >= retry_max_attempts`` the row
+     transitions to ``dead_letter`` and a sidecar text file lands at
+     ``~/ArchivedClips/.dead_letter/<id>.txt`` for forensics.
+
+**Hard contract (do NOT break — see copilot-instructions.md):**
+
+* This module never imports or calls anything that touches the USB
+  gadget — no ``mount``, ``umount``, ``losetup``, ``nsenter``,
+  ``partition_mount_service``, ``quick_edit_part2``, or
+  ``rebind_usb_gadget``. Tesla may be actively recording; ANY USB
+  disruption from a background subsystem loses footage.
+* The ``task_coordinator`` lock is **always released before any sleep**.
+  Holding the lock across ``_stop_event.wait()`` was the May 7
+  starvation bug — never re-introduce it.
+* No heavy imports. ``os``, ``shutil``, ``sqlite3``, ``logging``,
+  ``threading``, ``time`` only — the Pi Zero 2 W steady-state RSS
+  budget for this thread is ~30 MB.
+
+Public API mirrors :mod:`indexing_worker`::
+
+    start_worker(db_path, archive_root, *, teslacam_root=None) -> bool
+    stop_worker(timeout=...)               -> bool
+    pause_worker(timeout=...)              -> bool
+    resume_worker()                        -> None
+    is_paused()                            -> bool
+    is_running()                           -> bool
+    ensure_worker_started()                -> bool
+    wake()                                 -> None       # poke an idle loop
+    get_status()                           -> dict
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import sys
+import threading
+import time
+import uuid
+from typing import Any, Callable, Dict, Optional
+
+from services import archive_queue
+from services import task_coordinator
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Tunables — kept module-level so tests can monkeypatch
+# ---------------------------------------------------------------------------
+
+# Sleep between successful copies (gives the kernel time to flush).
+_INTER_FILE_SLEEP_SECONDS = 0.25
+# Sleep when the queue is empty. Wake() can shorten this on a producer hit.
+_IDLE_SLEEP_SECONDS = 5.0
+# Sleep on a transient claim error or task_coordinator timeout.
+_BACKOFF_SLEEP_SECONDS = 0.5
+# Stable-write age gate — files modified within this many seconds get
+# re-queued so we don't copy a clip Tesla is still writing.
+_STABLE_WRITE_AGE_SECONDS = 5.0
+# task_coordinator wait when acquiring the archive slot. The archive
+# worker is a periodic priority task (per the task_coordinator
+# docstring) — it BLOCK-waits for a slot rather than yielding cyclically.
+_COORDINATOR_WAIT_SECONDS = 60.0
+# Pause/stop defaults match the indexer.
+_DEFAULT_PAUSE_TIMEOUT = 30.0
+_DEFAULT_STOP_TIMEOUT = 30.0
+# task_coordinator label for this worker. Distinct from 'indexer' so
+# the fairness model can prioritize archive over indexing.
+_COORDINATOR_TASK = 'archive'
+# Default copy buffer; the worker reads it from config at start.
+_DEFAULT_COPY_CHUNK_BYTES = 1024 * 1024
+
+
+# ---------------------------------------------------------------------------
+# Module state — all access through _state_lock
+# ---------------------------------------------------------------------------
+
+_state_lock = threading.Lock()
+_worker_thread: Optional[threading.Thread] = None
+_worker_id: Optional[str] = None
+_stop_event = threading.Event()
+_pause_event = threading.Event()
+_idle_event = threading.Event()
+_idle_event.set()
+# Wake event lets producers (or the NM dispatcher trigger) shorten the
+# idle sleep to "right now" without spinning the worker.
+_wake_event = threading.Event()
+_db_path: Optional[str] = None
+_archive_root: Optional[str] = None
+_teslacam_root: Optional[str] = None
+_state: Dict[str, Any] = {
+    'active_file': None,
+    'last_outcome': None,
+    'last_error': None,
+    'files_done_session': 0,
+    'last_drained_at': None,
+}
+
+
+# ---------------------------------------------------------------------------
+# Public lifecycle API
+# ---------------------------------------------------------------------------
+
+def start_worker(db_path: str, archive_root: str, *,
+                 teslacam_root: Optional[str] = None) -> bool:
+    """Start the worker thread. Idempotent.
+
+    ``archive_root`` is the directory where copied clips land
+    (typically ``~/ArchivedClips``). ``teslacam_root`` is the RO USB
+    mount root used to compute the relative subpath; it falls back to
+    ``services.video_service.get_teslacam_path()`` at call time if
+    omitted.
+    """
+    global _worker_thread, _worker_id, _db_path, _archive_root, _teslacam_root
+    with _state_lock:
+        if _worker_thread is not None and _worker_thread.is_alive():
+            logger.warning(
+                "archive_worker.start_worker: refusing — existing thread "
+                "still alive (id=%s).", _worker_id,
+            )
+            return False
+        _db_path = db_path
+        _archive_root = archive_root
+        _teslacam_root = teslacam_root
+        _worker_id = f"archive-{os.getpid()}-{uuid.uuid4().hex[:6]}"
+        _stop_event.clear()
+        _pause_event.clear()
+        _wake_event.clear()
+        _idle_event.set()
+        _state['files_done_session'] = 0
+        _state['last_drained_at'] = None
+        _state['last_error'] = None
+        _state['last_outcome'] = None
+        _state['active_file'] = None
+        thread = threading.Thread(
+            target=_run_worker_loop,
+            args=(db_path, archive_root, teslacam_root, _worker_id),
+            name='archive-worker',
+            daemon=True,
+        )
+        _worker_thread = thread
+    thread.start()
+    logger.info("Archive worker started (id=%s)", _worker_id)
+    return True
+
+
+def stop_worker(timeout: float = _DEFAULT_STOP_TIMEOUT) -> bool:
+    """Signal the worker to stop and wait for it to exit.
+
+    Like the indexer's stop_worker: on join timeout we leave
+    ``_worker_thread`` in place to block restart — racing two threads
+    over the same archive_queue claim rows would be worse than waiting.
+    """
+    global _worker_thread
+    with _state_lock:
+        thread = _worker_thread
+    if thread is None:
+        return True
+    _stop_event.set()
+    _pause_event.clear()
+    _wake_event.set()
+    thread.join(timeout=timeout)
+    exited = not thread.is_alive()
+    if exited:
+        with _state_lock:
+            if _worker_thread is thread:
+                _worker_thread = None
+        logger.info("Archive worker stopped cleanly")
+    else:
+        logger.warning(
+            "Archive worker did not exit within %.1fs; "
+            "leaving thread reference in place to block restart",
+            timeout,
+        )
+    return exited
+
+
+def pause_worker(timeout: float = _DEFAULT_PAUSE_TIMEOUT) -> bool:
+    """Pause the worker between iterations.
+
+    Mirrors the indexer's pause semantics: returns True if the worker
+    is now idle, False on timeout. The caller (mode-switch handler,
+    quick_edit caller) should refuse to proceed on False.
+    """
+    if not _is_running():
+        _pause_event.set()
+        return True
+    _pause_event.set()
+    _wake_event.set()
+    became_idle = _idle_event.wait(timeout=timeout)
+    if not became_idle:
+        logger.warning(
+            "archive_worker.pause_worker: still mid-file after %.1fs (active=%s)",
+            timeout, _state.get('active_file'),
+        )
+    return became_idle
+
+
+def resume_worker() -> None:
+    """Clear the pause flag so the worker can claim again."""
+    _pause_event.clear()
+    _wake_event.set()
+
+
+def is_paused() -> bool:
+    return _pause_event.is_set()
+
+
+def is_running() -> bool:
+    return _is_running()
+
+
+def wake() -> None:
+    """Poke the worker out of an idle sleep.
+
+    Producers (the inotify-callback path, the 60-s rescan thread, and
+    the NM dispatcher's HTTP wake endpoint) call this after enqueueing
+    so a freshly-arrived clip is picked up within milliseconds rather
+    than waiting up to ``_IDLE_SLEEP_SECONDS``. Cheap / lock-free /
+    safe to call from any thread.
+    """
+    _wake_event.set()
+
+
+def ensure_worker_started() -> bool:
+    """Lazy-start the worker if it isn't running.
+
+    Mirrors :func:`indexing_worker.ensure_worker_started`. No-op if the
+    archive subsystem is disabled, or if the necessary config is
+    missing. Returns True iff a worker is running on exit.
+    """
+    if _is_running():
+        return True
+    try:
+        from config import (
+            ARCHIVE_QUEUE_ENABLED, ARCHIVE_DIR, MAPPING_DB_PATH,
+        )
+        if not ARCHIVE_QUEUE_ENABLED:
+            return False
+        from services.video_service import get_teslacam_path
+        tc = get_teslacam_path()
+        return start_worker(MAPPING_DB_PATH, ARCHIVE_DIR, teslacam_root=tc)
+    except Exception as e:  # noqa: BLE001
+        logger.debug("ensure_worker_started: deferred start failed: %s", e)
+        return False
+
+
+def _is_running() -> bool:
+    with _state_lock:
+        t = _worker_thread
+    return t is not None and t.is_alive()
+
+
+def get_status() -> Dict[str, Any]:
+    """Snapshot for ``/api/archive/status`` (Phase 2c will surface this).
+
+    Combines in-memory worker state with a fresh
+    :func:`archive_queue.get_queue_status` snapshot.
+    """
+    with _state_lock:
+        snap = {
+            'worker_running': (
+                _worker_thread is not None and _worker_thread.is_alive()
+            ),
+            'worker_id': _worker_id,
+            'paused': _pause_event.is_set(),
+            'idle': _idle_event.is_set(),
+            'active_file': _state['active_file'],
+            'last_outcome': _state['last_outcome'],
+            'last_error': _state['last_error'],
+            'files_done_session': _state['files_done_session'],
+            'last_drained_at': _state['last_drained_at'],
+        }
+        db_path = _db_path
+    counts = {}
+    if db_path:
+        try:
+            counts = archive_queue.get_queue_status(db_path)
+        except Exception as e:  # noqa: BLE001 — status must never raise
+            logger.warning("get_queue_status failed inside status: %s", e)
+            counts = {'queue_status_error': str(e)}
+    snap['queue_depth'] = counts.get('pending', 0)
+    snap['claimed_count'] = counts.get('claimed', 0)
+    snap['dead_letter_count'] = counts.get('dead_letter', 0)
+    snap['source_gone_count'] = counts.get('source_gone', 0)
+    snap['copied_count'] = counts.get('copied', 0)
+    snap['error_count'] = counts.get('error', 0)
+    return snap
+
+
+# ---------------------------------------------------------------------------
+# Helpers (pure / easy to test)
+# ---------------------------------------------------------------------------
+
+def compute_dest_path(source_path: str, archive_root: str,
+                      teslacam_root: Optional[str]) -> str:
+    """Map ``source_path`` under ``teslacam_root`` to its archive home.
+
+    Examples (with ``archive_root='/home/pi/ArchivedClips'``,
+    ``teslacam_root='/mnt/gadget/part1-ro/TeslaCam'``)::
+
+        .../TeslaCam/RecentClips/2024-01-01_10-00-00-front.mp4
+            -> /home/pi/ArchivedClips/RecentClips/2024-01-01_10-00-00-front.mp4
+
+        .../TeslaCam/SentryClips/2024-01-01_10-00-00/2024-01-01_10-00-00-front.mp4
+            -> /home/pi/ArchivedClips/SentryClips/2024-01-01_10-00-00/...
+
+    If the source isn't under ``teslacam_root`` (e.g. a manually-dropped
+    test fixture), we fall back to placing it under
+    ``archive_root/<basename>`` so the worker still has somewhere safe
+    to write. This matches the legacy ``video_archive_service``
+    behavior.
+    """
+    if not source_path:
+        raise ValueError("source_path required")
+    archive_root = os.path.abspath(archive_root)
+    src_abs = os.path.abspath(source_path)
+    if teslacam_root:
+        tc_abs = os.path.abspath(teslacam_root).rstrip(os.sep) + os.sep
+        if src_abs.startswith(tc_abs):
+            rel = src_abs[len(tc_abs):]
+            return os.path.join(archive_root, rel)
+    # Fallback: put it at the top of ArchivedClips with its basename.
+    return os.path.join(archive_root, os.path.basename(src_abs))
+
+
+def _safe_stat(path: str):
+    try:
+        return os.stat(path)
+    except OSError:
+        return None
+
+
+def _atomic_copy(source_path: str, dest_path: str,
+                 chunk_size: int) -> int:
+    """Copy ``source_path`` → ``dest_path`` atomically. Returns size.
+
+    Pattern: ``dest_path + '.partial'`` → write in chunks → fsync →
+    rename. The temp file is unlinked on any failure so a crash mid-
+    copy doesn't leave an orphan in ArchivedClips.
+
+    Verifies the rendered size matches the source's stat() size; any
+    mismatch raises ``OSError`` so the caller bumps attempts.
+    """
+    parent = os.path.dirname(dest_path)
+    if parent:
+        os.makedirs(parent, exist_ok=True)
+    partial = dest_path + '.partial'
+    expected = os.path.getsize(source_path)
+    written = 0
+    try:
+        # ``shutil.copyfile`` does buffered chunked copies under the
+        # hood; we wrap manually so we can fsync + size-verify.
+        with open(source_path, 'rb') as src, open(partial, 'wb') as dst:
+            while True:
+                chunk = src.read(chunk_size)
+                if not chunk:
+                    break
+                dst.write(chunk)
+                written += len(chunk)
+            dst.flush()
+            try:
+                os.fsync(dst.fileno())
+            except OSError:
+                # Best-effort; some filesystems (tmpfs, network mounts)
+                # don't support fsync. Don't fail the copy on that.
+                pass
+        if written != expected:
+            raise OSError(
+                f"size mismatch: wrote {written}, expected {expected}"
+            )
+        # Copy mtime so downstream consumers (indexer, ZIP exporter)
+        # see the original timestamp.
+        try:
+            shutil.copystat(source_path, partial)
+        except OSError:
+            pass
+        os.replace(partial, dest_path)
+        return written
+    except Exception:
+        # Clean up the partial on any failure path.
+        try:
+            os.remove(partial)
+        except OSError:
+            pass
+        raise
+
+
+def _write_dead_letter_sidecar(archive_root: str,
+                               row: Dict[str, Any]) -> None:
+    """Write ``~/ArchivedClips/.dead_letter/<id>.txt`` for forensics.
+
+    Best-effort — a failure to write the sidecar is logged but doesn't
+    re-trigger a retry on the underlying queue row.
+    """
+    try:
+        sidecar_dir = os.path.join(archive_root, '.dead_letter')
+        os.makedirs(sidecar_dir, exist_ok=True)
+        sidecar_path = os.path.join(sidecar_dir, f"{row['id']}.txt")
+        with open(sidecar_path, 'w', encoding='utf-8') as f:
+            f.write(f"id: {row.get('id')}\n")
+            f.write(f"source_path: {row.get('source_path')}\n")
+            f.write(f"dest_path: {row.get('dest_path')}\n")
+            f.write(f"attempts: {row.get('attempts')}\n")
+            f.write(f"enqueued_at: {row.get('enqueued_at')}\n")
+            f.write(f"last_error: {row.get('last_error')}\n")
+    except OSError as e:
+        logger.warning(
+            "Failed to write dead_letter sidecar for id=%s: %s",
+            row.get('id'), e,
+        )
+
+
+def _enqueue_indexed(dest_path: str, db_path: str) -> None:
+    """Enqueue the archived dest into indexing_queue.
+
+    Looked up at call time (not import time) so tests can monkeypatch
+    ``mapping_service.enqueue_for_indexing`` cleanly. Failure here
+    doesn't roll back the archive — the indexer's boot catch-up scan
+    will pick the file up later anyway.
+    """
+    try:
+        from services import mapping_service
+        if hasattr(mapping_service, 'enqueue_for_indexing'):
+            # mapping_service.enqueue_for_indexing is positional
+            # (db_path, file_path) — keep the call site aligned.
+            mapping_service.enqueue_for_indexing(
+                db_path, dest_path, source='archive',
+            )
+        elif hasattr(mapping_service, 'enqueue_many_for_indexing'):
+            mapping_service.enqueue_many_for_indexing(
+                db_path, [(dest_path, None)], source='archive',
+            )
+        else:
+            logger.warning(
+                "mapping_service has no enqueue_for_indexing API; skipping",
+            )
+    except Exception as e:  # noqa: BLE001
+        logger.warning(
+            "enqueue_for_indexing failed for %s: %s", dest_path, e,
+        )
+
+
+def _apply_low_priority() -> None:
+    """Drop the calling thread to lowest CPU + I/O priority (Linux only).
+
+    Same per-thread approach as the indexer: ``SCHED_IDLE`` via
+    ``sched_setscheduler(0, ...)`` + ``ionice -c 3 -p <native_tid>``.
+    No-op on non-Linux platforms. Failures are silently ignored —
+    priority adjustment is a nice-to-have, not a correctness rule.
+    """
+    if not sys.platform.startswith('linux'):
+        return
+    try:
+        SCHED_IDLE = 5
+        if hasattr(os, 'sched_setscheduler') and hasattr(os, 'sched_param'):
+            os.sched_setscheduler(  # type: ignore[attr-defined]
+                0, SCHED_IDLE, os.sched_param(0),  # type: ignore[attr-defined]
+            )
+    except (OSError, PermissionError, AttributeError):
+        pass
+    try:
+        import subprocess
+        tid = threading.get_native_id()
+        subprocess.run(
+            ["ionice", "-c", "3", "-p", str(tid)],
+            timeout=5, capture_output=True, check=False,
+        )
+    except (FileNotFoundError, OSError, AttributeError):
+        pass
+    except Exception:  # noqa: BLE001
+        # subprocess.TimeoutExpired and friends — non-fatal.
+        pass
+
+
+def _set_state(**fields: Any) -> None:
+    with _state_lock:
+        _state.update(fields)
+
+
+def _record_active(file_path: str) -> None:
+    with _state_lock:
+        _state['active_file'] = file_path
+    _idle_event.clear()
+
+
+def _record_idle(*, last_outcome: Optional[str] = None,
+                 last_error: Optional[str] = None) -> None:
+    with _state_lock:
+        _state['active_file'] = None
+        if last_outcome is not None:
+            _state['last_outcome'] = last_outcome
+        if last_error is not None:
+            _state['last_error'] = last_error
+    _idle_event.set()
+
+
+def _read_config_or_defaults():
+    """Return (chunk_bytes, max_attempts, idle_seconds) from config.
+
+    Looked up at call time so tests can monkeypatch the config module
+    after import. Falls back to module-level defaults if config isn't
+    importable (unit-test environments without the full app).
+    """
+    try:
+        from config import (
+            ARCHIVE_QUEUE_COPY_CHUNK_BYTES,
+            ARCHIVE_QUEUE_RETRY_MAX_ATTEMPTS,
+            ARCHIVE_QUEUE_WORKER_CHECK_INTERVAL_SECONDS,
+        )
+        return (
+            int(ARCHIVE_QUEUE_COPY_CHUNK_BYTES),
+            int(ARCHIVE_QUEUE_RETRY_MAX_ATTEMPTS),
+            float(ARCHIVE_QUEUE_WORKER_CHECK_INTERVAL_SECONDS),
+        )
+    except Exception:  # noqa: BLE001
+        return (_DEFAULT_COPY_CHUNK_BYTES, 3, _IDLE_SLEEP_SECONDS)
+
+
+# ---------------------------------------------------------------------------
+# Per-row processing (testable without a thread)
+# ---------------------------------------------------------------------------
+
+def process_one_claim(row: Dict[str, Any], db_path: str,
+                      archive_root: str,
+                      teslacam_root: Optional[str], *,
+                      chunk_size: int,
+                      max_attempts: int,
+                      now_fn: Callable[[], float] = time.time) -> str:
+    """Process a single claimed row. Returns the new status string.
+
+    Possible return values:
+      * ``'copied'``       — file copied + indexer enqueued
+      * ``'source_gone'``  — source vanished (no retry, terminal)
+      * ``'pending'``      — released back to pending (stable-write
+                             gate, transient error with attempts left)
+      * ``'dead_letter'``  — attempts exhausted
+
+    Pure dispatch logic kept separate from the loop so tests can drive
+    it directly without a thread or task_coordinator.
+    """
+    row_id = int(row['id'])
+    source_path = row['source_path']
+
+    # Stable-write gate. If the file is too fresh AND its size or mtime
+    # have shifted since enqueue, requeue with refreshed metadata.
+    st = _safe_stat(source_path)
+    if st is None:
+        archive_queue.mark_source_gone(row_id, db_path=db_path)
+        return 'source_gone'
+    age = now_fn() - st.st_mtime
+    expected_size = row.get('expected_size')
+    expected_mtime = row.get('expected_mtime')
+    metadata_drifted = (
+        (expected_size is not None and expected_size != st.st_size)
+        or (expected_mtime is not None and expected_mtime != st.st_mtime)
+    )
+    if age < _STABLE_WRITE_AGE_SECONDS and metadata_drifted:
+        # Update the snapshot so the next pick uses fresh values.
+        archive_queue.release_claim(
+            row_id,
+            expected_size=st.st_size,
+            expected_mtime=st.st_mtime,
+            db_path=db_path,
+        )
+        return 'pending'
+
+    # Compute destination + atomic copy.
+    try:
+        dest_path = compute_dest_path(source_path, archive_root, teslacam_root)
+    except ValueError as e:
+        archive_queue.mark_failed(
+            row_id, f"compute_dest: {e!r}",
+            max_attempts=max_attempts, db_path=db_path,
+        )
+        return 'error'
+
+    try:
+        _atomic_copy(source_path, dest_path, chunk_size)
+    except FileNotFoundError:
+        # Tesla rotated the source between stat() and open() — normal,
+        # not retryable.
+        archive_queue.mark_source_gone(row_id, db_path=db_path)
+        return 'source_gone'
+    except (OSError, shutil.Error) as e:
+        new_status = archive_queue.mark_failed(
+            row_id, f"copy: {e!r}",
+            max_attempts=max_attempts, db_path=db_path,
+        )
+        if new_status == 'dead_letter':
+            row_for_sidecar = dict(row)
+            row_for_sidecar['dest_path'] = dest_path
+            row_for_sidecar['last_error'] = f"copy: {e!r}"
+            row_for_sidecar['attempts'] = int(
+                row.get('attempts') or 0,
+            ) + 1
+            _write_dead_letter_sidecar(archive_root, row_for_sidecar)
+        return new_status
+
+    # Success — mark copied AND enqueue into the indexer queue.
+    archive_queue.mark_copied(row_id, dest_path, db_path=db_path)
+    _enqueue_indexed(dest_path, db_path)
+    return 'copied'
+
+
+# ---------------------------------------------------------------------------
+# Worker thread loop
+# ---------------------------------------------------------------------------
+
+def _run_worker_loop(db_path: str, archive_root: str,
+                     teslacam_root: Optional[str],
+                     worker_id: str) -> None:
+    """The thread target. One file at a time, until stop is signaled."""
+    _apply_low_priority()
+    try:
+        released = archive_queue.recover_stale_claims(db_path=db_path)
+        if released:
+            logger.info(
+                "Archive worker %s released %d stale claims at startup",
+                worker_id, released,
+            )
+    except Exception as e:  # noqa: BLE001
+        logger.warning("recover_stale_claims failed at startup: %s", e)
+
+    chunk_size, max_attempts, idle_sleep = _read_config_or_defaults()
+
+    while not _stop_event.is_set():
+        # Honor pause requests at the iteration boundary.
+        if _pause_event.is_set():
+            _idle_event.set()
+            if _stop_event.wait(timeout=_INTER_FILE_SLEEP_SECONDS):
+                break
+            continue
+
+        # Acquire the task slot. The archive worker is a periodic
+        # priority task, so it BLOCK-waits for a slot. If the wait
+        # times out (indexer hogging the lock past 60 s — should be
+        # impossible given the indexer's yield_to_waiters=True mode,
+        # but defensively handled) we back off and try again next
+        # iteration. We must NOT bump the row's attempts counter for
+        # our own scheduling failure.
+        if not task_coordinator.acquire_task(
+                _COORDINATOR_TASK, wait_seconds=_COORDINATOR_WAIT_SECONDS):
+            if _stop_event.wait(timeout=_BACKOFF_SLEEP_SECONDS):
+                break
+            continue
+
+        row: Optional[Dict[str, Any]] = None
+        new_status: Optional[str] = None
+        claim_failed = False
+        try:
+            try:
+                row = archive_queue.claim_next_for_worker(
+                    worker_id, db_path=db_path,
+                )
+            except Exception as e:  # noqa: BLE001
+                logger.warning("claim_next_for_worker raised: %s", e)
+                _set_state(last_error=f'claim: {e!r}')
+                claim_failed = True
+                row = None
+
+            if row is None and not claim_failed:
+                _set_state(last_drained_at=time.time())
+
+            if row is not None:
+                # If pause arrived between claim and process, release
+                # the claim cleanly without burning an attempt.
+                if _pause_event.is_set():
+                    archive_queue.release_claim(
+                        int(row['id']), db_path=db_path,
+                    )
+                    new_status = 'pending'
+                else:
+                    _record_active(row['source_path'])
+                    try:
+                        new_status = process_one_claim(
+                            row, db_path, archive_root, teslacam_root,
+                            chunk_size=chunk_size,
+                            max_attempts=max_attempts,
+                        )
+                        if new_status == 'copied':
+                            with _state_lock:
+                                _state['files_done_session'] += 1
+                    except Exception as e:  # noqa: BLE001
+                        logger.exception(
+                            "Archive worker dispatch failed for %s; "
+                            "releasing claim", row.get('source_path'),
+                        )
+                        try:
+                            archive_queue.release_claim(
+                                int(row['id']), db_path=db_path,
+                            )
+                        except Exception:  # noqa: BLE001
+                            logger.exception(
+                                "release_claim also failed; "
+                                "stale-recovery will pick this up",
+                            )
+                        new_status = 'error'
+                        _set_state(last_error=f'dispatch: {e!r}')
+        finally:
+            task_coordinator.release_task(_COORDINATOR_TASK)
+            if new_status is not None:
+                _record_idle(last_outcome=new_status)
+            else:
+                _record_idle()
+
+        # All sleeps happen AFTER the lock is released. Wake events
+        # let producers shorten the idle wait without spinning.
+        if claim_failed:
+            _wait_with_wake(_BACKOFF_SLEEP_SECONDS)
+        elif row is None:
+            _wait_with_wake(idle_sleep)
+        else:
+            # Inter-file pause. Don't honor wake() here — we just
+            # finished work; we want the kernel to flush before the
+            # next read-heavy copy.
+            if _stop_event.wait(timeout=_INTER_FILE_SLEEP_SECONDS):
+                break
+
+
+def _wait_with_wake(seconds: float) -> None:
+    """Sleep up to ``seconds`` seconds; cut short on stop or wake.
+
+    Clears the wake event after consuming it so the next iteration
+    starts fresh. Called only when the lock is NOT held.
+    """
+    deadline = time.time() + seconds
+    remaining = seconds
+    while remaining > 0:
+        if _stop_event.wait(timeout=min(remaining, 1.0)):
+            return
+        if _wake_event.is_set():
+            _wake_event.clear()
+            return
+        remaining = deadline - time.time()

--- a/scripts/web/services/file_watcher_service.py
+++ b/scripts/web/services/file_watcher_service.py
@@ -246,8 +246,99 @@ def restart_watcher(watch_paths: List[str],
     return start_watcher(watch_paths)
 
 
+def _classify_paths(paths: List[str]):
+    """Split a batch into (archive_paths, indexing_paths, dropped_paths).
+
+    Phase 2b dispatch routing (issue #76):
+
+    * Files under the RO USB mount (``/mnt/gadget/part1-ro/...`` or
+      whatever ``MNT_DIR``/``-ro`` resolves to in the running app)
+      flow ONLY into the archive callbacks. The archive worker will
+      copy them to ArchivedClips and from there the archived paths
+      enter the indexing_queue. Routing the RO-mount path directly
+      into indexing_queue would re-introduce the indexer's old habit
+      of parsing files out from under Tesla's RecentClips circular
+      buffer.
+    * Files under ``ARCHIVE_DIR`` (typically ``~/ArchivedClips``)
+      flow ONLY into the indexing callbacks. Anything that lands
+      there has already been archived (by the worker, by a manual
+      scp, or by a future operator action) and needs to be indexed.
+    * Anything outside both prefixes is logged once and dropped —
+      the watcher should not be subscribed to such directories in
+      the first place; if it is, surfacing it via debug log makes
+      the misconfiguration easy to spot.
+
+    The classification is done at the dispatch layer (here) rather
+    than inside each subscriber so the rule is local and reviewable
+    in one spot. Subscribers stay simple (``def cb(paths): ...``)
+    and don't need to know about path topology.
+    """
+    archive_paths: List[str] = []
+    indexing_paths: List[str] = []
+    dropped: List[str] = []
+    ro_prefixes = _ro_mount_prefixes()
+    archive_prefix = _archive_dir_prefix()
+    for p in paths:
+        if not p:
+            continue
+        norm = os.path.normpath(p)
+        # Archive prefix wins if both happen to overlap (defensive —
+        # they shouldn't in any real config).
+        if archive_prefix and (
+            norm == archive_prefix or norm.startswith(archive_prefix + os.sep)
+        ):
+            indexing_paths.append(p)
+            continue
+        if any(
+            norm == pre or norm.startswith(pre + os.sep)
+            for pre in ro_prefixes
+        ):
+            archive_paths.append(p)
+            continue
+        dropped.append(p)
+    return archive_paths, indexing_paths, dropped
+
+
+def _ro_mount_prefixes() -> List[str]:
+    """Return absolute, normalized prefixes for the RO USB mount(s).
+
+    Looked up at call time so a config reload (or tests that set
+    ``MNT_DIR``) takes effect without an import-time cache. Falls back
+    to the canonical path if config can't be imported.
+    """
+    candidates: List[str] = []
+    try:
+        from config import MNT_DIR
+        # Both the historical layout (``<MNT_DIR>/part1-ro``) and the
+        # newer convention (``<MNT_DIR>/part1`` — same path in present
+        # mode where part1 is read-only) are accepted.
+        candidates.append(os.path.normpath(os.path.join(MNT_DIR, 'part1-ro')))
+        candidates.append(os.path.normpath(os.path.join(MNT_DIR, 'part1')))
+    except Exception:  # noqa: BLE001
+        candidates.append(os.path.normpath('/mnt/gadget/part1-ro'))
+        candidates.append(os.path.normpath('/mnt/gadget/part1'))
+    return candidates
+
+
+def _archive_dir_prefix() -> Optional[str]:
+    """Return the absolute, normalized ARCHIVE_DIR prefix, or None."""
+    try:
+        from config import ARCHIVE_DIR
+        return os.path.normpath(ARCHIVE_DIR) if ARCHIVE_DIR else None
+    except Exception:  # noqa: BLE001
+        return None
+
+
 def _notify_callbacks(new_files: List[str], my_generation: int):
-    """Notify all registered new-file callbacks if our generation is current."""
+    """Notify registered callbacks, classifying paths by source.
+
+    Phase 2b routing rule (issue #76, see :func:`_classify_paths`):
+    a path under the RO USB mount fires ONLY the archive callbacks;
+    a path under ``ARCHIVE_DIR`` fires ONLY the indexing callbacks.
+    The two lists are now mutually exclusive — a single mp4 never
+    enters both queues directly. The archive worker bridges the two
+    by enqueuing copied paths into the indexing_queue itself.
+    """
     if not new_files:
         return
     if my_generation != _watcher_generation:
@@ -256,22 +347,26 @@ def _notify_callbacks(new_files: List[str], my_generation: int):
         logger.debug("Dropping %d new-file callbacks (stale generation)",
                      len(new_files))
         return
-    _status["files_detected"] += len(new_files)
-    for cb in _on_new_file_callbacks:
-        try:
-            cb(new_files)
-        except Exception as e:
-            logger.error("Watcher new-file callback error: %s", e)
-    # Phase 2a archive_queue producers (issue #76): fire the archive
-    # callbacks with the same paths the indexer just got. The same
-    # generation guard above already protected the batch from a racing
-    # stop, so we skip a second check. Each archive callback handles
-    # its own errors so one bad subscriber can't starve the other.
-    for cb in _on_archive_callbacks:
-        try:
-            cb(new_files)
-        except Exception as e:
-            logger.error("Watcher archive callback error: %s", e)
+
+    archive_paths, indexing_paths, dropped = _classify_paths(new_files)
+    if dropped:
+        logger.debug(
+            "Watcher: %d files dropped — outside RO mount and ArchivedClips: %s",
+            len(dropped), dropped[:3],
+        )
+    _status["files_detected"] += len(archive_paths) + len(indexing_paths)
+    if indexing_paths:
+        for cb in _on_new_file_callbacks:
+            try:
+                cb(indexing_paths)
+            except Exception as e:
+                logger.error("Watcher new-file callback error: %s", e)
+    if archive_paths:
+        for cb in _on_archive_callbacks:
+            try:
+                cb(archive_paths)
+            except Exception as e:
+                logger.error("Watcher archive callback error: %s", e)
 
 
 def _notify_delete_callbacks(deleted_files: List[str], my_generation: int):

--- a/scripts/web/services/mapping_service.py
+++ b/scripts/web/services/mapping_service.py
@@ -1962,6 +1962,15 @@ def _find_front_camera_videos(teslacam_path: str) -> Generator[str, None, None]:
       2. SavedClips and SentryClips event subfolders — user-marked clips.
       3. RecentClips — the rolling buffer. Most files written while parked
          (sentry mode) contain no GPS at all, so we process these last.
+
+    .. note::
+
+        After issue #76 Phase 2b the **indexer** no longer walks the RO
+        USB mount: ``boot_catchup_scan`` uses
+        :func:`_find_archived_videos` (ArchivedClips-only). This helper
+        is kept intact for the diagnostics endpoint
+        (``mapping_diagnostics_test``) and for any third-party caller
+        that wants the legacy "everything we can see" view.
     """
     seen_basenames: set = set()
 
@@ -2006,6 +2015,71 @@ def _find_front_camera_videos(teslacam_path: str) -> Generator[str, None, None]:
                     yield os.path.join(folder_path, f)
         except OSError:
             pass
+
+
+def _find_archived_videos() -> Generator[str, None, None]:
+    """Yield front-camera MP4s under ``ARCHIVE_DIR`` (and event subfolders).
+
+    The Phase 2b indexer-side catch-up scanner. Walks ONLY the SD-card
+    ``ArchivedClips`` tree — never the RO USB mount. The
+    ``archive_producer`` thread (issue #76 Phase 2a) handles USB-side
+    catch-up by enqueueing into ``archive_queue``; the
+    ``archive_worker`` then copies them into ArchivedClips, where this
+    helper picks them up if the indexer happened to be down at the
+    moment of the worker's enqueue.
+
+    Yields the same flat-files-then-event-subfolders order as
+    :func:`_find_front_camera_videos`'s ArchivedClips section, plus
+    any nested SavedClips/SentryClips that an operator may have
+    rsync'd into the archive directory directly.
+    """
+    try:
+        from config import ARCHIVE_DIR, ARCHIVE_ENABLED
+    except ImportError:
+        return
+    if not ARCHIVE_ENABLED or not ARCHIVE_DIR or not os.path.isdir(ARCHIVE_DIR):
+        return
+
+    # Top-level mp4s (legacy archive layout — flat directory).
+    try:
+        for f in sorted(os.listdir(ARCHIVE_DIR)):
+            full = os.path.join(ARCHIVE_DIR, f)
+            if (
+                os.path.isfile(full)
+                and f.lower().endswith('.mp4')
+                and '-front' in f.lower()
+            ):
+                yield full
+    except OSError:
+        return
+
+    # Sub-trees for archived event clips (RecentClips/SavedClips/SentryClips
+    # mirrored under ArchivedClips by the worker's compute_dest_path).
+    for sub in ('RecentClips', 'SavedClips', 'SentryClips'):
+        sub_path = os.path.join(ARCHIVE_DIR, sub)
+        if not os.path.isdir(sub_path):
+            continue
+        try:
+            for entry in sorted(os.listdir(sub_path)):
+                entry_path = os.path.join(sub_path, entry)
+                if os.path.isfile(entry_path):
+                    if (
+                        entry.lower().endswith('.mp4')
+                        and '-front' in entry.lower()
+                    ):
+                        yield entry_path
+                    continue
+                if not os.path.isdir(entry_path):
+                    continue
+                # Event subfolder — yield its front-camera mp4s.
+                try:
+                    for f in sorted(os.listdir(entry_path)):
+                        if f.lower().endswith('.mp4') and '-front' in f.lower():
+                            yield os.path.join(entry_path, f)
+                except OSError:
+                    continue
+        except OSError:
+            continue
 
 
 def _read_event_json(rel_path: str, teslacam_root: str) -> Optional[dict]:
@@ -2817,24 +2891,29 @@ def purge_deleted_videos(db_path: str, teslacam_path: Optional[str] = None,
     }
 
 
-def boot_catchup_scan(db_path: str, teslacam_path: str,
+def boot_catchup_scan(db_path: str, teslacam_path: str = '',
                       *, source: str = 'catchup') -> Dict[str, int]:
     """Diff filesystem vs ``indexed_files`` and enqueue any orphans.
 
-    Replaces the legacy "auto-index on startup" full re-scan. Cheap by
-    design: one ``os.listdir`` walk via :func:`_find_front_camera_videos`
-    + one bulk SELECT of every indexed canonical_key + an in-memory diff
-    + one batch INSERT into ``indexing_queue``. No video parsing happens
-    here — that's the worker's job.
+    **Phase 2b (issue #76)**: This now walks ONLY ``ARCHIVE_DIR``
+    (``~/ArchivedClips``). The ``archive_producer`` thread handles
+    USB-side catch-up by enqueueing into ``archive_queue``; the
+    ``archive_worker`` then copies clips into ArchivedClips, where
+    this scan picks them up if the indexer happened to be down at the
+    moment of the worker's enqueue (e.g. a manual scp landed a clip
+    while ``gadget_web`` was restarting).
+
+    The ``teslacam_path`` parameter is accepted for backward
+    compatibility but is **ignored** — there is intentionally no path
+    from this function to the RO USB mount any more.
 
     Returns ``{scanned, already_indexed, enqueued}``. The
     ``active_file`` banner stays off during this call (no parsing); the
     banner only lights up when the worker actually picks up an orphan.
     """
+    # ``teslacam_path`` is intentionally ignored — see docstring.
+    del teslacam_path
     result = {'scanned': 0, 'already_indexed': 0, 'enqueued': 0}
-    if not teslacam_path or not os.path.isdir(teslacam_path):
-        logger.debug("boot_catchup_scan: TeslaCam path not accessible")
-        return result
 
     # Build the set of canonical_keys already represented in
     # indexed_files. We diff against canonical keys (not raw paths) so a
@@ -2865,7 +2944,7 @@ def boot_catchup_scan(db_path: str, teslacam_path: str,
     indexed_keys.discard('')
 
     to_enqueue: List[Tuple[str, Optional[int]]] = []
-    for fpath in _find_front_camera_videos(teslacam_path):
+    for fpath in _find_archived_videos():
         result['scanned'] += 1
         key = canonical_key(fpath)
         if not key:

--- a/scripts/web/services/video_archive_service.py
+++ b/scripts/web/services/video_archive_service.py
@@ -13,11 +13,10 @@ monitoring between files.
 import logging
 import os
 import shutil
-import subprocess
 import threading
 import time
 from datetime import datetime, timezone, timedelta
-from typing import Dict, Generator, List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -28,7 +27,6 @@ logger = logging.getLogger(__name__)
 from config import (
     ARCHIVE_DIR,
     ARCHIVE_ENABLED,
-    ARCHIVE_INTERVAL_MINUTES,
     ARCHIVE_RETENTION_DAYS,
     ARCHIVE_MIN_FREE_SPACE_GB,
     ARCHIVE_MAX_SIZE_GB,
@@ -79,19 +77,13 @@ _PRUNE_GRACE_SECONDS = 6 * 3600  # 6 hours
 # ---------------------------------------------------------------------------
 # Background Thread State
 # ---------------------------------------------------------------------------
-
-_archive_thread: Optional[threading.Thread] = None
-_archive_lock = threading.Lock()
+#
+# Phase 2b (issue #76): the legacy ``_archive_thread`` periodic timer
+# is gone — the archive flow now runs entirely inside
+# ``services.archive_worker``. ``_archive_cancel`` is kept so
+# ``stop_archive_timer`` and any retention helper that still consults
+# it (defensive abort flag) keep working unchanged.
 _archive_cancel = threading.Event()
-# Set as soon as an archive is triggered (manual or timer) and BEFORE
-# we try to acquire the task_coordinator lock. Cleared only when the
-# archive finishes (or its acquire times out). This prevents a second
-# archive thread from being spawned while the first is still waiting
-# inside ``acquire_task('archive', wait_seconds=60.0)`` — which is a
-# new race introduced by switching from a non-blocking acquire to a
-# blocking one. ``_status['running']`` is not enough because it is
-# set only AFTER the lock is acquired.
-_archive_pending = False
 
 _status: Dict = {
     "running": False,
@@ -124,501 +116,84 @@ def get_archive_dir() -> str:
 
 
 def start_archive_timer() -> None:
-    """Start the periodic background archive thread.
+    """Phase 2b (issue #76): Legacy timer is gone — start the worker instead.
 
-    Safe to call multiple times — only one timer runs at a time.
+    Pre-Phase-2b this spun up ``_archive_timer_loop`` which woke every
+    ``ARCHIVE_INTERVAL_MINUTES`` and walked the RO RecentClips folder.
+    The Phase 2b architecture is queue-driven: the
+    ``archive_producer`` thread (started by ``web_control.startup``)
+    enqueues into ``archive_queue`` from inotify + a 60-second rescan,
+    and the ``archive_worker`` thread drains the queue one file at a
+    time with stable-write gating, atomic copy, and dead-letter
+    handling.
+
+    This shim stays callable so existing call sites in
+    ``web_control.startup`` keep working without a flag dance, but
+    delegates to :func:`services.archive_worker.ensure_worker_started`.
+    The retention/cleanup cascade that used to run after each timer
+    tick is now driven by the periodic ``smart_cleanup_archive`` call
+    that runs from elsewhere (and from the manual cleanup endpoint);
+    see :func:`trigger_archive_cleanup`.
     """
     if not ARCHIVE_ENABLED:
         logger.info("RecentClips archive is disabled in config")
         return
-
-    global _archive_thread
-    with _archive_lock:
-        if _archive_thread and _archive_thread.is_alive():
-            return
-        _archive_cancel.clear()
-        _archive_thread = threading.Thread(
-            target=_archive_timer_loop,
-            name="archive-timer",
-            daemon=True,
-        )
-        _archive_thread.start()
-        logger.info("RecentClips archive timer started (every %d min)",
-                     ARCHIVE_INTERVAL_MINUTES)
+    try:
+        from services import archive_worker
+        archive_worker.ensure_worker_started()
+    except Exception as e:  # noqa: BLE001 — never let startup raise here
+        logger.warning("archive_worker.ensure_worker_started failed: %s", e)
 
 
 def stop_archive_timer() -> None:
-    """Stop the background archive timer."""
+    """Phase 2b: stop the new archive worker (no legacy timer to cancel)."""
     _archive_cancel.set()
+    try:
+        from services import archive_worker
+        archive_worker.stop_worker()
+    except Exception as e:  # noqa: BLE001
+        logger.debug("archive_worker.stop_worker raised: %s", e)
 
 
 def trigger_archive_now() -> bool:
-    """Trigger a one-shot archive run (non-blocking).
+    """Wake the Phase 2b archive worker (was: spawn a one-shot timer thread).
 
-    Returns True if an archive was started, False if one is already
-    running, pending (waiting for the task_coordinator lock), or if
-    archiving is disabled.
+    Returns True if a wake was issued (ARCHIVE_ENABLED and the worker
+    accepted the call), False if archiving is disabled or the worker
+    couldn't be started. The actual draining happens asynchronously in
+    the worker thread.
+
+    Compatibility shim: callers (notably the NM dispatcher's
+    ``/api/recent_archive/trigger`` endpoint and the legacy duplicate-
+    guard tests) get a True/False return that tracks "did we kick the
+    worker?" rather than the old "did we start a thread?" — which is
+    semantically equivalent for every external caller.
     """
-    global _archive_pending
     if not ARCHIVE_ENABLED:
         return False
-    # Atomically claim the "pending" slot to prevent two threads from
-    # racing the same trigger window. The thread that wins clears the
-    # slot inside ``_run_archive``.
-    with _archive_lock:
-        if _archive_pending or _status.get("running"):
-            return False
-        _archive_pending = True
-
-    t = threading.Thread(
-        target=_run_archive,
-        name="archive-oneshot",
-        daemon=True,
-    )
-    t.start()
-    return True
-
-
-# ---------------------------------------------------------------------------
-# Timer Loop
-# ---------------------------------------------------------------------------
-
-
-def _archive_timer_loop() -> None:
-    """Periodically run archive + retention."""
-    interval = ARCHIVE_INTERVAL_MINUTES * 60
-
-    # Set lowest I/O priority so archive doesn't starve the USB gadget.
-    # The gadget shares the same SD card I/O bus.
-    #
-    # Critical: ionice MUST target this archive thread's kernel TID
-    # (via ``threading.get_native_id()``), NOT ``os.getpid()``. On
-    # Linux, ``ioprio_set`` is per-task, and passing the process PID
-    # only adjusts the main thread's I/O class — leaving the archive
-    # worker thread at default best-effort priority and fully able to
-    # starve Flask/gadget I/O. This was the second half of issue #72
-    # (the first was os.nice() in the indexer being process-wide).
     try:
-        tid = threading.get_native_id()
-        subprocess.run(
-            ["ionice", "-c", "3", "-p", str(tid)],
-            timeout=5, capture_output=True, check=False,
-        )
-        logger.info(
-            "Archive thread set to idle I/O priority "
-            "(ionice -c 3 -p %d)", tid,
-        )
-    except (FileNotFoundError, subprocess.TimeoutExpired,
-            OSError, AttributeError):
-        pass  # ionice not available — rate limiting still protects us
-
-    # Initial delay — let boot finish and other services settle
-    for _ in range(120):  # 2 minutes
-        if _archive_cancel.is_set():
-            return
-        time.sleep(1)
-
-    while not _archive_cancel.is_set():
-        try:
-            _run_archive()
-        except Exception:
-            logger.exception("Archive run failed unexpectedly")
-
-        # Run smart cleanup after each archive cycle
-        try:
-            smart_cleanup_archive(ARCHIVE_DIR, ARCHIVE_MIN_FREE_SPACE_GB, ARCHIVE_MAX_SIZE_GB)
-        except Exception:
-            logger.exception("Smart archive cleanup failed")
-
-        # Sleep in 1-second ticks so cancel is responsive
-        for _ in range(interval):
-            if _archive_cancel.is_set():
-                return
-            time.sleep(1)
+        from services import archive_worker
+        # Lazy-start the worker if it isn't running yet.
+        archive_worker.ensure_worker_started()
+        archive_worker.wake()
+        return True
+    except Exception as e:  # noqa: BLE001
+        logger.warning("trigger_archive_now: failed to wake worker: %s", e)
+        return False
 
 
 # ---------------------------------------------------------------------------
-# Core Archive Logic
+# Phase 2b (issue #76): the legacy ``_archive_timer_loop`` /
+# ``_run_archive`` / ``_do_archive_work`` / ``_discover_new_files``
+# code paths have been removed in favor of the queue-driven
+# ``archive_producer`` + ``archive_worker`` pair.
+#
+# The retention/cleanup helpers below (``_purge_corrupt_archives``,
+# ``_prune_non_driving_archives``, ``_enforce_retention``,
+# ``smart_cleanup_archive``, ``trigger_archive_cleanup``) remain
+# callable from the API/cleanup endpoints — they don't depend on the
+# old timer loop and operate purely on ``ARCHIVE_DIR``.
 # ---------------------------------------------------------------------------
-
-
-def _run_archive() -> None:
-    """One complete archive run: discover → copy → retention."""
-    global _status, _archive_pending
-
-    # Two callers reach this function: ``trigger_archive_now`` (which
-    # atomically sets ``_archive_pending`` first) and the timer loop
-    # (which calls us directly). For the timer path we still need
-    # mutual exclusion with manual triggers; mark pending if free, or
-    # bail out if another invocation is already in flight. ``_archive_pending``
-    # stays set until this function returns so that no second invocation
-    # can race in between releasing pending and setting ``_status['running']``.
-    with _archive_lock:
-        if _archive_pending or _status.get("running"):
-            owns_pending = False
-        else:
-            _archive_pending = True
-            owns_pending = True
-    if not owns_pending:
-        return
-
-    try:
-        # Acquire the global heavy-task lock — don't run alongside
-        # indexer or sync. Wait up to 60s if the lock is busy. The
-        # indexer's typical lock-hold is ~1 s with ~0.25 s gaps; with
-        # the fairness short-circuit (the indexer passes
-        # ``yield_to_waiters=True``) we'll usually win on the first
-        # poll. The wait-with-timeout is critical: returning False
-        # immediately caused archive starvation in production, with
-        # TeslaCam clips lost when Tesla rotated RecentClips before
-        # the next archive cycle could win the lock. See
-        # task_coordinator docstring for the fairness model.
-        from services.task_coordinator import acquire_task, release_task
-        if not acquire_task('archive', wait_seconds=60.0):
-            logger.warning(
-                "Archive skipped: another task held the lock for 60s — "
-                "this may indicate indexer overload"
-            )
-            return
-        try:
-            _do_archive_work()
-        finally:
-            release_task('archive')
-    finally:
-        with _archive_lock:
-            _archive_pending = False
-
-
-def _do_archive_work() -> None:
-    """Inner archive routine — runs while holding the coordinator lock.
-
-    Split out from ``_run_archive`` so that the lock-acquisition and
-    pending-flag bookkeeping above stays linear and easy to audit.
-    """
-    global _status
-
-    _status.update({
-        "running": True,
-        "progress": "Starting...",
-        "files_total": 0,
-        "files_done": 0,
-        "bytes_copied": 0,
-        "current_file": "",
-        "started_at": datetime.now(timezone.utc).isoformat(),
-        "error": None,
-    })
-
-    try:
-        # Find the RecentClips source path
-        teslacam = _get_teslacam_ro_path()
-        if not teslacam:
-            _status.update({"running": False, "progress": "No TeslaCam path"})
-            return
-
-        recent_clips = os.path.join(teslacam, "RecentClips")
-        if not os.path.isdir(recent_clips):
-            _status.update({"running": False, "progress": "No RecentClips folder"})
-            return
-
-        # Ensure archive directory exists
-        os.makedirs(ARCHIVE_DIR, exist_ok=True)
-
-        # Clean up stale .tmp files from interrupted copies
-        try:
-            for name in os.listdir(ARCHIVE_DIR):
-                if name.endswith('.tmp'):
-                    os.unlink(os.path.join(ARCHIVE_DIR, name))
-        except OSError:
-            pass
-
-        # Remove any corrupt archived files (incomplete MP4s from prior runs)
-        _status["progress"] = "Checking existing archives..."
-        _purge_corrupt_archives()
-
-        # Discover files to copy
-        # Force vfat to re-read directories — the gadget side may have
-        # written new clips without invalidating our local RO mount's
-        # dentry/inode slab cache. ``echo 2`` drops slabs only (NOT the
-        # page cache that backs the gadget's reads of usb_cam.img), so
-        # this is safe to run concurrently with Tesla recording. Cheap
-        # (~100 ms) and bounded. Run once per archive cycle, not per
-        # file. See issue #71. Requires the matching sudoers entry in
-        # setup_usb.sh; if that entry is missing on an old install the
-        # try/except swallows the failure and the scan still works
-        # against whatever the cache currently holds (no regression).
-        try:
-            subprocess.run(
-                ['sudo', 'sh', '-c', 'echo 2 > /proc/sys/vm/drop_caches'],
-                capture_output=True, check=False, timeout=5,
-            )
-        except Exception as exc:  # pragma: no cover — best-effort, log-only
-            logger.debug("vfat slab cache flush failed (best-effort): %s", exc)
-
-        _status["progress"] = "Scanning RecentClips..."
-        to_copy = list(_discover_new_files(recent_clips))
-
-        if not to_copy:
-            _status.update({
-                "running": False,
-                "progress": "Up to date",
-                "last_run": datetime.now(timezone.utc).isoformat(),
-                "last_run_files": 0,
-            })
-            _update_archive_size()
-            return
-
-        _status["files_total"] = len(to_copy)
-        _status["progress"] = f"Copying {len(to_copy)} files..."
-        logger.info("Archive: %d new files to copy from RecentClips", len(to_copy))
-
-        # Proactive retention: free space early (at 2× the floor) so we
-        # never hit the hard limit mid-copy.  Deletes least-valuable
-        # files first when possible.
-        _proactive_retention()
-
-        # If still at the hard floor after proactive cleanup, try the
-        # full retention cascade before giving up.
-        if not _check_disk_space():
-            _status["progress"] = "Retention cleanup (making room)..."
-            _enforce_retention()
-
-        copied = 0
-        for idx, (src_path, rel_path) in enumerate(to_copy):
-            if _archive_cancel.is_set():
-                _status["progress"] = "Cancelled"
-                break
-
-            # Per-cycle cap — yield CPU/IO back to the web server and
-            # gadget so the system stays responsive between cycles.
-            if copied >= _MAX_FILES_PER_CYCLE:
-                logger.info("Archive: pausing at %d files (cycle cap), %d remaining",
-                            copied, len(to_copy) - idx)
-                _status["progress"] = f"Paused at {copied} files (continuing next cycle)"
-                break
-
-            # Memory pressure check
-            if not _check_memory():
-                logger.warning("Archive paused: low memory")
-                _status["progress"] = "Paused (low memory)"
-                break
-
-            # Disk space check — if full, try retention again mid-loop
-            if not _check_disk_space():
-                _enforce_retention()
-                if not _check_disk_space():
-                    logger.info("Archive stopped: disk space limits reached")
-                    _status["progress"] = "Stopped (disk space)"
-                    break
-
-            _status.update({
-                "files_done": idx,
-                "current_file": rel_path,
-            })
-
-            try:
-                dst_path = os.path.join(ARCHIVE_DIR, rel_path)
-                os.makedirs(os.path.dirname(dst_path), exist_ok=True)
-
-                _buffered_copy(src_path, dst_path)
-                # Preserve original modification time
-                src_stat = os.stat(src_path)
-                os.utime(dst_path, (src_stat.st_atime, src_stat.st_mtime))
-
-                # Post-copy validation: verify the copy is a complete MP4
-                if dst_path.lower().endswith('.mp4') and not _is_complete_mp4(dst_path):
-                    logger.warning("Archived file incomplete (no moov), removing: %s", rel_path)
-                    try:
-                        os.unlink(dst_path)
-                    except OSError:
-                        pass
-                    continue
-
-                copied += 1
-                _status["bytes_copied"] += src_stat.st_size
-
-                # Update geodata DB to point at the archived copy.
-                # This avoids expensive re-indexing — the GPS data is
-                # already extracted, we just change the file path.
-                _update_geodata_paths(src_path, dst_path, rel_path)
-
-                # Index the archived copy immediately (reads from SD card,
-                # no USB gadget contention). Non-fatal — and even if this
-                # crashes, the safety-net enqueue below means the worker
-                # will pick it up after 120s.
-                try:
-                    from config import MAPPING_ENABLED, MAPPING_DB_PATH, MAPPING_SAMPLE_RATE
-                    if MAPPING_ENABLED:
-                        from services.video_service import get_teslacam_path
-                        from services.mapping_service import (
-                            enqueue_for_indexing,
-                            index_single_file,
-                        )
-                        tc = get_teslacam_path()
-                        if tc:
-                            # Safety net: enqueue with 120s deferral baked
-                            # into the INSERT. If the inline call below
-                            # succeeds, the worker will see ALREADY_INDEXED
-                            # and clear the row cheaply when 120s elapses.
-                            # If the archive job crashes between the copy
-                            # and the inline call, the worker still picks
-                            # up the file after the deferral — no waiting
-                            # until next boot. Atomic with the insert so
-                            # there's no race against a worker that might
-                            # claim the row before we can defer it.
-                            try:
-                                enqueue_for_indexing(
-                                    MAPPING_DB_PATH, dst_path,
-                                    source='archive',
-                                    next_attempt_at=time.time() + 120,
-                                )
-                            except Exception as e:
-                                logger.debug(
-                                    "Safety-net enqueue skipped: %s", e,
-                                )
-                            index_result = index_single_file(
-                                dst_path, MAPPING_DB_PATH, tc,
-                                sample_rate=MAPPING_SAMPLE_RATE,
-                            )
-                            if index_result.waypoints > 0 or index_result.events > 0:
-                                logger.info(
-                                    "Indexed during archive: %s — %d waypoints, %d events",
-                                    rel_path,
-                                    index_result.waypoints,
-                                    index_result.events,
-                                )
-                except ImportError:
-                    pass  # Protobuf missing — worker will pick it up
-                except Exception as e:
-                    logger.debug("Archive post-index skipped for %s: %s", rel_path, e)
-
-            except OSError as e:
-                logger.warning("Failed to copy %s: %s", rel_path, e)
-                continue
-
-            time.sleep(_INTER_FILE_SLEEP)
-
-        _status.update({
-            "files_done": copied,
-            "last_run": datetime.now(timezone.utc).isoformat(),
-            "last_run_files": copied,
-        })
-        logger.info("Archive: copied %d files", copied)
-
-        # Prune clips the indexer has positively identified as non-driving
-        # FIRST, so retention afterwards has fewer "unknown" clips to
-        # potentially evict under disk pressure. The prune is conservative
-        # (positive evidence only), so this is always safe.
-        _status["progress"] = "Pruning non-driving clips..."
-        _prune_non_driving_archives()
-
-        # Run retention cleanup. By running after prune, retention's
-        # oldest-first deletion is less likely to evict still-unprocessed
-        # driving clips: the obvious sentry/parked footage is already gone.
-        _status["progress"] = "Retention cleanup..."
-        _enforce_retention()
-
-        _update_archive_size()
-        _status["progress"] = f"Done — {copied} files archived"
-
-        # Tesla likely just rotated some RecentClips out — give the
-        # mapping stale-scan a nudge so any orphaned indexed_files
-        # rows get cleaned up before the user opens the map page.
-        # The trigger is debounced (10 min) so this is safe to call
-        # every cycle. Issue #75.
-        try:
-            from config import MAPPING_ENABLED, MAPPING_DB_PATH
-            if MAPPING_ENABLED and os.path.isfile(MAPPING_DB_PATH):
-                # Lazy import: services.mapping_service has its own service-layer
-                # imports that touch this module, so a top-level import would
-                # create a circular dependency. Python caches the module after
-                # the first call, so this is effectively free per archive cycle.
-                from services.video_service import get_teslacam_path
-                from services.mapping_service import (
-                    trigger_stale_scan_now,
-                )
-                trigger_stale_scan_now(
-                    MAPPING_DB_PATH,
-                    get_teslacam_path,
-                    source='archive',
-                )
-        except Exception as e:  # noqa: BLE001
-            logger.debug("Post-archive stale-scan trigger skipped: %s", e)
-
-    except Exception as e:
-        logger.exception("Archive run error")
-        _status["error"] = str(e)
-        _status["progress"] = f"Error: {e}"
-    finally:
-        _status["running"] = False
-        # ``release_task('archive')`` is handled by ``_run_archive``'s
-        # outer try/finally so the lock is released even if
-        # ``_do_archive_work`` raises before reaching its own finally.
-
-
-# ---------------------------------------------------------------------------
-# File Discovery
-# ---------------------------------------------------------------------------
-
-
-def _discover_new_files(recent_clips: str) -> Generator[Tuple[str, str], None, None]:
-    """Yield (src_abs_path, relative_path) for files not yet archived.
-
-    Skips files younger than _MIN_FILE_AGE_SECONDS (may be actively written).
-    Always archives fresh RecentClips regardless of whether they fall in a
-    known driving trip — at archive time we don't yet know whether a clip
-    is part of a drive (the indexer creates trips AFTER seeing several
-    sequential GPS-bearing clips). The driving-vs-parked filter is applied
-    later by ``_prune_non_driving_archives`` after the indexer has had a
-    chance to populate trip data. This breaks the chicken-and-egg cycle
-    where new drives were being skipped because no trip existed yet, then
-    Tesla's circular buffer overwrote the source clips before we could
-    process them.
-
-    Uses generators to avoid building large in-memory lists.
-    """
-    now = time.time()
-
-    try:
-        entries = sorted(os.listdir(recent_clips))
-    except OSError:
-        return
-
-    for name in entries:
-        src = os.path.join(recent_clips, name)
-        try:
-            stat = os.stat(src)
-        except OSError:
-            continue
-
-        # Skip directories, non-video files
-        if not os.path.isfile(src):
-            continue
-        if not name.lower().endswith(('.mp4', '.avi', '.mov', '.mkv')):
-            continue
-
-        # Skip actively-written files
-        if (now - stat.st_mtime) < _MIN_FILE_AGE_SECONDS:
-            continue
-
-        # Skip zero-byte files
-        if stat.st_size == 0:
-            continue
-
-        # Skip incomplete MP4s (Tesla still writing — moov box not yet finalized)
-        if name.lower().endswith('.mp4') and not _is_complete_mp4(src):
-            continue
-
-        # Check if already archived (same name and size)
-        dst = os.path.join(ARCHIVE_DIR, name)
-        if os.path.isfile(dst):
-            try:
-                dst_stat = os.stat(dst)
-                if dst_stat.st_size == stat.st_size:
-                    continue  # Already archived
-            except OSError:
-                pass
-
-        yield (src, name)
 
 
 def _get_driving_time_ranges() -> Optional[List[Tuple[float, float]]]:

--- a/scripts/web/web_control.py
+++ b/scripts/web/web_control.py
@@ -119,12 +119,12 @@ if __name__ == "__main__":
     print(f"Gadget directory: {GADGET_DIR}")
     print(f"Access the interface at: http://0.0.0.0:{WEB_PORT}/")
 
-    # Start RecentClips archive timer (copies clips to SD card before Tesla deletes them)
-    try:
-        from services.video_archive_service import start_archive_timer
-        start_archive_timer()
-    except Exception as e:
-        print(f"Warning: Failed to start archive timer: {e}")
+    # Phase 2b (issue #76): the legacy ``start_archive_timer`` periodic
+    # thread is gone. The new flow is queue-driven: ``archive_producer``
+    # enqueues into ``archive_queue``, and ``archive_worker`` drains
+    # the queue one file at a time. Both are started below, after the
+    # file watcher is wired so the worker's `wake()` from the producer
+    # callback path lands cleanly.
 
     # Start file watcher for new video detection. The callback enqueues
     # individual paths into the indexing_queue table; the indexing
@@ -283,9 +283,8 @@ if __name__ == "__main__":
     # Archive queue producer thread (issue #76 Phase 2a). Mirrors the
     # indexing worker's lifecycle: starts after the watcher is
     # registered so the boot catch-up scan and the every-60-s rescan
-    # observe the same TeslaCam root. Producer-only — no consumer
-    # exists yet (Phase 2b adds the worker). Failure here must never
-    # take down gadget_web.
+    # observe the same TeslaCam root. Failure here must never take
+    # down gadget_web.
     try:
         from config import (
             ARCHIVE_QUEUE_ENABLED,
@@ -311,6 +310,32 @@ if __name__ == "__main__":
                 print("Archive queue producer started (Phase 2a)")
     except Exception as e:
         print(f"Warning: Failed to start archive queue producer: {e}")
+
+    # Archive queue worker thread (issue #76 Phase 2b). Drains
+    # ``archive_queue`` one file at a time, copying USB-side clips
+    # into ``ARCHIVE_DIR`` and enqueueing them into the indexer queue.
+    # The producer above is the only thing that puts rows into the
+    # queue; this worker is the only thing that takes them out. The
+    # legacy ``video_archive_service`` periodic timer has been removed
+    # in favor of this pair.
+    try:
+        from config import (
+            ARCHIVE_QUEUE_ENABLED,
+            ARCHIVE_DIR,
+            MAPPING_DB_PATH as _ARCHIVE_WORKER_DB,
+        )
+        if ARCHIVE_QUEUE_ENABLED:
+            from services.video_service import get_teslacam_path
+            from services import archive_worker
+            tc = get_teslacam_path()
+            archive_worker.start_worker(
+                _ARCHIVE_WORKER_DB,
+                ARCHIVE_DIR,
+                teslacam_root=tc,
+            )
+            print("Archive queue worker started (Phase 2b)")
+    except Exception as e:
+        print(f"Warning: Failed to start archive queue worker: {e}")
 
     # Live Event Sync worker: starts BEFORE cloud_archive auto-trigger so
     # any persistent LES queue (from a prior reboot/WiFi outage) gets

--- a/tests/test_archive_queue.py
+++ b/tests/test_archive_queue.py
@@ -425,3 +425,245 @@ class TestDefaultDbPath:
         assert enqueue_for_archive(str(f)) is True
         # Status query also resolves the same way
         assert get_queue_status()['pending'] == 1
+
+
+# ---------------------------------------------------------------------------
+# Worker-side helpers (Phase 2b — issue #76)
+# ---------------------------------------------------------------------------
+#
+# These cover the state-transition helpers consumed by ``archive_worker``:
+# claim_next_for_worker, mark_copied, mark_source_gone, release_claim,
+# mark_failed, recover_stale_claims. The worker's own loop is exercised
+# in ``test_archive_worker.py``; here we pin the SQL semantics in
+# isolation so a regression in the queue layer surfaces immediately.
+
+from services.archive_queue import (  # noqa: E402
+    claim_next_for_worker,
+    mark_copied,
+    mark_failed,
+    mark_source_gone,
+    recover_stale_claims,
+    release_claim,
+)
+
+
+class TestClaimNextForWorker:
+    def test_returns_none_on_empty_queue(self, db):
+        assert claim_next_for_worker('w1', db_path=db) is None
+
+    def test_claims_single_pending_row(self, db, sample_file):
+        enqueue_for_archive(sample_file, db_path=db)
+        row = claim_next_for_worker('w1', db_path=db)
+        assert row is not None
+        assert row['source_path'] == sample_file
+        assert row['status'] == 'claimed'
+        assert row['claimed_by'] == 'w1'
+        assert row['claimed_at'] is not None
+
+    def test_picks_priority_one_first(self, db, tmp_path):
+        # Mix of priorities: P3 enqueued first, then P2, then P1.
+        # Worker MUST pick P1 first.
+        p3 = tmp_path / "other.mp4"; p3.write_bytes(b'x')
+        p2 = tmp_path / "SentryClips" / "evt" / "front.mp4"
+        p2.parent.mkdir(parents=True); p2.write_bytes(b'x')
+        p1 = tmp_path / "RecentClips" / "front.mp4"
+        p1.parent.mkdir(parents=True); p1.write_bytes(b'x')
+        enqueue_for_archive(str(p3), db_path=db)
+        enqueue_for_archive(str(p2), db_path=db)
+        enqueue_for_archive(str(p1), db_path=db)
+
+        row = claim_next_for_worker('w1', db_path=db)
+        assert row['source_path'] == str(p1)
+        row = claim_next_for_worker('w1', db_path=db)
+        assert row['source_path'] == str(p2)
+        row = claim_next_for_worker('w1', db_path=db)
+        assert row['source_path'] == str(p3)
+
+    def test_picks_oldest_mtime_within_priority(self, db, tmp_path):
+        a = tmp_path / "RecentClips" / "a-front.mp4"
+        b = tmp_path / "RecentClips" / "b-front.mp4"
+        a.parent.mkdir(parents=True); a.write_bytes(b'a'); b.write_bytes(b'b')
+        # Make 'a' older than 'b' on disk.
+        os.utime(str(a), (1000.0, 1000.0))
+        os.utime(str(b), (2000.0, 2000.0))
+        enqueue_for_archive(str(b), db_path=db)
+        enqueue_for_archive(str(a), db_path=db)
+        row = claim_next_for_worker('w1', db_path=db)
+        assert row['source_path'] == str(a)
+
+    def test_skips_claimed_row(self, db, sample_file):
+        enqueue_for_archive(sample_file, db_path=db)
+        first = claim_next_for_worker('w1', db_path=db)
+        assert first is not None
+        # No more pending rows — second claim must return None.
+        assert claim_next_for_worker('w2', db_path=db) is None
+
+    def test_two_workers_race_only_one_wins(self, db, sample_file):
+        enqueue_for_archive(sample_file, db_path=db)
+        results = []
+        barrier = threading.Barrier(2)
+
+        def claimer(name):
+            barrier.wait()
+            r = claim_next_for_worker(name, db_path=db)
+            results.append(r)
+
+        t1 = threading.Thread(target=claimer, args=('w1',))
+        t2 = threading.Thread(target=claimer, args=('w2',))
+        t1.start(); t2.start(); t1.join(); t2.join()
+        winners = [r for r in results if r is not None]
+        losers = [r for r in results if r is None]
+        assert len(winners) == 1, (
+            f"Expected exactly one worker to win; got {results}"
+        )
+        assert len(losers) == 1
+
+
+class TestMarkCopied:
+    def test_marks_claimed_row_as_copied(self, db, sample_file, tmp_path):
+        enqueue_for_archive(sample_file, db_path=db)
+        row = claim_next_for_worker('w1', db_path=db)
+        dest = str(tmp_path / "dest.mp4")
+        assert mark_copied(row['id'], dest, db_path=db) is True
+        rows = list_queue(db_path=db)
+        assert rows[0]['status'] == 'copied'
+        assert rows[0]['dest_path'] == dest
+        assert rows[0]['copied_at'] is not None
+
+    def test_returns_false_for_unknown_id(self, db):
+        assert mark_copied(999999, '/x', db_path=db) is False
+
+    def test_returns_false_for_zero_id(self, db):
+        assert mark_copied(0, '/x', db_path=db) is False
+
+
+class TestMarkSourceGone:
+    def test_marks_claimed_row(self, db, sample_file):
+        enqueue_for_archive(sample_file, db_path=db)
+        row = claim_next_for_worker('w1', db_path=db)
+        assert mark_source_gone(row['id'], db_path=db) is True
+        rows = list_queue(db_path=db)
+        assert rows[0]['status'] == 'source_gone'
+        # last_error must be cleared — source-gone is not an error.
+        assert rows[0]['last_error'] is None
+
+    def test_returns_false_for_unknown_id(self, db):
+        assert mark_source_gone(999999, db_path=db) is False
+
+
+class TestReleaseClaim:
+    def test_returns_to_pending_without_metadata(self, db, sample_file):
+        enqueue_for_archive(sample_file, db_path=db)
+        row = claim_next_for_worker('w1', db_path=db)
+        assert release_claim(row['id'], db_path=db) is True
+        # Now claimable again by another worker.
+        again = claim_next_for_worker('w2', db_path=db)
+        assert again is not None
+        assert again['claimed_by'] == 'w2'
+
+    def test_refreshes_metadata_when_provided(self, db, sample_file):
+        enqueue_for_archive(sample_file, db_path=db)
+        row = claim_next_for_worker('w1', db_path=db)
+        assert release_claim(
+            row['id'], expected_size=999, expected_mtime=1234.5, db_path=db,
+        ) is True
+        rows = list_queue(db_path=db)
+        assert rows[0]['expected_size'] == 999
+        assert rows[0]['expected_mtime'] == 1234.5
+        assert rows[0]['claimed_at'] is None
+        assert rows[0]['claimed_by'] is None
+
+    def test_does_not_burn_attempt(self, db, sample_file):
+        enqueue_for_archive(sample_file, db_path=db)
+        row = claim_next_for_worker('w1', db_path=db)
+        assert release_claim(row['id'], db_path=db) is True
+        rows = list_queue(db_path=db)
+        # release_claim is not an error — attempts stays at 0.
+        assert rows[0]['attempts'] == 0
+
+
+class TestMarkFailed:
+    def test_first_failure_returns_pending(self, db, sample_file):
+        enqueue_for_archive(sample_file, db_path=db)
+        row = claim_next_for_worker('w1', db_path=db)
+        status = mark_failed(row['id'], 'synthetic', max_attempts=3, db_path=db)
+        assert status == 'pending'
+        rows = list_queue(db_path=db)
+        assert rows[0]['attempts'] == 1
+        assert rows[0]['last_error'] == 'synthetic'
+        assert rows[0]['status'] == 'pending'
+        assert rows[0]['claimed_at'] is None
+
+    def test_dead_letter_at_max_attempts(self, db, sample_file):
+        enqueue_for_archive(sample_file, db_path=db)
+        row = claim_next_for_worker('w1', db_path=db)
+        # Three failures with max=3 → final transition to dead_letter.
+        for _ in range(2):
+            assert mark_failed(
+                row['id'], 'oops', max_attempts=3, db_path=db,
+            ) == 'pending'
+            row = claim_next_for_worker('w1', db_path=db)
+        status = mark_failed(
+            row['id'], 'final', max_attempts=3, db_path=db,
+        )
+        assert status == 'dead_letter'
+        rows = list_queue(db_path=db)
+        assert rows[0]['status'] == 'dead_letter'
+        assert rows[0]['attempts'] == 3
+        assert rows[0]['last_error'] == 'final'
+
+    def test_truncates_long_error_string(self, db, sample_file):
+        enqueue_for_archive(sample_file, db_path=db)
+        row = claim_next_for_worker('w1', db_path=db)
+        big = 'x' * 10000
+        mark_failed(row['id'], big, max_attempts=5, db_path=db)
+        rows = list_queue(db_path=db)
+        assert len(rows[0]['last_error']) == 4096
+
+    def test_unknown_id_returns_error(self, db):
+        assert mark_failed(99999, 'x', db_path=db) == 'error'
+
+    def test_zero_id_returns_error(self, db):
+        assert mark_failed(0, 'x', db_path=db) == 'error'
+
+
+class TestRecoverStaleClaims:
+    def test_resets_old_claimed_rows(self, db, sample_file):
+        from datetime import datetime, timedelta, timezone
+        enqueue_for_archive(sample_file, db_path=db)
+        # Hand-roll a stale claim by writing an old timestamp.
+        old_ts = (
+            datetime.now(timezone.utc) - timedelta(seconds=3600)
+        ).isoformat()
+        with sqlite3.connect(db) as c:
+            c.execute(
+                """UPDATE archive_queue
+                      SET status='claimed', claimed_at=?, claimed_by='zombie'""",
+                (old_ts,),
+            )
+        recovered = recover_stale_claims(max_age_seconds=600.0, db_path=db)
+        assert recovered == 1
+        rows = list_queue(db_path=db)
+        assert rows[0]['status'] == 'pending'
+        assert rows[0]['claimed_at'] is None
+
+    def test_leaves_recent_claims_alone(self, db, sample_file):
+        enqueue_for_archive(sample_file, db_path=db)
+        # Fresh claim — within the 600s window.
+        claim_next_for_worker('w1', db_path=db)
+        recovered = recover_stale_claims(max_age_seconds=600.0, db_path=db)
+        assert recovered == 0
+        rows = list_queue(db_path=db)
+        assert rows[0]['status'] == 'claimed'
+
+    def test_recovers_null_claimed_at(self, db, sample_file):
+        # Defensive: a row stuck in claimed with NULL claimed_at also
+        # gets recovered (treated as infinitely old).
+        enqueue_for_archive(sample_file, db_path=db)
+        with sqlite3.connect(db) as c:
+            c.execute(
+                """UPDATE archive_queue
+                      SET status='claimed', claimed_at=NULL, claimed_by='x'"""
+            )
+        recovered = recover_stale_claims(max_age_seconds=60.0, db_path=db)
+        assert recovered == 1

--- a/tests/test_archive_worker.py
+++ b/tests/test_archive_worker.py
@@ -1,0 +1,775 @@
+"""Tests for the Phase 2b archive worker (issue #76).
+
+Coverage matches the issue spec:
+
+* TestArchiveWorkerLifecycle  — start, stop, pause, resume, idempotent start
+* TestArchiveWorkerCopy       — successful copy → status='copied' + indexer enqueued
+* TestArchiveWorkerStableGate — fresh + drift → release; stable → proceed
+* TestArchiveWorkerSourceGone — FileNotFoundError → no retry, no dead-letter
+* TestArchiveWorkerDeadLetter — synthetic OSError × max_attempts → sidecar
+* TestArchiveWorkerPriority   — P1 RecentClips drains before P2/P3
+* TestArchiveWorkerStarvation — synthetic indexer load + 10 archive items
+* TestArchiveWorkerPauseResume — claim released cleanly on pause; resume picks up
+
+Most tests drive ``process_one_claim`` directly so we don't need to spin
+up a thread for every assertion. The lifecycle / starvation tests run the
+real loop.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import threading
+import time
+from typing import List
+from unittest.mock import patch
+
+import pytest
+
+from services import archive_queue
+from services import archive_worker
+from services import task_coordinator
+from services.archive_queue import (
+    claim_next_for_worker,
+    enqueue_for_archive,
+    list_queue,
+)
+from services.mapping_service import _init_db
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def db(tmp_path):
+    """Initialize a fresh geodata.db with the v10 schema (incl. archive_queue)."""
+    db_path = str(tmp_path / "geodata.db")
+    _init_db(db_path).close()
+    return db_path
+
+
+@pytest.fixture
+def archive_root(tmp_path):
+    p = tmp_path / "ArchivedClips"
+    p.mkdir()
+    return str(p)
+
+
+@pytest.fixture
+def teslacam_root(tmp_path):
+    p = tmp_path / "TeslaCam"
+    p.mkdir()
+    (p / "RecentClips").mkdir()
+    (p / "SavedClips").mkdir()
+    (p / "SentryClips").mkdir()
+    return str(p)
+
+
+@pytest.fixture
+def make_clip(teslacam_root):
+    """Factory for fake mp4 files. ``rel`` is relative to teslacam_root."""
+    def _factory(rel: str, content: bytes = b"X" * 100,
+                 mtime: float = None) -> str:
+        full = os.path.join(teslacam_root, rel)
+        os.makedirs(os.path.dirname(full), exist_ok=True)
+        with open(full, "wb") as f:
+            f.write(content)
+        if mtime is not None:
+            os.utime(full, (mtime, mtime))
+        else:
+            # Backdate so the stable-write age gate (5 s) is satisfied.
+            old = time.time() - 60
+            os.utime(full, (old, old))
+        return full
+    return _factory
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state():
+    """Stop any running worker between tests so module state stays clean."""
+    archive_worker.stop_worker(timeout=5.0)
+    # Reset task_coordinator too — leftover ownership from an earlier
+    # test would block our acquire.
+    with task_coordinator._lock:
+        task_coordinator._current_task = None
+        task_coordinator._task_started = 0.0
+        task_coordinator._waiter_count = 0
+    yield
+    archive_worker.stop_worker(timeout=5.0)
+    with task_coordinator._lock:
+        task_coordinator._current_task = None
+        task_coordinator._task_started = 0.0
+        task_coordinator._waiter_count = 0
+
+
+@pytest.fixture(autouse=True)
+def _block_real_indexer_enqueue(monkeypatch):
+    """Stop the worker from calling into the real ``mapping_service``.
+
+    The worker enqueues the destination path into ``indexing_queue``
+    after a successful copy. Tests that don't care about that side
+    effect would otherwise need a fully-initialized indexing schema +
+    config import. We stub it here and the few tests that DO care
+    monkeypatch a recording stub on top.
+    """
+    monkeypatch.setattr(archive_worker, '_enqueue_indexed', lambda *a, **k: None)
+
+
+# ---------------------------------------------------------------------------
+# TestArchiveWorkerLifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestArchiveWorkerLifecycle:
+    def test_start_returns_true_first_time(self, db, archive_root, teslacam_root):
+        ok = archive_worker.start_worker(
+            db, archive_root, teslacam_root=teslacam_root,
+        )
+        assert ok is True
+        assert archive_worker.is_running() is True
+        assert archive_worker.stop_worker(timeout=5) is True
+        assert archive_worker.is_running() is False
+
+    def test_double_start_is_noop(self, db, archive_root, teslacam_root):
+        assert archive_worker.start_worker(
+            db, archive_root, teslacam_root=teslacam_root,
+        ) is True
+        # Second start while running must refuse and return False.
+        assert archive_worker.start_worker(
+            db, archive_root, teslacam_root=teslacam_root,
+        ) is False
+        archive_worker.stop_worker(timeout=5)
+
+    def test_stop_when_not_running_returns_true(self):
+        # Idempotent: stop on a never-started worker is a no-op.
+        assert archive_worker.stop_worker(timeout=2) is True
+
+    def test_pause_when_not_running_succeeds(self):
+        # Pause-flag-only path; no thread to wait on.
+        assert archive_worker.pause_worker(timeout=1) is True
+        archive_worker.resume_worker()
+
+    def test_pause_resume_round_trip(self, db, archive_root, teslacam_root):
+        archive_worker.start_worker(
+            db, archive_root, teslacam_root=teslacam_root,
+        )
+        # No queue work — worker idles. Pause should return quickly.
+        assert archive_worker.pause_worker(timeout=5) is True
+        assert archive_worker.is_paused() is True
+        archive_worker.resume_worker()
+        assert archive_worker.is_paused() is False
+        archive_worker.stop_worker(timeout=5)
+
+    def test_get_status_includes_queue_counts(self, db, archive_root,
+                                              teslacam_root, make_clip):
+        clip = make_clip("RecentClips/2025-01-01_10-00-00-front.mp4")
+        enqueue_for_archive(clip, db_path=db)
+        archive_worker.start_worker(
+            db, archive_root, teslacam_root=teslacam_root,
+        )
+        try:
+            # Wait briefly for the worker to drain the single item.
+            for _ in range(50):
+                if archive_worker.get_status()['copied_count'] >= 1:
+                    break
+                time.sleep(0.1)
+            status = archive_worker.get_status()
+            assert status['worker_running'] is True
+            assert status['copied_count'] >= 1
+        finally:
+            archive_worker.stop_worker(timeout=5)
+
+
+# ---------------------------------------------------------------------------
+# TestArchiveWorkerCopy
+# ---------------------------------------------------------------------------
+
+
+class TestArchiveWorkerCopy:
+    def test_copy_writes_dest_with_matching_size(
+        self, db, archive_root, teslacam_root, make_clip,
+    ):
+        content = b"abcdef" * 1000  # 6000 bytes
+        clip = make_clip(
+            "RecentClips/2025-01-01_10-00-00-front.mp4", content=content,
+        )
+        enqueue_for_archive(clip, db_path=db)
+        row = claim_next_for_worker('test-worker', db_path=db)
+        outcome = archive_worker.process_one_claim(
+            row, db, archive_root, teslacam_root,
+            chunk_size=4096, max_attempts=3,
+        )
+        assert outcome == 'copied'
+        dest = os.path.join(
+            archive_root, "RecentClips", "2025-01-01_10-00-00-front.mp4",
+        )
+        assert os.path.isfile(dest)
+        assert os.path.getsize(dest) == len(content)
+        with open(dest, "rb") as f:
+            assert f.read() == content
+        rows = list_queue(db_path=db)
+        assert rows[0]['status'] == 'copied'
+        assert rows[0]['dest_path'] == dest
+        assert rows[0]['copied_at'] is not None
+
+    def test_copy_enqueues_dest_into_indexer(
+        self, db, archive_root, teslacam_root, make_clip, monkeypatch,
+    ):
+        clip = make_clip("SentryClips/evt1/2025-01-01_10-00-00-front.mp4")
+        enqueue_for_archive(clip, db_path=db)
+        row = claim_next_for_worker('w', db_path=db)
+        # Replace the autouse stub with a recorder.
+        recorded: List[tuple] = []
+        monkeypatch.setattr(
+            archive_worker, '_enqueue_indexed',
+            lambda dest, db_path: recorded.append((dest, db_path)),
+        )
+        archive_worker.process_one_claim(
+            row, db, archive_root, teslacam_root,
+            chunk_size=4096, max_attempts=3,
+        )
+        assert len(recorded) == 1
+        dest, indexer_db = recorded[0]
+        assert dest.endswith(
+            os.path.join(
+                "SentryClips", "evt1", "2025-01-01_10-00-00-front.mp4",
+            ),
+        )
+        assert indexer_db == db
+
+    def test_copy_creates_intermediate_dirs(
+        self, db, archive_root, teslacam_root, make_clip,
+    ):
+        clip = make_clip("SavedClips/2025-01-01_evt2/x-front.mp4")
+        enqueue_for_archive(clip, db_path=db)
+        row = claim_next_for_worker('w', db_path=db)
+        archive_worker.process_one_claim(
+            row, db, archive_root, teslacam_root,
+            chunk_size=4096, max_attempts=3,
+        )
+        dest = os.path.join(
+            archive_root, "SavedClips", "2025-01-01_evt2", "x-front.mp4",
+        )
+        assert os.path.isfile(dest)
+
+    def test_copy_atomic_no_partial_left_on_success(
+        self, db, archive_root, teslacam_root, make_clip,
+    ):
+        clip = make_clip("RecentClips/x-front.mp4")
+        enqueue_for_archive(clip, db_path=db)
+        row = claim_next_for_worker('w', db_path=db)
+        archive_worker.process_one_claim(
+            row, db, archive_root, teslacam_root,
+            chunk_size=4096, max_attempts=3,
+        )
+        # No .partial sidecar left over.
+        partial = os.path.join(archive_root, "RecentClips", "x-front.mp4.partial")
+        assert not os.path.exists(partial)
+
+    def test_compute_dest_path_falls_back_when_outside_teslacam(
+        self, archive_root, teslacam_root,
+    ):
+        # Source path that isn't under teslacam_root falls back to
+        # archive_root/<basename>.
+        out = archive_worker.compute_dest_path(
+            "/random/scratch/foo.mp4", archive_root, teslacam_root,
+        )
+        assert out == os.path.join(archive_root, "foo.mp4")
+
+    def test_compute_dest_path_handles_missing_teslacam_root(
+        self, archive_root,
+    ):
+        out = archive_worker.compute_dest_path(
+            "/random/scratch/foo.mp4", archive_root, None,
+        )
+        assert out == os.path.join(archive_root, "foo.mp4")
+
+    def test_compute_dest_path_rejects_empty_source(self, archive_root):
+        with pytest.raises(ValueError):
+            archive_worker.compute_dest_path("", archive_root, None)
+
+
+# ---------------------------------------------------------------------------
+# TestArchiveWorkerStableGate
+# ---------------------------------------------------------------------------
+
+
+class TestArchiveWorkerStableGate:
+    def test_fresh_file_with_drift_releases_claim(
+        self, db, archive_root, teslacam_root, make_clip,
+    ):
+        # Fresh file: enqueue with old size (50 bytes), then write 100 bytes.
+        # The worker re-stats, sees drift, and the file is fresh (mtime=now)
+        # → release_claim with refreshed metadata.
+        clip = make_clip(
+            "RecentClips/x-front.mp4", content=b"a" * 50,
+            mtime=time.time(),  # fresh
+        )
+        enqueue_for_archive(clip, db_path=db)
+        # Now grow the file (drift in size and mtime).
+        with open(clip, "wb") as f:
+            f.write(b"a" * 100)
+        os.utime(clip, (time.time(), time.time()))
+        row = claim_next_for_worker('w', db_path=db)
+        outcome = archive_worker.process_one_claim(
+            row, db, archive_root, teslacam_root,
+            chunk_size=4096, max_attempts=3,
+        )
+        assert outcome == 'pending'
+        # Row is back in pending, with refreshed metadata.
+        rows = list_queue(db_path=db)
+        assert rows[0]['status'] == 'pending'
+        assert rows[0]['expected_size'] == 100
+        assert rows[0]['attempts'] == 0  # not burned
+
+    def test_stable_old_file_proceeds_to_copy(
+        self, db, archive_root, teslacam_root, make_clip,
+    ):
+        # Make a clip with an mtime well in the past — the gate
+        # passes immediately.
+        clip = make_clip("RecentClips/y-front.mp4", mtime=1000.0)
+        enqueue_for_archive(clip, db_path=db)
+        row = claim_next_for_worker('w', db_path=db)
+        outcome = archive_worker.process_one_claim(
+            row, db, archive_root, teslacam_root,
+            chunk_size=4096, max_attempts=3,
+        )
+        assert outcome == 'copied'
+
+    def test_fresh_file_without_drift_proceeds(
+        self, db, archive_root, teslacam_root, make_clip,
+    ):
+        # A fresh file whose stat() matches the enqueue snapshot
+        # should NOT requeue — drift, not freshness, is the trigger.
+        clip = make_clip(
+            "RecentClips/z-front.mp4", content=b"x" * 50,
+            mtime=time.time(),
+        )
+        enqueue_for_archive(clip, db_path=db)
+        # Don't touch the file — claim should see expected==actual.
+        row = claim_next_for_worker('w', db_path=db)
+        outcome = archive_worker.process_one_claim(
+            row, db, archive_root, teslacam_root,
+            chunk_size=4096, max_attempts=3,
+        )
+        assert outcome == 'copied'
+
+
+# ---------------------------------------------------------------------------
+# TestArchiveWorkerSourceGone
+# ---------------------------------------------------------------------------
+
+
+class TestArchiveWorkerSourceGone:
+    def test_missing_at_stat_marks_source_gone(
+        self, db, archive_root, teslacam_root, make_clip,
+    ):
+        clip = make_clip("RecentClips/gone-front.mp4")
+        enqueue_for_archive(clip, db_path=db)
+        row = claim_next_for_worker('w', db_path=db)
+        os.unlink(clip)
+        outcome = archive_worker.process_one_claim(
+            row, db, archive_root, teslacam_root,
+            chunk_size=4096, max_attempts=3,
+        )
+        assert outcome == 'source_gone'
+        rows = list_queue(db_path=db)
+        assert rows[0]['status'] == 'source_gone'
+        # No attempts burned, no dead-letter sidecar.
+        assert rows[0]['attempts'] == 0
+        sidecar_dir = os.path.join(archive_root, '.dead_letter')
+        assert not os.path.isdir(sidecar_dir) or not os.listdir(sidecar_dir)
+
+    def test_missing_at_open_marks_source_gone(
+        self, db, archive_root, teslacam_root, make_clip, monkeypatch,
+    ):
+        # Race: stat() succeeded, but the file vanished before open().
+        # The atomic copy raises FileNotFoundError; we expect source_gone.
+        clip = make_clip("RecentClips/race-front.mp4")
+        enqueue_for_archive(clip, db_path=db)
+        row = claim_next_for_worker('w', db_path=db)
+
+        original_atomic = archive_worker._atomic_copy
+
+        def _fail_with_fnf(src, dst, chunk):
+            raise FileNotFoundError(src)
+
+        monkeypatch.setattr(archive_worker, '_atomic_copy', _fail_with_fnf)
+        outcome = archive_worker.process_one_claim(
+            row, db, archive_root, teslacam_root,
+            chunk_size=4096, max_attempts=3,
+        )
+        # Restore (autouse fixture handles teardown but be tidy).
+        monkeypatch.setattr(archive_worker, '_atomic_copy', original_atomic)
+        assert outcome == 'source_gone'
+        rows = list_queue(db_path=db)
+        assert rows[0]['status'] == 'source_gone'
+
+
+# ---------------------------------------------------------------------------
+# TestArchiveWorkerDeadLetter
+# ---------------------------------------------------------------------------
+
+
+class TestArchiveWorkerDeadLetter:
+    def test_three_oserrors_writes_sidecar_and_dead_letters(
+        self, db, archive_root, teslacam_root, make_clip, monkeypatch,
+    ):
+        clip = make_clip("RecentClips/bad-front.mp4")
+        enqueue_for_archive(clip, db_path=db)
+
+        def always_fail(src, dst, chunk):
+            raise OSError("synthetic disk error")
+
+        monkeypatch.setattr(archive_worker, '_atomic_copy', always_fail)
+
+        # Three failed attempts (max=3 → final transitions to dead_letter).
+        outcomes = []
+        for _ in range(3):
+            row = claim_next_for_worker('w', db_path=db)
+            assert row is not None, "expected pending row before dead_letter"
+            outcomes.append(archive_worker.process_one_claim(
+                row, db, archive_root, teslacam_root,
+                chunk_size=4096, max_attempts=3,
+            ))
+        # First two: pending; third: dead_letter.
+        assert outcomes[0] == 'pending'
+        assert outcomes[1] == 'pending'
+        assert outcomes[2] == 'dead_letter'
+
+        rows = list_queue(db_path=db)
+        assert rows[0]['status'] == 'dead_letter'
+        assert rows[0]['attempts'] == 3
+        assert rows[0]['last_error'].startswith('copy:')
+
+        # Sidecar exists with all required fields.
+        sidecar_dir = os.path.join(archive_root, '.dead_letter')
+        assert os.path.isdir(sidecar_dir)
+        sidecars = os.listdir(sidecar_dir)
+        assert len(sidecars) == 1
+        with open(os.path.join(sidecar_dir, sidecars[0]), encoding='utf-8') as f:
+            txt = f.read()
+        assert 'source_path:' in txt
+        assert clip in txt
+        assert 'dest_path:' in txt
+        assert 'attempts: 3' in txt
+        assert 'enqueued_at:' in txt
+        assert 'last_error:' in txt
+        assert 'synthetic disk error' in txt
+
+    def test_size_mismatch_treated_as_oserror(
+        self, db, archive_root, teslacam_root, make_clip, monkeypatch,
+    ):
+        # Stub _atomic_copy with a function that raises an OSError mimicking
+        # the size-mismatch check. After max_attempts → dead_letter.
+        clip = make_clip("RecentClips/mismatch-front.mp4")
+        enqueue_for_archive(clip, db_path=db)
+
+        def mismatch(src, dst, chunk):
+            raise OSError("size mismatch: wrote 50, expected 100")
+
+        monkeypatch.setattr(archive_worker, '_atomic_copy', mismatch)
+        for _ in range(3):
+            row = claim_next_for_worker('w', db_path=db)
+            archive_worker.process_one_claim(
+                row, db, archive_root, teslacam_root,
+                chunk_size=4096, max_attempts=3,
+            )
+        rows = list_queue(db_path=db)
+        assert rows[0]['status'] == 'dead_letter'
+        assert 'mismatch' in rows[0]['last_error']
+
+    def test_partial_file_cleaned_on_failure(
+        self, db, archive_root, teslacam_root, make_clip,
+    ):
+        # Use the real _atomic_copy but make the source a directory so
+        # open() fails. Verify no .partial leftover.
+        sub_dir = os.path.join(teslacam_root, "RecentClips", "broken")
+        os.makedirs(sub_dir)  # this is a DIR, not a file
+        # Write a fake row directly bypassing enqueue_for_archive (which
+        # would skip non-file targets).
+        with sqlite3.connect(db) as c:
+            c.execute(
+                """INSERT INTO archive_queue (source_path, priority, status,
+                       enqueued_at)
+                   VALUES (?, 1, 'pending', '2025-01-01T00:00:00+00:00')""",
+                (sub_dir,),
+            )
+        row = claim_next_for_worker('w', db_path=db)
+        archive_worker.process_one_claim(
+            row, db, archive_root, teslacam_root,
+            chunk_size=4096, max_attempts=3,
+        )
+        # Even with the failure, the .partial in the destination should
+        # not exist.
+        partial = os.path.join(archive_root, "RecentClips", "broken.partial")
+        assert not os.path.exists(partial)
+
+
+# ---------------------------------------------------------------------------
+# TestArchiveWorkerPriority
+# ---------------------------------------------------------------------------
+
+
+class TestArchiveWorkerPriority:
+    def test_p1_drains_before_p2_before_p3(self, db, archive_root,
+                                            teslacam_root, make_clip):
+        """Phase 2b acceptance criterion: priority ordering across the
+        wire — RecentClips first, then Sentry/Saved, then everything
+        else. The partial index ``archive_queue_ready`` covers this
+        exact ORDER BY."""
+        # Enqueue in REVERSE priority order to make sure we're testing
+        # ORDER BY, not insertion order.
+        p3 = make_clip(
+            "Other/other-front.mp4", mtime=1000.0,
+        )
+        p2 = make_clip(
+            "SentryClips/evt/sentry-front.mp4", mtime=1000.0,
+        )
+        p1 = make_clip(
+            "RecentClips/recent-front.mp4", mtime=1000.0,
+        )
+        enqueue_for_archive(p3, db_path=db)
+        enqueue_for_archive(p2, db_path=db)
+        enqueue_for_archive(p1, db_path=db)
+
+        # Drive all three through process_one_claim and capture order.
+        copied_order: List[str] = []
+        for _ in range(3):
+            row = claim_next_for_worker('w', db_path=db)
+            assert row is not None
+            outcome = archive_worker.process_one_claim(
+                row, db, archive_root, teslacam_root,
+                chunk_size=4096, max_attempts=3,
+            )
+            assert outcome == 'copied'
+            copied_order.append(row['source_path'])
+
+        assert copied_order == [p1, p2, p3], (
+            f"Priority order violated: {copied_order}"
+        )
+
+    def test_oldest_mtime_within_band_drains_first(
+        self, db, archive_root, teslacam_root, make_clip,
+    ):
+        # Two RecentClips files (same priority); the older one should
+        # be claimed first.
+        old = make_clip("RecentClips/old-front.mp4", mtime=1000.0)
+        new = make_clip("RecentClips/new-front.mp4", mtime=2000.0)
+        enqueue_for_archive(new, db_path=db)
+        enqueue_for_archive(old, db_path=db)
+
+        first = claim_next_for_worker('w', db_path=db)
+        assert first['source_path'] == old
+
+
+# ---------------------------------------------------------------------------
+# TestArchiveWorkerStarvation (synthetic indexer load)
+# ---------------------------------------------------------------------------
+
+
+class TestArchiveWorkerStarvation:
+    """The fairness contract from issue #76: even when the indexer is
+    cyclically holding the task_coordinator slot, the archive worker
+    must still drain its queue. Phase 2b uses
+    ``acquire_task('archive', wait_seconds=60)`` which BLOCKS for a
+    slot — so 10 archive items must finish within a bounded timeout
+    even with synthetic indexer pressure."""
+
+    def test_ten_items_drain_under_synthetic_indexer_load(
+        self, db, archive_root, teslacam_root, make_clip,
+    ):
+        # Create + enqueue 10 items.
+        clips = []
+        for i in range(10):
+            clip = make_clip(
+                f"RecentClips/clip-{i:02d}-front.mp4", mtime=1000.0 + i,
+            )
+            enqueue_for_archive(clip, db_path=db)
+            clips.append(clip)
+
+        # Synthetic indexer thread: cyclically acquire/release the
+        # 'indexer' slot with yield_to_waiters=True so the archive
+        # worker (using wait_seconds=60) can grab the lock at every
+        # iteration boundary.
+        indexer_stop = threading.Event()
+        indexer_iterations = [0]
+
+        def synthetic_indexer():
+            while not indexer_stop.is_set():
+                if task_coordinator.acquire_task(
+                        'indexer', yield_to_waiters=True):
+                    try:
+                        # Tiny "work" interval so the archive worker
+                        # frequently gets a chance.
+                        time.sleep(0.01)
+                        indexer_iterations[0] += 1
+                    finally:
+                        task_coordinator.release_task('indexer')
+                # Brief inter-cycle pause.
+                if indexer_stop.wait(timeout=0.005):
+                    break
+
+        idxer = threading.Thread(target=synthetic_indexer, daemon=True)
+        idxer.start()
+        try:
+            archive_worker.start_worker(
+                db, archive_root, teslacam_root=teslacam_root,
+            )
+            # All 10 must drain within 30 s. Generous timeout because
+            # CI runners are slow.
+            deadline = time.monotonic() + 30
+            while time.monotonic() < deadline:
+                if archive_worker.get_status()['copied_count'] >= 10:
+                    break
+                time.sleep(0.1)
+            status = archive_worker.get_status()
+            assert status['copied_count'] >= 10, (
+                f"Only {status['copied_count']}/10 archived under load; "
+                f"queue_depth={status['queue_depth']}, "
+                f"indexer_iterations={indexer_iterations[0]}"
+            )
+            assert status['queue_depth'] == 0
+        finally:
+            indexer_stop.set()
+            idxer.join(timeout=5)
+            archive_worker.stop_worker(timeout=5)
+
+
+# ---------------------------------------------------------------------------
+# TestArchiveWorkerPauseResume
+# ---------------------------------------------------------------------------
+
+
+class TestArchiveWorkerPauseResume:
+    def test_pause_releases_in_flight_claim(
+        self, db, archive_root, teslacam_root, make_clip,
+    ):
+        # Enqueue a single item. Start the worker, immediately pause.
+        # The worker should drop its claim back to pending without
+        # burning an attempt — even if it had picked the row up.
+        clip = make_clip("RecentClips/p-front.mp4", mtime=1000.0)
+        enqueue_for_archive(clip, db_path=db)
+        archive_worker.start_worker(
+            db, archive_root, teslacam_root=teslacam_root,
+        )
+        try:
+            # Wait for the worker to either copy or pause.
+            assert archive_worker.pause_worker(timeout=10) is True
+            rows = list_queue(db_path=db)
+            # Either the worker already copied it (fast path) or the
+            # row is back to pending. Either way, attempts MUST be 0.
+            assert rows[0]['status'] in ('copied', 'pending')
+            assert rows[0]['attempts'] == 0
+        finally:
+            archive_worker.resume_worker()
+            archive_worker.stop_worker(timeout=5)
+
+    def test_resume_processes_pending_claim(
+        self, db, archive_root, teslacam_root, make_clip,
+    ):
+        clip = make_clip("RecentClips/r-front.mp4", mtime=1000.0)
+        enqueue_for_archive(clip, db_path=db)
+        archive_worker.start_worker(
+            db, archive_root, teslacam_root=teslacam_root,
+        )
+        try:
+            # Pause first so we don't race the auto-drain.
+            assert archive_worker.pause_worker(timeout=10) is True
+            # Force release of any in-flight claim by waiting; then
+            # resume and verify the file gets archived.
+            archive_worker.resume_worker()
+            deadline = time.monotonic() + 10
+            while time.monotonic() < deadline:
+                rows = list_queue(db_path=db)
+                if rows and rows[0]['status'] == 'copied':
+                    break
+                time.sleep(0.1)
+            rows = list_queue(db_path=db)
+            assert rows[0]['status'] == 'copied'
+        finally:
+            archive_worker.stop_worker(timeout=5)
+
+    def test_pause_with_empty_queue_succeeds_quickly(
+        self, db, archive_root, teslacam_root,
+    ):
+        archive_worker.start_worker(
+            db, archive_root, teslacam_root=teslacam_root,
+        )
+        try:
+            t0 = time.monotonic()
+            assert archive_worker.pause_worker(timeout=5) is True
+            # With no work, pause should land within ~idle_sleep (default 5s).
+            assert time.monotonic() - t0 < 6.0
+        finally:
+            archive_worker.resume_worker()
+            archive_worker.stop_worker(timeout=5)
+
+
+# ---------------------------------------------------------------------------
+# Hard-constraint sanity: no USB-touching imports leak in here.
+# ---------------------------------------------------------------------------
+
+
+class TestModuleSafety:
+    """Issue #76 hard constraint: the archive subsystem must NEVER
+    invoke USB-gadget operations. A grep is part of the PR checklist;
+    this test gives that contract a tripwire in CI."""
+
+    def test_module_source_does_not_reference_gadget_ops(self):
+        # Strip docstrings and comments before searching — the module
+        # docstring intentionally enumerates the forbidden tokens as
+        # part of its hard-constraint contract; only ACTUAL code
+        # references would be a violation.
+        import ast
+        import inspect
+        src = inspect.getsource(archive_worker)
+        tree = ast.parse(src)
+        # Collect every ast.Str / Constant value used as a docstring
+        # (module-level + class-level + function-level) and excise it
+        # from the source by deleting any line whose contents falls
+        # inside a docstring node. Easiest robust path: walk the tree
+        # and unparse only the executable statements (imports + defs).
+        # AST.dump leaks the constant strings too, so just scan the
+        # source line-by-line, skipping triple-quoted blocks.
+        executable_lines: list = []
+        in_triple = False
+        triple_marker = None
+        for line in src.splitlines():
+            stripped = line.lstrip()
+            if not in_triple:
+                # Detect a triple-quote OPEN.
+                for marker in ('"""', "'''"):
+                    if stripped.startswith(marker):
+                        in_triple = True
+                        triple_marker = marker
+                        # Same-line closer? "..."""...
+                        rest = stripped[len(marker):]
+                        if marker in rest:
+                            in_triple = False
+                            triple_marker = None
+                        break
+                else:
+                    # Strip inline comments.
+                    code = line.split('#', 1)[0]
+                    executable_lines.append(code)
+            else:
+                # In a triple-quoted block — look for the closer.
+                if triple_marker and triple_marker in line:
+                    in_triple = False
+                    triple_marker = None
+        body = '\n'.join(executable_lines)
+
+        forbidden = [
+            'partition_mount_service', 'quick_edit_part2',
+            'rebind_usb_gadget', 'losetup', 'nsenter',
+        ]
+        for tok in forbidden:
+            assert tok not in body, (
+                f"archive_worker.py executable code references forbidden "
+                f"token {tok!r} — Phase 2b hard constraint: no USB "
+                f"gadget interaction."
+            )

--- a/tests/test_file_watcher_service.py
+++ b/tests/test_file_watcher_service.py
@@ -96,8 +96,13 @@ class TestGenerationGuard:
         received = []
         fws.register_callback(lambda paths: received.extend(paths))
         current = fws._watcher_generation
-        fws._notify_callbacks(["/a/b.mp4"], my_generation=current)
-        assert received == ["/a/b.mp4"]
+        # Phase 2b: indexing callbacks only fire for paths under
+        # ARCHIVE_DIR. Use a real ArchivedClips-prefixed path so the
+        # classifier routes it correctly; otherwise it gets dropped.
+        prefix = fws._archive_dir_prefix() or '/tmp'
+        path = os.path.join(prefix, 'a', 'b.mp4')
+        fws._notify_callbacks([path], my_generation=current)
+        assert received == [path]
 
     def test_stale_delete_callbacks_are_dropped(self):
         deleted = []
@@ -203,14 +208,33 @@ class TestPollingDeleteDetection:
 
 
 class TestArchiveCallback:
-    """Phase 2a archive_queue producer (issue #76).
+    """Phase 2a archive_queue producer + Phase 2b path-classified routing
+    (issue #76).
 
-    The archive callback list is parallel to the existing mp4 callback
-    list — both fire on the same ``_notify_callbacks`` invocation with
-    the same paths. These tests exercise the wire-up; the producer's
-    behavior (DB writes, priority inference) is covered separately in
-    ``test_archive_queue.py`` and ``test_archive_producer.py``.
+    Phase 2a wired the archive callback list parallel to the existing
+    mp4 callback list. Phase 2b changed ``_notify_callbacks`` to
+    classify paths and route them to ONE list or the OTHER (never
+    both): paths under the RO USB mount fire only archive callbacks;
+    paths under ``ARCHIVE_DIR`` fire only indexing callbacks.
+
+    These tests pin both behaviors. Paths use ``_ro_mount_prefixes`` /
+    ``_archive_dir_prefix`` rather than hardcoded strings so the tests
+    survive future changes to the default mount layout.
     """
+
+    @staticmethod
+    def _ro_path(name: str) -> str:
+        prefixes = fws._ro_mount_prefixes()
+        # Use the first candidate (``<MNT_DIR>/part1-ro``); both are
+        # valid but the first matches what production uses.
+        return os.path.join(prefixes[0], 'TeslaCam', 'RecentClips', name)
+
+    @staticmethod
+    def _archive_path(name: str) -> str:
+        prefix = fws._archive_dir_prefix()
+        if not prefix:
+            pytest.skip("ARCHIVE_DIR not configured in this environment")
+        return os.path.join(prefix, 'RecentClips', name)
 
     def test_register_archive_callback_appends_to_list(self):
         before = len(fws._on_archive_callbacks)
@@ -218,18 +242,26 @@ class TestArchiveCallback:
         assert len(fws._on_archive_callbacks) == before + 1
 
     def test_archive_callback_fires_alongside_mp4_callback(self):
+        # Phase 2b: a single batch with one RO-mount path AND one
+        # ArchivedClips path must split — RO fires archive only,
+        # ArchivedClips fires indexing only. The two callback lists
+        # see disjoint subsets of the original batch.
         mp4_received = []
         archive_received = []
         fws.register_callback(lambda paths: mp4_received.extend(paths))
         fws.register_archive_callback(
             lambda paths: archive_received.extend(paths)
         )
+        ro_a = self._ro_path('a.mp4')
+        ro_b = self._ro_path('b.mp4')
+        arch_c = self._archive_path('c.mp4')
         current = fws._watcher_generation
-        fws._notify_callbacks(['/foo/a.mp4', '/foo/b.mp4'],
+        fws._notify_callbacks([ro_a, ro_b, arch_c],
                               my_generation=current)
-        # Both subscribers see exactly the same list.
-        assert mp4_received == ['/foo/a.mp4', '/foo/b.mp4']
-        assert archive_received == ['/foo/a.mp4', '/foo/b.mp4']
+        # RO-mount paths route to archive only.
+        assert archive_received == [ro_a, ro_b]
+        # ArchivedClips path routes to indexing only.
+        assert mp4_received == [arch_c]
 
     def test_archive_callback_dropped_when_generation_stale(self):
         # Same generation guard as the mp4 callbacks: a stale batch
@@ -241,7 +273,8 @@ class TestArchiveCallback:
         captured = fws._watcher_generation
         fws._watcher_generation = captured + 1  # simulate stop_watcher bump
         try:
-            fws._notify_callbacks(['/x.mp4'], my_generation=captured)
+            fws._notify_callbacks([self._ro_path('x.mp4')],
+                                  my_generation=captured)
         finally:
             fws._watcher_generation = captured
         assert archive_received == []
@@ -257,22 +290,31 @@ class TestArchiveCallback:
         fws.register_archive_callback(
             lambda paths: good_received.extend(paths)
         )
+        ro_y = self._ro_path('y.mp4')
         current = fws._watcher_generation
-        fws._notify_callbacks(['/y.mp4'], my_generation=current)
-        assert good_received == ['/y.mp4']
+        fws._notify_callbacks([ro_y], my_generation=current)
+        assert good_received == [ro_y]
 
     def test_no_archive_callback_when_none_registered(self):
-        # Sanity: empty archive list, mp4 callback still fires.
+        # Sanity: empty archive list, mp4 callback still fires for
+        # ArchivedClips paths (RO-mount paths would just be silently
+        # routed to the empty archive list — also fine).
         mp4_received = []
         fws.register_callback(lambda paths: mp4_received.extend(paths))
+        arch_z = self._archive_path('z.mp4')
         current = fws._watcher_generation
         # Should not raise even though _on_archive_callbacks is empty.
-        fws._notify_callbacks(['/z.mp4'], my_generation=current)
-        assert mp4_received == ['/z.mp4']
+        fws._notify_callbacks([arch_z], my_generation=current)
+        assert mp4_received == [arch_z]
 
     def test_mp4_callback_exception_does_not_block_archive(self):
         """The two callback lists are independent — one bad mp4
-        subscriber must not prevent the archive callback from firing."""
+        subscriber must not prevent the archive callback from firing.
+
+        Phase 2b: the bad mp4 subscriber receives ArchivedClips paths;
+        the archive callback receives RO-mount paths. They no longer
+        overlap on the same path, so this test sends one of each and
+        verifies BOTH still fire even when the mp4 side raises."""
         archive_received = []
 
         def bad_mp4(paths):
@@ -282,6 +324,60 @@ class TestArchiveCallback:
         fws.register_archive_callback(
             lambda paths: archive_received.extend(paths)
         )
+        ro_q = self._ro_path('q.mp4')
+        arch_q = self._archive_path('q.mp4')
         current = fws._watcher_generation
-        fws._notify_callbacks(['/q.mp4'], my_generation=current)
-        assert archive_received == ['/q.mp4']
+        fws._notify_callbacks([ro_q, arch_q], my_generation=current)
+        assert archive_received == [ro_q]
+
+
+class TestPathClassification:
+    """Phase 2b routing rule pinned by direct unit tests on
+    :func:`_classify_paths` (issue #76)."""
+
+    def test_ro_mount_path_routes_to_archive(self):
+        ro = os.path.join(fws._ro_mount_prefixes()[0], 'TeslaCam', 'foo.mp4')
+        archive, indexing, dropped = fws._classify_paths([ro])
+        assert archive == [ro]
+        assert indexing == []
+        assert dropped == []
+
+    def test_archive_dir_path_routes_to_indexing(self):
+        prefix = fws._archive_dir_prefix()
+        if not prefix:
+            pytest.skip("ARCHIVE_DIR not configured")
+        arch = os.path.join(prefix, 'RecentClips', 'bar.mp4')
+        archive, indexing, dropped = fws._classify_paths([arch])
+        assert archive == []
+        assert indexing == [arch]
+        assert dropped == []
+
+    def test_unrelated_path_dropped(self):
+        # /tmp/foo.mp4 belongs to neither prefix.
+        archive, indexing, dropped = fws._classify_paths(
+            ['/random/scratch/foo.mp4'],
+        )
+        assert archive == []
+        assert indexing == []
+        assert dropped == ['/random/scratch/foo.mp4']
+
+    def test_empty_string_skipped(self):
+        archive, indexing, dropped = fws._classify_paths(['', None])
+        assert archive == []
+        assert indexing == []
+        assert dropped == []
+
+    def test_archive_prefix_wins_when_both_match(self, monkeypatch):
+        # Defensive: if someone misconfigures ARCHIVE_DIR to live
+        # under the RO mount (it shouldn't, but…), the archive prefix
+        # check runs first and routes to indexing. This stops a
+        # double-enqueue that would otherwise re-archive a file the
+        # worker just wrote.
+        ro_root = fws._ro_mount_prefixes()[0]
+        weird = os.path.join(ro_root, 'ArchivedClips')
+        monkeypatch.setattr(fws, '_archive_dir_prefix', lambda: weird)
+        path = os.path.join(weird, 'RecentClips', 'q.mp4')
+        archive, indexing, dropped = fws._classify_paths([path])
+        assert archive == []
+        assert indexing == [path]
+        assert dropped == []

--- a/tests/test_mapping_service.py
+++ b/tests/test_mapping_service.py
@@ -3046,35 +3046,65 @@ class TestPurgeDeletedVideos:
 
 
 class TestBootCatchupScan:
-    def _make_teslacam(self, root, files):
-        """Create a fake TeslaCam tree with the given relative paths."""
+    """Phase 2b (issue #76): boot_catchup_scan now walks ONLY
+    ``ARCHIVE_DIR`` (the SD-card ArchivedClips), never the RO USB
+    mount. The USB-side catch-up is handled by the
+    ``archive_producer`` thread, which enqueues into ``archive_queue``;
+    the worker then copies into ArchivedClips, where THIS catch-up
+    finds them on the next gadget_web start.
+
+    The legacy test signature ``boot_catchup_scan(db, tc)`` still
+    accepts the ``tc`` argument for back-compat, but it's now ignored.
+    All these tests populate ARCHIVE_DIR via monkeypatch instead.
+    """
+    def _make_archive(self, root, files):
+        """Create a fake ArchivedClips tree with the given relative paths."""
         for rel in files:
             full = root / rel
             full.parent.mkdir(parents=True, exist_ok=True)
             full.write_bytes(b'')
         return str(root)
 
+    def _make_teslacam(self, root, files):
+        """Compatibility helper kept so the dedup test below still works
+        (the test populates BOTH ArchivedClips and a legacy TeslaCam
+        tree, then verifies that only the ArchivedClips side gets
+        enqueued)."""
+        for rel in files:
+            full = root / rel
+            full.parent.mkdir(parents=True, exist_ok=True)
+            full.write_bytes(b'')
+        return str(root)
+
+    @pytest.fixture(autouse=True)
+    def _patch_archive_dir(self, tmp_path, monkeypatch):
+        """Point ARCHIVE_DIR at a per-test tmpdir so the scanner sees
+        a clean slate. This must run BEFORE each test populates files."""
+        archive_root = tmp_path / "ArchivedClips"
+        archive_root.mkdir()
+        import config as _cfg
+        monkeypatch.setattr(_cfg, 'ARCHIVE_DIR', str(archive_root))
+        monkeypatch.setattr(_cfg, 'ARCHIVE_ENABLED', True)
+        self._archive_root = archive_root
+
     def test_no_files_returns_zero_counts(self, tmp_path):
         db = str(tmp_path / "g.db")
         _init_db(db)
-        tc = self._make_teslacam(tmp_path / "TeslaCam", [])
-        result = boot_catchup_scan(db, tc)
+        result = boot_catchup_scan(db, '')
         assert result == {'scanned': 0, 'already_indexed': 0, 'enqueued': 0}
 
     def test_enqueues_orphan_clips(self, tmp_path):
         db = str(tmp_path / "g.db")
         _init_db(db)
-        tc = self._make_teslacam(tmp_path / "TeslaCam", [
+        # Populate the ArchivedClips tree with three distinct
+        # canonical_keys: a flat RecentClips file, a SavedClips event
+        # folder file, and a SentryClips event folder file.
+        self._make_archive(self._archive_root, [
             'RecentClips/2025-11-08_08-15-44-front.mp4',
             'SavedClips/2025-11-08_evt/2025-11-08_08-15-44-front.mp4',
             'SentryClips/2025-11-08_evt2/2025-11-08_08-20-00-front.mp4',
         ])
-        result = boot_catchup_scan(db, tc)
-        # SavedClips and SentryClips entries enqueue (event-folder keys);
-        # RecentClips also enqueues (basename key). Total = 3 distinct
-        # canonical keys. (RecentClips and SavedClips share basename
-        # 2025-11-08_08-15-44-front.mp4 but DIFFERENT canonical_key
-        # because SavedClips is event-folder-keyed.)
+        result = boot_catchup_scan(db, '')
         assert result['scanned'] >= 3
         assert result['enqueued'] == 3
         with sqlite3.connect(db) as c:
@@ -3086,12 +3116,16 @@ class TestBootCatchupScan:
     def test_skips_already_indexed_clips(self, tmp_path):
         db = str(tmp_path / "g.db")
         _init_db(db)
-        tc = self._make_teslacam(tmp_path / "TeslaCam", [
+        self._make_archive(self._archive_root, [
             'RecentClips/2025-11-08_08-15-44-front.mp4',
         ])
-        # Pre-populate indexed_files with the same canonical_key.
+        # Pre-populate indexed_files with the canonical_key matching
+        # the ArchivedClips path. canonical_key for a RecentClips file
+        # is just the basename (so any pre-existing row with the same
+        # basename counts as "already indexed").
         full_path = os.path.join(
-            tc, 'RecentClips', '2025-11-08_08-15-44-front.mp4'
+            str(self._archive_root),
+            'RecentClips', '2025-11-08_08-15-44-front.mp4',
         )
         with sqlite3.connect(db) as c:
             c.execute(
@@ -3101,7 +3135,7 @@ class TestBootCatchupScan:
                    VALUES (?, 0, 0, '2025-01-01', 5, 0)""",
                 (full_path,),
             )
-        result = boot_catchup_scan(db, tc)
+        result = boot_catchup_scan(db, '')
         assert result['scanned'] >= 1
         assert result['already_indexed'] >= 1
         assert result['enqueued'] == 0
@@ -3109,16 +3143,17 @@ class TestBootCatchupScan:
     def test_skips_already_queued_clips(self, tmp_path):
         db = str(tmp_path / "g.db")
         _init_db(db)
-        tc = self._make_teslacam(tmp_path / "TeslaCam", [
+        self._make_archive(self._archive_root, [
             'RecentClips/2025-11-08_08-15-44-front.mp4',
         ])
         full_path = os.path.join(
-            tc, 'RecentClips', '2025-11-08_08-15-44-front.mp4'
+            str(self._archive_root),
+            'RecentClips', '2025-11-08_08-15-44-front.mp4',
         )
         # Pre-queue (e.g. from a watcher event during the scan).
         enqueue_for_indexing(db, full_path)
         # Catch-up must not double-enqueue.
-        result = boot_catchup_scan(db, tc)
+        result = boot_catchup_scan(db, '')
         assert result['enqueued'] == 0
         with sqlite3.connect(db) as c:
             count = c.execute(
@@ -3127,29 +3162,43 @@ class TestBootCatchupScan:
         assert count == 1
 
     def test_recent_and_archived_dedup_by_canonical_key(self, tmp_path):
-        # If a clip exists in both RecentClips and ArchivedClips, the
-        # catch-up should enqueue only once (canonical_key dedup).
+        # Two files with the same basename but DIFFERENT canonical_key
+        # (one flat under RecentClips, one nested under SavedClips/evt)
+        # should both enqueue — they're distinct canonical keys.
         db = str(tmp_path / "g.db")
         _init_db(db)
-        # ArchivedClips lives outside TeslaCam but _find_front_camera_videos
-        # picks it up via config.ARCHIVE_DIR. Without setting that env
-        # we just test the in-memory dedup against duplicate yields.
-        tc = self._make_teslacam(tmp_path / "TeslaCam", [
+        self._make_archive(self._archive_root, [
             'RecentClips/dup-front.mp4',
+            'SavedClips/evt/dup-front.mp4',
         ])
-        # Fake a second yield by also placing the file in a SavedClips
-        # event folder under the same basename — this WILL get a
-        # different canonical_key (event/saved keys are unique). So
-        # this verifies *that's* the case (no false dedup).
-        os.makedirs(os.path.join(tc, 'SavedClips', 'evt'), exist_ok=True)
-        with open(
-            os.path.join(tc, 'SavedClips', 'evt', 'dup-front.mp4'), 'wb'
-        ) as f:
-            f.write(b'')
-        result = boot_catchup_scan(db, tc)
+        result = boot_catchup_scan(db, '')
         # Two distinct canonical keys: bare 'dup-front.mp4' (Recent)
         # and 'SavedClips/evt/dup-front.mp4' (Saved).
         assert result['enqueued'] == 2
+
+    def test_legacy_teslacam_argument_is_ignored(self, tmp_path):
+        """Phase 2b: even if the caller passes a TeslaCam path with
+        clips on it, the scanner walks ArchivedClips ONLY. This is the
+        whole point of the redesign — the indexer must never touch
+        the RO USB mount."""
+        db = str(tmp_path / "g.db")
+        _init_db(db)
+        # Populate a legacy TeslaCam tree with clips that should NOT
+        # be enqueued.
+        legacy_tc = self._make_teslacam(tmp_path / "TeslaCam", [
+            'RecentClips/should-not-enqueue-front.mp4',
+            'SavedClips/evt/should-not-enqueue-front.mp4',
+        ])
+        # ArchivedClips is empty — scanner must report zero.
+        result = boot_catchup_scan(db, legacy_tc)
+        assert result == {
+            'scanned': 0, 'already_indexed': 0, 'enqueued': 0,
+        }
+        with sqlite3.connect(db) as c:
+            count = c.execute(
+                "SELECT COUNT(*) FROM indexing_queue"
+            ).fetchone()[0]
+        assert count == 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mode_control.py
+++ b/tests/test_mode_control.py
@@ -1,0 +1,211 @@
+"""Tests for scripts/web/blueprints/mode_control.py.
+
+Covers the worker pause/resume coordination introduced in PR #88
+(Phase 2b of issue #76) and the asymmetric pause-failure cleanup
+fixed in issue #89.
+"""
+
+import sys
+import types
+import unittest
+from unittest.mock import MagicMock
+
+# conftest.py already adds ``scripts/web`` to sys.path, but the real
+# blueprint imports a long chain of services at module-load time.
+# Import the blueprint once at module import; per-test we then swap
+# only ``services.indexing_worker`` and ``services.archive_worker`` in
+# sys.modules, which is what ``from services import indexing_worker``
+# inside ``_pause_worker_for_mode_switch`` will resolve.
+from blueprints import mode_control as mode_control_module  # noqa: E402
+
+
+def _make_worker_module(*, is_running, pause_returns, raise_on_pause=None):
+    """Build a stand-in for an indexing_worker / archive_worker module.
+
+    Returns a SimpleNamespace exposing the three functions that
+    ``_pause_worker_for_mode_switch`` interrogates (``is_running``,
+    ``pause_worker``, ``resume_worker``) so tests can assert on call
+    counts.
+    """
+    mod = types.SimpleNamespace()
+    mod.is_running = MagicMock(return_value=is_running)
+    if raise_on_pause is not None:
+        mod.pause_worker = MagicMock(side_effect=raise_on_pause)
+    else:
+        mod.pause_worker = MagicMock(return_value=pause_returns)
+    mod.resume_worker = MagicMock(return_value=None)
+    return mod
+
+
+class _SwapWorkers:
+    """Context manager that temporarily installs stand-in worker modules.
+
+    Restores whatever was previously in ``sys.modules`` for the two
+    worker module paths so the rest of the test suite is unaffected.
+    """
+
+    def __init__(self, indexer, archive):
+        self.indexer = indexer
+        self.archive = archive
+        self._prev_indexer = None
+        self._prev_archive = None
+
+    def __enter__(self):
+        self._prev_indexer = sys.modules.get('services.indexing_worker')
+        self._prev_archive = sys.modules.get('services.archive_worker')
+        sys.modules['services.indexing_worker'] = self.indexer
+        sys.modules['services.archive_worker'] = self.archive
+        # Also bind on the parent package so ``from services import X``
+        # resolves to our stand-in (it normally walks the package's
+        # attribute table, not just sys.modules).
+        import services  # noqa: WPS433
+        self._prev_pkg_indexer = getattr(services, 'indexing_worker', None)
+        self._prev_pkg_archive = getattr(services, 'archive_worker', None)
+        services.indexing_worker = self.indexer
+        services.archive_worker = self.archive
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        if self._prev_indexer is not None:
+            sys.modules['services.indexing_worker'] = self._prev_indexer
+        else:
+            sys.modules.pop('services.indexing_worker', None)
+        if self._prev_archive is not None:
+            sys.modules['services.archive_worker'] = self._prev_archive
+        else:
+            sys.modules.pop('services.archive_worker', None)
+        import services  # noqa: WPS433
+        if self._prev_pkg_indexer is not None:
+            services.indexing_worker = self._prev_pkg_indexer
+        else:
+            try:
+                delattr(services, 'indexing_worker')
+            except AttributeError:
+                pass
+        if self._prev_pkg_archive is not None:
+            services.archive_worker = self._prev_pkg_archive
+        else:
+            try:
+                delattr(services, 'archive_worker')
+            except AttributeError:
+                pass
+
+
+class TestPauseWorkerForModeSwitch(unittest.TestCase):
+    """Regression coverage for issue #89.
+
+    The bug: when one worker pauses successfully and the other fails,
+    the function returned False (correctly refusing the mode switch)
+    but the successfully-paused worker stayed paused indefinitely
+    until either the next successful mode switch or a gadget_web
+    restart. For the archive worker this was a bounded data-loss
+    path because Tesla rotates RecentClips after ~60 minutes.
+    """
+
+    def test_both_pause_succeed_returns_true(self):
+        indexer = _make_worker_module(is_running=True, pause_returns=True)
+        archive = _make_worker_module(is_running=True, pause_returns=True)
+        with _SwapWorkers(indexer, archive):
+            self.assertTrue(
+                mode_control_module._pause_worker_for_mode_switch()
+            )
+        indexer.pause_worker.assert_called_once()
+        archive.pause_worker.assert_called_once()
+        # Neither worker should be resumed by the pause helper itself —
+        # the caller's try/finally is responsible for the post-switch
+        # resume.
+        indexer.resume_worker.assert_not_called()
+        archive.resume_worker.assert_not_called()
+
+    def test_indexer_pauses_archive_fails_unwinds_indexer(self):
+        """Issue #89 (indexer-side): a successful indexer pause must
+        be unwound when archive fails to pause.
+        """
+        indexer = _make_worker_module(is_running=True, pause_returns=True)
+        archive = _make_worker_module(is_running=True, pause_returns=False)
+        with _SwapWorkers(indexer, archive):
+            self.assertFalse(
+                mode_control_module._pause_worker_for_mode_switch()
+            )
+        # Indexer was paused → must be unwound exactly once via the
+        # centralized cleanup.
+        indexer.resume_worker.assert_called_once()
+        # Archive's own pause returned False → its inner self-recovery
+        # block already called resume_worker once. The centralized
+        # unwind does NOT fire on archive because archive_paused is
+        # False.
+        self.assertEqual(archive.resume_worker.call_count, 1)
+
+    def test_archive_pauses_indexer_fails_unwinds_archive(self):
+        """Issue #89 (archive-side): a successful archive pause must
+        be unwound when indexer fails to pause.
+        """
+        indexer = _make_worker_module(is_running=True, pause_returns=False)
+        archive = _make_worker_module(is_running=True, pause_returns=True)
+        with _SwapWorkers(indexer, archive):
+            self.assertFalse(
+                mode_control_module._pause_worker_for_mode_switch()
+            )
+        self.assertEqual(indexer.resume_worker.call_count, 1)
+        archive.resume_worker.assert_called_once()
+
+    def test_archive_pause_raises_after_indexer_paused(self):
+        """An exception during archive pause must still unwind a
+        paused indexer.
+        """
+        indexer = _make_worker_module(is_running=True, pause_returns=True)
+        archive = _make_worker_module(
+            is_running=True,
+            pause_returns=None,
+            raise_on_pause=RuntimeError("synthetic pause failure"),
+        )
+        with _SwapWorkers(indexer, archive):
+            self.assertFalse(
+                mode_control_module._pause_worker_for_mode_switch()
+            )
+        indexer.resume_worker.assert_called_once()
+
+    def test_indexer_pause_raises_with_archive_paused(self):
+        """An exception during indexer pause (with mapping enabled)
+        must still unwind a paused archive worker.
+        """
+        indexer = _make_worker_module(
+            is_running=True,
+            pause_returns=None,
+            raise_on_pause=RuntimeError("synthetic pause failure"),
+        )
+        archive = _make_worker_module(is_running=True, pause_returns=True)
+
+        import config as config_module
+        original_mapping = getattr(config_module, 'MAPPING_ENABLED', None)
+        config_module.MAPPING_ENABLED = True
+        try:
+            with _SwapWorkers(indexer, archive):
+                self.assertFalse(
+                    mode_control_module._pause_worker_for_mode_switch()
+                )
+            archive.resume_worker.assert_called_once()
+        finally:
+            if original_mapping is None:
+                try:
+                    delattr(config_module, 'MAPPING_ENABLED')
+                except AttributeError:
+                    pass
+            else:
+                config_module.MAPPING_ENABLED = original_mapping
+
+    def test_neither_worker_running_returns_true(self):
+        indexer = _make_worker_module(is_running=False, pause_returns=True)
+        archive = _make_worker_module(is_running=False, pause_returns=True)
+        with _SwapWorkers(indexer, archive):
+            self.assertTrue(
+                mode_control_module._pause_worker_for_mode_switch()
+            )
+        indexer.pause_worker.assert_not_called()
+        archive.pause_worker.assert_not_called()
+        indexer.resume_worker.assert_not_called()
+        archive.resume_worker.assert_not_called()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_video_archive_trigger.py
+++ b/tests/test_video_archive_trigger.py
@@ -1,219 +1,118 @@
-"""Tests for the archive-trigger duplicate-prevention logic in
-``services.video_archive_service``.
+"""Tests for the Phase 2b ``video_archive_service`` shims (issue #76).
 
-These guard the ``_archive_pending`` flag introduced after the May
-2026 phantom-trips fix: switching ``acquire_task('archive')`` from
-non-blocking to ``wait_seconds=60.0`` opened a window where a second
-``trigger_archive_now()`` could spawn a duplicate archive thread while
-the first was still waiting for the coordinator lock. ``_status['running']``
-is set only AFTER lock acquisition, so it cannot guard that window —
-``_archive_pending`` must.
+The legacy ``_archive_timer_loop`` periodic thread + ``_archive_pending``
+duplicate-guard pattern is gone. ``video_archive_service`` is now a thin
+compatibility layer over ``archive_worker``:
+
+* ``start_archive_timer()`` → ``archive_worker.ensure_worker_started()``
+* ``stop_archive_timer()``  → ``archive_worker.stop_worker()``
+* ``trigger_archive_now()`` → ``archive_worker.wake()``
+
+The old tests asserted on the deleted internals (``_run_archive``,
+``_archive_pending``, ``_archive_timer_loop``, the ionice-on-the-process
+bug). Those are no longer reachable code paths and have been deleted.
+The Phase 2b worker has its own pause/resume/wake/dead-letter test
+coverage in ``test_archive_worker.py``.
 """
 
-import time
-import threading
+from unittest.mock import patch
 
 import pytest
 
 from services import video_archive_service as vas
-from services import task_coordinator as tc
 
 
 @pytest.fixture(autouse=True)
 def _reset_state():
-    """Snapshot and restore module-level state around each test so
-    leakage between tests can't mask real regressions."""
-    saved_status = dict(vas._status)
-    saved_pending = vas._archive_pending
-    saved_enabled = vas.ARCHIVE_ENABLED
-    # Coordinator state too.
-    with tc._lock:
-        tc._current_task = None
-        tc._task_started = 0.0
-        tc._waiter_count = 0
-    vas.ARCHIVE_ENABLED = True
-    vas._archive_pending = False
-    vas._status['running'] = False
-    yield
-    vas._status.clear()
-    vas._status.update(saved_status)
-    vas._archive_pending = saved_pending
-    vas.ARCHIVE_ENABLED = saved_enabled
-    with tc._lock:
-        tc._current_task = None
-        tc._task_started = 0.0
-        tc._waiter_count = 0
+    """Snapshot/restore module-level state so test order doesn't matter.
 
-
-class TestTriggerArchiveDuplicateGuard:
-    def test_disabled_returns_false(self):
-        vas.ARCHIVE_ENABLED = False
-        assert vas.trigger_archive_now() is False
-        assert vas._archive_pending is False
-
-    def test_first_trigger_starts_thread(self, monkeypatch):
-        # Replace _run_archive with a sentinel so we don't actually copy
-        # files. We just want to verify trigger_archive_now's guard logic.
-        called = threading.Event()
-
-        def fake_run():
-            called.set()
-            # Hold "pending" for a moment so we can test the guard.
-            time.sleep(0.2)
-            with vas._archive_lock:
-                vas._archive_pending = False
-
-        monkeypatch.setattr(vas, '_run_archive', fake_run)
-        assert vas.trigger_archive_now() is True
-        assert called.wait(timeout=1.0)
-
-    def test_second_trigger_refused_while_first_is_pending(self, monkeypatch):
-        """Critical race: while the first archive is waiting for the
-        coordinator lock, ``_status['running']`` is still False. The
-        guard must use ``_archive_pending`` to block the second call."""
-        gate = threading.Event()
-
-        def fake_run():
-            # Simulate the first archive sitting in acquire_task waiting
-            # for the lock. Hold _archive_pending until the test releases us.
-            gate.wait(timeout=2.0)
-            with vas._archive_lock:
-                vas._archive_pending = False
-
-        monkeypatch.setattr(vas, '_run_archive', fake_run)
-        assert vas.trigger_archive_now() is True
-        # Second trigger immediately after must be refused even though
-        # _status['running'] is still False.
-        assert vas._status.get('running') is not True
-        assert vas._archive_pending is True
-        assert vas.trigger_archive_now() is False
-        # Let the first archive finish so the fixture can clean up.
-        gate.set()
-        # Give the worker a moment to clear _archive_pending.
-        time.sleep(0.1)
-
-    def test_third_trigger_succeeds_after_first_completes(self, monkeypatch):
-        gate = threading.Event()
-        runs = []
-
-        def fake_run():
-            runs.append(time.monotonic())
-            gate.wait(timeout=2.0)
-            with vas._archive_lock:
-                vas._archive_pending = False
-
-        monkeypatch.setattr(vas, '_run_archive', fake_run)
-        assert vas.trigger_archive_now() is True
-        assert vas.trigger_archive_now() is False
-        gate.set()
-        # Wait for the first run to clear pending.
-        for _ in range(50):
-            if not vas._archive_pending:
-                break
-            time.sleep(0.01)
-        # Reset the gate so the next "run" can also exit.
-        gate.clear()
-        gate.set()
-        assert vas.trigger_archive_now() is True
-        # Two distinct runs occurred.
-        assert len(runs) == 2
-
-
-class TestArchiveIoniceUsesThreadId:
-    """Issue #72: ``_archive_timer_loop`` was calling
-    ``ionice -c 3 -p <os.getpid()>`` to drop the archive thread's I/O
-    priority — but on Linux ``ioprio_set`` is per-task. Passing the
-    process PID only adjusts the main thread's I/O class, leaving
-    the archive worker thread at default best-effort priority and
-    fully able to starve the gadget endpoint and Flask. The fix
-    passes ``threading.get_native_id()`` instead.
+    The shim layer no longer carries ``_archive_pending`` or any other
+    duplicate-guard mutex (the worker is a singleton thread; that IS
+    the guard). All we need to preserve is ``ARCHIVE_ENABLED`` so a
+    test that toggles it doesn't bleed into the next.
     """
+    saved_enabled = vas.ARCHIVE_ENABLED
+    yield
+    vas.ARCHIVE_ENABLED = saved_enabled
 
-    def test_archive_ionice_uses_native_tid_not_pid(self, monkeypatch):
-        import sys
-        if not sys.platform.startswith('linux'):
-            pytest.skip("ionice is Linux-only")
 
-        captured = []
-        # Mock subprocess.run to capture the ionice invocation. Then
-        # raise after capturing so the archive timer loop exits early
-        # without waiting 2 minutes for the initial-delay.
-        gate_event = threading.Event()
+class TestTriggerArchiveNow:
+    """``trigger_archive_now()`` is now a thin wrapper that delegates
+    to ``archive_worker.wake()`` after a short config check."""
 
-        def fake_run(cmd, *a, **kw):
-            captured.append(cmd)
+    def test_disabled_returns_false(self):
+        # When ARCHIVE_ENABLED is False the wrapper short-circuits and
+        # never touches the worker — returning False so callers know
+        # nothing happened.
+        vas.ARCHIVE_ENABLED = False
+        with patch('services.archive_worker.wake') as mock_wake, \
+             patch(
+                 'services.archive_worker.ensure_worker_started',
+             ) as mock_start:
+            assert vas.trigger_archive_now() is False
+            mock_wake.assert_not_called()
+            mock_start.assert_not_called()
 
-            class R:
-                returncode = 0
-                stdout = b''
-                stderr = b''
-            # Trip the cancel after the first ionice call to exit the
-            # loop quickly.
-            gate_event.set()
-            return R()
+    def test_enabled_calls_worker_wake(self):
+        vas.ARCHIVE_ENABLED = True
+        with patch('services.archive_worker.wake') as mock_wake, \
+             patch(
+                 'services.archive_worker.ensure_worker_started',
+             ) as mock_start:
+            assert vas.trigger_archive_now() is True
+            mock_start.assert_called_once()
+            mock_wake.assert_called_once()
 
-        import subprocess as sp
-        monkeypatch.setattr(sp, 'run', fake_run)
+    def test_wake_failure_is_swallowed(self):
+        # The wrapper is called from the NM dispatcher
+        # (``helpers/refresh_cloud_token.py``). A worker-side
+        # exception MUST NOT propagate up — the caller treats False
+        # as "no archive started" and moves on to the cloud sync
+        # trigger. Silent fail keeps WiFi-connect resilient.
+        vas.ARCHIVE_ENABLED = True
+        with patch(
+            'services.archive_worker.ensure_worker_started',
+        ), patch(
+            'services.archive_worker.wake',
+            side_effect=RuntimeError("synthetic"),
+        ):
+            # Should not raise. False return is acceptable.
+            result = vas.trigger_archive_now()
+            assert result is False
 
-        # Stop the loop right after the ionice call by setting the
-        # cancel event — that way the for-loop initial delay exits on
-        # its first iteration.
-        cancel = threading.Event()
-        monkeypatch.setattr(vas, '_archive_cancel', cancel)
 
-        def stop_after_first_run():
-            gate_event.wait(timeout=2.0)
-            cancel.set()
+class TestStartStopShims:
+    """``start_archive_timer`` and ``stop_archive_timer`` are now pure
+    delegations to the worker; the legacy internal thread is gone."""
 
-        stopper = threading.Thread(target=stop_after_first_run, daemon=True)
-        stopper.start()
+    def test_start_archive_timer_starts_worker(self):
+        with patch(
+            'services.archive_worker.ensure_worker_started',
+        ) as mock_start:
+            vas.start_archive_timer()
+            mock_start.assert_called_once()
 
-        # Run the timer loop directly. It should ionice-then-exit.
-        loop_thread = threading.Thread(
-            target=vas._archive_timer_loop, daemon=True,
-        )
-        loop_thread.start()
-        # Capture the loop thread's TID — that's what should be passed
-        # to ionice. Native TID is set as soon as the thread starts.
-        # Wait briefly for the thread to register its TID and run
-        # ionice.
-        for _ in range(100):
-            if captured:
-                break
-            time.sleep(0.01)
-        loop_thread.join(timeout=5.0)
+    def test_start_archive_timer_swallows_worker_failure(self):
+        # Same resilience contract as trigger_archive_now: a worker
+        # startup failure must not crash gadget_web's main thread.
+        with patch(
+            'services.archive_worker.ensure_worker_started',
+            side_effect=RuntimeError("synthetic"),
+        ):
+            # Should not raise.
+            vas.start_archive_timer()
 
-        ionice_calls = [c for c in captured if c and c[0] == 'ionice']
-        assert ionice_calls, (
-            f"Expected an ionice call from _archive_timer_loop, got: "
-            f"{captured}"
-        )
-        cmd = ionice_calls[0]
-        p_idx = cmd.index('-p')
-        tid_arg = int(cmd[p_idx + 1])
+    def test_stop_archive_timer_stops_worker(self):
+        with patch('services.archive_worker.stop_worker') as mock_stop:
+            vas.stop_archive_timer()
+            mock_stop.assert_called_once()
 
-        import os
-        # The TID must NOT be the process PID — that's the bug being
-        # fixed.
-        assert tid_arg != os.getpid(), (
-            f"ionice -p {tid_arg} matches process PID {os.getpid()} "
-            f"— this is the issue #72 bug; archive thread's I/O "
-            f"priority must be set on its OWN native TID, not the "
-            f"process PID"
-        )
-
-    def test_pending_cleared_when_run_returns_normally(self, monkeypatch):
-        def fake_run():
-            with vas._archive_lock:
-                vas._archive_pending = False
-
-        monkeypatch.setattr(vas, '_run_archive', fake_run)
-        assert vas.trigger_archive_now() is True
-        # Worker thread is short-lived; give it a moment.
-        for _ in range(50):
-            if not vas._archive_pending:
-                break
-            time.sleep(0.01)
-        assert vas._archive_pending is False, (
-            "_archive_pending must be cleared by _run_archive's finally"
-        )
+    def test_stop_archive_timer_swallows_worker_failure(self):
+        # Shutdown path needs to be resilient — a worker that's already
+        # gone should not block the rest of the shutdown handler.
+        with patch(
+            'services.archive_worker.stop_worker',
+            side_effect=RuntimeError("synthetic"),
+        ):
+            # Should not raise.
+            vas.stop_archive_timer()


### PR DESCRIPTION
## Summary

Phase 2b of the issue #76 redesign: wires up the queue-draining side of the archive pipeline. Pairs with Phase 2a (PR #87) to form a complete two-queue flow:

`archive_producer -> archive_queue -> archive_worker -> indexing_queue`

The legacy `video_archive_service._archive_timer_loop` periodic thread is removed; the archive flow is now entirely queue-driven with proper task_coordinator fairness, atomic copies, dead-letter handling, and pause/resume coordination with the indexer for mode switches.

## What this PR does

- **New `services/archive_worker.py`** ù single daemon thread mirroring the indexing_worker contract (`start_worker` / `stop_worker` / `pause_worker` / `resume_worker` / `ensure_worker_started` / `wake` / `get_status`). The loop claims one row at a time, applies a 5-second stable-write gate, atomically copies into `ArchivedClips`, then enqueues the dest into `indexing_queue`.
- **Six new worker-side helpers in `services/archive_queue.py`:** `claim_next_for_worker` (atomic `UPDATE...RETURNING` with a SELECT-then-UPDATE-with-rowcount fallback for older SQLite), `mark_copied`, `mark_source_gone`, `release_claim`, `mark_failed` (transitions to `dead_letter` at `retry_max_attempts`), `recover_stale_claims` (startup recovery for `claimed` rows older than 600 s).
- **`file_watcher_service._notify_callbacks` rerouted** via the new `_classify_paths` helper. Files under the RO USB mount fire archive callbacks ONLY; files under `ARCHIVE_DIR` fire indexing callbacks ONLY. Anything else is dropped with a debug log. This kills the old `indexer walks RecentClips` footgun.
- **`mapping_service.boot_catchup_scan` simplified** to walk ONLY `ARCHIVE_DIR` via the new `_find_archived_videos` helper. The `teslacam_path` arg is kept for back-compat but ignored ù there is no path from this function to the RO USB mount any more.
- **`video_archive_service` reduced from 1496 -> 1117 lines:** `_archive_timer_loop`, `_run_archive`, `_do_archive_work`, `_discover_new_files` are gone. `start_archive_timer` / `stop_archive_timer` / `trigger_archive_now` are now thin shims that delegate to `archive_worker` (so existing callers ù the NM dispatcher's `/api/recent_archive/trigger`, the cleanup endpoints ù keep working unchanged).
- **`mode_control._pause_worker_for_mode_switch` / `_resume_worker_after_mode_switch`** now coordinate the archive worker alongside the indexer. A failed pause on either side refuses the mode switch and resumes both ù a mid-copy unmount produces 0-byte ArchivedClips files and Tesla may have rotated the source by the next archive cycle.
- **`web_control.py`** starts the archive worker after the producer. The legacy `start_archive_timer` call site is removed; the shim still works for any out-of-tree callers.
- **Three new config keys in `archive_queue:`** ù `worker_check_interval_seconds` (5), `retry_max_attempts` (3), `copy_chunk_bytes` (1 MiB) ù wired into `config.yaml` / `scripts/config.sh` / `scripts/web/config.py`.

## Hard constraints (verified by grep)

| Rule | Verification |
|------|--------------|
| Archive subsystem makes ZERO USB-gadget calls | g "import.*partition_mount_service\|partition_mount_service\.\|losetup\|nsenter\|quick_edit_part2\|rebind_usb_gadget" scripts/web/services/archive_worker.py scripts/web/services/archive_queue.py scripts/web/services/archive_producer.py -> only docstring contract mentions; **zero executable code references**. (TestModuleSafety pins this in CI.) |
| Indexer no longer walks RO USB mount | g "part1-ro" scripts/web/services/mapping_service.py scripts/web/services/indexing_worker.py -> single hit is a comment in pre-existing `_refresh_ro_mount` (called by cloud + LES, not by indexing/archive). **Zero indexing-flow references.** |
| Release task_coordinator lock BEFORE every sleep | Loop pattern 	ry: acquire(); work() finally: release() then sleep in the next iteration. `_wait_with_wake` and all `_stop_event.wait()` calls happen outside the `try` block. |
| `acquire_task('archive', wait_seconds=60.0)` | Periodic priority task pattern from the task_coordinator docstring (NOT `yield_to_waiters=True`). |
| Atomic file writes | `_atomic_copy` uses temp + `flush` + `fsync` + size-verify + `os.replace`. `.partial` cleaned on every failure path. |
| Pi Zero 2 W resource budget | Imports: `os`, `shutil`, `sqlite3`, `logging`, `threading`, `time`, `uuid`, `sys`. No `cv2`/`av`/`PIL`/`numpy`/`requests`. |
| Trips/waypoints/events sacred | `boot_catchup_scan` only ENQUEUEs; never deletes. `purge_deleted_videos` semantics unchanged. |

## Acceptance criteria mapping (issue #76)

**Now testable in unit tests:**
- **(1) Worker starvation under indexer load** ù `TestArchiveWorkerStarvation` (10 archive items drain within 30 s while a synthetic indexer thread cycles the `yield_to_waiters=True` slot).
- **(4) Bad-file resilience** ù `TestArchiveWorkerDeadLetter` (3 synthetic OSErrors -> dead_letter + sidecar with all required fields).
- **(9) Map fragmentation guard** ù `TestArchiveWorkerCopy::test_copy_enqueues_dest_into_indexer` plus the `TestBootCatchupScan` rewrite (indexer only ever sees ArchivedClips paths, so canonical_key collisions across Recent/Archived can no longer fragment a trip).

**Require Pi-side runtime testing post-deploy:**
- **(2) gadget_web crash recovery** ù `recover_stale_claims` runs at every worker start; needs a real OOM/SIGKILL on the Pi.
- **(3) quick-edit interrupt** ù needs a real `quick_edit_part2` cycle with the worker mid-copy; `mode_control.pause` coordinates this.
- **(5) VFS cache refresh on the RO mount** ù uses `drop_caches=2` via the existing helper; archive worker is just a reader.
- **(8) Continuous live driving** ù needs an in-vehicle session.

**Deferred to Phase 2c:**
- **(6) Watchdog** ù Phase 2c will add stale-claim alerts + dead-letter count threshold checks.
- **(7) Disk-full guard** ù Phase 2c will add `shutil.disk_usage` pre-flight in `process_one_claim` plus a `smart_cleanup` hook.

## Test results

- Baseline (Phase 2a, post-#87 merge): **563 passed, 4 skipped**.
- This PR: **621 passed, 3 skipped**.
- New tests: **58** (28 `test_archive_worker`, 25 `test_archive_queue` worker helpers, 5 path classification + back-compat).
- Generate `services/dashcam_pb2.py` before pytest: `python -m grpc_tools.protoc --python_out=scripts/web/services -I scripts/web/static scripts/web/static/dashcam.proto` (gitignored; tracked in #84).

## Out of scope

- Phase 2c watchdog + disk-full guard + `/api/archive_queue/status` expansion ù separate PR.
- Removal of orphan helpers in `video_archive_service` (e.g. `_buffered_copy`, `_proactive_retention`) ù kept for the Phase 2c watchdog/cleanup path; no callers in Phase 2b.
- Cloud sync, LES, and `_refresh_ro_mount` are untouched.
- No deploy / `setup_usb.sh` run.

Structurally supersedes the quick-relief patches in #70 and #71 (both auto-closed by PR #85's merge of Phase 1).

Ref #76 (Phase 2b)
