### PR TITLE
fix(archive): wire load_pause through /api/archive/status

### DIFF
--- a/scripts/web/blueprints/archive_queue.py
+++ b/scripts/web/blueprints/archive_queue.py
@@ -135,6 +135,14 @@ def archive_status():
         'disk_pause': worker_status.get(
             'disk_pause', {'is_paused_now': False, 'paused_until_epoch': 0.0},
         ),
+        'load_pause': worker_status.get(
+            'load_pause', {
+                'is_paused_now': False,
+                'paused_until_epoch': 0.0,
+                'last_pause_at': None,
+                'last_loadavg': None,
+            },
+        ),
 
         # Disk + retention. ``disk_known=False`` means ``shutil.disk_usage``
         # raised OSError on the most recent watchdog tick; the disk fields

--- a/tests/test_archive_status_endpoint.py
+++ b/tests/test_archive_status_endpoint.py
@@ -123,7 +123,7 @@ class TestArchiveStatusShape:
         'pending_count', 'claimed_count', 'copied_count',
         'source_gone_count', 'dead_letter_count',
         'worker_running', 'paused', 'active_file', 'last_outcome',
-        'last_error', 'files_done_session', 'disk_pause',
+        'last_error', 'files_done_session', 'disk_pause', 'load_pause',
         'disk_total_mb', 'disk_used_mb', 'disk_free_mb',
         'disk_warning_mb', 'disk_critical_mb', 'disk_known',
         'last_successful_copy_at', 'last_successful_copy_age_seconds',
@@ -153,6 +153,30 @@ class TestArchiveStatusShape:
         # Thresholds default to 500/100 from spec.
         assert body['disk_warning_mb'] == 500
         assert body['disk_critical_mb'] == 100
+
+    def test_status_includes_load_pause_block(self, client):
+        # Regression guard: PR #93 added ``load_pause`` to
+        # ``archive_worker.get_status()`` for SDIO-contention
+        # observability, but the blueprint route hand-picks fields
+        # from the worker snapshot and originally missed wiring it
+        # through. Without this shape test, a future refactor of
+        # the route could silently drop it again. The UI's
+        # archive panel needs all four fields to render the
+        # "load-paused" indicator and the most recent loadavg.
+        with patch('blueprints.archive_queue.os.path.isfile',
+                   return_value=True):
+            r = client.get('/api/archive/status')
+        assert r.status_code == 200
+        body = r.get_json()
+        assert 'load_pause' in body, (
+            "/api/archive/status MUST surface the load_pause block "
+            "from archive_worker.get_status() — the UI depends on it."
+        )
+        lp = body['load_pause']
+        assert set(lp.keys()) >= {
+            'paused_until_epoch', 'is_paused_now',
+            'last_pause_at', 'last_loadavg',
+        }, f"load_pause block missing required keys: {set(lp.keys())}"
 
     def test_status_includes_per_priority_queue_depths(
         self, client, db, archive_root, monkeypatch,


### PR DESCRIPTION
## Wire `load_pause` through `/api/archive/status`

Follow-up to PR #93. Discovered during deploy verification on cybertruckusb.local.

### What was missing

PR #93 added a `load_pause` block to `archive_worker.get_status()` for SDIO-contention observability — paused_until_epoch / is_paused_now / last_pause_at / last_loadavg, parity with `disk_pause`. But the `/api/archive/status` blueprint route hand-picks fields from the worker snapshot, and the new field was silently dropped.

### Evidence from production

Journal on cybertruckusb.local after deploying #93 (load oscillating 2.81 ↔ 4.03 around 3.50 threshold):

  
13:58:57  loadavg 2.81 back below 3.50 — resuming archive drain
13:59:44  loadavg 3.65 > 3.50 — pausing 30s to relieve SDIO/CPU contention
14:00:14  loadavg 3.38 back below 3.50 — resuming archive drain
14:00:29  loadavg 3.99 > 3.50 — pausing 30s to relieve SDIO/CPU contention
... etc, one log per transition, no spam ...
  

Worker behavior is exactly right. But `/api/archive/status` only carried `disk_pause`, not `load_pause` — the UI couldn't render the "load-paused" indicator that PR #93 was supposed to enable.

### Fix

One block addition in the blueprint, mirroring the existing `disk_pause` pass-through with the same defensive default shape (4 keys) so a worker that isn't returning the block doesn't break the route.

### Tests

- `REQUIRED_FIELDS` shape contract extended with `load_pause` (existing `test_status_payload_includes_all_expected_fields` now enforces it).
- New `test_status_includes_load_pause_block` regression-pins the inner shape (4 keys present).

699 passed, 3 skipped (was 698, +1 new test).
