### PR TITLE
fix(archive): SDIO-aware throttling to prevent watchdog reboots

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -63,7 +63,7 @@ These devices run in a vehicle; power can drop at any time. Prioritize atomic wr
 - **Desktop services disabled**: pipewire, wireplumber, colord masked (saves ~30MB RAM).
 - **Persistent swap**: 1GB swap file at `/var/swap/fsck.swap` in /etc/fstab.
 - **Setup optimization**: `optimize_memory_for_setup()` disables lightdm, enables swap before package install.
-- **Watchdog**: Hardware watchdog configured (15s timeout, monitors load/memory).
+- **Watchdog**: Hardware watchdog configured (90s timeout, `max-load-1=24`, `max-load-5=16`). The 90s timeout (was 60s) gives headroom for transient SDIO bus contention — the Pi Zero 2 W shares one SDIO controller between the SD card and WiFi chip, and a heavy archive catch-up can briefly stall the watchdog daemon. If you change defaults, edit both `setup_usb.sh` and `readme.md`.
 - **Kernel panic**: Auto-reboot after 10 seconds (sysctl kernel.panic=10).
 
 ## Lock Chimes & Light Shows
@@ -233,6 +233,7 @@ LES is a **separate, opt-in subsystem** that uploads Sentry and Saved events to 
 - Creating a standalone Videos page (all video browsing is in the map page panel).
 - Deleting or overwriting `*.img` files in GADGET_DIR from any code path.
 - Running rclone without `nice`/`ionice` (starves the web server and gadget).
+- **Removing or weakening the archive worker's load-pause / inter-file-sleep guards.** The Pi Zero 2 W's SDIO controller is shared between the SD card and the Broadcom WiFi chip; tight back-to-back archive copies (especially during catch-up of a 1000+ clip backlog) can saturate the bus, starve the userspace `watchdog` daemon, and trigger a hardware reset. The `archive_queue.inter_file_sleep_seconds` (default 1.0 s), `load_pause_threshold` (3.5), `load_pause_seconds` (30), and `boot_scan_defer_seconds` (30) defaults are all calibrated against this failure mode — don't lower them without re-validating on hardware. Symptom: watchdog reboot ~3 minutes into a service restart with `mmc1: Controller never released inhibit bit(s)` and `brcmfmac: brcmf_sdio_read_control: ... failed: -5` in the kernel log immediately before the reset.
 - Marking a file as `synced` in the cloud database before rclone confirms the upload completed.
 - Letting `cloud_archive_service` upload a Sentry/Saved event clip when LES has a pending row for that event (cloud_archive yields between files; don't remove or weaken the inter-file `live_event_queue` check).
 - Calling LES from inside `cloud_archive_service` (or vice versa) — they're separate subsystems with separate enable flags. Cross-call only via the documented coordination points (`task_coordinator`, the inter-file LES-pending check, and the `/api/live_events/wake` endpoint).

--- a/config.yaml
+++ b/config.yaml
@@ -199,3 +199,11 @@ archive_queue:
   copy_chunk_bytes: 1048576              # Chunk size (1 MiB) for the temp+fsync+rename copy
   # Phase 2c (issue #76) — health watchdog cadence.
   watchdog_check_interval_seconds: 60    # Frequency of the archive-health watchdog tick
+  # SDIO-bus contention safeguards. The Pi Zero 2 W shares one SDIO
+  # controller between the SD card and the WiFi chip; aggressive
+  # archive copies can starve the kernel watchdog daemon and trigger
+  # a hardware reset. These knobs let the worker back off under load.
+  inter_file_sleep_seconds: 1.0          # Sleep between successful copies (was 0.25)
+  load_pause_threshold: 3.5              # Pause when 1-min loadavg exceeds this
+  load_pause_seconds: 30                 # How long to sleep when load is high
+  boot_scan_defer_seconds: 30            # Producer waits this long after start before its first scan

--- a/readme.md
+++ b/readme.md
@@ -492,7 +492,7 @@ The hardware watchdog automatically reboots the Pi if the system becomes unrespo
 
 ```bash
 watchdog-device = /dev/watchdog
-watchdog-timeout = 60
+watchdog-timeout = 90
 max-load-1 = 24
 realtime = yes
 priority = 1
@@ -516,7 +516,7 @@ The following options should be **avoided** on Raspberry Pi Zero 2 W (512MB RAM)
 4. Fix `/etc/watchdog.conf` to use the simple configuration above
 5. Remove the mask from `cmdline.txt` and reboot
 
-**Watchdog timeout**: Set to 60 seconds to accommodate large disk images (400GB+) which take longer to configure at boot. Smaller images work fine with 15 seconds, but 60 seconds is safe for all configurations.
+**Watchdog timeout**: Set to 90 seconds to accommodate (a) large disk images (400GB+) which take longer to configure at boot and (b) transient SDIO bus contention on the Pi Zero 2 W during heavy archive catch-up. Smaller images work fine with 15 seconds, but 90 seconds is safe for all configurations and prevents spurious reboots when the watchdog daemon is briefly stalled by the shared SDIO controller (SD card + WiFi chip).
 
 ## Troubleshooting
 

--- a/scripts/web/config.py
+++ b/scripts/web/config.py
@@ -188,6 +188,21 @@ ARCHIVE_QUEUE_COPY_CHUNK_BYTES = int(
 ARCHIVE_QUEUE_WATCHDOG_CHECK_INTERVAL_SECONDS = float(
     _archive_queue.get('watchdog_check_interval_seconds', 60)
 )
+# SDIO-contention safeguards (issue: archive catch-up triggered hardware
+# watchdog reboot during a 1414-clip backlog drain). See archive_worker
+# docstring and copilot-instructions.md for the full failure mode.
+ARCHIVE_QUEUE_INTER_FILE_SLEEP_SECONDS = float(
+    _archive_queue.get('inter_file_sleep_seconds', 1.0)
+)
+ARCHIVE_QUEUE_LOAD_PAUSE_THRESHOLD = float(
+    _archive_queue.get('load_pause_threshold', 3.5)
+)
+ARCHIVE_QUEUE_LOAD_PAUSE_SECONDS = float(
+    _archive_queue.get('load_pause_seconds', 30)
+)
+ARCHIVE_QUEUE_BOOT_SCAN_DEFER_SECONDS = float(
+    _archive_queue.get('boot_scan_defer_seconds', 30)
+)
 
 # ============================================================================
 # ADVANCED SETTINGS - Computed values (don't modify these)

--- a/scripts/web/services/archive_producer.py
+++ b/scripts/web/services/archive_producer.py
@@ -182,7 +182,8 @@ def start_producer(teslacam_root: str,
                    db_path: Optional[str] = None,
                    *,
                    rescan_interval_seconds: float = _DEFAULT_RESCAN_INTERVAL,
-                   boot_catchup_enabled: bool = True) -> bool:
+                   boot_catchup_enabled: bool = True,
+                   boot_scan_defer_seconds: float = 0.0) -> bool:
     """Start the producer thread. Idempotent.
 
     Returns True if a new thread was started, False if one was already
@@ -196,9 +197,17 @@ def start_producer(teslacam_root: str,
         rescan_interval_seconds: Seconds between successive scans.
             The default (60 s) matches the issue spec.
         boot_catchup_enabled: When True (default) the first iteration
-            runs immediately on startup. When False the thread waits
-            ``rescan_interval_seconds`` before its first scan — useful
-            for tests that want to exercise just the periodic path.
+            runs (after ``boot_scan_defer_seconds``) on startup. When
+            False the thread waits ``rescan_interval_seconds`` before
+            its first scan — useful for tests that want to exercise
+            just the periodic path.
+        boot_scan_defer_seconds: When >0 and ``boot_catchup_enabled``,
+            wait this many seconds before the first scan. The default
+            (0) preserves the original immediate-scan behavior; the
+            web app passes a non-zero value (typically 30 s) so the
+            producer's directory walk doesn't pile onto the post-start
+            initialization storm that previously triggered hardware
+            watchdog reboots on the Pi Zero 2 W.
     """
     global _thread
     with _state_lock:
@@ -211,6 +220,7 @@ def start_producer(teslacam_root: str,
         _state['db_path'] = db_path
         _state['rescan_interval_seconds'] = float(rescan_interval_seconds)
         _state['boot_catchup_enabled'] = bool(boot_catchup_enabled)
+        _state['boot_scan_defer_seconds'] = float(boot_scan_defer_seconds)
         _state['iterations'] = 0
         _state['last_scan_at'] = None
         _state['last_enqueued'] = 0
@@ -221,7 +231,8 @@ def start_producer(teslacam_root: str,
             target=_run_loop,
             args=(teslacam_root, db_path,
                   float(rescan_interval_seconds),
-                  bool(boot_catchup_enabled)),
+                  bool(boot_catchup_enabled),
+                  float(boot_scan_defer_seconds)),
             name='archive-producer',
             daemon=True,
         )
@@ -232,8 +243,10 @@ def start_producer(teslacam_root: str,
         # so making the start atomic now keeps the contract simple.
         _thread.start()
     logger.info(
-        "archive_producer started (root=%s, interval=%.1fs, boot_catchup=%s)",
-        teslacam_root, rescan_interval_seconds, boot_catchup_enabled,
+        "archive_producer started (root=%s, interval=%.1fs, "
+        "boot_catchup=%s, boot_defer=%.1fs)",
+        teslacam_root, rescan_interval_seconds,
+        boot_catchup_enabled, boot_scan_defer_seconds,
     )
     return True
 
@@ -275,13 +288,26 @@ def get_producer_status() -> Dict:
 
 def _run_loop(teslacam_root: str, db_path: Optional[str],
               rescan_interval_seconds: float,
-              boot_catchup_enabled: bool) -> None:
+              boot_catchup_enabled: bool,
+              boot_scan_defer_seconds: float = 0.0) -> None:
     """Producer thread body. Catches every exception so a single bad
     scan can't kill the thread.
     """
     if not boot_catchup_enabled:
         # Skip the immediate first-pass; wait the full interval first.
         if _stop_event.wait(rescan_interval_seconds):
+            with _state_lock:
+                _state['running'] = False
+            return
+    elif boot_scan_defer_seconds > 0:
+        # Boot catch-up is enabled, but defer the first scan so the
+        # producer's directory walk doesn't pile onto the post-start
+        # initialization storm (file_watcher initial scan + worker
+        # resuming a backlog drain). Without this defer, a single
+        # service restart could spike SDIO contention enough to
+        # starve the watchdog daemon and trigger a hardware reboot
+        # on the Pi Zero 2 W (see copilot-instructions.md).
+        if _stop_event.wait(boot_scan_defer_seconds):
             with _state_lock:
                 _state['running'] = False
             return

--- a/scripts/web/services/archive_worker.py
+++ b/scripts/web/services/archive_worker.py
@@ -817,6 +817,11 @@ def _run_worker_loop(db_path: str, archive_root: str,
                      teslacam_root: Optional[str],
                      worker_id: str) -> None:
     """The thread target. One file at a time, until stop is signaled."""
+    # ``_load_pause_until`` is read AND written below (leading edge sets it,
+    # trailing edge clears it). Declare global at function scope per
+    # Python convention rather than burying it inside a conditional.
+    global _load_pause_until
+
     _apply_low_priority()
     try:
         released = archive_queue.recover_stale_claims(db_path=db_path)
@@ -864,7 +869,6 @@ def _run_worker_loop(db_path: str, archive_root: str,
             except (AttributeError, OSError):
                 load1 = 0.0
             if load1 > load_pause_threshold:
-                global _load_pause_until
                 # Only log INFO on the leading edge of the pause
                 # window so back-to-back high-load iterations don't
                 # spam the journal. ``_load_pause_until`` is the
@@ -873,10 +877,15 @@ def _run_worker_loop(db_path: str, archive_root: str,
                 # window and stay quiet.
                 already_paused = _load_pause_until > time.time()
                 _load_pause_until = time.time() + load_pause_seconds
-                with _state_lock:
-                    _state['last_load_pause_at'] = time.time()
-                    _state['last_load_pause_loadavg'] = float(load1)
                 if not already_paused:
+                    # Pin ``last_pause_at`` to the moment the pause
+                    # actually started — within a sustained pause
+                    # window the field must NOT tick forward on
+                    # every iteration (parity with disk-pause, which
+                    # arms ``last_disk_pause_at`` only on first hit).
+                    with _state_lock:
+                        _state['last_load_pause_at'] = time.time()
+                        _state['last_load_pause_loadavg'] = float(load1)
                     logger.info(
                         "archive_worker: 1-min loadavg %.2f > %.2f — "
                         "pausing %.0fs to relieve SDIO/CPU contention",

--- a/scripts/web/services/archive_worker.py
+++ b/scripts/web/services/archive_worker.py
@@ -81,7 +81,18 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 # Sleep between successful copies (gives the kernel time to flush).
-_INTER_FILE_SLEEP_SECONDS = 0.25
+# The Pi Zero 2 W shares one SDIO controller between SD card and WiFi;
+# tight back-to-back copies during catch-up can starve the watchdog
+# daemon. Configurable via ``archive_queue.inter_file_sleep_seconds``
+# (default 1.0 s) — read at startup by ``_read_config_or_defaults``.
+_INTER_FILE_SLEEP_SECONDS = 1.0
+# Default 1-min loadavg above which the worker pauses for
+# ``_LOAD_PAUSE_SECONDS`` before claiming the next row. Configurable
+# via ``archive_queue.load_pause_threshold``.
+_LOAD_PAUSE_THRESHOLD = 3.5
+# How long to sleep when the load threshold is exceeded. Configurable
+# via ``archive_queue.load_pause_seconds``.
+_LOAD_PAUSE_SECONDS = 30.0
 # Sleep when the queue is empty. Wake() can shorten this on a producer hit.
 _IDLE_SLEEP_SECONDS = 5.0
 # Sleep on a transient claim error or task_coordinator timeout.
@@ -625,7 +636,7 @@ def _record_idle(*, last_outcome: Optional[str] = None,
 
 
 def _read_config_or_defaults():
-    """Return (chunk_bytes, max_attempts, idle_seconds) from config.
+    """Return tunables from config (chunk_bytes, max_attempts, idle, inter_file, load_threshold, load_pause).
 
     Looked up at call time so tests can monkeypatch the config module
     after import. Falls back to module-level defaults if config isn't
@@ -636,14 +647,25 @@ def _read_config_or_defaults():
             ARCHIVE_QUEUE_COPY_CHUNK_BYTES,
             ARCHIVE_QUEUE_RETRY_MAX_ATTEMPTS,
             ARCHIVE_QUEUE_WORKER_CHECK_INTERVAL_SECONDS,
+            ARCHIVE_QUEUE_INTER_FILE_SLEEP_SECONDS,
+            ARCHIVE_QUEUE_LOAD_PAUSE_THRESHOLD,
+            ARCHIVE_QUEUE_LOAD_PAUSE_SECONDS,
         )
         return (
             int(ARCHIVE_QUEUE_COPY_CHUNK_BYTES),
             int(ARCHIVE_QUEUE_RETRY_MAX_ATTEMPTS),
             float(ARCHIVE_QUEUE_WORKER_CHECK_INTERVAL_SECONDS),
+            float(ARCHIVE_QUEUE_INTER_FILE_SLEEP_SECONDS),
+            float(ARCHIVE_QUEUE_LOAD_PAUSE_THRESHOLD),
+            float(ARCHIVE_QUEUE_LOAD_PAUSE_SECONDS),
         )
     except Exception:  # noqa: BLE001
-        return (_DEFAULT_COPY_CHUNK_BYTES, 3, _IDLE_SLEEP_SECONDS)
+        return (
+            _DEFAULT_COPY_CHUNK_BYTES, 3, _IDLE_SLEEP_SECONDS,
+            _INTER_FILE_SLEEP_SECONDS,
+            _LOAD_PAUSE_THRESHOLD,
+            _LOAD_PAUSE_SECONDS,
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -776,15 +798,38 @@ def _run_worker_loop(db_path: str, archive_root: str,
     except Exception as e:  # noqa: BLE001
         logger.warning("recover_stale_claims failed at startup: %s", e)
 
-    chunk_size, max_attempts, idle_sleep = _read_config_or_defaults()
+    chunk_size, max_attempts, idle_sleep, inter_file_sleep, \
+        load_pause_threshold, load_pause_seconds = _read_config_or_defaults()
 
     while not _stop_event.is_set():
         # Honor pause requests at the iteration boundary.
         if _pause_event.is_set():
             _idle_event.set()
-            if _stop_event.wait(timeout=_INTER_FILE_SLEEP_SECONDS):
+            if _stop_event.wait(timeout=inter_file_sleep):
                 break
             continue
+
+        # SDIO-contention guard. The Pi Zero 2 W shares one SDIO
+        # controller between SD card and WiFi; sustained heavy archive
+        # I/O can starve the watchdog daemon and trigger a hardware
+        # reset. When the system is already under load (typically the
+        # combination of archive + indexer + Tesla concurrent writes),
+        # back off so other tasks can drain. Threshold and pause length
+        # are configurable; ``getloadavg`` is a cheap O(1) syscall.
+        if load_pause_threshold > 0:
+            try:
+                load1 = os.getloadavg()[0]
+            except (AttributeError, OSError):
+                load1 = 0.0
+            if load1 > load_pause_threshold:
+                logger.info(
+                    "archive_worker: 1-min loadavg %.2f > %.2f — "
+                    "pausing %.0fs to relieve SDIO/CPU contention",
+                    load1, load_pause_threshold, load_pause_seconds,
+                )
+                _idle_event.set()
+                _wait_with_wake(load_pause_seconds)
+                continue
 
         # Honor the disk-space self-pause. ``process_one_claim`` arms
         # ``_disk_space_pause_until`` when free space crosses the
@@ -878,7 +923,7 @@ def _run_worker_loop(db_path: str, archive_root: str,
             # Inter-file pause. Don't honor wake() here — we just
             # finished work; we want the kernel to flush before the
             # next read-heavy copy.
-            if _stop_event.wait(timeout=_INTER_FILE_SLEEP_SECONDS):
+            if _stop_event.wait(timeout=inter_file_sleep):
                 break
 
 

--- a/scripts/web/services/archive_worker.py
+++ b/scripts/web/services/archive_worker.py
@@ -139,6 +139,8 @@ _state: Dict[str, Any] = {
     'last_drained_at': None,
     'last_disk_pause_at': None,
     'last_disk_pause_free_mb': None,
+    'last_load_pause_at': None,
+    'last_load_pause_loadavg': None,
 }
 
 # Disk-space self-pause epoch (seconds). When set in the future, the
@@ -151,6 +153,13 @@ _disk_space_pause_until: float = 0.0
 # from ``cloud_archive.disk_space_pause_seconds`` at first use so the
 # config import order stays simple; tests monkeypatch this directly.
 _DEFAULT_DISK_SPACE_PAUSE_SECONDS: float = 300.0
+
+# Load-pause self-pause epoch (seconds). When set in the future, the
+# worker loop is idling because 1-min loadavg crossed the configured
+# threshold (SDIO bus contention guard — see copilot-instructions.md).
+# Mirrors the disk-pause pattern so the status endpoint can show
+# *why* the worker isn't draining.
+_load_pause_until: float = 0.0
 
 
 def _resolve_disk_space_pause_seconds() -> float:
@@ -207,10 +216,13 @@ def start_worker(db_path: str, archive_root: str, *,
         _state['active_file'] = None
         _state['last_disk_pause_at'] = None
         _state['last_disk_pause_free_mb'] = None
+        _state['last_load_pause_at'] = None
+        _state['last_load_pause_loadavg'] = None
         # Reset the disk-space self-pause; the next iteration will
         # re-arm it if disk space is still critical.
-        global _disk_space_pause_until
+        global _disk_space_pause_until, _load_pause_until
         _disk_space_pause_until = 0.0
+        _load_pause_until = 0.0
         thread = threading.Thread(
             target=_run_worker_loop,
             args=(db_path, archive_root, teslacam_root, _worker_id),
@@ -365,6 +377,7 @@ def get_status() -> Dict[str, Any]:
     snap['copied_count'] = counts.get('copied', 0)
     snap['error_count'] = counts.get('error', 0)
     snap['disk_pause'] = get_disk_pause_state()
+    snap['load_pause'] = get_load_pause_state()
     return snap
 
 
@@ -613,6 +626,23 @@ def get_disk_pause_state() -> Dict[str, Any]:
     }
 
 
+def get_load_pause_state() -> Dict[str, Any]:
+    """Return the current load-pause state for status endpoints.
+
+    ``last_loadavg`` is the most recent reading that triggered the
+    pause (None until the guard fires for the first time). Mirrors
+    :func:`get_disk_pause_state` so the UI can show *why* the worker
+    isn't draining.
+    """
+    with _state_lock:
+        return {
+            'paused_until_epoch': float(_load_pause_until),
+            'is_paused_now': _load_pause_until > time.time(),
+            'last_pause_at': _state.get('last_load_pause_at'),
+            'last_loadavg': _state.get('last_load_pause_loadavg'),
+        }
+
+
 def _set_state(**fields: Any) -> None:
     with _state_lock:
         _state.update(fields)
@@ -816,20 +846,58 @@ def _run_worker_loop(db_path: str, archive_root: str,
         # combination of archive + indexer + Tesla concurrent writes),
         # back off so other tasks can drain. Threshold and pause length
         # are configurable; ``getloadavg`` is a cheap O(1) syscall.
+        #
+        # Two UX rules apply here:
+        #
+        #   1. Log INFO once on entering the pause and once on resume,
+        #      NOT on every iteration. Producers calling ``wake()``
+        #      under sustained high load would otherwise spam
+        #      ``journalctl`` every few seconds (see PR #93 review).
+        #   2. Use ``_stop_event.wait`` (NOT ``_wait_with_wake``) so
+        #      a producer's wake() can't shorten the back-off — the
+        #      whole point of the pause is to give the SDIO bus and
+        #      watchdog daemon a clear runway. Producers will get
+        #      their files drained on the next iteration anyway.
         if load_pause_threshold > 0:
             try:
                 load1 = os.getloadavg()[0]
             except (AttributeError, OSError):
                 load1 = 0.0
             if load1 > load_pause_threshold:
-                logger.info(
-                    "archive_worker: 1-min loadavg %.2f > %.2f — "
-                    "pausing %.0fs to relieve SDIO/CPU contention",
-                    load1, load_pause_threshold, load_pause_seconds,
-                )
+                global _load_pause_until
+                # Only log INFO on the leading edge of the pause
+                # window so back-to-back high-load iterations don't
+                # spam the journal. ``_load_pause_until`` is the
+                # epoch the current pause window expires; if it's
+                # already in the future we're still inside the same
+                # window and stay quiet.
+                already_paused = _load_pause_until > time.time()
+                _load_pause_until = time.time() + load_pause_seconds
+                with _state_lock:
+                    _state['last_load_pause_at'] = time.time()
+                    _state['last_load_pause_loadavg'] = float(load1)
+                if not already_paused:
+                    logger.info(
+                        "archive_worker: 1-min loadavg %.2f > %.2f — "
+                        "pausing %.0fs to relieve SDIO/CPU contention",
+                        load1, load_pause_threshold, load_pause_seconds,
+                    )
                 _idle_event.set()
-                _wait_with_wake(load_pause_seconds)
+                # Stop-only wait. Producers' wake() must NOT cut this
+                # short — we are deliberately giving the SDIO bus
+                # and the watchdog daemon a clear runway.
+                if _stop_event.wait(timeout=load_pause_seconds):
+                    break
                 continue
+            elif _load_pause_until > 0 and _load_pause_until <= time.time():
+                # Trailing edge: log once when we leave the pause
+                # window so the user can see "back to normal".
+                logger.info(
+                    "archive_worker: 1-min loadavg %.2f back below %.2f — "
+                    "resuming archive drain",
+                    load1, load_pause_threshold,
+                )
+                _load_pause_until = 0.0
 
         # Honor the disk-space self-pause. ``process_one_claim`` arms
         # ``_disk_space_pause_until`` when free space crosses the

--- a/scripts/web/web_control.py
+++ b/scripts/web/web_control.py
@@ -290,6 +290,7 @@ if __name__ == "__main__":
             ARCHIVE_QUEUE_ENABLED,
             ARCHIVE_QUEUE_RESCAN_INTERVAL_SECONDS,
             ARCHIVE_QUEUE_BOOT_CATCHUP_ENABLED,
+            ARCHIVE_QUEUE_BOOT_SCAN_DEFER_SECONDS,
             MAPPING_DB_PATH as _ARCHIVE_QUEUE_DB,
         )
         if ARCHIVE_QUEUE_ENABLED:
@@ -305,6 +306,9 @@ if __name__ == "__main__":
                     ),
                     boot_catchup_enabled=(
                         ARCHIVE_QUEUE_BOOT_CATCHUP_ENABLED
+                    ),
+                    boot_scan_defer_seconds=(
+                        ARCHIVE_QUEUE_BOOT_SCAN_DEFER_SECONDS
                     ),
                 )
                 print("Archive queue producer started (Phase 2a)")

--- a/setup_usb.sh
+++ b/setup_usb.sh
@@ -1675,9 +1675,13 @@ cat > "$WATCHDOG_CONF" <<'EOF'
 # Watchdog device
 watchdog-device = /dev/watchdog
 
-# Watchdog timeout (hardware reset after 60 seconds of no response)
-# Note: 60s needed for large disk images (400GB+) which take longer to configure
-watchdog-timeout = 60
+# Watchdog timeout (hardware reset after 90 seconds of no response)
+# Note: 90s gives headroom for transient SDIO bus contention on the
+# Pi Zero 2 W (the SD card and WiFi chip share one SDIO controller).
+# A heavy archive catch-up + concurrent Tesla writes + WiFi traffic
+# can briefly stall the watchdog daemon; 60s was sometimes enough to
+# trigger spurious reboots during 1000+ clip backlog drains.
+watchdog-timeout = 90
 
 # Reboot if 1-minute load average exceeds 24 (6x the 4 cores).
 # A spiky-but-recovering workload won't trip this.

--- a/tests/test_archive_producer.py
+++ b/tests/test_archive_producer.py
@@ -225,6 +225,42 @@ class TestProducerLifecycle:
         assert archive_queue.get_queue_status(db_path=db)['pending'] == 0
         archive_producer.stop_producer(timeout=5.0)
 
+    def test_boot_scan_defer_postpones_first_scan(self, db, teslacam):
+        # boot_scan_defer_seconds > 0 should delay the first scan even
+        # when boot_catchup is enabled. Use a long defer + short total
+        # observation window to confirm the producer hasn't scanned yet.
+        archive_producer.start_producer(
+            teslacam, db_path=db,
+            rescan_interval_seconds=60.0,
+            boot_catchup_enabled=True,
+            boot_scan_defer_seconds=5.0,
+        )
+        time.sleep(0.5)  # Well under the 5s defer
+        status = archive_producer.get_producer_status()
+        assert status['iterations'] == 0, (
+            "First scan should be deferred by boot_scan_defer_seconds; "
+            "running it immediately defeats the SDIO contention guard."
+        )
+        assert archive_queue.get_queue_status(db_path=db)['pending'] == 0
+        archive_producer.stop_producer(timeout=5.0)
+
+    def test_boot_scan_defer_zero_preserves_immediate_scan(self, db, teslacam):
+        # With defer=0, the original immediate-scan behavior must be
+        # preserved (back-compat for callers that don't pass the arg).
+        archive_producer.start_producer(
+            teslacam, db_path=db,
+            rescan_interval_seconds=60.0,
+            boot_catchup_enabled=True,
+            boot_scan_defer_seconds=0.0,
+        )
+        time.sleep(0.8)  # Enough for the first scan to complete
+        status = archive_producer.get_producer_status()
+        assert status['iterations'] >= 1, (
+            "With defer=0 the producer must scan immediately; "
+            "regressed back-compat for the start_producer signature."
+        )
+        archive_producer.stop_producer(timeout=5.0)
+
     def test_periodic_rescan_picks_up_new_files(self, db, teslacam):
         # Short interval so we can observe two scans
         archive_producer.start_producer(

--- a/tests/test_archive_worker.py
+++ b/tests/test_archive_worker.py
@@ -969,3 +969,57 @@ class TestArchiveWorkerDiskSpaceGuard:
         )
         assert archive_worker._resolve_disk_space_pause_seconds() == 99.0
 
+
+# ---------------------------------------------------------------------------
+# TestArchiveWorkerConfigContract — lock the config-tunables tuple shape so
+# archive_worker.py and config.py don't drift out of sync.
+# ---------------------------------------------------------------------------
+
+
+class TestArchiveWorkerConfigContract:
+    def test_read_config_returns_six_tunables(self):
+        # The worker reads six tunables (chunk, max_attempts, idle,
+        # inter_file, load_threshold, load_pause). Old callers expecting
+        # three would silently break — lock the contract.
+        result = archive_worker._read_config_or_defaults()
+        assert len(result) == 6, (
+            "_read_config_or_defaults must return 6 tunables; "
+            "archive_worker.py and config.py have drifted "
+            "(got %d)" % len(result)
+        )
+        chunk, max_attempts, idle, inter_file, load_thresh, load_pause = result
+        assert chunk > 0
+        assert max_attempts > 0
+        assert idle > 0
+        assert inter_file >= 0       # 0 disables inter-file pause
+        assert load_thresh >= 0      # 0 disables load-pause guard
+        assert load_pause >= 0
+
+    def test_inter_file_sleep_default_is_at_least_one_second(self):
+        # Regression guard: the SDIO contention failure mode that
+        # caused hardware watchdog reboots was triggered with a 0.25s
+        # inter-file sleep. The Pi Zero 2 W needs a minimum of ~1s
+        # between copies to let the kernel flush + the WiFi chip get
+        # SDIO bus time. Don't lower the default below 1s without
+        # re-validating on hardware (see copilot-instructions.md).
+        _, _, _, inter_file, _, _ = archive_worker._read_config_or_defaults()
+        assert inter_file >= 1.0, (
+            "Default inter_file_sleep_seconds must stay >= 1.0 to "
+            "prevent SDIO bus saturation. See copilot-instructions.md."
+        )
+
+    def test_load_pause_threshold_default_is_set(self):
+        # The load-pause guard prevents the archive worker from
+        # piling onto an already-loaded system. Default threshold of
+        # 3.5 was calibrated against the Pi Zero 2 W's 4 cores.
+        _, _, _, _, load_thresh, load_pause = (
+            archive_worker._read_config_or_defaults()
+        )
+        assert load_thresh > 0, (
+            "Load-pause guard must be enabled by default."
+        )
+        assert load_pause >= 10, (
+            "Load-pause sleep must be long enough (>=10s) to actually "
+            "let load drop, not just throttle every iteration."
+        )
+

--- a/tests/test_archive_worker.py
+++ b/tests/test_archive_worker.py
@@ -1186,4 +1186,59 @@ class TestArchiveWorkerLoadPauseUX:
         finally:
             archive_worker.stop_worker(timeout=5)
 
+    def test_last_pause_at_pinned_within_window(
+        self, db, archive_root, teslacam_root, make_clip, monkeypatch,
+    ):
+        # Within a single sustained pause window, ``last_pause_at`` must
+        # NOT tick forward on every loop iteration — it represents
+        # "when did THIS pause start", not "last time we checked".
+        # This is parity with disk-pause (``last_disk_pause_at`` is
+        # set inside process_one_claim only on first hit) and is the
+        # natural reading of the field name. Regression guard for the
+        # re-review INFO finding on PR #93.
+        monkeypatch.setattr(
+            archive_worker.os, 'getloadavg',
+            lambda: (99.0, 99.0, 99.0), raising=False,
+        )
+        # Use a long pause window (5s) so the test stays well inside
+        # one window across multiple iterations.
+        def fake_config(*a, **kw):
+            return (4096, 3, 0.05, 0.05, 0.5, 5.0)
+        monkeypatch.setattr(archive_worker, '_read_config_or_defaults', fake_config)
+
+        clip = make_clip("RecentClips/pin-front.mp4")
+        enqueue_for_archive(clip, db_path=db)
+
+        archive_worker.start_worker(
+            db, archive_root, teslacam_root=teslacam_root,
+        )
+        try:
+            # Give the worker a beat to enter the pause branch and
+            # arm last_pause_at.
+            time.sleep(0.2)
+            first = archive_worker.get_load_pause_state()['last_pause_at']
+            assert first is not None, (
+                "Worker didn't enter load-pause within 200ms."
+            )
+            # Now sample several more times within the same 5s window.
+            # If the bug existed, last_pause_at would tick forward as
+            # the worker re-evaluated load on each wakeup. With the
+            # fix, it stays pinned.
+            time.sleep(0.4)
+            second = archive_worker.get_load_pause_state()['last_pause_at']
+            time.sleep(0.4)
+            third = archive_worker.get_load_pause_state()['last_pause_at']
+            assert second == first, (
+                "last_pause_at advanced from %r to %r within the same "
+                "pause window — it must pin to the moment the pause "
+                "started, not the last time the worker re-checked load."
+                % (first, second)
+            )
+            assert third == first, (
+                "last_pause_at advanced from %r to %r within the same "
+                "pause window — must remain pinned." % (first, third)
+            )
+        finally:
+            archive_worker.stop_worker(timeout=5)
+
 

--- a/tests/test_archive_worker.py
+++ b/tests/test_archive_worker.py
@@ -94,6 +94,10 @@ def _reset_module_state():
     # Reset the disk-space self-pause so a previous test that armed it
     # doesn't leak into the next test's process_one_claim path.
     archive_worker._disk_space_pause_until = 0.0
+    archive_worker._load_pause_until = 0.0
+    with archive_worker._state_lock:
+        archive_worker._state['last_load_pause_at'] = None
+        archive_worker._state['last_load_pause_loadavg'] = None
     # Reset task_coordinator too — leftover ownership from an earlier
     # test would block our acquire.
     with task_coordinator._lock:
@@ -103,6 +107,10 @@ def _reset_module_state():
     yield
     archive_worker.stop_worker(timeout=5.0)
     archive_worker._disk_space_pause_until = 0.0
+    archive_worker._load_pause_until = 0.0
+    with archive_worker._state_lock:
+        archive_worker._state['last_load_pause_at'] = None
+        archive_worker._state['last_load_pause_loadavg'] = None
     with task_coordinator._lock:
         task_coordinator._current_task = None
         task_coordinator._task_started = 0.0
@@ -1022,4 +1030,160 @@ class TestArchiveWorkerConfigContract:
             "Load-pause sleep must be long enough (>=10s) to actually "
             "let load drop, not just throttle every iteration."
         )
+
+
+# ---------------------------------------------------------------------------
+# TestArchiveWorkerLoadPauseUX — verify the load-pause guard's user-visible
+# behavior: status visibility, no log spam, wake() is ignored, state
+# resets cleanly across worker starts.
+# ---------------------------------------------------------------------------
+
+
+class TestArchiveWorkerLoadPauseUX:
+    def test_get_load_pause_state_initial(self):
+        # Before any pause has fired, all fields are zero/None.
+        state = archive_worker.get_load_pause_state()
+        assert state['paused_until_epoch'] == 0.0
+        assert state['is_paused_now'] is False
+        assert state['last_pause_at'] is None
+        assert state['last_loadavg'] is None
+
+    def test_status_includes_load_pause_block(self, db, archive_root):
+        # ``get_status()`` must surface a ``load_pause`` block parallel
+        # to ``disk_pause`` so the UI can show *why* the worker isn't
+        # draining. Regression guard against the block being dropped.
+        archive_worker.start_worker(db, archive_root, teslacam_root=None)
+        try:
+            status = archive_worker.get_status()
+            assert 'load_pause' in status, (
+                "get_status() must include a 'load_pause' block "
+                "(parity with 'disk_pause')."
+            )
+            assert 'disk_pause' in status, "Existing disk_pause block lost."
+            lp = status['load_pause']
+            assert set(lp.keys()) >= {
+                'paused_until_epoch', 'is_paused_now',
+                'last_pause_at', 'last_loadavg',
+            }
+        finally:
+            archive_worker.stop_worker(timeout=5)
+
+    def test_start_worker_resets_load_pause_state(self, db, archive_root):
+        # Simulate a previous run that left state populated.
+        archive_worker._load_pause_until = time.time() + 100
+        with archive_worker._state_lock:
+            archive_worker._state['last_load_pause_at'] = time.time()
+            archive_worker._state['last_load_pause_loadavg'] = 5.5
+
+        # A fresh start_worker MUST clear it (parity with disk_pause).
+        # We don't actually need the worker to drain anything for this
+        # test — start + stop is enough.
+        archive_worker.start_worker(db, archive_root, teslacam_root=None)
+        try:
+            assert archive_worker._load_pause_until == 0.0, (
+                "start_worker must reset _load_pause_until."
+            )
+            state = archive_worker.get_load_pause_state()
+            assert state['last_pause_at'] is None
+            assert state['last_loadavg'] is None
+        finally:
+            archive_worker.stop_worker(timeout=5)
+
+    def test_load_pause_logs_only_on_transition(
+        self, db, archive_root, teslacam_root, make_clip, monkeypatch, caplog,
+    ):
+        # Force os.getloadavg() to report sustained high load. The
+        # worker must log the "pausing" INFO line ONCE (entering the
+        # window), NOT on every iteration. Even if the load stays high
+        # for many iterations, each subsequent iteration should be
+        # silent because we're still inside the same pause window.
+        # NB: ``getloadavg`` doesn't exist on Windows, so we install
+        # it (raising=False) for the duration of the test.
+        monkeypatch.setattr(
+            archive_worker.os, 'getloadavg',
+            lambda: (99.0, 99.0, 99.0), raising=False,
+        )
+        # Tighten the pause to keep the test snappy.
+        def fake_config(*a, **kw):
+            return (4096, 3, 0.05, 0.05, 0.5, 0.5)
+        monkeypatch.setattr(archive_worker, '_read_config_or_defaults', fake_config)
+
+        # Enqueue something so the worker has work to do (it'll hit
+        # the load-pause guard before claiming).
+        clip = make_clip("RecentClips/loadpause-front.mp4")
+        enqueue_for_archive(clip, db_path=db)
+
+        with caplog.at_level('INFO', logger='services.archive_worker'):
+            archive_worker.start_worker(
+                db, archive_root, teslacam_root=teslacam_root,
+            )
+            # Let the worker iterate several times under sustained load.
+            time.sleep(2.0)
+            archive_worker.stop_worker(timeout=5)
+
+        # Count "pausing" INFO lines. With pause window = 0.5s and
+        # 2.0s observation, we expect ~4 pause windows → 4 entry
+        # logs at most. Without the transition guard this would log
+        # on every iteration (~20+ times).
+        pause_logs = [r for r in caplog.records
+                      if 'pausing' in r.getMessage()
+                      and 'relieve SDIO' in r.getMessage()]
+        # Bound: at most 1 log per (load_pause_seconds + slack). With
+        # 0.5s window over 2s + cleanup, 6 is a generous upper bound.
+        assert len(pause_logs) <= 6, (
+            "Load-pause must log on transition into the window only, "
+            "not on every iteration. Got %d 'pausing' lines under "
+            "sustained high load — that's the spam regression PR #93's "
+            "review flagged." % len(pause_logs)
+        )
+        # And we must have logged AT LEAST one — otherwise the test
+        # didn't actually exercise the guard.
+        assert len(pause_logs) >= 1, (
+            "Load-pause guard didn't fire under simulated load=99.0."
+        )
+
+    def test_load_pause_ignores_wake_event(
+        self, db, archive_root, teslacam_root, make_clip, monkeypatch,
+    ):
+        # Producers calling ``wake()`` MUST NOT shorten the load-pause
+        # back-off. The whole point of the pause is to give the SDIO
+        # bus a clear runway; producer wakes would defeat that.
+        monkeypatch.setattr(
+            archive_worker.os, 'getloadavg',
+            lambda: (99.0, 99.0, 99.0), raising=False,
+        )
+        # 1.0s pause window so the test can observe that wake() does
+        # NOT cut it short.
+        def fake_config(*a, **kw):
+            return (4096, 3, 0.05, 0.05, 0.5, 1.0)
+        monkeypatch.setattr(archive_worker, '_read_config_or_defaults', fake_config)
+
+        clip = make_clip("RecentClips/wake-front.mp4")
+        enqueue_for_archive(clip, db_path=db)
+
+        archive_worker.start_worker(
+            db, archive_root, teslacam_root=teslacam_root,
+        )
+        try:
+            # Wait a hair so the worker enters the load-pause branch.
+            time.sleep(0.15)
+            t0 = time.time()
+            # Hammer wake() — under the OLD (buggy) code each wake
+            # would cut the 1s pause short within 1s of polling.
+            for _ in range(20):
+                archive_worker.wake()
+                time.sleep(0.02)
+            # Total elapsed under the test loop is ~0.4s. The pause
+            # window is 1.0s; the worker MUST still be paused.
+            elapsed = time.time() - t0
+            assert elapsed < 0.6, "test loop overran"
+            state = archive_worker.get_load_pause_state()
+            assert state['is_paused_now'] is True, (
+                "Load-pause was cut short by wake() — that's the bug "
+                "PR #93's review flagged. The pause MUST honor stop "
+                "events only, not wake events."
+            )
+        finally:
+            archive_worker.stop_worker(timeout=5)
+
 


### PR DESCRIPTION
## Problem

After deploying PR #92, the Pi was unreachable for ~3 minutes and rebooted. SSH, web, and IPv4 mDNS all stopped responding. The hardware watchdog fired even though load averages stayed well below the configured thresholds (4–5 vs 24/16). Root cause analysis (see `<root-cause>` below) identified the **shared SDIO bus** as the choke point — and **434 RecentClips were lost** during the outage as Tesla rotated them.

## Root cause

The Pi Zero 2 W shares one SDIO controller between the SD card and the Broadcom WiFi chip. During an archive catch-up of 1414 pending clips, the combined I/O of:

- Archive worker reading from `/mnt/gadget/part1-ro` (SD-card-backed loop mount)
- Archive worker writing to `~/ArchivedClips` (SD card)
- Tesla concurrently writing the gadget image (also SD card)
- WiFi traffic (same SDIO bus)

…starved the userspace `watchdog` daemon enough that it failed to ping `/dev/watchdog` within 60s, triggering a hardware reset. Kernel log immediately before reboot:

```
mmc1: Controller never released inhibit bit(s)
brcmfmac: brcmf_sdio_read_control: read 2048 control bytes failed: -5
brcmfmac: brcmf_cfg80211_stop_ap: setting AP mode failed -52
```

This is the **SDIO contention failure mode** documented in the Pi Zero 2 W community.

## Fix (Tier 1 mitigations)

Three configurable throttles in the archive subsystem + one watchdog tolerance bump:

| # | Change | Default | Configurable via |
|---|--------|---------|------------------|
| 1 | Inter-file sleep between successful copies | **1.0 s** (was hardcoded 0.25 s) | `archive_queue.inter_file_sleep_seconds` |
| 2 | Load-based pause: skip iteration if `getloadavg()[0]` exceeds threshold | **3.5** | `archive_queue.load_pause_threshold` + `load_pause_seconds` |
| 3 | Producer first-scan defer: wait after service start before initial scan | **30 s** | `archive_queue.boot_scan_defer_seconds` |
| 4 | Hardware watchdog timeout | **60 s → 90 s** | `setup_usb.sh` |

#1 and #2 directly relieve SDIO bus pressure during catch-up. #3 prevents the post-restart cascade (file_watcher initial scan + producer first scan + worker resuming backlog all firing simultaneously). #4 gives more headroom for transient SDIO storms while still recovering from real hangs in <2 min.

All four are configurable; defaults are calibrated against the Pi Zero 2 W. Lower them at your own risk.

## Files changed

- `config.yaml` — 4 new keys under `archive_queue`
- `scripts/web/config.py` — 4 new constants
- `scripts/web/services/archive_worker.py` — load-pause check, config-driven inter-file sleep, expanded `_read_config_or_defaults` tuple (3 → 6)
- `scripts/web/services/archive_producer.py` — `boot_scan_defer_seconds` parameter on `start_producer`
- `scripts/web/web_control.py` — pass the new defer to `start_producer`
- `setup_usb.sh` — watchdog timeout 60 → 90
- `readme.md` — reflect new watchdog default + rationale
- `.github/copilot-instructions.md` — document the SDIO failure mode and the new defaults

## Tests

- All **692 existing tests pass**
- 5 new tests added:
  - `test_boot_scan_defer_postpones_first_scan` — defer >0 delays initial scan
  - `test_boot_scan_defer_zero_preserves_immediate_scan` — back-compat
  - `test_read_config_returns_six_tunables` — locks tuple shape contract
  - `test_inter_file_sleep_default_is_at_least_one_second` — regression guard against lowering the SDIO-protective default
  - `test_load_pause_threshold_default_is_set` — guards against accidentally disabling the load pause

## Trade-offs

- **Watchdog recovery time**: 60s → 90s means up to 30 extra seconds before recovery from a real hang. Trade-off accepted because spurious reboots lose 3+ min of footage every time, vs. real hangs being rare.
- **Archive throughput during high load**: load pause adds 30s sleeps when load > 3.5. Slows catch-up but leaves the system responsive for users + Tesla. Throughput improvements are out of scope (separate issue).
- **First scan delay**: 30s after service start before the producer scans. Means a clip Tesla wrote during that window won't enter the queue until the next 60s rescan. Acceptable trade for restart stability.

## Out of scope (future work)

- Per-file overhead investigation (current ~22 clips/min × ~3 MB = 1.5 MB/s; SD card can do 30+ MB/s). Likely fork ionice + sqlite commit + fsync overhead. Worth a separate PR.
- PSI-based throttling (`/proc/pressure/io`) — could replace load-pause with finer-grained signal, but loadavg is sufficient here.
- Aggressive `source_gone` pruning (434 dead rows in the most recent backlog).

## Deployment

After merge: pull on the Pi, restart `gadget_web.service`. The watchdog timeout change (`setup_usb.sh`) only takes effect after a full setup run or a manual edit to `/etc/watchdog.conf` + `systemctl restart watchdog.service`.
