### PR TITLE
feat(issue-76): Phase 2c — archive watchdog + observability + storage

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -134,6 +134,14 @@ cloud_archive:
   cloud_auto_cleanup: false              # Auto-delete old cloud videos when storage is low
   cloud_cleanup_threshold_pct: 90        # Delete when cloud usage exceeds this %
   cloud_min_retention_days: 30           # Keep at least this many days of videos
+  # Phase 2c (issue #76) — local ArchivedClips storage management on the SD card.
+  # The retention prune walks ~/ArchivedClips and deletes *.mp4 files older than
+  # this many days; trip/waypoint/event rows in geodata.db are preserved (only
+  # their video_path pointer is nulled). Disk-space guard refuses new copies and
+  # logs CRITICAL when the SD card free space drops below disk_space_critical_mb.
+  archived_clips_retention_days: 30      # Local SD-card retention for ArchivedClips/*.mp4
+  disk_space_warning_mb: 500             # Log WARNING when SD-card free space drops below this
+  disk_space_critical_mb: 100            # Refuse new archive copies when free space drops below this
 
 # ============================================================================
 # Live Event Sync Configuration
@@ -188,3 +196,5 @@ archive_queue:
   worker_check_interval_seconds: 5       # Idle/empty-queue sleep between worker iterations
   retry_max_attempts: 3                  # OSError retries before a row goes to dead_letter
   copy_chunk_bytes: 1048576              # Chunk size (1 MiB) for the temp+fsync+rename copy
+  # Phase 2c (issue #76) — health watchdog cadence.
+  watchdog_check_interval_seconds: 60    # Frequency of the archive-health watchdog tick

--- a/config.yaml
+++ b/config.yaml
@@ -142,6 +142,7 @@ cloud_archive:
   archived_clips_retention_days: 30      # Local SD-card retention for ArchivedClips/*.mp4
   disk_space_warning_mb: 500             # Log WARNING when SD-card free space drops below this
   disk_space_critical_mb: 100            # Refuse new archive copies when free space drops below this
+  disk_space_pause_seconds: 300          # How long the worker stays paused after a disk-critical refusal
 
 # ============================================================================
 # Live Event Sync Configuration

--- a/scripts/config.sh
+++ b/scripts/config.sh
@@ -84,6 +84,7 @@ eval "$(yq -r '
   "CLOUD_ARCHIVE_RETENTION_DAYS=\"" + (.cloud_archive.archived_clips_retention_days // .archive.retention_days // 30 | tostring) + "\"",
   "CLOUD_ARCHIVE_DISK_SPACE_WARNING_MB=\"" + (.cloud_archive.disk_space_warning_mb // 500 | tostring) + "\"",
   "CLOUD_ARCHIVE_DISK_SPACE_CRITICAL_MB=\"" + (.cloud_archive.disk_space_critical_mb // 100 | tostring) + "\"",
+  "CLOUD_ARCHIVE_DISK_SPACE_PAUSE_SECONDS=\"" + (.cloud_archive.disk_space_pause_seconds // 300 | tostring) + "\"",
   "TESLA_API_CLIENT_ID=\"" + (.tesla_api.client_id // "") + "\""
 ' "$CONFIG_YAML")"
 

--- a/scripts/config.sh
+++ b/scripts/config.sh
@@ -80,6 +80,10 @@ eval "$(yq -r '
   "ARCHIVE_QUEUE_WORKER_CHECK_INTERVAL_SECONDS=\"" + (.archive_queue.worker_check_interval_seconds // 5 | tostring) + "\"",
   "ARCHIVE_QUEUE_RETRY_MAX_ATTEMPTS=\"" + (.archive_queue.retry_max_attempts // 3 | tostring) + "\"",
   "ARCHIVE_QUEUE_COPY_CHUNK_BYTES=\"" + (.archive_queue.copy_chunk_bytes // 1048576 | tostring) + "\"",
+  "ARCHIVE_QUEUE_WATCHDOG_CHECK_INTERVAL_SECONDS=\"" + (.archive_queue.watchdog_check_interval_seconds // 60 | tostring) + "\"",
+  "CLOUD_ARCHIVE_RETENTION_DAYS=\"" + (.cloud_archive.archived_clips_retention_days // .archive.retention_days // 30 | tostring) + "\"",
+  "CLOUD_ARCHIVE_DISK_SPACE_WARNING_MB=\"" + (.cloud_archive.disk_space_warning_mb // 500 | tostring) + "\"",
+  "CLOUD_ARCHIVE_DISK_SPACE_CRITICAL_MB=\"" + (.cloud_archive.disk_space_critical_mb // 100 | tostring) + "\"",
   "TESLA_API_CLIENT_ID=\"" + (.tesla_api.client_id // "") + "\""
 ' "$CONFIG_YAML")"
 

--- a/scripts/web/blueprints/archive_queue.py
+++ b/scripts/web/blueprints/archive_queue.py
@@ -1,13 +1,16 @@
-"""Blueprint for the Phase 2a archive_queue observability stub (issue #76).
+"""Blueprint for the archive observability + storage endpoints (issue #76).
 
-Exposes a single read-only JSON endpoint:
+Exposes the read-only JSON endpoints that power the Settings → Archive
+panel, the Storage panel, and the persistent archive-health banner:
 
-* ``GET /api/archive_queue/status`` — counts per status plus producer
-  thread state.
-
-This is the minimum surface needed to verify Phase 2a is enqueueing
-correctly during the deployment window. The full per-priority counts,
-dead-letter inspection, and retry endpoints land in Phase 2c.
+* ``GET /api/archive/status`` — combined health + queue + worker +
+  disk + retention snapshot. The single source of truth for the UI.
+* ``GET /api/archive/dead_letters`` — list dead-letter rows for the
+  "View dead letters" modal.
+* ``POST /api/archive/prune_now`` — synchronous retention prune.
+* ``GET /api/archive_queue/status`` — Phase 2a observability stub kept
+  as a thin alias so deploy-time scripts and external probes don't
+  need a coordinated cutover.
 
 Image-gated on ``IMG_CAM_PATH`` (the queued clips live on the cam
 image / part1). Returns 503 JSON when the cam image is missing so
@@ -18,15 +21,16 @@ from __future__ import annotations
 
 import logging
 import os
+from typing import Any, Dict
 
-from flask import Blueprint, jsonify
+from flask import Blueprint, jsonify, request
 
 from config import ARCHIVE_QUEUE_ENABLED, IMG_CAM_PATH
 
 logger = logging.getLogger(__name__)
 
 archive_queue_bp = Blueprint(
-    'archive_queue', __name__, url_prefix='/api/archive_queue',
+    'archive_queue', __name__,
 )
 
 
@@ -36,15 +40,13 @@ def _require_cam_image():
         return jsonify({"error": "Feature unavailable"}), 503
 
 
-@archive_queue_bp.route('/status', methods=['GET'])
-def status():
-    """Return queue counts plus producer state.
+# ---------------------------------------------------------------------------
+# Phase 2a alias (kept intentionally — small, no-cost back-compat)
+# ---------------------------------------------------------------------------
 
-    When ``archive_queue.enabled`` is False in ``config.yaml`` the
-    queue counts are still returned (rows from a previous enabled
-    install are still visible), but ``producer.running`` will be False
-    because :mod:`web_control` skipped the producer thread startup.
-    """
+@archive_queue_bp.route('/api/archive_queue/status', methods=['GET'])
+def status():
+    """Return queue counts plus producer state (Phase 2a alias)."""
     from services import archive_queue, archive_producer
 
     try:
@@ -64,3 +66,166 @@ def status():
         "counts": counts,
         "producer": producer,
     })
+
+
+# ---------------------------------------------------------------------------
+# Phase 2c — combined status endpoint (single source of truth for the UI)
+# ---------------------------------------------------------------------------
+
+def _safe_call(fn, default):
+    try:
+        return fn()
+    except Exception:  # noqa: BLE001
+        logger.exception("/api/archive/status sub-call crashed")
+        return default
+
+
+@archive_queue_bp.route('/api/archive/status', methods=['GET'])
+def archive_status():
+    """Return the full archive subsystem snapshot.
+
+    Combines:
+      * watchdog health (severity, message, staleness)
+      * worker liveness (running, paused, active_file, last_outcome)
+      * queue depths per priority + per status
+      * SD-card disk usage
+      * retention bookkeeping (next prune due, last prune summary)
+
+    Designed so the Settings page can render every panel from a single
+    poll. JSON only; no template rendering. ~1 KB payload.
+    """
+    from services import archive_queue, archive_watchdog, archive_worker
+
+    health = _safe_call(archive_watchdog.get_status, {})
+    worker_status = _safe_call(archive_worker.get_status, {})
+    counts = _safe_call(archive_queue.get_queue_status, {})
+    by_priority = _safe_call(
+        archive_queue.get_pending_counts_by_priority, {1: 0, 2: 0, 3: 0},
+    )
+
+    response: Dict[str, Any] = {
+        # Top-level health (severity, message, banner trigger).
+        'severity': health.get('severity', 'ok'),
+        'message': health.get('message', ''),
+        'enabled': bool(ARCHIVE_QUEUE_ENABLED),
+        'checked_at': health.get('checked_at'),
+        'watchdog_running': health.get('watchdog_running', False),
+
+        # Per-priority pending counts (RecentClips first).
+        'queue_depth_p1': int(by_priority.get(1, 0)),
+        'queue_depth_p2': int(by_priority.get(2, 0)),
+        'queue_depth_p3': int(by_priority.get(3, 0)),
+
+        # Per-status counts (matches Phase 2a alias for convenience).
+        'pending_count': int(counts.get('pending', 0)),
+        'claimed_count': int(counts.get('claimed', 0)),
+        'copied_count': int(counts.get('copied', 0)),
+        'source_gone_count': int(counts.get('source_gone', 0)),
+        'dead_letter_count': int(counts.get('dead_letter', 0)),
+
+        # Worker liveness.
+        'worker_running': bool(worker_status.get('worker_running', False)),
+        'paused': bool(worker_status.get('paused', False)),
+        'active_file': worker_status.get('active_file'),
+        'last_outcome': worker_status.get('last_outcome'),
+        'last_error': worker_status.get('last_error'),
+        'files_done_session': int(
+            worker_status.get('files_done_session', 0),
+        ),
+        'disk_pause': worker_status.get(
+            'disk_pause', {'is_paused_now': False, 'paused_until_epoch': 0.0},
+        ),
+
+        # Disk + retention.
+        'disk_total_mb': int(health.get('disk_total_mb', 0)),
+        'disk_used_mb': int(health.get('disk_used_mb', 0)),
+        'disk_free_mb': int(health.get('disk_free_mb', 0)),
+        'disk_warning_mb': int(health.get('disk_warning_mb', 500)),
+        'disk_critical_mb': int(health.get('disk_critical_mb', 100)),
+        'last_successful_copy_at': health.get('last_successful_copy_at'),
+        'last_successful_copy_age_seconds': health.get(
+            'last_successful_copy_age_seconds',
+        ),
+    }
+
+    retention = (health.get('retention') or {})
+    response['retention_days'] = int(retention.get('retention_days', 30))
+    response['last_prune_at'] = retention.get('last_prune_at')
+    response['last_prune_deleted'] = int(retention.get(
+        'last_prune_deleted', 0,
+    ))
+    response['last_prune_freed_bytes'] = int(retention.get(
+        'last_prune_freed_bytes', 0,
+    ))
+    response['last_prune_error'] = retention.get('last_prune_error')
+    response['next_prune_due_at'] = retention.get('next_prune_due_at')
+
+    return jsonify(response)
+
+
+# ---------------------------------------------------------------------------
+# Phase 2c — dead-letter inspection
+# ---------------------------------------------------------------------------
+
+@archive_queue_bp.route('/api/archive/dead_letters', methods=['GET'])
+def archive_dead_letters():
+    """Return up to ``limit`` dead-letter rows for forensic inspection.
+
+    Used by the Settings → Archive panel "View dead letters" modal.
+    Each row already includes ``last_error`` so the user can see why
+    that clip moved out of pending.
+    """
+    from services import archive_queue
+    try:
+        limit = int(request.args.get('limit', 50))
+    except (TypeError, ValueError):
+        limit = 50
+    limit = max(1, min(limit, 500))
+    rows = _safe_call(
+        lambda: archive_queue.list_queue(
+            limit=limit, status='dead_letter',
+        ),
+        [],
+    )
+    return jsonify({'rows': rows, 'count': len(rows)})
+
+
+# ---------------------------------------------------------------------------
+# Phase 2c — manual retention prune trigger
+# ---------------------------------------------------------------------------
+
+@archive_queue_bp.route('/api/archive/prune_now', methods=['POST'])
+def archive_prune_now():
+    """Run a retention prune synchronously and return the summary.
+
+    Designed to be called from the Settings → Storage "Prune now"
+    button. For typical ArchivedClips sizes (a few hundred files) the
+    prune completes in well under a second; the user's spinner does
+    not become an actual UX problem.
+
+    Returns 503 if the watchdog hasn't been started (which would mean
+    the archive subsystem is disabled in config).
+    """
+    from services import archive_watchdog
+    if not archive_watchdog.is_running():
+        return jsonify({
+            'started': False,
+            'message': 'Archive watchdog is not running.',
+        }), 503
+    try:
+        summary = archive_watchdog.force_prune_now()
+    except Exception as e:  # noqa: BLE001
+        logger.exception("archive_prune_now failed")
+        return jsonify({'started': False, 'message': str(e)}), 500
+    return jsonify({
+        'started': True,
+        'deleted_count': int(summary.get('deleted_count', 0)),
+        'freed_bytes': int(summary.get('freed_bytes', 0)),
+        'scanned': int(summary.get('scanned', 0)),
+        'duration_seconds': float(summary.get('duration_seconds', 0.0)),
+        'cutoff_iso': summary.get('cutoff_iso'),
+        'retention_days': int(summary.get(
+            'retention_days', 30,
+        )),
+    })
+

--- a/scripts/web/blueprints/archive_queue.py
+++ b/scripts/web/blueprints/archive_queue.py
@@ -136,12 +136,17 @@ def archive_status():
             'disk_pause', {'is_paused_now': False, 'paused_until_epoch': 0.0},
         ),
 
-        # Disk + retention.
+        # Disk + retention. ``disk_known=False`` means ``shutil.disk_usage``
+        # raised OSError on the most recent watchdog tick; the disk fields
+        # are then stale/zero and the severity overlay was skipped — the
+        # UI should suppress the storage panel rather than render a
+        # misleading "0 of 0 MB" pie.
         'disk_total_mb': int(health.get('disk_total_mb', 0)),
         'disk_used_mb': int(health.get('disk_used_mb', 0)),
         'disk_free_mb': int(health.get('disk_free_mb', 0)),
         'disk_warning_mb': int(health.get('disk_warning_mb', 500)),
         'disk_critical_mb': int(health.get('disk_critical_mb', 100)),
+        'disk_known': bool(health.get('disk_known', True)),
         'last_successful_copy_at': health.get('last_successful_copy_at'),
         'last_successful_copy_age_seconds': health.get(
             'last_successful_copy_age_seconds',

--- a/scripts/web/config.py
+++ b/scripts/web/config.py
@@ -130,6 +130,9 @@ CLOUD_ARCHIVE_DISK_SPACE_WARNING_MB = int(_cloud.get(
 CLOUD_ARCHIVE_DISK_SPACE_CRITICAL_MB = int(_cloud.get(
     'disk_space_critical_mb', 100,
 ))
+CLOUD_ARCHIVE_DISK_SPACE_PAUSE_SECONDS = float(_cloud.get(
+    'disk_space_pause_seconds', 300,
+))
 
 # Live Event Sync Configuration
 # Separate first-class subsystem from cloud_archive — own queue, worker, and config.

--- a/scripts/web/config.py
+++ b/scripts/web/config.py
@@ -114,6 +114,23 @@ CLOUD_MIN_RETENTION_DAYS = int(_cloud.get('cloud_min_retention_days', 30))
 CLOUD_ARCHIVE_DB_PATH = os.path.join(GADGET_DIR, 'cloud_sync.db')
 CLOUD_PROVIDER_CREDS_PATH = os.path.join(GADGET_DIR, 'cloud_provider.enc')
 
+# Phase 2c (issue #76) — local SD-card storage management for ArchivedClips.
+# These are scoped under ``cloud_archive`` in config.yaml per the issue spec.
+# The retention value falls back to the legacy ``archive.retention_days`` so
+# existing installs that already tuned ``archive.retention_days`` keep their
+# preferred value without editing the new key. The disk-space thresholds are
+# new and have no legacy equivalent.
+CLOUD_ARCHIVE_RETENTION_DAYS = int(_cloud.get(
+    'archived_clips_retention_days',
+    int(config.get('archive', {}).get('retention_days', 30)),
+))
+CLOUD_ARCHIVE_DISK_SPACE_WARNING_MB = int(_cloud.get(
+    'disk_space_warning_mb', 500,
+))
+CLOUD_ARCHIVE_DISK_SPACE_CRITICAL_MB = int(_cloud.get(
+    'disk_space_critical_mb', 100,
+))
+
 # Live Event Sync Configuration
 # Separate first-class subsystem from cloud_archive — own queue, worker, and config.
 # Shares CLOUD_ARCHIVE_PROVIDER + CLOUD_PROVIDER_CREDS_PATH for credentials only.
@@ -164,6 +181,9 @@ ARCHIVE_QUEUE_RETRY_MAX_ATTEMPTS = int(
 )
 ARCHIVE_QUEUE_COPY_CHUNK_BYTES = int(
     _archive_queue.get('copy_chunk_bytes', 1048576)
+)
+ARCHIVE_QUEUE_WATCHDOG_CHECK_INTERVAL_SECONDS = float(
+    _archive_queue.get('watchdog_check_interval_seconds', 60)
 )
 
 # ============================================================================

--- a/scripts/web/services/archive_queue.py
+++ b/scripts/web/services/archive_queue.py
@@ -641,6 +641,57 @@ def mark_failed(row_id: int, error: str, *,
         return 'error'
 
 
+def get_pending_counts_by_priority(db_path: Optional[str] = None) -> Dict[int, int]:
+    """Return a mapping of ``priority -> pending_row_count``.
+
+    Always includes the canonical priorities (1, 2, 3) in the result so
+    callers don't need to deal with missing keys. Phase 2c surfaces this
+    in ``/api/archive/status`` as ``queue_depth_p1/p2/p3`` so the UI can
+    show RecentClips backlog separately from event/other backlogs.
+    """
+    counts: Dict[int, int] = {1: 0, 2: 0, 3: 0}
+    db_path = _resolve_db_path(db_path)
+    try:
+        with _open_archive_conn(db_path) as conn:
+            for row in conn.execute(
+                """
+                SELECT priority, COUNT(*) AS n FROM archive_queue
+                 WHERE status = 'pending'
+                 GROUP BY priority
+                """
+            ).fetchall():
+                prio = int(row['priority'] or 3)
+                counts[prio] = int(row['n'] or 0)
+    except sqlite3.Error as e:
+        logger.warning("get_pending_counts_by_priority failed: %s", e)
+    return counts
+
+
+def get_last_copied_at(db_path: Optional[str] = None) -> Optional[str]:
+    """Return the ISO timestamp of the most recent successful copy.
+
+    Used by :mod:`services.archive_watchdog` to compute staleness
+    severity. Returns ``None`` when no row has been copied yet (fresh
+    install, freshly-cleared queue) — the watchdog treats that as ``ok``
+    when the queue is empty and the worker is running.
+    """
+    db_path = _resolve_db_path(db_path)
+    try:
+        with _open_archive_conn(db_path) as conn:
+            row = conn.execute(
+                """
+                SELECT MAX(copied_at) AS m FROM archive_queue
+                 WHERE status = 'copied' AND copied_at IS NOT NULL
+                """
+            ).fetchone()
+            if row is None:
+                return None
+            return row['m']
+    except sqlite3.Error as e:
+        logger.warning("get_last_copied_at failed: %s", e)
+        return None
+
+
 def recover_stale_claims(*,
                          max_age_seconds: float = 600.0,
                          db_path: Optional[str] = None) -> int:

--- a/scripts/web/services/archive_watchdog.py
+++ b/scripts/web/services/archive_watchdog.py
@@ -122,6 +122,7 @@ _last_health: Dict[str, Any] = {
     'dead_letter_count': 0,
     'pending_count': 0,
     'disk_free_mb': 0,
+    'disk_known': True,
     'disk_warning': False,
     'checked_at': None,
 }
@@ -293,12 +294,21 @@ def _classify_severity(*,
                        last_copy_age_seconds: Optional[float],
                        disk_free_mb: int,
                        disk_warning_mb: int,
-                       disk_critical_mb: int) -> tuple:
+                       disk_critical_mb: int,
+                       disk_known: bool = True) -> tuple:
     """Return ``(severity, message)`` for the watchdog tick.
 
     Pure function so tests can drive every branch without mocking the
     DB or filesystem. Disk-space severity overrides staleness severity
     when it's higher (CRITICAL beats ERROR beats WARNING beats OK).
+
+    ``disk_known`` is False when ``shutil.disk_usage`` raised OSError
+    (e.g. ``archive_root`` briefly inaccessible). In that case the
+    disk overlay is skipped entirely so a transient stat failure does
+    not pop a misleading "0 MB free, CRITICAL" banner. The companion
+    ``archive_worker._check_disk_space_guard`` likewise fails open on
+    OSError — the watchdog now matches that "fail-quiet on stat
+    error" behavior.
     """
     # Staleness severity. Only escalates when there is pending work in
     # the queue — an idle worker with an empty queue is normal.
@@ -346,8 +356,13 @@ def _classify_severity(*,
             f"pending — videos are being lost!"
         )
 
-    # Disk-space severity overlay.
-    if disk_free_mb < disk_critical_mb:
+    # Disk-space severity overlay. Skip entirely when the disk-usage
+    # stat failed (``disk_known=False``) so a transient OSError does
+    # not surface as "0 MB free, CRITICAL".
+    if not disk_known:
+        disk_sev = 'ok'
+        disk_msg = ''
+    elif disk_free_mb < disk_critical_mb:
         disk_sev = 'critical'
         disk_msg = (
             f"SD card free space is CRITICAL: {disk_free_mb} MB "
@@ -393,6 +408,7 @@ def _compute_health(db_path: str, archive_root: str) -> Dict[str, Any]:
         worker_paused = False
 
     usage = _safe_disk_usage(archive_root)
+    disk_known = usage is not None
     disk_free_mb = int(usage.free // (1024 * 1024)) if usage else 0
     disk_total_mb = int(usage.total // (1024 * 1024)) if usage else 0
     disk_used_mb = max(disk_total_mb - disk_free_mb, 0)
@@ -405,6 +421,7 @@ def _compute_health(db_path: str, archive_root: str) -> Dict[str, Any]:
         disk_free_mb=disk_free_mb,
         disk_warning_mb=disk_warning_mb,
         disk_critical_mb=disk_critical_mb,
+        disk_known=disk_known,
     )
 
     snap: Dict[str, Any] = {
@@ -421,7 +438,12 @@ def _compute_health(db_path: str, archive_root: str) -> Dict[str, Any]:
         'disk_used_mb': disk_used_mb,
         'disk_warning_mb': disk_warning_mb,
         'disk_critical_mb': disk_critical_mb,
-        'disk_warning': severity != 'ok' and disk_free_mb < disk_warning_mb,
+        'disk_known': disk_known,
+        'disk_warning': (
+            disk_known
+            and severity != 'ok'
+            and disk_free_mb < disk_warning_mb
+        ),
         'checked_at': _iso_now(),
     }
     return snap

--- a/scripts/web/services/archive_watchdog.py
+++ b/scripts/web/services/archive_watchdog.py
@@ -1,0 +1,711 @@
+"""Archive health watchdog and retention prune (issue #76 — Phase 2c).
+
+Single daemon thread that observes the archive subsystem and reports
+health to the web UI. Two responsibilities, both interleaved into one
+thread to stay under the Pi Zero 2 W resource budget:
+
+1. **Health watchdog** (every 60 s by default): compute staleness of the
+   most recent successful copy, classify a severity, and surface the
+   summary via :func:`get_health` for the ``/api/archive/status`` JSON
+   endpoint and the persistent UI banner.
+
+2. **Retention prune** (daily, with 5–15 min jitter on first run): walk
+   ``ArchivedClips/`` and ``os.remove()`` ``*.mp4`` files older than the
+   configured retention. Files in ``.dead_letter/`` are never touched.
+   For every deleted clip we call
+   :func:`mapping_service.purge_deleted_videos` so the
+   ``indexed_files`` row goes away — but **trips, waypoints, and
+   detected_events are preserved** (only their ``video_path`` pointer
+   is nulled). This contract is load-bearing; see
+   ``copilot-instructions.md`` for the May 7 trip-loss regression that
+   forced it.
+
+**Hard contract (do NOT break — see copilot-instructions.md):**
+
+* This module never imports or calls anything that touches the USB
+  gadget — no ``mount``, ``umount``, ``losetup``, ``nsenter``,
+  ``partition_mount_service``, ``quick_edit_part2``, or
+  ``rebind_usb_gadget``. Tesla may be actively recording; ANY USB
+  disruption from a background subsystem loses footage. The watchdog
+  is a pure observer of ``archive_queue`` rows + local-FS disk usage.
+* No heavy imports — ``os``, ``sqlite3``, ``logging``, ``shutil``,
+  ``random``, ``threading``, ``time``, ``datetime`` only. Steady-state
+  RSS budget is ~5 MB.
+* Lock-before-sleep — when the retention prune holds the
+  ``task_coordinator`` 'retention' slot it MUST release the lock
+  before any ``_stop_event.wait()``.
+
+Public API mirrors the indexer / archive_worker style::
+
+    start_watchdog(db_path, archive_root) -> bool
+    stop_watchdog(timeout=...)            -> bool
+    is_running()                          -> bool
+    wake()                                -> None
+    get_health()                          -> dict
+    force_prune_now()                     -> dict   # synchronous prune
+    get_status()                          -> dict   # full snapshot
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import random
+import shutil
+import sqlite3
+import threading
+import time
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+from services import archive_queue
+from services import task_coordinator
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Tunables — module-level so tests can monkeypatch
+# ---------------------------------------------------------------------------
+
+# Default tick interval. Overridden by ``ARCHIVE_QUEUE_WATCHDOG_CHECK_INTERVAL_SECONDS``.
+_DEFAULT_CHECK_INTERVAL = 60.0
+
+# Severity thresholds (seconds since the last successful copy). Active
+# only when the queue has pending work — an empty queue with no recent
+# copy is normal (no clips to archive).
+_STALE_WARNING_SECONDS = 5 * 60       # 5 min  → WARNING
+_STALE_ERROR_SECONDS = 10 * 60        # 10 min → ERROR + banner
+_STALE_CRITICAL_SECONDS = 20 * 60     # 20 min → CRITICAL + persistent banner
+
+# Retention cadence: 24 h with 5–15 min jitter on first iteration so a
+# fleet of Pis doesn't all prune at the same wall clock time.
+_RETENTION_INTERVAL_SECONDS = 24 * 3600
+_RETENTION_FIRST_RUN_JITTER_MIN_SECONDS = 5 * 60
+_RETENTION_FIRST_RUN_JITTER_MAX_SECONDS = 15 * 60
+
+# task_coordinator wait used by the retention prune. The retention prune
+# is a periodic priority task — it BLOCK-waits up to this many seconds
+# for the indexer/archive_worker to yield, then proceeds.
+_RETENTION_COORDINATOR_WAIT_SECONDS = 60.0
+_RETENTION_COORDINATOR_TASK = 'retention'
+
+# Diagnostic subdirectory inside ``archive_root`` that the prune must
+# never touch. Mirrors the worker's dead-letter sidecar location.
+_DEAD_LETTER_DIRNAME = '.dead_letter'
+
+# Default stop/join timeouts.
+_DEFAULT_STOP_TIMEOUT = 30.0
+
+
+# ---------------------------------------------------------------------------
+# Module state — every read/write through ``_state_lock``
+# ---------------------------------------------------------------------------
+
+_state_lock = threading.Lock()
+_thread: Optional[threading.Thread] = None
+_stop_event = threading.Event()
+_wake_event = threading.Event()
+_db_path: Optional[str] = None
+_archive_root: Optional[str] = None
+_check_interval: float = _DEFAULT_CHECK_INTERVAL
+
+# Last cached health snapshot — refreshed each tick, served by
+# :func:`get_health` so HTTP polling is O(1).
+_last_health: Dict[str, Any] = {
+    'severity': 'ok',
+    'message': 'Archive watchdog has not yet run.',
+    'last_successful_copy_at': None,
+    'last_successful_copy_age_seconds': None,
+    'worker_running': False,
+    'paused': False,
+    'dead_letter_count': 0,
+    'pending_count': 0,
+    'disk_free_mb': 0,
+    'disk_warning': False,
+    'checked_at': None,
+}
+
+# Retention bookkeeping.
+_retention_state: Dict[str, Any] = {
+    'last_prune_at': None,        # ISO timestamp of last completed prune
+    'last_prune_deleted': 0,
+    'last_prune_freed_bytes': 0,
+    'last_prune_error': None,
+    'next_prune_due_at': None,    # epoch seconds
+}
+
+
+# ---------------------------------------------------------------------------
+# Public lifecycle API
+# ---------------------------------------------------------------------------
+
+def start_watchdog(db_path: str, archive_root: str, *,
+                   check_interval_seconds: Optional[float] = None) -> bool:
+    """Start the watchdog thread. Idempotent.
+
+    ``archive_root`` is the directory whose disk-space we watch
+    (typically ``ARCHIVE_DIR`` / ``~/ArchivedClips``). ``db_path`` is
+    the SQLite DB containing the ``archive_queue`` table (typically
+    ``MAPPING_DB_PATH`` / ``geodata.db``).
+    """
+    global _thread, _db_path, _archive_root, _check_interval
+    with _state_lock:
+        if _thread is not None and _thread.is_alive():
+            logger.debug("archive_watchdog.start_watchdog: already running")
+            return False
+        _db_path = db_path
+        _archive_root = archive_root
+        if check_interval_seconds is not None:
+            _check_interval = float(check_interval_seconds)
+        else:
+            _check_interval = _resolve_default_interval()
+        _stop_event.clear()
+        _wake_event.clear()
+        # Stagger the first retention prune so a fleet doesn't all run
+        # in lockstep on the same minute.
+        jitter = random.uniform(
+            _RETENTION_FIRST_RUN_JITTER_MIN_SECONDS,
+            _RETENTION_FIRST_RUN_JITTER_MAX_SECONDS,
+        )
+        _retention_state['next_prune_due_at'] = time.time() + jitter
+        thread = threading.Thread(
+            target=_run_loop,
+            args=(db_path, archive_root, _check_interval),
+            name='archive-watchdog',
+            daemon=True,
+        )
+        _thread = thread
+    thread.start()
+    logger.info(
+        "Archive watchdog started (db=%s, root=%s, interval=%.1fs)",
+        db_path, archive_root, _check_interval,
+    )
+    return True
+
+
+def stop_watchdog(timeout: float = _DEFAULT_STOP_TIMEOUT) -> bool:
+    """Signal the watchdog to stop and wait for it to exit. Idempotent."""
+    global _thread
+    with _state_lock:
+        thread = _thread
+    if thread is None:
+        return True
+    _stop_event.set()
+    _wake_event.set()
+    thread.join(timeout=timeout)
+    exited = not thread.is_alive()
+    if exited:
+        with _state_lock:
+            if _thread is thread:
+                _thread = None
+        logger.info("Archive watchdog stopped cleanly")
+    else:
+        logger.warning(
+            "Archive watchdog did not exit within %.1fs", timeout,
+        )
+    return exited
+
+
+def is_running() -> bool:
+    with _state_lock:
+        t = _thread
+    return t is not None and t.is_alive()
+
+
+def wake() -> None:
+    """Cut short the current sleep so the next tick happens immediately.
+
+    Cheap, lock-free, safe to call from any thread (including request
+    handlers).
+    """
+    _wake_event.set()
+
+
+# ---------------------------------------------------------------------------
+# Health / severity classification
+# ---------------------------------------------------------------------------
+
+def _resolve_default_interval() -> float:
+    """Look up the configured check interval at start time.
+
+    Looked up dynamically so tests can monkeypatch the config import.
+    Falls back to :data:`_DEFAULT_CHECK_INTERVAL` when the config
+    module isn't importable (unit-test environments).
+    """
+    try:
+        from config import ARCHIVE_QUEUE_WATCHDOG_CHECK_INTERVAL_SECONDS
+        return float(ARCHIVE_QUEUE_WATCHDOG_CHECK_INTERVAL_SECONDS)
+    except Exception:  # noqa: BLE001
+        return _DEFAULT_CHECK_INTERVAL
+
+
+def _resolve_disk_thresholds() -> tuple:
+    """Return (warning_mb, critical_mb) from config or sensible defaults."""
+    try:
+        from config import (
+            CLOUD_ARCHIVE_DISK_SPACE_WARNING_MB,
+            CLOUD_ARCHIVE_DISK_SPACE_CRITICAL_MB,
+        )
+        return (
+            int(CLOUD_ARCHIVE_DISK_SPACE_WARNING_MB),
+            int(CLOUD_ARCHIVE_DISK_SPACE_CRITICAL_MB),
+        )
+    except Exception:  # noqa: BLE001
+        return (500, 100)
+
+
+def _resolve_retention_days() -> int:
+    """Return the configured ArchivedClips retention in days."""
+    try:
+        from config import CLOUD_ARCHIVE_RETENTION_DAYS
+        return int(CLOUD_ARCHIVE_RETENTION_DAYS)
+    except Exception:  # noqa: BLE001
+        return 30
+
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _parse_iso(ts: Optional[str]) -> Optional[float]:
+    if not ts:
+        return None
+    try:
+        # Accept both 'YYYY-MM-DDTHH:MM:SS+00:00' and trailing 'Z'.
+        cleaned = ts.replace('Z', '+00:00')
+        return datetime.fromisoformat(cleaned).timestamp()
+    except (ValueError, TypeError):
+        return None
+
+
+def _safe_disk_usage(path: str):
+    """Return ``shutil.disk_usage`` or None on failure (path missing, etc.)."""
+    try:
+        return shutil.disk_usage(path)
+    except OSError:
+        return None
+
+
+def _classify_severity(*,
+                       worker_running: bool,
+                       pending_count: int,
+                       last_copy_age_seconds: Optional[float],
+                       disk_free_mb: int,
+                       disk_warning_mb: int,
+                       disk_critical_mb: int) -> tuple:
+    """Return ``(severity, message)`` for the watchdog tick.
+
+    Pure function so tests can drive every branch without mocking the
+    DB or filesystem. Disk-space severity overrides staleness severity
+    when it's higher (CRITICAL beats ERROR beats WARNING beats OK).
+    """
+    # Staleness severity. Only escalates when there is pending work in
+    # the queue — an idle worker with an empty queue is normal.
+    if pending_count == 0 or last_copy_age_seconds is None:
+        stale_sev = 'ok'
+        stale_msg = (
+            "Archive worker is idle (no pending clips)."
+            if pending_count == 0 else
+            "Archive worker has not yet copied a clip."
+        )
+    elif last_copy_age_seconds < _STALE_WARNING_SECONDS:
+        stale_sev = 'ok'
+        stale_msg = (
+            f"Archive worker is healthy "
+            f"({pending_count} pending, last copy "
+            f"{int(last_copy_age_seconds)}s ago)."
+        )
+    elif last_copy_age_seconds < _STALE_ERROR_SECONDS:
+        stale_sev = 'warning'
+        stale_msg = (
+            f"Archive worker is slow: no copy in "
+            f"{int(last_copy_age_seconds // 60)} min "
+            f"({pending_count} pending)."
+        )
+    elif last_copy_age_seconds < _STALE_CRITICAL_SECONDS:
+        stale_sev = 'error'
+        stale_msg = (
+            f"Archive worker may be stalled: no copy in "
+            f"{int(last_copy_age_seconds // 60)} min "
+            f"({pending_count} pending) — videos may be lost!"
+        )
+    else:
+        stale_sev = 'critical'
+        stale_msg = (
+            f"Archive worker is STALLED: no copy in "
+            f"{int(last_copy_age_seconds // 60)} min "
+            f"({pending_count} pending) — videos are being lost!"
+        )
+
+    # Worker-down with pending work is critical regardless of staleness.
+    if (not worker_running) and pending_count > 0:
+        stale_sev = 'critical'
+        stale_msg = (
+            f"Archive worker is NOT RUNNING with {pending_count} clips "
+            f"pending — videos are being lost!"
+        )
+
+    # Disk-space severity overlay.
+    if disk_free_mb < disk_critical_mb:
+        disk_sev = 'critical'
+        disk_msg = (
+            f"SD card free space is CRITICAL: {disk_free_mb} MB "
+            f"(< {disk_critical_mb} MB threshold). New archive copies "
+            "are blocked."
+        )
+    elif disk_free_mb < disk_warning_mb:
+        disk_sev = 'warning'
+        disk_msg = (
+            f"SD card free space is low: {disk_free_mb} MB "
+            f"(< {disk_warning_mb} MB threshold)."
+        )
+    else:
+        disk_sev = 'ok'
+        disk_msg = ''
+
+    # Resolve the higher-severity message.
+    rank = {'ok': 0, 'warning': 1, 'error': 2, 'critical': 3}
+    if rank[disk_sev] > rank[stale_sev]:
+        return disk_sev, disk_msg
+    if rank[disk_sev] == rank[stale_sev] and disk_sev != 'ok':
+        return stale_sev, f"{stale_msg} {disk_msg}".strip()
+    return stale_sev, stale_msg
+
+
+def _compute_health(db_path: str, archive_root: str) -> Dict[str, Any]:
+    """Read the queue + disk + worker state and return a health snapshot."""
+    counts = archive_queue.get_queue_status(db_path)
+    pending_count = int(counts.get('pending', 0))
+    dead_letter_count = int(counts.get('dead_letter', 0))
+    last_copy_iso = archive_queue.get_last_copied_at(db_path)
+    last_copy_ts = _parse_iso(last_copy_iso)
+    age = (time.time() - last_copy_ts) if last_copy_ts else None
+
+    # Worker liveness via the public archive_worker API.
+    try:
+        from services import archive_worker
+        worker_running = archive_worker.is_running()
+        worker_paused = archive_worker.is_paused()
+    except Exception as e:  # noqa: BLE001
+        logger.debug("archive_worker introspection failed: %s", e)
+        worker_running = False
+        worker_paused = False
+
+    usage = _safe_disk_usage(archive_root)
+    disk_free_mb = int(usage.free // (1024 * 1024)) if usage else 0
+    disk_total_mb = int(usage.total // (1024 * 1024)) if usage else 0
+    disk_used_mb = max(disk_total_mb - disk_free_mb, 0)
+    disk_warning_mb, disk_critical_mb = _resolve_disk_thresholds()
+
+    severity, message = _classify_severity(
+        worker_running=worker_running,
+        pending_count=pending_count,
+        last_copy_age_seconds=age,
+        disk_free_mb=disk_free_mb,
+        disk_warning_mb=disk_warning_mb,
+        disk_critical_mb=disk_critical_mb,
+    )
+
+    snap: Dict[str, Any] = {
+        'severity': severity,
+        'message': message,
+        'last_successful_copy_at': last_copy_iso,
+        'last_successful_copy_age_seconds': int(age) if age is not None else None,
+        'worker_running': bool(worker_running),
+        'paused': bool(worker_paused),
+        'dead_letter_count': dead_letter_count,
+        'pending_count': pending_count,
+        'disk_free_mb': disk_free_mb,
+        'disk_total_mb': disk_total_mb,
+        'disk_used_mb': disk_used_mb,
+        'disk_warning_mb': disk_warning_mb,
+        'disk_critical_mb': disk_critical_mb,
+        'disk_warning': severity != 'ok' and disk_free_mb < disk_warning_mb,
+        'checked_at': _iso_now(),
+    }
+    return snap
+
+
+def get_health() -> Dict[str, Any]:
+    """Return the most recent cached health snapshot.
+
+    Cheap (returns a copy of the in-memory dict). Updated by the
+    background loop every ``check_interval`` seconds; an HTTP polling
+    UI never blocks on a DB query.
+    """
+    with _state_lock:
+        return dict(_last_health)
+
+
+def get_status() -> Dict[str, Any]:
+    """Return health + retention state in one snapshot."""
+    with _state_lock:
+        snap = dict(_last_health)
+        snap['retention'] = dict(_retention_state)
+        snap['retention']['retention_days'] = _resolve_retention_days()
+        snap['watchdog_running'] = (
+            _thread is not None and _thread.is_alive()
+        )
+        snap['check_interval_seconds'] = _check_interval
+    return snap
+
+
+# ---------------------------------------------------------------------------
+# Retention prune
+# ---------------------------------------------------------------------------
+
+def _iter_archive_mp4_files(archive_root: str):
+    """Yield (abs_path, mtime, size_bytes) for every .mp4 under archive_root.
+
+    Walks the tree without following symlinks; skips the
+    ``.dead_letter`` diagnostic subdirectory entirely so user-visible
+    forensic info isn't auto-deleted.
+    """
+    if not archive_root or not os.path.isdir(archive_root):
+        return
+    for dirpath, dirnames, filenames in os.walk(archive_root, followlinks=False):
+        # Prune .dead_letter so os.walk doesn't descend into it.
+        dirnames[:] = [
+            d for d in dirnames if d != _DEAD_LETTER_DIRNAME
+        ]
+        for fn in filenames:
+            if not fn.lower().endswith('.mp4'):
+                continue
+            full = os.path.join(dirpath, fn)
+            try:
+                st = os.stat(full)
+            except OSError:
+                continue
+            yield full, st.st_mtime, st.st_size
+
+
+def _delete_one_mp4(path: str, db_path: str) -> int:
+    """Atomically delete one mp4 + reconcile geodata.
+
+    Returns the freed byte count (0 on failure). Uses
+    :func:`mapping_service.purge_deleted_videos` to reconcile the
+    indexed_files row WITHOUT touching trips/waypoints/events. See the
+    docstring on ``purge_deleted_videos`` for why that contract is
+    load-bearing.
+    """
+    try:
+        size = os.path.getsize(path)
+    except OSError:
+        size = 0
+    try:
+        os.remove(path)
+    except OSError as e:
+        logger.warning(
+            "archive_retention: failed to remove %s: %s", path, e,
+        )
+        return 0
+    # Reconcile geodata (best-effort — failure here doesn't undo the delete).
+    try:
+        from services.mapping_service import purge_deleted_videos
+        purge_deleted_videos(db_path, deleted_paths=[path])
+    except Exception as e:  # noqa: BLE001
+        logger.debug(
+            "archive_retention: purge_deleted_videos failed for %s: %s",
+            path, e,
+        )
+    return int(size)
+
+
+def _run_retention_prune(archive_root: str, db_path: str,
+                         retention_days: int) -> Dict[str, Any]:
+    """Walk ``archive_root`` and delete .mp4 files older than retention.
+
+    Returns a summary dict suitable for logging and the
+    ``/api/archive/prune_now`` response::
+
+        {'deleted_count': N, 'freed_bytes': M, 'scanned': K,
+         'cutoff_iso': 'YYYY-MM-DD...', 'duration_seconds': S}
+
+    Holds the ``task_coordinator`` 'retention' slot for the duration so
+    the archive worker yields cleanly. Releases the slot before
+    returning.
+    """
+    started = time.time()
+    cutoff = started - (max(int(retention_days), 1) * 86400)
+    cutoff_iso = datetime.fromtimestamp(cutoff, tz=timezone.utc).isoformat()
+    summary: Dict[str, Any] = {
+        'deleted_count': 0,
+        'freed_bytes': 0,
+        'scanned': 0,
+        'cutoff_iso': cutoff_iso,
+        'retention_days': int(retention_days),
+        'duration_seconds': 0.0,
+    }
+    if not archive_root or not os.path.isdir(archive_root):
+        summary['duration_seconds'] = round(time.time() - started, 3)
+        return summary
+
+    acquired = task_coordinator.acquire_task(
+        _RETENTION_COORDINATOR_TASK,
+        wait_seconds=_RETENTION_COORDINATOR_WAIT_SECONDS,
+    )
+    if not acquired:
+        logger.info(
+            "archive_retention: skipped — could not acquire 'retention' "
+            "task slot within %.1fs",
+            _RETENTION_COORDINATOR_WAIT_SECONDS,
+        )
+        summary['duration_seconds'] = round(time.time() - started, 3)
+        return summary
+
+    try:
+        for path, mtime, _size in _iter_archive_mp4_files(archive_root):
+            summary['scanned'] += 1
+            if mtime > cutoff:
+                continue
+            age_days = (time.time() - mtime) / 86400.0
+            freed = _delete_one_mp4(path, db_path)
+            if freed > 0 or not os.path.exists(path):
+                summary['deleted_count'] += 1
+                summary['freed_bytes'] += freed
+                logger.info(
+                    "archive_retention: removed %s (age=%.1f days, "
+                    "freed=%d bytes)",
+                    path, age_days, freed,
+                )
+    finally:
+        # Release BEFORE any further sleep / outside callers.
+        task_coordinator.release_task(_RETENTION_COORDINATOR_TASK)
+        summary['duration_seconds'] = round(time.time() - started, 3)
+
+    return summary
+
+
+def force_prune_now() -> Dict[str, Any]:
+    """Run a retention prune synchronously. Returns the summary dict.
+
+    Exposed via ``POST /api/archive/prune_now`` and the Settings →
+    Storage panel. Called inline on the request thread; for
+    ArchivedClips of a few hundred files this completes in under a
+    second.
+    """
+    with _state_lock:
+        archive_root = _archive_root
+        db_path = _db_path
+    if not archive_root or not db_path:
+        return {
+            'deleted_count': 0,
+            'freed_bytes': 0,
+            'scanned': 0,
+            'error': 'watchdog not started',
+        }
+    retention_days = _resolve_retention_days()
+    summary = _run_retention_prune(archive_root, db_path, retention_days)
+    # Update bookkeeping so the Settings panel reflects the manual run.
+    with _state_lock:
+        _retention_state['last_prune_at'] = _iso_now()
+        _retention_state['last_prune_deleted'] = int(summary['deleted_count'])
+        _retention_state['last_prune_freed_bytes'] = int(summary['freed_bytes'])
+        _retention_state['last_prune_error'] = None
+        _retention_state['next_prune_due_at'] = (
+            time.time() + _RETENTION_INTERVAL_SECONDS
+        )
+    return summary
+
+
+# ---------------------------------------------------------------------------
+# Watchdog thread loop
+# ---------------------------------------------------------------------------
+
+def _maybe_run_retention(archive_root: str, db_path: str) -> None:
+    """Run retention prune if the daily interval has elapsed.
+
+    Called from the watchdog tick. Updates ``_retention_state`` either
+    way so the Settings panel can show "next prune in N hours".
+    """
+    with _state_lock:
+        due_at = _retention_state.get('next_prune_due_at')
+    if due_at is None or time.time() < float(due_at):
+        return
+    retention_days = _resolve_retention_days()
+    try:
+        summary = _run_retention_prune(archive_root, db_path, retention_days)
+        with _state_lock:
+            _retention_state['last_prune_at'] = _iso_now()
+            _retention_state['last_prune_deleted'] = int(
+                summary['deleted_count']
+            )
+            _retention_state['last_prune_freed_bytes'] = int(
+                summary['freed_bytes']
+            )
+            _retention_state['last_prune_error'] = None
+            _retention_state['next_prune_due_at'] = (
+                time.time() + _RETENTION_INTERVAL_SECONDS
+            )
+        logger.info(
+            "archive_retention: prune complete (deleted=%d, freed=%d "
+            "bytes, scanned=%d, %.2fs)",
+            summary['deleted_count'], summary['freed_bytes'],
+            summary['scanned'], summary['duration_seconds'],
+        )
+    except Exception as e:  # noqa: BLE001
+        logger.exception("archive_retention: prune failed")
+        with _state_lock:
+            _retention_state['last_prune_error'] = str(e)
+            # Retry tomorrow even on failure — don't loop on a broken FS.
+            _retention_state['next_prune_due_at'] = (
+                time.time() + _RETENTION_INTERVAL_SECONDS
+            )
+
+
+def _log_severity_change(prev: Optional[str], new: str, message: str) -> None:
+    """Log severity transitions at appropriate levels.
+
+    Logged only on transition (not every tick) so the journal stays
+    readable. The first run from None always logs at INFO so we have
+    a "watchdog started" landmark.
+    """
+    if prev == new:
+        return
+    if new == 'critical':
+        logger.critical("archive_watchdog: %s", message)
+    elif new == 'error':
+        logger.error("archive_watchdog: %s", message)
+    elif new == 'warning':
+        logger.warning("archive_watchdog: %s", message)
+    else:
+        logger.info("archive_watchdog: %s", message)
+
+
+def _run_loop(db_path: str, archive_root: str, interval_seconds: float) -> None:
+    """The thread target. One pass per interval until stop is signaled."""
+    prev_severity: Optional[str] = None
+    while not _stop_event.is_set():
+        try:
+            snap = _compute_health(db_path, archive_root)
+            with _state_lock:
+                _last_health.update(snap)
+            _log_severity_change(
+                prev_severity, snap['severity'], snap['message'],
+            )
+            prev_severity = snap['severity']
+        except sqlite3.Error as e:
+            logger.warning("archive_watchdog: DB error during tick: %s", e)
+        except Exception as e:  # noqa: BLE001
+            logger.exception("archive_watchdog: unexpected tick failure")
+
+        # Retention is interleaved into the watchdog cadence to avoid
+        # spawning a second thread on the Pi Zero 2 W.
+        try:
+            _maybe_run_retention(archive_root, db_path)
+        except Exception as e:  # noqa: BLE001
+            logger.exception(
+                "archive_watchdog: retention interleave failed"
+            )
+
+        # Sleep with wake-event support so callers can force an
+        # immediate re-check (e.g. after disk-space recovery). We wait
+        # on the wake event; ``stop_watchdog()`` also sets it so a
+        # shutdown unblocks instantly. The stop check after the wait
+        # ensures we exit promptly when both events are set.
+        woke = _wake_event.wait(timeout=interval_seconds)
+        if _stop_event.is_set():
+            break
+        if woke:
+            _wake_event.clear()

--- a/scripts/web/services/archive_worker.py
+++ b/scripts/web/services/archive_worker.py
@@ -136,8 +136,27 @@ _state: Dict[str, Any] = {
 # :func:`process_one_claim`; cleared automatically once the deadline
 # passes (the watchdog will re-evaluate on its next tick).
 _disk_space_pause_until: float = 0.0
-# Default duration of the disk-space pause (seconds). Tests monkeypatch.
-_DEFAULT_DISK_SPACE_PAUSE_SECONDS = 300.0
+# Default duration of the disk-space pause (seconds). Resolved lazily
+# from ``cloud_archive.disk_space_pause_seconds`` at first use so the
+# config import order stays simple; tests monkeypatch this directly.
+_DEFAULT_DISK_SPACE_PAUSE_SECONDS: float = 300.0
+
+
+def _resolve_disk_space_pause_seconds() -> float:
+    """Return the configured disk-space pause duration in seconds.
+
+    Falls back to ``_DEFAULT_DISK_SPACE_PAUSE_SECONDS`` (which tests
+    can monkeypatch) when the config attribute is missing or not a
+    finite positive number.
+    """
+    try:
+        from config import CLOUD_ARCHIVE_DISK_SPACE_PAUSE_SECONDS as cfg
+        cfg_val = float(cfg)
+        if cfg_val > 0:
+            return cfg_val
+    except (ImportError, TypeError, ValueError):
+        pass
+    return _DEFAULT_DISK_SPACE_PAUSE_SECONDS
 
 
 # ---------------------------------------------------------------------------
@@ -562,7 +581,7 @@ def _check_disk_space_guard(archive_root: str) -> str:
             "Archive disk-space CRITICAL: %d MB free at %s "
             "(< %d MB threshold) — refusing new copies for %.0fs",
             free_mb, archive_root, crit_mb,
-            _DEFAULT_DISK_SPACE_PAUSE_SECONDS,
+            _resolve_disk_space_pause_seconds(),
         )
         return 'critical'
     if free_mb < warn_mb:
@@ -687,7 +706,7 @@ def process_one_claim(row: Dict[str, Any], db_path: str,
     if disk_verdict == 'critical':
         archive_queue.release_claim(row_id, db_path=db_path)
         _disk_space_pause_until = (
-            now_fn() + _DEFAULT_DISK_SPACE_PAUSE_SECONDS
+            now_fn() + _resolve_disk_space_pause_seconds()
         )
         try:
             free_mb = int(

--- a/scripts/web/services/archive_worker.py
+++ b/scripts/web/services/archive_worker.py
@@ -126,7 +126,18 @@ _state: Dict[str, Any] = {
     'last_error': None,
     'files_done_session': 0,
     'last_drained_at': None,
+    'last_disk_pause_at': None,
+    'last_disk_pause_free_mb': None,
 }
+
+# Disk-space self-pause epoch (seconds). When set in the future, the
+# worker loop idles instead of claiming new rows. Set when the disk
+# falls below the configured critical threshold during
+# :func:`process_one_claim`; cleared automatically once the deadline
+# passes (the watchdog will re-evaluate on its next tick).
+_disk_space_pause_until: float = 0.0
+# Default duration of the disk-space pause (seconds). Tests monkeypatch.
+_DEFAULT_DISK_SPACE_PAUSE_SECONDS = 300.0
 
 
 # ---------------------------------------------------------------------------
@@ -164,6 +175,12 @@ def start_worker(db_path: str, archive_root: str, *,
         _state['last_error'] = None
         _state['last_outcome'] = None
         _state['active_file'] = None
+        _state['last_disk_pause_at'] = None
+        _state['last_disk_pause_free_mb'] = None
+        # Reset the disk-space self-pause; the next iteration will
+        # re-arm it if disk space is still critical.
+        global _disk_space_pause_until
+        _disk_space_pause_until = 0.0
         thread = threading.Thread(
             target=_run_worker_loop,
             args=(db_path, archive_root, teslacam_root, _worker_id),
@@ -317,6 +334,7 @@ def get_status() -> Dict[str, Any]:
     snap['source_gone_count'] = counts.get('source_gone', 0)
     snap['copied_count'] = counts.get('copied', 0)
     snap['error_count'] = counts.get('error', 0)
+    snap['disk_pause'] = get_disk_pause_state()
     return snap
 
 
@@ -505,6 +523,66 @@ def _apply_low_priority() -> None:
         pass
 
 
+def _resolve_disk_thresholds_mb() -> tuple:
+    """Return ``(warning_mb, critical_mb)`` for the disk-space guard.
+
+    Looked up at call time so tests can monkeypatch the config import.
+    Falls back to (500, 100) when the config module isn't importable
+    (unit-test environments).
+    """
+    try:
+        from config import (
+            CLOUD_ARCHIVE_DISK_SPACE_WARNING_MB,
+            CLOUD_ARCHIVE_DISK_SPACE_CRITICAL_MB,
+        )
+        return (
+            int(CLOUD_ARCHIVE_DISK_SPACE_WARNING_MB),
+            int(CLOUD_ARCHIVE_DISK_SPACE_CRITICAL_MB),
+        )
+    except Exception:  # noqa: BLE001
+        return (500, 100)
+
+
+def _check_disk_space_guard(archive_root: str) -> str:
+    """Classify free disk space at ``archive_root``.
+
+    Returns one of ``'ok'``, ``'warning'``, ``'critical'``. ``'critical'``
+    means a copy MUST NOT proceed. ``'warning'`` is informational; the
+    copy proceeds but logs a WARNING line. Stat failures return ``'ok'``
+    so a transient FS hiccup doesn't lock the archive subsystem out.
+    """
+    try:
+        usage = shutil.disk_usage(archive_root)
+    except OSError:
+        return 'ok'
+    free_mb = int(usage.free // (1024 * 1024))
+    warn_mb, crit_mb = _resolve_disk_thresholds_mb()
+    if free_mb < crit_mb:
+        logger.critical(
+            "Archive disk-space CRITICAL: %d MB free at %s "
+            "(< %d MB threshold) — refusing new copies for %.0fs",
+            free_mb, archive_root, crit_mb,
+            _DEFAULT_DISK_SPACE_PAUSE_SECONDS,
+        )
+        return 'critical'
+    if free_mb < warn_mb:
+        logger.warning(
+            "Archive disk-space LOW: %d MB free at %s "
+            "(< %d MB threshold) — proceeding with copy",
+            free_mb, archive_root, warn_mb,
+        )
+        return 'warning'
+    return 'ok'
+
+
+def get_disk_pause_state() -> Dict[str, Any]:
+    """Return the current disk-space pause state for status endpoints."""
+    return {
+        'paused_until_epoch': float(_disk_space_pause_until),
+        'is_paused_now': _disk_space_pause_until > time.time(),
+    }
+
+
 def _set_state(**fields: Any) -> None:
     with _state_lock:
         _state.update(fields)
@@ -597,6 +675,31 @@ def process_one_claim(row: Dict[str, Any], db_path: str,
         )
         return 'pending'
 
+    # Disk-space pre-archive guard. We do this AFTER the stable-write
+    # gate (which requires only stat() on the source) but BEFORE any
+    # write attempt to ``archive_root``. A 'critical' verdict releases
+    # the claim back to pending without burning an attempt and arms a
+    # module-level pause so the worker stops claiming for ~5 minutes;
+    # the watchdog re-evaluates on its next tick. 'warning' is logged
+    # but the copy proceeds — we only refuse new copies on critical.
+    global _disk_space_pause_until
+    disk_verdict = _check_disk_space_guard(archive_root)
+    if disk_verdict == 'critical':
+        archive_queue.release_claim(row_id, db_path=db_path)
+        _disk_space_pause_until = (
+            now_fn() + _DEFAULT_DISK_SPACE_PAUSE_SECONDS
+        )
+        try:
+            free_mb = int(
+                shutil.disk_usage(archive_root).free // (1024 * 1024)
+            )
+        except OSError:
+            free_mb = -1
+        with _state_lock:
+            _state['last_disk_pause_at'] = time.time()
+            _state['last_disk_pause_free_mb'] = free_mb
+        return 'pending'
+
     # Compute destination + atomic copy.
     try:
         dest_path = compute_dest_path(source_path, archive_root, teslacam_root)
@@ -662,6 +765,16 @@ def _run_worker_loop(db_path: str, archive_root: str,
             _idle_event.set()
             if _stop_event.wait(timeout=_INTER_FILE_SLEEP_SECONDS):
                 break
+            continue
+
+        # Honor the disk-space self-pause. ``process_one_claim`` arms
+        # ``_disk_space_pause_until`` when free space crosses the
+        # critical threshold; the loop idles here until the deadline
+        # passes (the watchdog tick will then re-evaluate).
+        if _disk_space_pause_until > time.time():
+            _idle_event.set()
+            remaining = _disk_space_pause_until - time.time()
+            _wait_with_wake(min(remaining, idle_sleep))
             continue
 
         # Acquire the task slot. The archive worker is a periodic

--- a/scripts/web/static/css/style.css
+++ b/scripts/web/static/css/style.css
@@ -2698,3 +2698,168 @@ details summary span:first-of-type {
 .btn-sm { padding: 4px 10px; font-size: 0.8125rem; min-height: 36px; }
 .btn-icon { padding: 8px; min-width: 44px; min-height: 44px; justify-content: center; }
 .btn .nav-icon { width: 16px; height: 16px; flex-shrink: 0; }
+
+
+/* ========================================================================
+   Phase 2c — Archive watchdog banner + Settings panels (issue #76)
+   ======================================================================== */
+
+/* Banner — sits between nav and main content, sticky on desktop. Three
+   severity tiers map to existing message-tone tokens so dark+light mode
+   work automatically. */
+.archive-watchdog-banner {
+    padding: 14px 20px;
+    margin-bottom: 16px;
+    border-radius: 8px;
+    border: 1px solid transparent;
+    box-shadow: 0 2px 8px var(--shadow, rgba(0,0,0,0.15));
+    position: sticky;
+    top: 0;
+    z-index: 999;
+}
+.archive-watchdog-banner[hidden] { display: none; }
+
+.archive-watchdog-warning {
+    background: var(--msg-warning-bg);
+    color: var(--msg-warning-text);
+    border-color: var(--warning-border, var(--msg-warning-text));
+}
+.archive-watchdog-error {
+    background: var(--msg-error-bg);
+    color: var(--msg-error-text);
+    border-color: var(--msg-error-text);
+}
+.archive-watchdog-critical {
+    background: var(--msg-error-bg);
+    color: var(--msg-error-text);
+    border-color: var(--msg-error-text);
+    animation: archive-watchdog-pulse 2s ease-in-out infinite;
+}
+
+@keyframes archive-watchdog-pulse {
+    0%, 100% { box-shadow: 0 2px 8px rgba(0,0,0,0.15); }
+    50%      { box-shadow: 0 2px 18px var(--msg-error-text); }
+}
+
+.archive-watchdog-content {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    flex-wrap: wrap;
+}
+.archive-watchdog-icon { flex-shrink: 0; }
+.archive-watchdog-icon .nav-icon {
+    width: 24px;
+    height: 24px;
+}
+.archive-watchdog-message {
+    flex: 1;
+    min-width: 200px;
+    font-weight: 500;
+}
+.archive-watchdog-actions {
+    display: flex;
+    gap: 8px;
+    flex-shrink: 0;
+}
+.archive-watchdog-btn {
+    min-height: 44px;
+    min-width: 44px;
+    padding: 8px 16px;
+    border: 1px solid currentColor;
+    border-radius: 6px;
+    background: transparent;
+    color: inherit;
+    font-weight: 600;
+    cursor: pointer;
+    font-size: 0.875rem;
+}
+.archive-watchdog-btn:hover:not(:disabled) {
+    background: rgba(255, 255, 255, 0.15);
+}
+.archive-watchdog-btn:disabled {
+    opacity: 0.55;
+    cursor: not-allowed;
+}
+.archive-watchdog-btn-secondary {
+    opacity: 0.85;
+}
+
+@media (max-width: 768px) {
+    .archive-watchdog-banner {
+        position: relative;
+        top: auto;
+    }
+    .archive-watchdog-content {
+        flex-direction: column;
+        align-items: stretch;
+        text-align: center;
+    }
+    .archive-watchdog-actions {
+        justify-content: center;
+    }
+}
+
+/* Storage progress bar */
+.storage-progress {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+.storage-progress-bar {
+    height: 14px;
+    background: var(--bg-secondary, #f0f0f0);
+    border-radius: 7px;
+    overflow: hidden;
+    border: 1px solid var(--border-color, #e0e0e0);
+}
+.storage-progress-fill {
+    height: 100%;
+    background: var(--accent-color, #2563EB);
+    transition: width 0.3s ease, background 0.3s ease;
+}
+.storage-progress-fill.warning {
+    background: var(--warning-text, var(--msg-warning-text));
+}
+.storage-progress-fill.critical {
+    background: var(--msg-error-text);
+}
+.storage-progress-text {
+    font-size: 0.8125rem;
+    color: var(--text-secondary);
+    display: flex;
+    justify-content: space-between;
+}
+
+/* Archive status panel — chip + table layout */
+.archive-status-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    gap: 12px;
+    margin-bottom: 12px;
+}
+.archive-status-chip {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    padding: 12px;
+    background: var(--bg-secondary, #f7f7f7);
+    border: 1px solid var(--border-color, #e0e0e0);
+    border-radius: 8px;
+}
+.archive-status-chip .chip-label {
+    font-size: 0.75rem;
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    margin-bottom: 4px;
+}
+.archive-status-chip .chip-value {
+    font-size: 1.25rem;
+    font-weight: 600;
+    color: var(--text-primary);
+    font-variant-numeric: tabular-nums;
+}
+.archive-status-chip.has-issue .chip-value {
+    color: var(--msg-error-text);
+}

--- a/scripts/web/static/icons/lucide-sprite.svg
+++ b/scripts/web/static/icons/lucide-sprite.svg
@@ -204,4 +204,16 @@
   <symbol id="icon-image" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
     <rect width="18" height="18" x="3" y="3" rx="2" ry="2"/><circle cx="9" cy="9" r="2"/><path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21"/>
   </symbol>
+
+  <symbol id="icon-alert-circle" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <circle cx="12" cy="12" r="10"/><line x1="12" x2="12" y1="8" y2="12"/><line x1="12" x2="12.01" y1="16" y2="16"/>
+  </symbol>
+
+  <symbol id="icon-shield-alert" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z"/><path d="M12 8v4"/><path d="M12 16h.01"/>
+  </symbol>
+
+  <symbol id="icon-database" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M3 5V19A9 3 0 0 0 21 19V5"/><path d="M3 12A9 3 0 0 0 21 12"/>
+  </symbol>
 </svg>

--- a/scripts/web/templates/base.html
+++ b/scripts/web/templates/base.html
@@ -227,9 +227,6 @@
                 } else if (severity === 'error') {
                     banner.classList.add('archive-watchdog-error');
                     icon = 'icon-alert-circle';
-                } else if (severity === 'warning') {
-                    banner.classList.add('archive-watchdog-warning');
-                    icon = 'icon-alert-triangle';
                 }
                 if (iconUse) iconUse.setAttribute('href', SPRITE + '#' + icon);
                 if (messageEl) messageEl.textContent = message || '';

--- a/scripts/web/templates/base.html
+++ b/scripts/web/templates/base.html
@@ -109,6 +109,40 @@
     </nav>
 
     <main class="main-content{% if expandable %} expandable{% endif %}" role="main">
+        {% if videos_available %}
+        <!-- Phase 2c: archive watchdog banner. Hidden by default; the
+             polling JS below shows it when /api/archive/status returns
+             severity 'error' or 'critical'. Dismiss is sticky for 1h. -->
+        <div class="archive-watchdog-banner" id="archive-watchdog-banner"
+             role="alert" aria-live="polite" hidden>
+            <div class="archive-watchdog-content">
+                <div class="archive-watchdog-icon">
+                    <svg class="nav-icon" aria-hidden="true">
+                        <use id="archive-watchdog-icon-use"
+                             href="{{ url_for('static', filename='icons/lucide-sprite.svg') }}#icon-alert-triangle"></use>
+                    </svg>
+                </div>
+                <div class="archive-watchdog-message" id="archive-watchdog-message">
+                    Archive subsystem health degraded.
+                </div>
+                <div class="archive-watchdog-actions">
+                    <button type="button"
+                            class="archive-watchdog-btn"
+                            id="archive-watchdog-run-btn"
+                            aria-label="Run archive now">
+                        Run archive now
+                    </button>
+                    <button type="button"
+                            class="archive-watchdog-btn archive-watchdog-btn-secondary"
+                            id="archive-watchdog-dismiss-btn"
+                            aria-label="Dismiss banner for 1 hour">
+                        Dismiss
+                    </button>
+                </div>
+            </div>
+        </div>
+        {% endif %}
+
         {% if operation_in_progress %}
         <div class="operation-banner" id="operation-banner">
             <div class="operation-content">
@@ -155,6 +189,115 @@
         // Auto-refresh when operation completes
         window.operationInProgress = true;
         window.lockAge = {{ lock_age|default(0) }};
+    </script>
+    {% endif %}
+    {% if videos_available %}
+    <script>
+        // Phase 2c: archive watchdog banner — polls /api/archive/status
+        // every 60 s and shows a sticky bar when severity is 'error' or
+        // 'critical'. Dismiss persists for 1 h via sessionStorage.
+        (function() {
+            const POLL_INTERVAL_MS = 60000;
+            const DISMISS_KEY = 'archiveWatchdogDismissUntil';
+            const banner = document.getElementById('archive-watchdog-banner');
+            if (!banner) return;
+            const messageEl = document.getElementById('archive-watchdog-message');
+            const iconUse = document.getElementById('archive-watchdog-icon-use');
+            const runBtn = document.getElementById('archive-watchdog-run-btn');
+            const dismissBtn = document.getElementById('archive-watchdog-dismiss-btn');
+            const SPRITE = '{{ url_for("static", filename="icons/lucide-sprite.svg") }}';
+
+            function dismissedNow() {
+                try {
+                    const until = parseInt(
+                        sessionStorage.getItem(DISMISS_KEY) || '0', 10);
+                    return Date.now() < until;
+                } catch (e) { return false; }
+            }
+
+            function applySeverity(severity, message) {
+                banner.classList.remove(
+                    'archive-watchdog-warning',
+                    'archive-watchdog-error',
+                    'archive-watchdog-critical');
+                let icon = 'icon-alert-triangle';
+                if (severity === 'critical') {
+                    banner.classList.add('archive-watchdog-critical');
+                    icon = 'icon-shield-alert';
+                } else if (severity === 'error') {
+                    banner.classList.add('archive-watchdog-error');
+                    icon = 'icon-alert-circle';
+                } else if (severity === 'warning') {
+                    banner.classList.add('archive-watchdog-warning');
+                    icon = 'icon-alert-triangle';
+                }
+                if (iconUse) iconUse.setAttribute('href', SPRITE + '#' + icon);
+                if (messageEl) messageEl.textContent = message || '';
+            }
+
+            async function poll() {
+                if (dismissedNow()) {
+                    banner.hidden = true;
+                    return;
+                }
+                try {
+                    const r = await fetch('/api/archive/status', {
+                        credentials: 'same-origin',
+                    });
+                    if (!r.ok) { banner.hidden = true; return; }
+                    const data = await r.json();
+                    if (data.severity === 'error'
+                        || data.severity === 'critical') {
+                        applySeverity(data.severity, data.message);
+                        banner.hidden = false;
+                    } else {
+                        banner.hidden = true;
+                    }
+                } catch (e) {
+                    // Network blip — leave the banner state unchanged.
+                }
+            }
+
+            if (runBtn) {
+                runBtn.addEventListener('click', async function() {
+                    runBtn.disabled = true;
+                    try {
+                        const r = await fetch(
+                            '/api/recent_archive/trigger',
+                            { method: 'POST',
+                              credentials: 'same-origin' });
+                        if (typeof showToast === 'function') {
+                            showToast(
+                                r.ok
+                                ? 'Archive run triggered.'
+                                : 'Failed to trigger archive run.',
+                                r.ok ? 'success' : 'error');
+                        }
+                    } catch (e) {
+                        if (typeof showToast === 'function') {
+                            showToast('Network error triggering archive.',
+                                'error');
+                        }
+                    } finally {
+                        runBtn.disabled = false;
+                        setTimeout(poll, 2000);
+                    }
+                });
+            }
+            if (dismissBtn) {
+                dismissBtn.addEventListener('click', function() {
+                    try {
+                        sessionStorage.setItem(
+                            DISMISS_KEY,
+                            String(Date.now() + 60 * 60 * 1000));
+                    } catch (e) {}
+                    banner.hidden = true;
+                });
+            }
+
+            poll();
+            setInterval(poll, POLL_INTERVAL_MS);
+        })();
     </script>
     {% endif %}
     {% block scripts %}{% endblock %}

--- a/scripts/web/templates/index.html
+++ b/scripts/web/templates/index.html
@@ -249,6 +249,133 @@
         </div>
     </details>
 
+    {% if videos_available %}
+    <!-- Archive Status (Phase 2c — issue #76) -->
+    <details class="settings-section">
+        <summary>Archive Status</summary>
+        <div class="section-content">
+            <p style="font-size:0.85rem; color:var(--text-secondary); margin:0 0 12px">
+                Live view of the RecentClips archive subsystem. Updates every 30 seconds.
+                If the worker stalls or dies, a banner appears at the top of every page.
+            </p>
+            <div class="archive-status-grid" id="archive-status-chips">
+                <div class="archive-status-chip">
+                    <span class="chip-label">Worker</span>
+                    <span class="chip-value" id="chip-worker">—</span>
+                </div>
+                <div class="archive-status-chip">
+                    <span class="chip-label">Pending P1</span>
+                    <span class="chip-value" id="chip-p1">—</span>
+                </div>
+                <div class="archive-status-chip">
+                    <span class="chip-label">Pending P2</span>
+                    <span class="chip-value" id="chip-p2">—</span>
+                </div>
+                <div class="archive-status-chip">
+                    <span class="chip-label">Pending P3</span>
+                    <span class="chip-value" id="chip-p3">—</span>
+                </div>
+                <div class="archive-status-chip" id="chip-dl-wrap">
+                    <span class="chip-label">Dead-letter</span>
+                    <span class="chip-value" id="chip-dl">—</span>
+                </div>
+                <div class="archive-status-chip">
+                    <span class="chip-label">Last copy</span>
+                    <span class="chip-value" id="chip-lastcopy" style="font-size:0.95rem">—</span>
+                </div>
+            </div>
+            <p style="font-size:0.85rem; color:var(--text-secondary); margin:0 0 8px"
+               id="archive-active-file-row" hidden>
+                <strong>Currently copying:</strong>
+                <span id="archive-active-file" style="font-family:monospace"></span>
+            </p>
+            <p style="font-size:0.85rem; color:var(--msg-error-text); margin:0 0 8px"
+               id="archive-last-error-row" hidden>
+                <strong>Last error:</strong>
+                <span id="archive-last-error"></span>
+            </p>
+            <div style="display:flex; gap:8px; flex-wrap:wrap; margin-top:12px">
+                <button type="button" class="btn btn-primary"
+                        id="archive-run-now-btn"
+                        style="min-height:44px">
+                    <svg class="nav-icon" aria-hidden="true"><use href="{{ url_for('static', filename='icons/lucide-sprite.svg') }}#icon-refresh-cw"></use></svg>
+                    Run archive now
+                </button>
+                <button type="button" class="btn btn-secondary"
+                        id="archive-view-dl-btn"
+                        style="min-height:44px">
+                    <svg class="nav-icon" aria-hidden="true"><use href="{{ url_for('static', filename='icons/lucide-sprite.svg') }}#icon-info"></use></svg>
+                    View dead letters
+                </button>
+            </div>
+            <div id="archive-dl-modal" hidden
+                 style="margin-top:12px; padding:12px; background:var(--bg-secondary); border:1px solid var(--border-color); border-radius:8px;">
+                <div style="display:flex; justify-content:space-between; align-items:center; margin-bottom:8px">
+                    <strong>Dead-letter queue</strong>
+                    <button type="button" class="btn btn-ghost"
+                            id="archive-dl-close-btn"
+                            aria-label="Close dead-letter list">×</button>
+                </div>
+                <div id="archive-dl-content" style="font-size:0.85rem; max-height:300px; overflow:auto">
+                    Loading…
+                </div>
+            </div>
+        </div>
+    </details>
+
+    <!-- Storage (Phase 2c — issue #76) -->
+    <details class="settings-section">
+        <summary>Storage</summary>
+        <div class="section-content">
+            <p style="font-size:0.85rem; color:var(--text-secondary); margin:0 0 12px">
+                SD card disk usage for ArchivedClips. Files older than the retention window
+                are automatically deleted once a day.
+            </p>
+            <div class="storage-progress" style="margin-bottom:14px">
+                <div class="storage-progress-bar"
+                     role="progressbar"
+                     aria-label="ArchivedClips disk usage"
+                     aria-valuemin="0" aria-valuemax="100"
+                     id="storage-progress-bar-aria">
+                    <div class="storage-progress-fill" id="storage-progress-fill"
+                         style="width:0%"></div>
+                </div>
+                <div class="storage-progress-text">
+                    <span id="storage-used-text">— used</span>
+                    <span id="storage-free-text">— free</span>
+                </div>
+            </div>
+            <div class="archive-status-grid" style="margin-bottom:12px">
+                <div class="archive-status-chip">
+                    <span class="chip-label">Retention</span>
+                    <span class="chip-value" id="chip-retention">—</span>
+                </div>
+                <div class="archive-status-chip">
+                    <span class="chip-label">Last prune</span>
+                    <span class="chip-value" id="chip-lastprune"
+                          style="font-size:0.95rem">—</span>
+                </div>
+                <div class="archive-status-chip">
+                    <span class="chip-label">Last freed</span>
+                    <span class="chip-value" id="chip-lastfreed"
+                          style="font-size:0.95rem">—</span>
+                </div>
+            </div>
+            <p style="font-size:0.8rem; color:var(--text-secondary); margin:0 0 8px">
+                Clips older than the retention window above are automatically deleted.
+                Trips, waypoints, and detected events are <strong>preserved</strong> —
+                only the dashcam clip is removed.
+            </p>
+            <button type="button" class="btn btn-secondary"
+                    id="storage-prune-now-btn"
+                    style="min-height:44px">
+                <svg class="nav-icon" aria-hidden="true"><use href="{{ url_for('static', filename='icons/lucide-sprite.svg') }}#icon-trash-2"></use></svg>
+                Prune now
+            </button>
+        </div>
+    </details>
+    {% endif %}
+
     <!-- Mapping & Indexing Settings -->
     <details class="settings-section">
         <summary>Mapping & Indexing</summary>
@@ -900,5 +1027,220 @@ function updateFsckHistory() {
 if (document.getElementById('fsck-status-container')) {
     updateLastChecks(); updateFsckHistory(); updateFsckStatus();
 }
+
+// =====================================================================
+// Phase 2c (issue #76) — Archive Status & Storage panels
+// =====================================================================
+(function() {
+    const POLL_MS = 30000;
+    if (!document.getElementById('archive-status-chips')) return;
+
+    function fmtAgo(iso) {
+        if (!iso) return 'never';
+        const t = Date.parse(iso);
+        if (isNaN(t)) return 'never';
+        const ageS = Math.max(0, Math.floor((Date.now() - t) / 1000));
+        if (ageS < 60) return ageS + 's ago';
+        if (ageS < 3600) return Math.floor(ageS / 60) + ' min ago';
+        if (ageS < 86400) return Math.floor(ageS / 3600) + ' h ago';
+        return Math.floor(ageS / 86400) + ' d ago';
+    }
+
+    function fmtBytes(bytes) {
+        if (!bytes || bytes <= 0) return '0 B';
+        const u = ['B','KB','MB','GB','TB'];
+        let n = bytes;
+        let i = 0;
+        while (n >= 1024 && i < u.length - 1) { n /= 1024; i++; }
+        return n.toFixed(n < 10 ? 1 : 0) + ' ' + u[i];
+    }
+
+    function fmtMb(mb) {
+        if (!mb && mb !== 0) return '—';
+        if (mb >= 1024) return (mb / 1024).toFixed(1) + ' GB';
+        return mb + ' MB';
+    }
+
+    function setText(id, txt) {
+        const el = document.getElementById(id);
+        if (el) el.textContent = txt;
+    }
+
+    function applyStatus(data) {
+        // Worker chip
+        const workerEl = document.getElementById('chip-worker');
+        if (workerEl) {
+            let label = 'Stopped';
+            if (data.paused) label = 'Paused';
+            else if (data.worker_running) label = 'Running';
+            workerEl.textContent = label;
+            workerEl.parentElement.classList.toggle(
+                'has-issue', !data.worker_running);
+        }
+        setText('chip-p1', data.queue_depth_p1);
+        setText('chip-p2', data.queue_depth_p2);
+        setText('chip-p3', data.queue_depth_p3);
+        setText('chip-dl', data.dead_letter_count);
+        const dlWrap = document.getElementById('chip-dl-wrap');
+        if (dlWrap) dlWrap.classList.toggle(
+            'has-issue', (data.dead_letter_count || 0) > 0);
+        setText('chip-lastcopy', fmtAgo(data.last_successful_copy_at));
+
+        const activeRow = document.getElementById('archive-active-file-row');
+        if (activeRow) {
+            if (data.active_file) {
+                activeRow.hidden = false;
+                setText('archive-active-file', data.active_file);
+            } else {
+                activeRow.hidden = true;
+            }
+        }
+        const errRow = document.getElementById('archive-last-error-row');
+        if (errRow) {
+            if (data.last_error) {
+                errRow.hidden = false;
+                setText('archive-last-error', data.last_error);
+            } else {
+                errRow.hidden = true;
+            }
+        }
+
+        // Storage progress bar
+        const fill = document.getElementById('storage-progress-fill');
+        const aria = document.getElementById('storage-progress-bar-aria');
+        if (fill && aria && data.disk_total_mb > 0) {
+            const pct = Math.min(100,
+                Math.round(100 * data.disk_used_mb / data.disk_total_mb));
+            fill.style.width = pct + '%';
+            aria.setAttribute('aria-valuenow', pct);
+            fill.classList.remove('warning', 'critical');
+            if (pct >= 95) fill.classList.add('critical');
+            else if (pct >= 90) fill.classList.add('warning');
+        }
+        setText('storage-used-text',
+            fmtMb(data.disk_used_mb) + ' used (' +
+            fmtMb(data.disk_total_mb) + ' total)');
+        setText('storage-free-text', fmtMb(data.disk_free_mb) + ' free');
+        setText('chip-retention',
+            data.retention_days
+            ? data.retention_days + ' days'
+            : '—');
+        setText('chip-lastprune', fmtAgo(data.last_prune_at));
+        setText('chip-lastfreed',
+            data.last_prune_deleted
+            ? data.last_prune_deleted + ' files (' +
+              fmtBytes(data.last_prune_freed_bytes) + ')'
+            : 'no files');
+    }
+
+    async function poll() {
+        try {
+            const r = await fetch('/api/archive/status', {
+                credentials: 'same-origin',
+            });
+            if (!r.ok) return;
+            const data = await r.json();
+            applyStatus(data);
+        } catch (e) { /* network blip */ }
+    }
+
+    const runBtn = document.getElementById('archive-run-now-btn');
+    if (runBtn) {
+        runBtn.addEventListener('click', async function() {
+            runBtn.disabled = true;
+            try {
+                const r = await fetch('/api/recent_archive/trigger', {
+                    method: 'POST', credentials: 'same-origin'
+                });
+                if (typeof showToast === 'function') {
+                    showToast(
+                        r.ok ? 'Archive run triggered.'
+                             : 'Failed to trigger archive run.',
+                        r.ok ? 'success' : 'error');
+                }
+            } finally {
+                runBtn.disabled = false;
+                setTimeout(poll, 2000);
+            }
+        });
+    }
+
+    const pruneBtn = document.getElementById('storage-prune-now-btn');
+    if (pruneBtn) {
+        pruneBtn.addEventListener('click', async function() {
+            pruneBtn.disabled = true;
+            try {
+                const r = await fetch('/api/archive/prune_now', {
+                    method: 'POST', credentials: 'same-origin'
+                });
+                const data = await r.json().catch(() => ({}));
+                if (typeof showToast === 'function') {
+                    if (r.ok && data.started) {
+                        showToast(
+                            'Prune complete: ' +
+                            (data.deleted_count || 0) + ' files removed.',
+                            'success');
+                    } else {
+                        showToast(
+                            data.message || 'Prune failed.', 'error');
+                    }
+                }
+            } finally {
+                pruneBtn.disabled = false;
+                setTimeout(poll, 1000);
+            }
+        });
+    }
+
+    const dlBtn = document.getElementById('archive-view-dl-btn');
+    const dlModal = document.getElementById('archive-dl-modal');
+    const dlContent = document.getElementById('archive-dl-content');
+    const dlClose = document.getElementById('archive-dl-close-btn');
+    if (dlBtn && dlModal) {
+        dlBtn.addEventListener('click', async function() {
+            dlModal.hidden = false;
+            dlContent.textContent = 'Loading…';
+            try {
+                const r = await fetch('/api/archive/dead_letters', {
+                    credentials: 'same-origin'
+                });
+                const data = await r.json();
+                if (!data.rows || data.rows.length === 0) {
+                    dlContent.innerHTML = '<em>No dead-letter rows.</em>';
+                    return;
+                }
+                let html = '<table style="width:100%; border-collapse:collapse">';
+                html += '<thead><tr>'
+                     + '<th style="text-align:left; padding:4px">Source</th>'
+                     + '<th style="text-align:left; padding:4px">Attempts</th>'
+                     + '<th style="text-align:left; padding:4px">Error</th>'
+                     + '</tr></thead><tbody>';
+                for (const row of data.rows) {
+                    const src = String(row.source_path || '')
+                        .replace(/&/g, '&amp;').replace(/</g, '&lt;');
+                    const err = String(row.last_error || '')
+                        .replace(/&/g, '&amp;').replace(/</g, '&lt;');
+                    html += '<tr>'
+                         + '<td style="padding:4px; font-family:monospace">' + src + '</td>'
+                         + '<td style="padding:4px">' + (row.attempts || 0) + '</td>'
+                         + '<td style="padding:4px">' + err + '</td>'
+                         + '</tr>';
+                }
+                html += '</tbody></table>';
+                dlContent.innerHTML = html;
+            } catch (e) {
+                dlContent.innerHTML = '<em>Failed to load.</em>';
+            }
+        });
+    }
+    if (dlClose && dlModal) {
+        dlClose.addEventListener('click', function() {
+            dlModal.hidden = true;
+        });
+    }
+
+    poll();
+    setInterval(poll, POLL_MS);
+})();
 </script>
 {% endblock %}

--- a/scripts/web/web_control.py
+++ b/scripts/web/web_control.py
@@ -334,6 +334,22 @@ if __name__ == "__main__":
                 teslacam_root=tc,
             )
             print("Archive queue worker started (Phase 2b)")
+
+            # Phase 2c: archive watchdog + retention prune. Single
+            # daemon thread that observes the queue/worker, exposes
+            # ``/api/archive/status``, and runs the daily retention
+            # prune on ``ArchivedClips``. Pure local-FS observer — it
+            # never touches the USB gadget.
+            try:
+                from services import archive_watchdog
+                archive_watchdog.start_watchdog(
+                    _ARCHIVE_WORKER_DB, ARCHIVE_DIR,
+                )
+                print("Archive watchdog started (Phase 2c)")
+            except Exception as e:  # noqa: BLE001
+                print(
+                    f"Warning: Failed to start archive watchdog: {e}"
+                )
     except Exception as e:
         print(f"Warning: Failed to start archive queue worker: {e}")
 

--- a/tests/test_archive_status_endpoint.py
+++ b/tests/test_archive_status_endpoint.py
@@ -1,0 +1,282 @@
+"""Tests for the Phase 2c /api/archive/* endpoints (issue #76)."""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import time
+from unittest.mock import patch
+
+import pytest
+
+from services import archive_queue
+from services import archive_watchdog
+from services import archive_worker
+from services import task_coordinator
+from services.mapping_service import _init_db
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def db(tmp_path):
+    db_path = str(tmp_path / "geodata.db")
+    _init_db(db_path).close()
+    return db_path
+
+
+@pytest.fixture
+def archive_root(tmp_path):
+    p = tmp_path / "ArchivedClips"
+    p.mkdir()
+    return str(p)
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state():
+    archive_watchdog.stop_watchdog(timeout=5.0)
+    archive_worker.stop_worker(timeout=5.0)
+    archive_worker._disk_space_pause_until = 0.0
+    with task_coordinator._lock:
+        task_coordinator._current_task = None
+        task_coordinator._task_started = 0.0
+        task_coordinator._waiter_count = 0
+    yield
+    archive_watchdog.stop_watchdog(timeout=5.0)
+    archive_worker.stop_worker(timeout=5.0)
+    archive_worker._disk_space_pause_until = 0.0
+    with task_coordinator._lock:
+        task_coordinator._current_task = None
+        task_coordinator._task_started = 0.0
+        task_coordinator._waiter_count = 0
+
+
+@pytest.fixture
+def app(tmp_path):
+    """Build a minimal Flask app with just the archive_queue blueprint.
+
+    We build it directly rather than importing ``web_control.app`` so
+    the tests don't drag in the full TeslaUSB stack (Samba, mode
+    service, partition mount service, etc.).
+    """
+    from flask import Flask
+    from blueprints.archive_queue import archive_queue_bp
+    flask_app = Flask(__name__)
+    flask_app.register_blueprint(archive_queue_bp)
+    flask_app.config['TESTING'] = True
+    return flask_app
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestArchiveStatusImageGate:
+    def test_returns_503_when_cam_image_missing(self, client):
+        with patch('blueprints.archive_queue.os.path.isfile',
+                   return_value=False):
+            r = client.get('/api/archive/status')
+        assert r.status_code == 503
+        body = r.get_json()
+        assert 'error' in body
+
+    def test_returns_200_when_cam_image_present(self, client):
+        with patch('blueprints.archive_queue.os.path.isfile',
+                   return_value=True):
+            r = client.get('/api/archive/status')
+        assert r.status_code == 200
+
+    def test_legacy_alias_returns_200(self, client):
+        # Phase 2a alias kept intact.
+        with patch('blueprints.archive_queue.os.path.isfile',
+                   return_value=True):
+            r = client.get('/api/archive_queue/status')
+        assert r.status_code == 200
+
+    def test_dead_letters_endpoint_image_gated(self, client):
+        with patch('blueprints.archive_queue.os.path.isfile',
+                   return_value=False):
+            r = client.get('/api/archive/dead_letters')
+        assert r.status_code == 503
+
+    def test_prune_now_endpoint_image_gated(self, client):
+        with patch('blueprints.archive_queue.os.path.isfile',
+                   return_value=False):
+            r = client.post('/api/archive/prune_now')
+        assert r.status_code == 503
+
+
+class TestArchiveStatusShape:
+    REQUIRED_FIELDS = {
+        'severity', 'message', 'enabled', 'checked_at',
+        'queue_depth_p1', 'queue_depth_p2', 'queue_depth_p3',
+        'pending_count', 'claimed_count', 'copied_count',
+        'source_gone_count', 'dead_letter_count',
+        'worker_running', 'paused', 'active_file', 'last_outcome',
+        'last_error', 'files_done_session', 'disk_pause',
+        'disk_total_mb', 'disk_used_mb', 'disk_free_mb',
+        'disk_warning_mb', 'disk_critical_mb',
+        'last_successful_copy_at', 'last_successful_copy_age_seconds',
+        'retention_days', 'last_prune_at', 'last_prune_deleted',
+        'last_prune_freed_bytes', 'last_prune_error', 'next_prune_due_at',
+        'watchdog_running',
+    }
+
+    def test_status_payload_includes_all_expected_fields(self, client):
+        with patch('blueprints.archive_queue.os.path.isfile',
+                   return_value=True):
+            r = client.get('/api/archive/status')
+        assert r.status_code == 200
+        body = r.get_json()
+        missing = self.REQUIRED_FIELDS - set(body.keys())
+        assert not missing, f"Status payload missing fields: {missing}"
+
+    def test_status_includes_disk_info(self, client):
+        with patch('blueprints.archive_queue.os.path.isfile',
+                   return_value=True):
+            r = client.get('/api/archive/status')
+        body = r.get_json()
+        # All disk fields are integers (MB).
+        assert isinstance(body['disk_total_mb'], int)
+        assert isinstance(body['disk_used_mb'], int)
+        assert isinstance(body['disk_free_mb'], int)
+        # Thresholds default to 500/100 from spec.
+        assert body['disk_warning_mb'] == 500
+        assert body['disk_critical_mb'] == 100
+
+    def test_status_includes_per_priority_queue_depths(
+        self, client, db, archive_root, monkeypatch,
+    ):
+        # Enqueue rows of different priorities and verify counts.
+        archive_queue.enqueue_for_archive(
+            "/tc/RecentClips/p1.mp4", db_path=db, priority=1,
+        )
+        archive_queue.enqueue_for_archive(
+            "/tc/RecentClips/p1b.mp4", db_path=db, priority=1,
+        )
+        archive_queue.enqueue_for_archive(
+            "/tc/SentryClips/evt/p2.mp4", db_path=db, priority=2,
+        )
+        archive_queue.enqueue_for_archive(
+            "/tc/SavedClips/evt/p3.mp4", db_path=db, priority=3,
+        )
+        # Pin the DB resolver so the endpoint reads our test DB.
+        monkeypatch.setattr(
+            archive_queue, '_resolve_db_path', lambda _p=None: db,
+        )
+        with patch('blueprints.archive_queue.os.path.isfile',
+                   return_value=True):
+            r = client.get('/api/archive/status')
+        body = r.get_json()
+        assert body['queue_depth_p1'] == 2
+        assert body['queue_depth_p2'] == 1
+        assert body['queue_depth_p3'] == 1
+        assert body['pending_count'] == 4
+
+    def test_severity_default_is_ok(self, client):
+        with patch('blueprints.archive_queue.os.path.isfile',
+                   return_value=True):
+            r = client.get('/api/archive/status')
+        body = r.get_json()
+        assert body['severity'] in ('ok', 'warning', 'error', 'critical')
+
+
+class TestPruneNowEndpoint:
+    def test_returns_503_when_watchdog_not_running(self, client):
+        with patch('blueprints.archive_queue.os.path.isfile',
+                   return_value=True):
+            r = client.post('/api/archive/prune_now')
+        assert r.status_code == 503
+        body = r.get_json()
+        assert body['started'] is False
+
+    def test_runs_synchronously_and_returns_summary(
+        self, client, db, archive_root, monkeypatch,
+    ):
+        # Plant an old mp4 we expect the prune to delete.
+        old_mtime = time.time() - (40 * 86400)
+        old_file = os.path.normpath(
+            os.path.join(archive_root, "RecentClips", "old.mp4")
+        )
+        os.makedirs(os.path.dirname(old_file), exist_ok=True)
+        with open(old_file, 'wb') as f:
+            f.write(b"X" * 1024)
+        os.utime(old_file, (old_mtime, old_mtime))
+
+        # Start the watchdog so the endpoint guard passes.
+        archive_watchdog.start_watchdog(
+            db, archive_root, check_interval_seconds=60,
+        )
+        try:
+            with patch('blueprints.archive_queue.os.path.isfile',
+                       return_value=True):
+                r = client.post('/api/archive/prune_now')
+            assert r.status_code == 200
+            body = r.get_json()
+            assert body['started'] is True
+            assert body['deleted_count'] == 1
+            assert body['freed_bytes'] >= 1024
+            assert body['retention_days'] == 30
+            assert not os.path.exists(old_file)
+        finally:
+            archive_watchdog.stop_watchdog(timeout=5)
+
+
+class TestDeadLettersEndpoint:
+    def test_returns_empty_list_when_no_dead_letters(
+        self, client, db, monkeypatch,
+    ):
+        monkeypatch.setattr(
+            archive_queue, '_resolve_db_path', lambda _p=None: db,
+        )
+        with patch('blueprints.archive_queue.os.path.isfile',
+                   return_value=True):
+            r = client.get('/api/archive/dead_letters')
+        assert r.status_code == 200
+        body = r.get_json()
+        assert body['rows'] == []
+        assert body['count'] == 0
+
+    def test_returns_dead_letter_rows_with_last_error(
+        self, client, db, monkeypatch,
+    ):
+        # Insert a synthetic dead-letter row.
+        with sqlite3.connect(db) as conn:
+            conn.execute(
+                "INSERT INTO archive_queue("
+                " source_path, status, priority, enqueued_at, attempts,"
+                " last_error) "
+                "VALUES (?, 'dead_letter', 2, ?, 5, ?)",
+                ("/tc/SentryClips/evt/x.mp4", "2025-01-01T00:00:00Z",
+                 "Permission denied"),
+            )
+        monkeypatch.setattr(
+            archive_queue, '_resolve_db_path', lambda _p=None: db,
+        )
+        with patch('blueprints.archive_queue.os.path.isfile',
+                   return_value=True):
+            r = client.get('/api/archive/dead_letters')
+        body = r.get_json()
+        assert body['count'] == 1
+        assert body['rows'][0]['source_path'] == "/tc/SentryClips/evt/x.mp4"
+        assert body['rows'][0]['last_error'] == "Permission denied"
+        assert body['rows'][0]['status'] == 'dead_letter'
+
+    def test_limit_param_clamped(self, client, db, monkeypatch):
+        monkeypatch.setattr(
+            archive_queue, '_resolve_db_path', lambda _p=None: db,
+        )
+        with patch('blueprints.archive_queue.os.path.isfile',
+                   return_value=True):
+            r = client.get('/api/archive/dead_letters?limit=99999')
+        assert r.status_code == 200

--- a/tests/test_archive_status_endpoint.py
+++ b/tests/test_archive_status_endpoint.py
@@ -125,7 +125,7 @@ class TestArchiveStatusShape:
         'worker_running', 'paused', 'active_file', 'last_outcome',
         'last_error', 'files_done_session', 'disk_pause',
         'disk_total_mb', 'disk_used_mb', 'disk_free_mb',
-        'disk_warning_mb', 'disk_critical_mb',
+        'disk_warning_mb', 'disk_critical_mb', 'disk_known',
         'last_successful_copy_at', 'last_successful_copy_age_seconds',
         'retention_days', 'last_prune_at', 'last_prune_deleted',
         'last_prune_freed_bytes', 'last_prune_error', 'next_prune_due_at',

--- a/tests/test_archive_watchdog.py
+++ b/tests/test_archive_watchdog.py
@@ -323,6 +323,40 @@ class TestArchiveWatchdogSeverity:
         assert archive_watchdog._STALE_ERROR_SECONDS == 10 * 60
         assert archive_watchdog._STALE_CRITICAL_SECONDS == 20 * 60
 
+    def test_disk_known_false_skips_disk_overlay(self):
+        # Regression: PR #90 reviewer Info #1.
+        # When disk_usage stat fails (disk_known=False), the disk
+        # overlay must be skipped entirely so a transient OSError
+        # does NOT escalate severity to 'critical' via disk_free_mb=0.
+        sev, msg = archive_watchdog._classify_severity(
+            worker_running=True,
+            pending_count=0,
+            last_copy_age_seconds=None,
+            disk_free_mb=0,            # would normally be < critical
+            disk_warning_mb=500,
+            disk_critical_mb=100,
+            disk_known=False,          # OSError happened
+        )
+        assert sev == 'ok'
+        assert 'CRITICAL' not in msg
+        assert '0 MB' not in msg
+
+    def test_disk_known_false_does_not_mask_stale_critical(self):
+        # disk_known=False must not suppress a real staleness-driven
+        # critical: the worker is dead with pending work — the user
+        # MUST see that banner regardless of disk-stat health.
+        sev, msg = archive_watchdog._classify_severity(
+            worker_running=False,
+            pending_count=4,
+            last_copy_age_seconds=30,
+            disk_free_mb=0,
+            disk_warning_mb=500,
+            disk_critical_mb=100,
+            disk_known=False,
+        )
+        assert sev == 'critical'
+        assert 'not running' in msg.lower()
+
 
 # ---------------------------------------------------------------------------
 # TestArchiveWatchdogDiskSpace
@@ -371,10 +405,34 @@ class TestArchiveWatchdogDiskSpace:
     ):
         missing = str(tmp_path / "nonexistent_archive_root")
         snap = archive_watchdog._compute_health(db, missing)
-        # Disk fields default to 0; severity should not crash.
+        # Disk fields default to 0 for backward-compat with the JSON
+        # payload, but ``disk_known`` is False so the disk overlay was
+        # skipped (i.e. severity was NOT escalated to 'critical' on a
+        # transient stat failure).
         assert snap['disk_free_mb'] == 0
         assert snap['disk_total_mb'] == 0
-        assert snap['severity'] in ('ok', 'warning', 'error', 'critical')
+        assert snap['disk_known'] is False
+        # The disk overlay was skipped — severity must not be 'critical'
+        # purely because disk_free_mb=0.
+        assert snap['severity'] in ('ok', 'warning', 'error')
+
+    def test_oserror_does_not_escalate_to_disk_critical(
+        self, db, archive_root, monkeypatch,
+    ):
+        # Regression: PR #90 reviewer Info #1.
+        # When ``shutil.disk_usage`` raises OSError (transient FS hiccup),
+        # the watchdog must NOT report a misleading "0 MB free, CRITICAL"
+        # banner. Worker fails open on OSError; watchdog now matches.
+        def _raise(_p):
+            raise OSError("transient stat failure")
+        monkeypatch.setattr(archive_watchdog.shutil, 'disk_usage', _raise)
+        snap = archive_watchdog._compute_health(db, archive_root)
+        assert snap['disk_known'] is False
+        # Severity comes from staleness (idle queue ⇒ ok), not disk.
+        assert snap['severity'] == 'ok'
+        # Critical-disk message must NOT appear.
+        assert 'CRITICAL' not in snap['message']
+        assert '0 MB' not in snap['message']
 
 
 # ---------------------------------------------------------------------------
@@ -388,7 +446,7 @@ class TestArchiveWatchdogReporting:
         'last_successful_copy_age_seconds', 'worker_running', 'paused',
         'dead_letter_count', 'pending_count', 'disk_free_mb',
         'disk_total_mb', 'disk_used_mb', 'disk_warning',
-        'disk_warning_mb', 'disk_critical_mb', 'checked_at',
+        'disk_warning_mb', 'disk_critical_mb', 'disk_known', 'checked_at',
     }
 
     def test_get_health_shape(self, db, archive_root, monkeypatch):

--- a/tests/test_archive_watchdog.py
+++ b/tests/test_archive_watchdog.py
@@ -1,0 +1,740 @@
+"""Tests for the Phase 2c archive watchdog + retention prune (issue #76).
+
+Coverage matches the issue spec:
+
+* TestArchiveWatchdogLifecycle      — start, stop, idempotent
+* TestArchiveWatchdogSeverity       — every branch of _classify_severity
+* TestArchiveWatchdogDiskSpace      — synthetic disk_usage drives warn/crit
+* TestArchiveWatchdogReporting      — get_health() / get_status() shape
+* TestArchiveRetention              — prune deletes mp4 by mtime, preserves
+                                      .dead_letter, calls purge_deleted_videos,
+                                      DOES NOT delete trips/waypoints/events
+                                      (the May 7 contract)
+
+The severity classifier is a pure function (`_classify_severity`) so most
+branches are tested without mocking the DB or filesystem at all.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import time
+
+import pytest
+
+from services import archive_queue
+from services import archive_watchdog
+from services import archive_worker
+from services import task_coordinator
+from services.archive_queue import enqueue_for_archive
+from services.mapping_service import _init_db
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def db(tmp_path):
+    """Initialize a fresh geodata.db with the v10 schema (incl. archive_queue)."""
+    db_path = str(tmp_path / "geodata.db")
+    _init_db(db_path).close()
+    return db_path
+
+
+@pytest.fixture
+def archive_root(tmp_path):
+    p = tmp_path / "ArchivedClips"
+    p.mkdir()
+    return str(p)
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state():
+    """Stop watchdog + worker + reset coordinator state between tests."""
+    archive_watchdog.stop_watchdog(timeout=5.0)
+    archive_worker.stop_worker(timeout=5.0)
+    archive_worker._disk_space_pause_until = 0.0
+    with task_coordinator._lock:
+        task_coordinator._current_task = None
+        task_coordinator._task_started = 0.0
+        task_coordinator._waiter_count = 0
+    # Reset watchdog module state so each test starts clean.
+    archive_watchdog._last_health = {
+        'severity': 'ok',
+        'message': 'Archive watchdog has not yet run.',
+        'last_successful_copy_at': None,
+        'last_successful_copy_age_seconds': None,
+        'worker_running': False,
+        'paused': False,
+        'dead_letter_count': 0,
+        'pending_count': 0,
+        'disk_free_mb': 0,
+        'disk_warning': False,
+        'checked_at': None,
+    }
+    archive_watchdog._retention_state = {
+        'last_prune_at': None,
+        'last_prune_deleted': 0,
+        'last_prune_freed_bytes': 0,
+        'last_prune_error': None,
+        'next_prune_due_at': None,
+    }
+    yield
+    archive_watchdog.stop_watchdog(timeout=5.0)
+    archive_worker.stop_worker(timeout=5.0)
+    archive_worker._disk_space_pause_until = 0.0
+    with task_coordinator._lock:
+        task_coordinator._current_task = None
+        task_coordinator._task_started = 0.0
+        task_coordinator._waiter_count = 0
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _FakeUsage:
+    def __init__(self, total: int, used: int, free: int):
+        self.total = total
+        self.used = used
+        self.free = free
+
+
+def _fake_usage(free_mb: int, total_mb: int = 32_000) -> _FakeUsage:
+    return _FakeUsage(
+        total=total_mb * 1024 * 1024,
+        used=max(total_mb - free_mb, 0) * 1024 * 1024,
+        free=free_mb * 1024 * 1024,
+    )
+
+
+def _make_archive_mp4(root: str, rel: str, *, mtime: float,
+                      size: int = 100) -> str:
+    # Normalize the rel path so subsequent string-comparison assertions
+    # match regardless of which path separator the caller used.
+    full = os.path.normpath(os.path.join(root, rel))
+    os.makedirs(os.path.dirname(full), exist_ok=True)
+    with open(full, 'wb') as f:
+        f.write(b"X" * size)
+    os.utime(full, (mtime, mtime))
+    return full
+
+
+# ---------------------------------------------------------------------------
+# TestArchiveWatchdogLifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestArchiveWatchdogLifecycle:
+    def test_start_returns_true_first_time(self, db, archive_root):
+        ok = archive_watchdog.start_watchdog(
+            db, archive_root, check_interval_seconds=0.1,
+        )
+        assert ok is True
+        assert archive_watchdog.is_running() is True
+        assert archive_watchdog.stop_watchdog(timeout=5) is True
+        assert archive_watchdog.is_running() is False
+
+    def test_double_start_is_noop(self, db, archive_root):
+        assert archive_watchdog.start_watchdog(
+            db, archive_root, check_interval_seconds=0.1,
+        ) is True
+        assert archive_watchdog.start_watchdog(
+            db, archive_root, check_interval_seconds=0.1,
+        ) is False
+        archive_watchdog.stop_watchdog(timeout=5)
+
+    def test_stop_when_not_running_returns_true(self):
+        assert archive_watchdog.stop_watchdog(timeout=2) is True
+
+    def test_wake_does_not_crash_when_not_running(self):
+        # wake() must never raise — it's safe to call from any thread.
+        archive_watchdog.wake()
+
+    def test_loop_runs_at_least_once(self, db, archive_root):
+        archive_watchdog.start_watchdog(
+            db, archive_root, check_interval_seconds=0.05,
+        )
+        try:
+            # Wait briefly for first tick to populate _last_health.
+            for _ in range(50):
+                snap = archive_watchdog.get_health()
+                if snap.get('checked_at') is not None:
+                    break
+                time.sleep(0.05)
+            snap = archive_watchdog.get_health()
+            assert snap['checked_at'] is not None
+            assert snap['severity'] in ('ok', 'warning', 'error', 'critical')
+        finally:
+            archive_watchdog.stop_watchdog(timeout=5)
+
+
+# ---------------------------------------------------------------------------
+# TestArchiveWatchdogSeverity (acceptance criterion 6 — pure function)
+# ---------------------------------------------------------------------------
+
+
+class TestArchiveWatchdogSeverity:
+    """Drive every branch of `_classify_severity` without filesystem/DB."""
+
+    def test_ok_when_no_pending(self):
+        sev, msg = archive_watchdog._classify_severity(
+            worker_running=True,
+            pending_count=0,
+            last_copy_age_seconds=None,
+            disk_free_mb=10_000,
+            disk_warning_mb=500,
+            disk_critical_mb=100,
+        )
+        assert sev == 'ok'
+        assert 'idle' in msg.lower()
+
+    def test_ok_when_recent_copy_and_pending(self):
+        sev, _msg = archive_watchdog._classify_severity(
+            worker_running=True,
+            pending_count=3,
+            last_copy_age_seconds=60,  # 1 min — fresh
+            disk_free_mb=10_000,
+            disk_warning_mb=500,
+            disk_critical_mb=100,
+        )
+        assert sev == 'ok'
+
+    def test_warning_at_5_min_stale_with_pending(self):
+        sev, msg = archive_watchdog._classify_severity(
+            worker_running=True,
+            pending_count=2,
+            last_copy_age_seconds=6 * 60,  # 6 min
+            disk_free_mb=10_000,
+            disk_warning_mb=500,
+            disk_critical_mb=100,
+        )
+        assert sev == 'warning'
+        assert 'slow' in msg.lower() or 'min' in msg.lower()
+
+    def test_error_at_10_min_stale_with_pending(self):
+        # Acceptance criterion 6: 10 min trigger — banner-worthy.
+        sev, msg = archive_watchdog._classify_severity(
+            worker_running=True,
+            pending_count=5,
+            last_copy_age_seconds=15 * 60,  # 15 min
+            disk_free_mb=10_000,
+            disk_warning_mb=500,
+            disk_critical_mb=100,
+        )
+        assert sev == 'error'
+        assert 'stalled' in msg.lower() or 'lost' in msg.lower()
+
+    def test_critical_at_20_min_stale_with_pending(self):
+        sev, msg = archive_watchdog._classify_severity(
+            worker_running=True,
+            pending_count=10,
+            last_copy_age_seconds=25 * 60,  # 25 min
+            disk_free_mb=10_000,
+            disk_warning_mb=500,
+            disk_critical_mb=100,
+        )
+        assert sev == 'critical'
+        assert 'stalled' in msg.lower() or 'lost' in msg.lower()
+
+    def test_critical_when_worker_dead_with_pending(self):
+        sev, msg = archive_watchdog._classify_severity(
+            worker_running=False,
+            pending_count=4,
+            last_copy_age_seconds=30,  # would otherwise be ok
+            disk_free_mb=10_000,
+            disk_warning_mb=500,
+            disk_critical_mb=100,
+        )
+        assert sev == 'critical'
+        assert 'not running' in msg.lower()
+
+    def test_worker_dead_but_no_pending_is_ok(self):
+        # No pending work + no worker is fine (e.g., disabled subsystem).
+        sev, _msg = archive_watchdog._classify_severity(
+            worker_running=False,
+            pending_count=0,
+            last_copy_age_seconds=None,
+            disk_free_mb=10_000,
+            disk_warning_mb=500,
+            disk_critical_mb=100,
+        )
+        assert sev == 'ok'
+
+    def test_disk_warning_when_otherwise_ok(self):
+        sev, msg = archive_watchdog._classify_severity(
+            worker_running=True,
+            pending_count=0,
+            last_copy_age_seconds=None,
+            disk_free_mb=300,  # < 500 MB
+            disk_warning_mb=500,
+            disk_critical_mb=100,
+        )
+        assert sev == 'warning'
+        assert '300' in msg or 'low' in msg.lower()
+
+    def test_disk_critical_overrides_stale_warning(self):
+        # Stale = warning, disk = critical → final severity = critical.
+        sev, msg = archive_watchdog._classify_severity(
+            worker_running=True,
+            pending_count=2,
+            last_copy_age_seconds=6 * 60,  # warning
+            disk_free_mb=50,  # critical
+            disk_warning_mb=500,
+            disk_critical_mb=100,
+        )
+        assert sev == 'critical'
+        assert 'critical' in msg.lower()
+
+    def test_stale_critical_overrides_disk_warning(self):
+        # Stale = critical, disk = warning → final = critical (stale wins).
+        sev, _msg = archive_watchdog._classify_severity(
+            worker_running=True,
+            pending_count=2,
+            last_copy_age_seconds=25 * 60,  # critical
+            disk_free_mb=300,  # warning
+            disk_warning_mb=500,
+            disk_critical_mb=100,
+        )
+        assert sev == 'critical'
+
+    def test_equal_severity_combines_messages(self):
+        # Both warning → message should contain both halves.
+        sev, msg = archive_watchdog._classify_severity(
+            worker_running=True,
+            pending_count=2,
+            last_copy_age_seconds=6 * 60,
+            disk_free_mb=300,
+            disk_warning_mb=500,
+            disk_critical_mb=100,
+        )
+        assert sev == 'warning'
+        # Message has staleness AND disk info combined.
+        assert 'slow' in msg.lower()
+        assert '300' in msg
+
+    def test_severity_thresholds_are_5_10_20_minutes(self):
+        # Verify the literal threshold constants the issue spec mandates.
+        assert archive_watchdog._STALE_WARNING_SECONDS == 5 * 60
+        assert archive_watchdog._STALE_ERROR_SECONDS == 10 * 60
+        assert archive_watchdog._STALE_CRITICAL_SECONDS == 20 * 60
+
+
+# ---------------------------------------------------------------------------
+# TestArchiveWatchdogDiskSpace
+# ---------------------------------------------------------------------------
+
+
+class TestArchiveWatchdogDiskSpace:
+    def test_disk_thresholds_default_to_500_and_100(self, monkeypatch):
+        # Force the config import to fail.
+        import builtins
+        real_import = builtins.__import__
+
+        def _fail_import(name, *a, **kw):
+            if name == 'config':
+                raise ImportError("simulated")
+            return real_import(name, *a, **kw)
+        monkeypatch.setattr(builtins, '__import__', _fail_import)
+        warn_mb, crit_mb = archive_watchdog._resolve_disk_thresholds()
+        assert (warn_mb, crit_mb) == (500, 100)
+
+    def test_compute_health_with_low_disk_yields_warning(
+        self, db, archive_root, monkeypatch,
+    ):
+        monkeypatch.setattr(
+            archive_watchdog.shutil, 'disk_usage',
+            lambda _p: _fake_usage(free_mb=300),
+        )
+        snap = archive_watchdog._compute_health(db, archive_root)
+        assert snap['severity'] == 'warning'
+        assert snap['disk_free_mb'] == 300
+        assert snap['disk_total_mb'] == 32_000
+
+    def test_compute_health_with_critical_disk_yields_critical(
+        self, db, archive_root, monkeypatch,
+    ):
+        monkeypatch.setattr(
+            archive_watchdog.shutil, 'disk_usage',
+            lambda _p: _fake_usage(free_mb=50),
+        )
+        snap = archive_watchdog._compute_health(db, archive_root)
+        assert snap['severity'] == 'critical'
+        assert snap['disk_free_mb'] == 50
+
+    def test_compute_health_returns_zero_when_archive_root_missing(
+        self, db, tmp_path,
+    ):
+        missing = str(tmp_path / "nonexistent_archive_root")
+        snap = archive_watchdog._compute_health(db, missing)
+        # Disk fields default to 0; severity should not crash.
+        assert snap['disk_free_mb'] == 0
+        assert snap['disk_total_mb'] == 0
+        assert snap['severity'] in ('ok', 'warning', 'error', 'critical')
+
+
+# ---------------------------------------------------------------------------
+# TestArchiveWatchdogReporting (issue spec — get_health/get_status shape)
+# ---------------------------------------------------------------------------
+
+
+class TestArchiveWatchdogReporting:
+    REQUIRED_HEALTH_FIELDS = {
+        'severity', 'message', 'last_successful_copy_at',
+        'last_successful_copy_age_seconds', 'worker_running', 'paused',
+        'dead_letter_count', 'pending_count', 'disk_free_mb',
+        'disk_total_mb', 'disk_used_mb', 'disk_warning',
+        'disk_warning_mb', 'disk_critical_mb', 'checked_at',
+    }
+
+    def test_get_health_shape(self, db, archive_root, monkeypatch):
+        monkeypatch.setattr(
+            archive_watchdog.shutil, 'disk_usage',
+            lambda _p: _fake_usage(free_mb=10_000),
+        )
+        snap = archive_watchdog._compute_health(db, archive_root)
+        # _compute_health populates the same fields get_health serves.
+        for f in self.REQUIRED_HEALTH_FIELDS:
+            assert f in snap, f"missing field {f}"
+        assert snap['severity'] in ('ok', 'warning', 'error', 'critical')
+        assert isinstance(snap['disk_free_mb'], int)
+        assert isinstance(snap['disk_total_mb'], int)
+
+    def test_get_status_includes_retention_and_running_flag(
+        self, db, archive_root, monkeypatch,
+    ):
+        monkeypatch.setattr(
+            archive_watchdog.shutil, 'disk_usage',
+            lambda _p: _fake_usage(free_mb=10_000),
+        )
+        archive_watchdog.start_watchdog(
+            db, archive_root, check_interval_seconds=0.05,
+        )
+        try:
+            for _ in range(50):
+                snap = archive_watchdog.get_status()
+                if snap.get('checked_at') is not None:
+                    break
+                time.sleep(0.05)
+            snap = archive_watchdog.get_status()
+            assert 'retention' in snap
+            assert 'retention_days' in snap['retention']
+            assert 'last_prune_at' in snap['retention']
+            assert 'next_prune_due_at' in snap['retention']
+            assert snap['watchdog_running'] is True
+        finally:
+            archive_watchdog.stop_watchdog(timeout=5)
+
+    def test_get_health_has_age_when_copy_exists(
+        self, db, archive_root, monkeypatch,
+    ):
+        # Simulate a copied row by inserting directly.
+        with sqlite3.connect(db) as conn:
+            conn.execute(
+                "INSERT INTO archive_queue("
+                " source_path, dest_path, expected_size, expected_mtime,"
+                " status, copied_at, priority, enqueued_at, attempts) "
+                "VALUES (?, ?, ?, ?, 'copied', ?, 1, ?, 0)",
+                (
+                    "/teslacam/RecentClips/x.mp4",
+                    os.path.join(archive_root, "RecentClips/x.mp4"),
+                    100, time.time() - 30,
+                    "2025-01-01T00:00:00+00:00",
+                    "2025-01-01T00:00:00+00:00",
+                ),
+            )
+        monkeypatch.setattr(
+            archive_watchdog.shutil, 'disk_usage',
+            lambda _p: _fake_usage(free_mb=10_000),
+        )
+        snap = archive_watchdog._compute_health(db, archive_root)
+        assert snap['last_successful_copy_at'] == "2025-01-01T00:00:00+00:00"
+        assert snap['last_successful_copy_age_seconds'] is not None
+        assert snap['last_successful_copy_age_seconds'] > 0
+
+
+# ---------------------------------------------------------------------------
+# TestArchiveRetention (issue spec — trip preservation contract)
+# ---------------------------------------------------------------------------
+
+
+class TestArchiveRetention:
+    def test_old_files_are_deleted(self, db, archive_root):
+        old_mtime = time.time() - (40 * 86400)  # 40 days old
+        path = _make_archive_mp4(
+            archive_root, "RecentClips/old.mp4", mtime=old_mtime,
+        )
+        summary = archive_watchdog._run_retention_prune(
+            archive_root, db, retention_days=30,
+        )
+        assert summary['deleted_count'] == 1
+        assert not os.path.exists(path)
+
+    def test_new_files_are_kept(self, db, archive_root):
+        new_mtime = time.time() - (5 * 86400)  # 5 days old
+        path = _make_archive_mp4(
+            archive_root, "RecentClips/new.mp4", mtime=new_mtime,
+        )
+        summary = archive_watchdog._run_retention_prune(
+            archive_root, db, retention_days=30,
+        )
+        assert summary['deleted_count'] == 0
+        assert os.path.isfile(path)
+
+    def test_dead_letter_files_are_never_deleted(self, db, archive_root):
+        old_mtime = time.time() - (90 * 86400)  # 90 days old
+        protected = _make_archive_mp4(
+            archive_root, ".dead_letter/forensic.mp4", mtime=old_mtime,
+        )
+        # And one non-dead-letter old file as a control.
+        will_be_pruned = _make_archive_mp4(
+            archive_root, "RecentClips/old.mp4", mtime=old_mtime,
+        )
+        archive_watchdog._run_retention_prune(
+            archive_root, db, retention_days=30,
+        )
+        assert os.path.isfile(protected), \
+            ".dead_letter must NEVER be touched by retention prune"
+        assert not os.path.exists(will_be_pruned)
+
+    def test_purge_deleted_videos_called_for_each_deleted_mp4(
+        self, db, archive_root, monkeypatch,
+    ):
+        old_mtime = time.time() - (40 * 86400)
+        paths = [
+            os.path.normpath(_make_archive_mp4(
+                archive_root, "RecentClips/a.mp4", mtime=old_mtime,
+            )),
+            os.path.normpath(_make_archive_mp4(
+                archive_root, "RecentClips/b.mp4", mtime=old_mtime,
+            )),
+        ]
+        purged = []
+        from services import mapping_service
+
+        def _spy(db_path, *, deleted_paths):
+            purged.append([os.path.normpath(p) for p in deleted_paths])
+        monkeypatch.setattr(
+            mapping_service, 'purge_deleted_videos', _spy,
+        )
+        summary = archive_watchdog._run_retention_prune(
+            archive_root, db, retention_days=30,
+        )
+        assert summary['deleted_count'] == 2
+        # purge_deleted_videos called once per deleted file.
+        assert len(purged) == 2
+        flat = [p for sub in purged for p in sub]
+        assert set(flat) == set(paths)
+
+    def test_trips_and_waypoints_are_NEVER_deleted_by_retention(
+        self, db, archive_root,
+    ):
+        """Hard contract: retention NEVER cascade-deletes trips/waypoints/events.
+
+        See copilot-instructions.md — the May 7 McDonalds-trip data loss.
+        ``purge_deleted_videos`` is documented to ONLY delete the
+        indexed_files row + NULL out video_path on related rows.
+        """
+        # Insert a trip + waypoint + detected_event referencing a
+        # video we're about to retention-prune. Waypoints store the
+        # CANONICAL relative path (e.g. ``RecentClips/<base>``) — NOT
+        # the absolute filesystem path. ``purge_deleted_videos``
+        # canonical-keys the deleted absolute path and matches against
+        # the relative form in the DB.
+        old_mtime = time.time() - (40 * 86400)
+        path = _make_archive_mp4(
+            archive_root, "RecentClips/trip-clip.mp4", mtime=old_mtime,
+        )
+        # Canonical waypoint video_path uses forward slash (DB convention,
+        # platform-independent — RecentClips is the canonical prefix).
+        rel_video_path = "RecentClips/trip-clip.mp4"
+        with sqlite3.connect(db) as conn:
+            conn.execute(
+                "INSERT INTO trips(start_time, end_time, source_folder) "
+                "VALUES ('2025-01-01T10:00:00Z','2025-01-01T11:00:00Z','test')"
+            )
+            trip_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+            conn.execute(
+                "INSERT INTO waypoints(trip_id, lat, lon, "
+                "timestamp, video_path) VALUES (?, 37.0, -122.0, "
+                "'2025-01-01T10:00:01Z', ?)",
+                (trip_id, rel_video_path),
+            )
+            conn.execute(
+                "INSERT INTO detected_events(trip_id, event_type, "
+                "timestamp, lat, lon, video_path) VALUES "
+                "(?, 'sentry', '2025-01-01T10:00:01Z', 37.0, -122.0, ?)",
+                (trip_id, rel_video_path),
+            )
+            conn.execute(
+                "INSERT INTO indexed_files(file_path, file_size, "
+                "indexed_at) VALUES (?, 100, '2025-01-01T10:00:01Z')",
+                (path,),
+            )
+
+        # Snapshot pre-prune row counts.
+        with sqlite3.connect(db) as conn:
+            trip_count_before = conn.execute(
+                "SELECT COUNT(*) FROM trips").fetchone()[0]
+            wpt_count_before = conn.execute(
+                "SELECT COUNT(*) FROM waypoints").fetchone()[0]
+            evt_count_before = conn.execute(
+                "SELECT COUNT(*) FROM detected_events").fetchone()[0]
+            idx_count_before = conn.execute(
+                "SELECT COUNT(*) FROM indexed_files").fetchone()[0]
+
+        summary = archive_watchdog._run_retention_prune(
+            archive_root, db, retention_days=30,
+        )
+        assert summary['deleted_count'] == 1
+
+        with sqlite3.connect(db) as conn:
+            trip_count_after = conn.execute(
+                "SELECT COUNT(*) FROM trips").fetchone()[0]
+            wpt_count_after = conn.execute(
+                "SELECT COUNT(*) FROM waypoints").fetchone()[0]
+            evt_count_after = conn.execute(
+                "SELECT COUNT(*) FROM detected_events").fetchone()[0]
+            idx_count_after = conn.execute(
+                "SELECT COUNT(*) FROM indexed_files").fetchone()[0]
+            wpt_video_path = conn.execute(
+                "SELECT video_path FROM waypoints WHERE trip_id=?",
+                (trip_id,),
+            ).fetchone()[0]
+            evt_video_path = conn.execute(
+                "SELECT video_path FROM detected_events WHERE trip_id=?",
+                (trip_id,),
+            ).fetchone()[0]
+
+        # Trip / waypoint / event row counts UNCHANGED.
+        assert trip_count_after == trip_count_before, \
+            "Retention must NOT delete trips (May 7 contract)"
+        assert wpt_count_after == wpt_count_before, \
+            "Retention must NOT delete waypoints (May 7 contract)"
+        assert evt_count_after == evt_count_before, \
+            "Retention must NOT delete detected_events (May 7 contract)"
+        # video_path nulled out.
+        assert wpt_video_path is None
+        assert evt_video_path is None
+        # indexed_files row gone.
+        assert idx_count_after == idx_count_before - 1
+
+    def test_returns_summary_with_required_fields(self, db, archive_root):
+        summary = archive_watchdog._run_retention_prune(
+            archive_root, db, retention_days=30,
+        )
+        for f in ('deleted_count', 'freed_bytes', 'scanned',
+                  'cutoff_iso', 'retention_days', 'duration_seconds'):
+            assert f in summary
+        assert summary['retention_days'] == 30
+
+    def test_force_prune_now_updates_bookkeeping(
+        self, db, archive_root, monkeypatch,
+    ):
+        old_mtime = time.time() - (40 * 86400)
+        _make_archive_mp4(
+            archive_root, "RecentClips/old.mp4", mtime=old_mtime,
+        )
+        # force_prune_now reads module state for paths.
+        archive_watchdog._db_path = db
+        archive_watchdog._archive_root = archive_root
+        summary = archive_watchdog.force_prune_now()
+        assert summary['deleted_count'] == 1
+        snap = archive_watchdog.get_status()
+        assert snap['retention']['last_prune_at'] is not None
+        assert snap['retention']['last_prune_deleted'] == 1
+
+    def test_force_prune_now_returns_error_when_not_started(self):
+        # No paths configured → returns error key, no exception.
+        archive_watchdog._db_path = None
+        archive_watchdog._archive_root = None
+        summary = archive_watchdog.force_prune_now()
+        assert 'error' in summary
+        assert summary['deleted_count'] == 0
+
+    def test_iter_skips_dead_letter_directory(self, archive_root):
+        old = time.time() - (90 * 86400)
+        _make_archive_mp4(
+            archive_root, "RecentClips/keep.mp4", mtime=old,
+        )
+        _make_archive_mp4(
+            archive_root, ".dead_letter/skip.mp4", mtime=old,
+        )
+        seen = [p for p, _m, _s in
+                archive_watchdog._iter_archive_mp4_files(archive_root)]
+        assert any(p.endswith('keep.mp4') for p in seen)
+        assert not any('.dead_letter' in p for p in seen), \
+            "_iter_archive_mp4_files must not yield .dead_letter contents"
+
+
+# ---------------------------------------------------------------------------
+# Hard-contract grep (mirrors the archive_worker test pattern)
+# ---------------------------------------------------------------------------
+
+
+class TestNoUSBGadgetCalls:
+    """archive_watchdog must NEVER call USB-gadget primitives."""
+
+    def test_no_forbidden_tokens_in_executable_code(self):
+        path = os.path.abspath(
+            os.path.join(
+                os.path.dirname(__file__), "..", "scripts", "web",
+                "services", "archive_watchdog.py",
+            )
+        )
+        with open(path, "r", encoding="utf-8") as f:
+            src = f.read()
+        # Strip docstrings and comments to avoid false matches in the
+        # explanatory header. We use a simple line-based filter.
+        executable_lines = []
+        in_triple = False
+        triple_marker = None
+        for line in src.splitlines():
+            stripped = line.lstrip()
+            if not in_triple:
+                for marker in ('"""', "'''"):
+                    if stripped.startswith(marker):
+                        in_triple = True
+                        triple_marker = marker
+                        rest = stripped[len(marker):]
+                        if marker in rest:
+                            in_triple = False
+                            triple_marker = None
+                        break
+                else:
+                    code = line.split('#', 1)[0]
+                    executable_lines.append(code)
+            else:
+                if triple_marker and triple_marker in line:
+                    in_triple = False
+                    triple_marker = None
+        body = '\n'.join(executable_lines)
+        forbidden = [
+            'partition_mount_service', 'quick_edit_part2',
+            'rebind_usb_gadget', 'losetup', 'nsenter',
+        ]
+        for tok in forbidden:
+            assert tok not in body, (
+                f"archive_watchdog.py executable code references forbidden "
+                f"token {tok!r} — Phase 2c hard constraint: no USB "
+                f"gadget interaction."
+            )
+
+    def test_no_delete_from_trips_waypoints_events(self):
+        path = os.path.abspath(
+            os.path.join(
+                os.path.dirname(__file__), "..", "scripts", "web",
+                "services", "archive_watchdog.py",
+            )
+        )
+        with open(path, "r", encoding="utf-8") as f:
+            src = f.read().lower()
+        for table in ('trips', 'waypoints', 'detected_events'):
+            assert f"delete from {table}" not in src, (
+                f"archive_watchdog.py must NOT contain DELETE FROM {table}"
+                " — May 7 trip-loss contract"
+            )

--- a/tests/test_archive_worker.py
+++ b/tests/test_archive_worker.py
@@ -91,6 +91,9 @@ def make_clip(teslacam_root):
 def _reset_module_state():
     """Stop any running worker between tests so module state stays clean."""
     archive_worker.stop_worker(timeout=5.0)
+    # Reset the disk-space self-pause so a previous test that armed it
+    # doesn't leak into the next test's process_one_claim path.
+    archive_worker._disk_space_pause_until = 0.0
     # Reset task_coordinator too — leftover ownership from an earlier
     # test would block our acquire.
     with task_coordinator._lock:
@@ -99,6 +102,7 @@ def _reset_module_state():
         task_coordinator._waiter_count = 0
     yield
     archive_worker.stop_worker(timeout=5.0)
+    archive_worker._disk_space_pause_until = 0.0
     with task_coordinator._lock:
         task_coordinator._current_task = None
         task_coordinator._task_started = 0.0
@@ -773,3 +777,154 @@ class TestModuleSafety:
                 f"token {tok!r} — Phase 2b hard constraint: no USB "
                 f"gadget interaction."
             )
+
+
+# ---------------------------------------------------------------------------
+# TestArchiveWorkerDiskSpaceGuard (Phase 2c — issue #76, acceptance 7)
+# ---------------------------------------------------------------------------
+
+
+class _FakeUsage:
+    """``shutil.disk_usage``-shaped namedtuple-replacement."""
+    def __init__(self, total: int, used: int, free: int):
+        self.total = total
+        self.used = used
+        self.free = free
+
+
+class TestArchiveWorkerDiskSpaceGuard:
+    """Acceptance criterion 7: disk-full guard refuses copy + releases claim.
+
+    The Phase 2c spec requires:
+      * < 100 MB free → log CRITICAL, do NOT copy, release claim back
+        to pending (no attempt counted), arm a 5-min worker-side pause.
+      * < 500 MB free → log WARNING, proceed (copy still happens).
+      * Both thresholds are configurable via ``cloud_archive.disk_space_*_mb``.
+    """
+
+    def _set_thresholds(self, monkeypatch, *, warning_mb: int, critical_mb: int):
+        monkeypatch.setattr(
+            archive_worker, '_resolve_disk_thresholds_mb',
+            lambda: (warning_mb, critical_mb),
+        )
+
+    def _fake_disk_usage(self, monkeypatch, *, free_mb: int,
+                          total_mb: int = 32_000):
+        used_mb = max(total_mb - free_mb, 0)
+        usage = _FakeUsage(
+            total=total_mb * 1024 * 1024,
+            used=used_mb * 1024 * 1024,
+            free=free_mb * 1024 * 1024,
+        )
+        monkeypatch.setattr(archive_worker.shutil, 'disk_usage',
+                            lambda _path: usage)
+
+    def test_critical_free_refuses_copy_and_releases_claim(
+        self, db, archive_root, teslacam_root, make_clip, monkeypatch, caplog,
+    ):
+        clip = make_clip("RecentClips/x-front.mp4")
+        enqueue_for_archive(clip, db_path=db)
+        row = claim_next_for_worker('w', db_path=db)
+
+        self._set_thresholds(monkeypatch, warning_mb=500, critical_mb=100)
+        self._fake_disk_usage(monkeypatch, free_mb=50)  # < critical
+
+        dest_before = os.path.join(
+            archive_root, "RecentClips", "x-front.mp4",
+        )
+        assert not os.path.exists(dest_before)
+
+        with caplog.at_level('CRITICAL', logger='services.archive_worker'):
+            outcome = archive_worker.process_one_claim(
+                row, db, archive_root, teslacam_root,
+                chunk_size=4096, max_attempts=3,
+            )
+
+        assert outcome == 'pending', (
+            "Disk-critical must release the claim back to pending"
+        )
+        # Destination must not have been written.
+        assert not os.path.exists(dest_before)
+
+        # Row reverted to pending; attempts NOT incremented.
+        rows = list_queue(db_path=db)
+        assert len(rows) == 1
+        assert rows[0]['status'] == 'pending'
+        assert rows[0]['claimed_by'] is None
+        assert rows[0]['attempts'] == 0  # no attempt burned
+        # CRITICAL log captured.
+        assert any('CRITICAL' in rec.message or rec.levelname == 'CRITICAL'
+                   for rec in caplog.records), \
+            "Disk-critical refusal must log at CRITICAL level"
+
+        # Module-level pause armed.
+        pause = archive_worker.get_disk_pause_state()
+        assert pause['is_paused_now'] is True
+        assert pause['paused_until_epoch'] > time.time()
+
+    def test_warning_free_proceeds_with_copy(
+        self, db, archive_root, teslacam_root, make_clip, monkeypatch, caplog,
+    ):
+        clip = make_clip("RecentClips/y-front.mp4", content=b"X" * 200)
+        enqueue_for_archive(clip, db_path=db)
+        row = claim_next_for_worker('w', db_path=db)
+
+        self._set_thresholds(monkeypatch, warning_mb=500, critical_mb=100)
+        self._fake_disk_usage(monkeypatch, free_mb=300)  # warn but not critical
+
+        with caplog.at_level('WARNING', logger='services.archive_worker'):
+            outcome = archive_worker.process_one_claim(
+                row, db, archive_root, teslacam_root,
+                chunk_size=4096, max_attempts=3,
+            )
+
+        assert outcome == 'copied'
+        dest = os.path.join(archive_root, "RecentClips", "y-front.mp4")
+        assert os.path.isfile(dest)
+        # Warning level emitted.
+        assert any(rec.levelname == 'WARNING'
+                   for rec in caplog.records), \
+            "Disk-warning copy must log at WARNING level"
+
+    def test_ample_free_no_log_no_pause(
+        self, db, archive_root, teslacam_root, make_clip, monkeypatch,
+    ):
+        clip = make_clip("RecentClips/z-front.mp4", content=b"X" * 200)
+        enqueue_for_archive(clip, db_path=db)
+        row = claim_next_for_worker('w', db_path=db)
+
+        self._set_thresholds(monkeypatch, warning_mb=500, critical_mb=100)
+        self._fake_disk_usage(monkeypatch, free_mb=10_000)  # plenty
+
+        outcome = archive_worker.process_one_claim(
+            row, db, archive_root, teslacam_root,
+            chunk_size=4096, max_attempts=3,
+        )
+        assert outcome == 'copied'
+        # No pause armed.
+        pause = archive_worker.get_disk_pause_state()
+        assert pause['is_paused_now'] is False
+
+    def test_disk_pause_state_present_in_get_status(
+        self, db, archive_root, teslacam_root,
+    ):
+        archive_worker.start_worker(
+            db, archive_root, teslacam_root=teslacam_root,
+        )
+        try:
+            status = archive_worker.get_status()
+            assert 'disk_pause' in status
+            assert 'is_paused_now' in status['disk_pause']
+            assert 'paused_until_epoch' in status['disk_pause']
+        finally:
+            archive_worker.stop_worker(timeout=5)
+
+    def test_check_disk_space_guard_handles_oserror(self, monkeypatch):
+        # OSError on stat → 'ok' (don't lock the subsystem out on a
+        # transient FS hiccup).
+        def _boom(_path):
+            raise OSError("simulated FS hiccup")
+        monkeypatch.setattr(archive_worker.shutil, 'disk_usage', _boom)
+        verdict = archive_worker._check_disk_space_guard("/anywhere")
+        assert verdict == 'ok'
+

--- a/tests/test_archive_worker.py
+++ b/tests/test_archive_worker.py
@@ -928,3 +928,44 @@ class TestArchiveWorkerDiskSpaceGuard:
         verdict = archive_worker._check_disk_space_guard("/anywhere")
         assert verdict == 'ok'
 
+    def test_resolve_disk_space_pause_seconds_uses_config(self, monkeypatch):
+        # PR #90 reviewer Info #4: hardcoded constant promoted to
+        # ``cloud_archive.disk_space_pause_seconds``. The resolver must
+        # read the configured value when present.
+        import sys
+        fake = type(sys)('fake_config')
+        fake.CLOUD_ARCHIVE_DISK_SPACE_PAUSE_SECONDS = 600.0
+        monkeypatch.setitem(sys.modules, 'config', fake)
+        assert archive_worker._resolve_disk_space_pause_seconds() == 600.0
+
+    def test_resolve_disk_space_pause_seconds_falls_back_on_invalid(
+        self, monkeypatch,
+    ):
+        # Negative or zero values are rejected — fall back to the
+        # module default so tests can monkeypatch it directly.
+        import sys
+        fake = type(sys)('fake_config')
+        fake.CLOUD_ARCHIVE_DISK_SPACE_PAUSE_SECONDS = 0
+        monkeypatch.setitem(sys.modules, 'config', fake)
+        monkeypatch.setattr(
+            archive_worker, '_DEFAULT_DISK_SPACE_PAUSE_SECONDS', 42.0,
+        )
+        assert archive_worker._resolve_disk_space_pause_seconds() == 42.0
+
+    def test_resolve_disk_space_pause_seconds_falls_back_on_missing_config(
+        self, monkeypatch,
+    ):
+        # If config import raises, the resolver returns the module default.
+        import builtins
+        real_import = builtins.__import__
+
+        def _fail_import(name, *a, **kw):
+            if name == 'config':
+                raise ImportError("simulated")
+            return real_import(name, *a, **kw)
+        monkeypatch.setattr(builtins, '__import__', _fail_import)
+        monkeypatch.setattr(
+            archive_worker, '_DEFAULT_DISK_SPACE_PAUSE_SECONDS', 99.0,
+        )
+        assert archive_worker._resolve_disk_space_pause_seconds() == 99.0
+


### PR DESCRIPTION
## Summary

Final phase of issue #76 (Two-Queue Pipeline). Adds the health watchdog, observability surface, and storage management that complete the zero-loss archive architecture started in Phase 2a (PR #87) and Phase 2b (PR #88).

**This PR closes #76.**

## What this PR delivers

| # | Deliverable | Files |
|---|-------------|-------|
| 1 | `archive_watchdog` thread | `scripts/web/services/archive_watchdog.py` (NEW) |
| 2 | Disk-space pre-archive guard | `scripts/web/services/archive_worker.py` |
| 3 | Retention prune (daily, with jitter) | `scripts/web/services/archive_watchdog.py` |
| 4 | `/api/archive/status` + `/api/archive/dead_letters` + `/api/archive/prune_now` | `scripts/web/blueprints/archive_queue.py` |
| 5 | Watchdog wired into `gadget_web` | `scripts/web/web_control.py` |
| 6 | UI banner | `scripts/web/templates/base.html` |
| 7 | Settings → Archive Status panel | `scripts/web/templates/index.html` |
| 8 | Settings → Storage panel | `scripts/web/templates/index.html` |
| 9 | Phase 2c CSS | `scripts/web/static/css/style.css` |
| 10 | Lucide icons (`alert-circle`, `shield-alert`, `database`) | `scripts/web/static/icons/lucide-sprite.svg` |
| 11 | Config keys (3 new) | `config.yaml`, `scripts/config.sh`, `scripts/web/config.py` |

## Behavior

### Watchdog severity classification

| Condition | Severity |
|-----------|----------|
| `< 5 min` stale OR queue empty | `ok` |
| `5–10 min` stale + pending items | `warning` (logs WARNING) |
| `10–20 min` stale + pending items | `error` (logs ERROR + UI banner) |
| `> 20 min` stale + pending items | `critical` (logs CRITICAL + persistent banner) |
| Worker not running + pending items | `critical` |
| Free disk `< 500 MB` | overlays warning tier |
| Free disk `< 100 MB` | overlays critical tier |

### Disk-space pre-archive guard

- `process_one_claim` calls `shutil.disk_usage(archive_root).free` BEFORE `_atomic_copy`.
- `< 500 MB` → log WARNING and proceed.
- `< 100 MB` → log CRITICAL, `release_claim`, set 5 min pause, return `'pending'`.
- Worker loop honors the pause and idle-sleeps until it expires.
- Configurable via `cloud_archive.disk_space_warning_mb` (500) / `cloud_archive.disk_space_critical_mb` (100).
- `OSError` from `shutil.disk_usage` falls open (proceed) so a bad mount never wedges the worker.

### Retention prune

- Default `cloud_archive.archived_clips_retention_days = 30`.
- Daily timer with 5–15 min jitter; runs once at startup, then every retention day.
- Walks `~/ArchivedClips/`, deletes `*.mp4` with `mtime > retention_days` old.
- **SKIPS `.dead_letter/`** entirely (diagnostic preservation).
- Calls `purge_deleted_videos` for each deleted mp4 — which only NULLs `waypoints.video_path` and `detected_events.video_path`. **NEVER deletes trips/waypoints/events.** Trip preservation contract enforced (the May 7 McDonalds-trip data loss must not recur).
- Holds `task_coordinator.acquire_task('retention')` across the walk; releases BEFORE every `_stop_event.wait()` (lock-before-sleep pattern).

### Observability — `/api/archive/status` JSON shape

```json
{
  "severity": "ok|warning|error|critical",
  "message": "human-readable summary",
  "last_successful_copy_at": "2026-05-11T10:25:51Z",
  "last_successful_copy_age_seconds": 42,
  "worker_running": true,
  "paused": false,
  "queue_depth_p1": 0,
  "queue_depth_p2": 0,
  "queue_depth_p3": 0,
  "claimed_count": 0,
  "dead_letter_count": 0,
  "active_file": null,
  "last_error": null,
  "disk_total_mb": 30000,
  "disk_free_mb": 12345,
  "disk_used_mb": 17655,
  "disk_warning": false,
  "retention_days": 30,
  "last_prune_at": "2026-05-11T05:12:33Z"
}
```

All four endpoints are image-gated on `IMG_CAM_PATH` (return 503 JSON when missing).

### UI

- **Banner** in `base.html`: only renders when `videos_available`. Triggers on `severity in {'error','critical'}`. Polls every 60 s. Color-coded per design tokens (`--msg-warning-bg` / `--msg-error-bg` / `--warning-border`). Lucide icons only (`alert-triangle`, `alert-circle`, `shield-alert`). Buttons: "Run archive now" + "Dismiss" (1 h sessionStorage). Mobile-first, full-width sticky bar, 44 px touch targets.
- **Archive Status panel** in `index.html`: queue depths per priority, dead-letter count + "View dead letters" link, worker status, last-successful-copy timestamp, "Run archive now". Auto-refresh 30 s.
- **Storage panel** in `index.html`: disk usage progress bar (amber > 90 %, red > 95 %), retention days explanation, last-prune timestamp, "Prune now" (POSTs `/api/archive/prune_now`). Auto-refresh 30 s.

## Tests

**54 net-new tests, all passing.** Test count: **627 baseline → 681 with Phase 2c** (3 unrelated skips unchanged).

| Test file | Class | Coverage |
|-----------|-------|----------|
| `tests/test_archive_watchdog.py` (NEW) | `TestArchiveWatchdogLifecycle` | start/stop idempotency, wake semantics |
| | `TestArchiveWatchdogSeverity` | All 5 boundaries inc. **10-min trigger required by Acceptance 6** (mocked time) |
| | `TestArchiveWatchdogDiskSpace` | < 500 → warning, < 100 → critical, overlay logic |
| | `TestArchiveWatchdogReporting` | `get_health()` shape and field coverage |
| | `TestArchiveRetention` | files > N days deleted; ≤ N kept; **`.dead_letter` NEVER deleted**; `purge_deleted_videos` called per mp4; **TRIPS/WAYPOINTS/EVENTS NEVER deleted** (regression test for May 7 data loss) |
| | `TestNoUSBGadgetCalls` | static grep that the module never names mount/umount/losetup/nsenter/partition_mount_service/quick_edit_part2/rebind_usb_gadget |
| `tests/test_archive_status_endpoint.py` (NEW) | `TestImageGate` | 503 JSON when `IMG_CAM_PATH` missing |
| | `TestStatusShape` | all required fields present + types |
| | `TestPruneNowEndpoint` | POST triggers `force_prune_now` |
| | `TestDeadLettersEndpoint` | `limit` param, ordering |
| `tests/test_archive_worker.py` (modified) | `TestArchiveWorkerDiskSpaceGuard` | **Acceptance 7 (Disk-full guard)** via mocked `shutil.disk_usage`: critical tier refuses + releases + 5-min pause; warning proceeds; `OSError` falls open |

## Hard-constraint verification

```
$ grep -E "partition_mount_service|quick_edit_part2|rebind_usb_gadget|losetup|nsenter" \
    scripts/web/services/archive_watchdog.py
(no output — 0 matches)

$ grep -E "DELETE FROM (trips|waypoints|detected_events)" \
    scripts/web/services/archive_watchdog.py
(no output — 0 matches)
```

Both `archive_worker.py` and `blueprints/archive_queue.py` are also clean of the same patterns (verified). The `TestNoUSBGadgetCalls` test in `test_archive_watchdog.py` enforces this in CI going forward.

## Acceptance criteria coverage (issue #76, all 10)

| # | Criterion | Status |
|---|-----------|--------|
| 1 | Synthetic starvation test | ✅ Phase 2a unit tests + Phase 2b worker tests cover the queue mechanics. **Pi-side runtime validation deferred to deploy.** |
| 2 | gadget_web crash test | ✅ Phase 2a boot-catchup-scan tests + Phase 2b restart-recovery tests. Pi-side runtime deferred. |
| 3 | Quick-edit interrupt test | ✅ PR #78 `task_coordinator` fairness + Phase 2b worker yield-on-acquire. Pi-side runtime deferred. |
| 4 | Bad-file resilience | ✅ Phase 2b dead_letter tests cover N-attempts + sidecar path. |
| 5 | VFS cache test | ✅ Phase 2b inotify producer tests; Pi-side runtime deferred. |
| 6 | **Watchdog test** | ✅ **`TestArchiveWatchdogSeverity` covers the 10-minute trigger via mocked time** (this PR). Pi-side runtime deferred. |
| 7 | **Disk-full guard** | ✅ **`TestArchiveWorkerDiskSpaceGuard` covers the < 100 MB refusal path** (this PR). Pi-side runtime deferred. |
| 8 | Continuous live driving | ⏳ Pure runtime; deferred to deploy. |
| 9 | Map fragmentation regression | ✅ PR #78 trip-merge tests; verified clean on subsequent indexer changes. |
| 10 | No regression in `quick_edit_part2` / USB gadget timing | ✅ Static grep contract above + `TestNoUSBGadgetCalls`. |

**6 of 10** are now covered by automated tests across Phase 1 + Phase 2a + Phase 2b + Phase 2c. The remaining 4 (1, 2, 3, 5, 8) are pure live-Pi runtime tests deferred to deploy validation.

## Cross-phase summary — Two-Queue Pipeline is COMPLETE

| Phase | PR | What landed |
|-------|----|-----|
| Phase 1 | #78 | `task_coordinator` fairness + lock-before-sleep + indexer yield + trip-merge runtime defense + float-precision fix + v8→v9 schema migration. Emergency stop-gap on the existing single-mutex model. |
| Phase 2a | #87 | `archive_queue` table + v9→v10 schema migration + `enqueue_for_archive` API + file watcher / boot catchup / 60 s rescan producers. No worker yet. |
| Phase 2b | #88 (+ #89 fix) | `archive_worker` single daemon (mirrors PR #67 indexing-worker pattern) + indexer decoupling from RO USB mount + `video_archive_service.*` shims for Phase 2a callers + worker-restart safety on stale claims. |
| Phase 2c | **this PR** | `archive_watchdog` thread + `/api/archive/status` + retention prune + disk-space guard + Settings UI panels + banner. |

The architecture diagram from issue #76 is now fully realized:

```
RecentClips (P1) ──┐                        ┌──────────────────┐
SentryClips (P2) ──┼─► file_watcher ───────►│  archive_queue   │
SavedClips  (P2) ──┘                        └─────┬────────────┘
                                                  │
                                   ┌──────────────▼────────────────┐
                                   │  archive_worker (single)      │
                                   │  - acquire_task('archive', N) │
                                   │  - priority P1>P2>P3          │
                                   │  - oldest-mtime first         │
                                   │  - disk-space guard           │  <─ Phase 2c
                                   └──────────────┬────────────────┘
                                                  │ on success
                                                  ▼
                                          ┌────────────────┐
                                          │ indexing_queue │
                                          └─────┬──────────┘
                                                │
                                       ┌────────▼─────────┐
                                       │ indexing_worker  │
                                       └──────────────────┘
                                                  ▲
                                   ┌──────────────┴────────────────┐
                                   │  archive_watchdog (observer)  │  <─ Phase 2c
                                   │  - 60 s health check          │
                                   │  - retention prune            │
                                   │  - /api/archive/status        │
                                   │  - UI banner trigger          │
                                   └───────────────────────────────┘
```

## Deploy notes

- ✅ **No new sudoers entries.**
- ✅ **No new systemd units.** Watchdog runs inside `gadget_web.service`.
- ✅ **No new dependencies.** All imports are stdlib (`os`, `sqlite3`, `logging`, `threading`, `time`, `shutil`, `datetime`).
- 🔧 **Three new config keys default sensibly.** Review `config.yaml` only if you want non-default values:
  ```yaml
  cloud_archive:
    archived_clips_retention_days: 30   # delete ArchivedClips/*.mp4 older than this
    disk_space_warning_mb: 500          # log WARNING below this free space
    disk_space_critical_mb: 100         # refuse new copies below this free space

  archive_queue:
    watchdog_check_interval_seconds: 60 # how often the watchdog runs
  ```
- 🔧 **After deploy:** `sudo systemctl restart gadget_web.service` to pick up the watchdog thread + new endpoints.
- 🧪 **Pi-side runtime acceptance tests** (1, 2, 3, 5, 8) should be re-run on the actual hardware before declaring done in production.

## Files changed

- **NEW** `scripts/web/services/archive_watchdog.py` (~720 lines)
- **NEW** `tests/test_archive_watchdog.py` (35 tests)
- **NEW** `tests/test_archive_status_endpoint.py` (14 tests)
- **REWRITE** `scripts/web/blueprints/archive_queue.py` (4 endpoints; Phase 2a alias kept)
- **MODIFIED** `scripts/web/services/archive_worker.py` (+disk-space guard, +get_disk_pause_state, +disk_pause in get_status)
- **MODIFIED** `scripts/web/services/archive_queue.py` (+get_pending_counts_by_priority, +get_last_copied_at)
- **MODIFIED** `scripts/web/web_control.py` (start watchdog after worker)
- **MODIFIED** `scripts/web/templates/base.html` (banner + polling JS)
- **MODIFIED** `scripts/web/templates/index.html` (Archive Status + Storage panels)
- **MODIFIED** `scripts/web/static/css/style.css` (~150 lines Phase 2c styling)
- **MODIFIED** `scripts/web/static/icons/lucide-sprite.svg` (3 new icons)
- **MODIFIED** `tests/test_archive_worker.py` (+TestArchiveWorkerDiskSpaceGuard, 5 tests)
- **MODIFIED** `config.yaml`, `scripts/config.sh`, `scripts/web/config.py` (4 new config keys)

Total: 15 files, +2,947 / −18 lines.

---

Closes #76
