### PR TITLE
fix(#91): add _retention_running guard so concurrent prune_now returns fast

### DIFF
--- a/scripts/web/blueprints/archive_queue.py
+++ b/scripts/web/blueprints/archive_queue.py
@@ -230,6 +230,16 @@ def archive_prune_now():
     except Exception as e:  # noqa: BLE001
         logger.exception("archive_prune_now failed")
         return jsonify({'started': False, 'message': str(e)}), 500
+    # Issue #91: when a prune is already in flight (Settings click +
+    # watchdog tick + disk-critical cleanup race), surface a clear
+    # "already running" status instead of a misleading "0 files
+    # removed" success toast.
+    if summary.get('status') == 'already_running':
+        return jsonify({
+            'started': False,
+            'status': 'already_running',
+            'message': 'A retention prune is already in progress.',
+        }), 200
     return jsonify({
         'started': True,
         'deleted_count': int(summary.get('deleted_count', 0)),

--- a/scripts/web/services/archive_watchdog.py
+++ b/scripts/web/services/archive_watchdog.py
@@ -137,6 +137,17 @@ _retention_state: Dict[str, Any] = {
     'next_prune_due_at': None,    # epoch seconds
 }
 
+# Issue #91 duplicate-trigger guard. Set to True at the start of any
+# in-flight ``_run_retention_prune`` call, cleared in the outer
+# ``finally``. A second concurrent caller (e.g. Settings UI "Prune now"
+# landing while the watchdog tick is mid-walk, or a debounce-bypassed
+# disk-critical cleanup spawning a daemon thread that races the UI
+# click) sees the flag set and short-circuits with
+# ``status='already_running'`` instead of block-waiting up to 60 s on
+# ``task_coordinator.acquire_task('retention', wait_seconds=60.0)``.
+# Always read/written under ``_state_lock``.
+_retention_running: bool = False
+
 
 # ---------------------------------------------------------------------------
 # Public lifecycle API
@@ -663,7 +674,14 @@ def _run_retention_prune(archive_root: str, db_path: str,
     Holds the ``task_coordinator`` 'retention' slot for the duration so
     the archive worker yields cleanly. Releases the slot before
     returning.
+
+    Issue #91: a module-level ``_retention_running`` flag short-circuits
+    a second concurrent call so a stacked Settings UI click + watchdog
+    tick + disk-critical cleanup can't pile up 60-second waits on the
+    ``task_coordinator`` 'retention' slot. Short-circuited callers get
+    a summary with ``status='already_running'``.
     """
+    global _retention_running
     started = time.time()
     cutoff = started - (max(int(retention_days), 1) * 86400)
     cutoff_iso = datetime.fromtimestamp(cutoff, tz=timezone.utc).isoformat()
@@ -686,47 +704,69 @@ def _run_retention_prune(archive_root: str, db_path: str,
         summary['duration_seconds'] = round(time.time() - started, 3)
         return summary
 
-    acquired = task_coordinator.acquire_task(
-        _RETENTION_COORDINATOR_TASK,
-        wait_seconds=_RETENTION_COORDINATOR_WAIT_SECONDS,
-    )
-    if not acquired:
-        logger.info(
-            "archive_retention: skipped — could not acquire 'retention' "
-            "task slot within %.1fs",
-            _RETENTION_COORDINATOR_WAIT_SECONDS,
-        )
-        summary['duration_seconds'] = round(time.time() - started, 3)
-        return summary
+    # Issue #91 — duplicate-trigger guard. Atomic check-and-set so two
+    # concurrent callers can't both pass. The flag MUST be set before
+    # ``acquire_task`` (which can block 60 s); otherwise the second
+    # caller would still queue on the lock.
+    with _state_lock:
+        if _retention_running:
+            summary['status'] = 'already_running'
+            summary['duration_seconds'] = round(time.time() - started, 3)
+            logger.info(
+                "archive_retention: skipped — another prune is already "
+                "in flight (returning status='already_running')"
+            )
+            return summary
+        _retention_running = True
 
     try:
-        for path, mtime, _size in _iter_archive_mp4_files(archive_root):
-            summary['scanned'] += 1
-            if mtime > cutoff:
-                continue
-            age_days = (time.time() - mtime) / 86400.0
-            if enforce_cloud_check:
-                if not _is_synced_to_cloud(path, archive_root, cloud_db_path):
-                    summary['kept_unsynced_count'] += 1
-                    logger.warning(
-                        "archive_retention: KEPT %s past retention "
-                        "(age=%.1f days) — not yet synced to cloud",
-                        path, age_days,
-                    )
+        acquired = task_coordinator.acquire_task(
+            _RETENTION_COORDINATOR_TASK,
+            wait_seconds=_RETENTION_COORDINATOR_WAIT_SECONDS,
+        )
+        if not acquired:
+            logger.info(
+                "archive_retention: skipped — could not acquire 'retention' "
+                "task slot within %.1fs",
+                _RETENTION_COORDINATOR_WAIT_SECONDS,
+            )
+            summary['duration_seconds'] = round(time.time() - started, 3)
+            return summary
+
+        try:
+            for path, mtime, _size in _iter_archive_mp4_files(archive_root):
+                summary['scanned'] += 1
+                if mtime > cutoff:
                     continue
-            freed = _delete_one_mp4(path, db_path)
-            if freed > 0 or not os.path.exists(path):
-                summary['deleted_count'] += 1
-                summary['freed_bytes'] += freed
-                logger.info(
-                    "archive_retention: removed %s (age=%.1f days, "
-                    "freed=%d bytes)",
-                    path, age_days, freed,
-                )
+                age_days = (time.time() - mtime) / 86400.0
+                if enforce_cloud_check:
+                    if not _is_synced_to_cloud(path, archive_root, cloud_db_path):
+                        summary['kept_unsynced_count'] += 1
+                        logger.warning(
+                            "archive_retention: KEPT %s past retention "
+                            "(age=%.1f days) — not yet synced to cloud",
+                            path, age_days,
+                        )
+                        continue
+                freed = _delete_one_mp4(path, db_path)
+                if freed > 0 or not os.path.exists(path):
+                    summary['deleted_count'] += 1
+                    summary['freed_bytes'] += freed
+                    logger.info(
+                        "archive_retention: removed %s (age=%.1f days, "
+                        "freed=%d bytes)",
+                        path, age_days, freed,
+                    )
+        finally:
+            # Release BEFORE any further sleep / outside callers.
+            task_coordinator.release_task(_RETENTION_COORDINATOR_TASK)
+            summary['duration_seconds'] = round(time.time() - started, 3)
     finally:
-        # Release BEFORE any further sleep / outside callers.
-        task_coordinator.release_task(_RETENTION_COORDINATOR_TASK)
-        summary['duration_seconds'] = round(time.time() - started, 3)
+        # Always clear the duplicate-trigger guard, even on exception
+        # or short-circuited acquire_task. Otherwise a single failed
+        # prune would lock out every subsequent attempt.
+        with _state_lock:
+            _retention_running = False
 
     if summary['kept_unsynced_count'] > 0:
         logger.info(
@@ -759,6 +799,13 @@ def force_prune_now() -> Dict[str, Any]:
         }
     retention_days = _resolve_retention_days()
     summary = _run_retention_prune(archive_root, db_path, retention_days)
+    # Issue #91: when short-circuited because another prune is already
+    # running, do NOT touch ``_retention_state`` — overwriting the
+    # in-flight first run's eventual results with zeros would corrupt
+    # the Settings panel's "last prune" display. Caller (the blueprint)
+    # propagates the ``status`` field to the front end.
+    if summary.get('status') == 'already_running':
+        return summary
     # Update bookkeeping so the Settings panel reflects the manual run.
     with _state_lock:
         _retention_state['last_prune_at'] = _iso_now()
@@ -791,6 +838,15 @@ def _maybe_run_retention(archive_root: str, db_path: str) -> None:
     retention_days = _resolve_retention_days()
     try:
         summary = _run_retention_prune(archive_root, db_path, retention_days)
+        # Issue #91: when short-circuited because another prune is in
+        # flight (e.g. a concurrent UI ``Prune now`` click), don't
+        # update bookkeeping or advance ``next_prune_due_at``. The
+        # in-flight prune will update both when it completes; we just
+        # need to retry the tick promptly (the watchdog loops every
+        # ``check_interval`` seconds anyway, and the in-flight run's
+        # completion will reset ``next_prune_due_at`` to "now + 24h").
+        if summary.get('status') == 'already_running':
+            return
         with _state_lock:
             _retention_state['last_prune_at'] = _iso_now()
             _retention_state['last_prune_deleted'] = int(

--- a/scripts/web/templates/index.html
+++ b/scripts/web/templates/index.html
@@ -1180,6 +1180,13 @@ if (document.getElementById('fsck-status-container')) {
                             'Prune complete: ' +
                             (data.deleted_count || 0) + ' files removed.',
                             'success');
+                    } else if (r.ok && data.status === 'already_running') {
+                        // Issue #91: another prune (watchdog tick or
+                        // disk-critical cleanup) is in flight.
+                        showToast(
+                            data.message ||
+                            'A retention prune is already running.',
+                            'info');
                     } else {
                         showToast(
                             data.message || 'Prune failed.', 'error');

--- a/tests/test_archive_watchdog.py
+++ b/tests/test_archive_watchdog.py
@@ -83,6 +83,10 @@ def _reset_module_state():
         'last_prune_error': None,
         'next_prune_due_at': None,
     }
+    # Issue #91 — reset duplicate-trigger guard so a test that
+    # exercises the short-circuit path doesn't leak the True flag
+    # into the next test.
+    archive_watchdog._retention_running = False
     yield
     archive_watchdog.stop_watchdog(timeout=5.0)
     archive_worker.stop_worker(timeout=5.0)
@@ -91,6 +95,7 @@ def _reset_module_state():
         task_coordinator._current_task = None
         task_coordinator._task_started = 0.0
         task_coordinator._waiter_count = 0
+    archive_watchdog._retention_running = False
 
 
 # ---------------------------------------------------------------------------
@@ -1102,3 +1107,252 @@ class TestResolveDeleteUnsynced:
             archive_watchdog, '_is_cloud_configured', lambda: False,
         )
         assert archive_watchdog._resolve_delete_unsynced() is False
+
+
+# ---------------------------------------------------------------------------
+# Issue #91 — duplicate-trigger guard for retention prune
+# ---------------------------------------------------------------------------
+
+
+class TestRetentionRunningGuard:
+    """Issue #91: a second concurrent caller of ``_run_retention_prune``
+    (e.g. Settings UI ``Prune now`` click landing while the watchdog
+    tick is mid-walk, OR ``archive_worker._maybe_trigger_critical_cleanup``
+    spawns a daemon thread that races a UI click) must NOT block the
+    request thread for up to 60 s on
+    ``task_coordinator.acquire_task('retention', wait_seconds=60.0)``.
+
+    The fix is a module-level ``_retention_running`` boolean flag set
+    BEFORE ``acquire_task`` and cleared in the outer ``finally``. A
+    second caller sees the flag and short-circuits with a summary
+    carrying ``status='already_running'``.
+    """
+
+    def test_short_circuit_returns_already_running_status(
+        self, db, archive_root, monkeypatch,
+    ):
+        # Pre-set the flag to simulate an in-flight prune.
+        archive_watchdog._retention_running = True
+
+        # Spy on task_coordinator.acquire_task — the short-circuit
+        # MUST happen BEFORE we touch the coordinator. If the spy is
+        # called, the guard is broken.
+        called = []
+
+        def spy_acquire(*a, **kw):
+            called.append((a, kw))
+            return True
+
+        monkeypatch.setattr(
+            archive_watchdog.task_coordinator, 'acquire_task', spy_acquire,
+        )
+
+        summary = archive_watchdog._run_retention_prune(
+            archive_root, db, retention_days=30,
+        )
+
+        assert summary.get('status') == 'already_running', (
+            "When _retention_running is True, the function must return "
+            "a summary with status='already_running'."
+        )
+        assert called == [], (
+            "Short-circuited callers must NOT call task_coordinator."
+            "acquire_task — that's the whole point of the guard."
+        )
+        assert summary['deleted_count'] == 0
+        assert summary['scanned'] == 0
+        # Flag must remain True — we faked the in-flight prune; the
+        # real one (which set it) is still expected to clear it.
+        assert archive_watchdog._retention_running is True
+
+    def test_flag_cleared_on_normal_completion(
+        self, db, archive_root, monkeypatch,
+    ):
+        old = time.time() - (60 * 86400)
+        _make_archive_mp4(archive_root, "RecentClips/old.mp4", mtime=old)
+        # Sanity: flag starts False.
+        assert archive_watchdog._retention_running is False
+        archive_watchdog._run_retention_prune(
+            archive_root, db, retention_days=30,
+        )
+        assert archive_watchdog._retention_running is False, (
+            "Flag must be cleared after a normal run so the next "
+            "caller can proceed."
+        )
+
+    def test_flag_cleared_on_exception(
+        self, db, archive_root, monkeypatch,
+    ):
+        old = time.time() - (60 * 86400)
+        _make_archive_mp4(archive_root, "RecentClips/old.mp4", mtime=old)
+
+        def boom(*a, **kw):
+            raise RuntimeError("synthetic walk failure")
+
+        monkeypatch.setattr(
+            archive_watchdog, '_iter_archive_mp4_files', boom,
+        )
+        with pytest.raises(RuntimeError, match="synthetic"):
+            archive_watchdog._run_retention_prune(
+                archive_root, db, retention_days=30,
+            )
+        assert archive_watchdog._retention_running is False, (
+            "Flag must be released even when the walk raises — "
+            "otherwise a single failed prune would lock out every "
+            "subsequent attempt forever."
+        )
+
+    def test_flag_cleared_when_acquire_task_fails(
+        self, db, archive_root, monkeypatch,
+    ):
+        # acquire_task returns False (e.g. another heavy task is
+        # holding the slot) — the function returns without doing
+        # work, but MUST still clear the flag.
+        monkeypatch.setattr(
+            archive_watchdog.task_coordinator, 'acquire_task',
+            lambda *a, **kw: False,
+        )
+        # release_task should NOT be called when acquire_task returned
+        # False — guard against a regression that calls release on a
+        # slot we never acquired.
+        released = []
+        monkeypatch.setattr(
+            archive_watchdog.task_coordinator, 'release_task',
+            lambda name: released.append(name),
+        )
+        summary = archive_watchdog._run_retention_prune(
+            archive_root, db, retention_days=30,
+        )
+        assert summary['scanned'] == 0
+        assert summary['deleted_count'] == 0
+        # Flag must be cleared so the next call can try again.
+        assert archive_watchdog._retention_running is False
+        # And release_task must NOT have been called for a slot we
+        # never held.
+        assert released == [], (
+            f"release_task called for {released!r} despite "
+            f"acquire_task returning False"
+        )
+
+    def test_force_prune_now_returns_status_when_short_circuited(
+        self, db, archive_root, monkeypatch,
+    ):
+        archive_watchdog._db_path = db
+        archive_watchdog._archive_root = archive_root
+        archive_watchdog._retention_running = True
+        # Snapshot bookkeeping so we can prove it's not overwritten.
+        snap_before = dict(archive_watchdog._retention_state)
+
+        summary = archive_watchdog.force_prune_now()
+        assert summary.get('status') == 'already_running'
+
+        # CRITICAL: bookkeeping must NOT be touched on short-circuit —
+        # otherwise the in-flight first run's eventual results would
+        # be silently overwritten with zeros.
+        snap_after = dict(archive_watchdog._retention_state)
+        assert snap_after == snap_before, (
+            f"_retention_state was mutated on short-circuit: "
+            f"{snap_before!r} -> {snap_after!r}. "
+            f"Bookkeeping updates must be skipped when "
+            f"status='already_running'."
+        )
+
+    def test_maybe_run_retention_skips_bookkeeping_on_short_circuit(
+        self, db, archive_root, monkeypatch,
+    ):
+        # Make the watchdog tick think the prune is due.
+        archive_watchdog._retention_state['next_prune_due_at'] = (
+            time.time() - 1.0
+        )
+        archive_watchdog._retention_running = True
+        snap_before = dict(archive_watchdog._retention_state)
+
+        archive_watchdog._maybe_run_retention(archive_root, db)
+
+        snap_after = dict(archive_watchdog._retention_state)
+        assert snap_after == snap_before, (
+            "Watchdog tick must not advance next_prune_due_at or "
+            "touch any other bookkeeping when the prune was "
+            "short-circuited; otherwise the in-flight prune's "
+            "eventual results would be lost."
+        )
+
+    def test_two_sequential_calls_both_succeed(
+        self, db, archive_root, monkeypatch,
+    ):
+        """Sanity: the guard does not break repeat-after-completion."""
+        old = time.time() - (60 * 86400)
+        _make_archive_mp4(archive_root, "RecentClips/a.mp4", mtime=old)
+        s1 = archive_watchdog._run_retention_prune(
+            archive_root, db, retention_days=30,
+        )
+        assert s1['deleted_count'] == 1
+        assert 'status' not in s1
+
+        # Second sequential call (after the first cleared the flag)
+        # must run normally — not be falsely treated as a duplicate.
+        _make_archive_mp4(archive_root, "RecentClips/b.mp4", mtime=old)
+        s2 = archive_watchdog._run_retention_prune(
+            archive_root, db, retention_days=30,
+        )
+        assert s2['deleted_count'] == 1
+        assert 'status' not in s2
+
+    def test_concurrent_threaded_call_short_circuits(
+        self, db, archive_root, monkeypatch,
+    ):
+        """Two real threads — verify only one runs the walk and the
+        other observes ``status='already_running'``."""
+        import threading
+        old = time.time() - (60 * 86400)
+        # 5 files so the first walk takes a measurable moment.
+        for i in range(5):
+            _make_archive_mp4(
+                archive_root, f"RecentClips/x{i}.mp4", mtime=old,
+            )
+
+        # Slow down the walk so the second caller is guaranteed to
+        # arrive while the first is in-flight.
+        gate = threading.Event()
+        original_iter = archive_watchdog._iter_archive_mp4_files
+
+        def slow_iter(root):
+            for item in original_iter(root):
+                gate.wait(timeout=2.0)
+                yield item
+
+        monkeypatch.setattr(
+            archive_watchdog, '_iter_archive_mp4_files', slow_iter,
+        )
+
+        results = {}
+
+        def runner(key):
+            results[key] = archive_watchdog._run_retention_prune(
+                archive_root, db, retention_days=30,
+            )
+
+        t1 = threading.Thread(target=runner, args=('first',), daemon=True)
+        t1.start()
+        # Give t1 a moment to set the flag and enter the walk.
+        time.sleep(0.05)
+        t2 = threading.Thread(target=runner, args=('second',), daemon=True)
+        t2.start()
+        # Second call should short-circuit immediately (no acquire_task
+        # wait, no walk).
+        t2.join(timeout=2.0)
+        assert not t2.is_alive(), (
+            "Second concurrent caller must short-circuit immediately, "
+            "not block on the lock or the walk."
+        )
+        # Now release the gate so t1 can finish.
+        gate.set()
+        t1.join(timeout=10.0)
+        assert not t1.is_alive()
+
+        assert results['second'].get('status') == 'already_running'
+        # First caller did the actual work.
+        assert results['first'].get('status') != 'already_running'
+        assert results['first']['deleted_count'] == 5
+        # Flag must be cleared after the first finishes.
+        assert archive_watchdog._retention_running is False


### PR DESCRIPTION
## Summary

Closes #91 — `archive_watchdog`: add `_retention_pending` guard so concurrent `force_prune_now` returns fast.

A second concurrent caller of `force_prune_now()` (Settings UI **Prune now** click landing while the watchdog tick or `archive_worker._maybe_trigger_critical_cleanup` is already running a prune) was blocking the request thread for up to 60 seconds on `task_coordinator.acquire_task('retention', wait_seconds=60.0)`.

## Three concurrent paths into `_run_retention_prune`

1. `force_prune_now()` from `POST /api/archive/prune_now` (Settings UI button).
2. `_maybe_run_retention()` from the watchdog tick (~once/day after jitter).
3. `archive_worker._maybe_trigger_critical_cleanup()` spawns a daemon thread that calls `force_prune_now()` when disk space crosses the critical threshold.

The race is narrow but real: a network blip + duplicate UI click + simultaneous watchdog/critical-cleanup trigger all aligning is enough to block the request thread.

## Fix

Module-level `_retention_running` boolean guard (Option 1 from the issue):

- **`_run_retention_prune`** atomically check-and-sets the flag under `_state_lock` **before** `acquire_task`. If already True, returns `summary['status'] = 'already_running'` immediately (microseconds, no lock wait).
- **Outer `try/finally`** always clears the flag — even on exceptions or `acquire_task` failure, so a single failed prune cannot lock out every subsequent attempt.
- **`force_prune_now`** and **`_maybe_run_retention`** skip bookkeeping/state updates when `status='already_running'` — avoids overwriting the in-flight first run's eventual results with zeros from a short-circuited concurrent call.
- **Blueprint** propagates the new status: returns `{'started': false, 'status': 'already_running', 'message': '…'}` with HTTP 200 (the watchdog IS running, the prune is just busy).
- **Settings JS** shows an info-level "A retention prune is already running." toast instead of a misleading "Prune complete: 0 files removed." success.

## Files changed

| File | Change |
|------|--------|
| `scripts/web/services/archive_watchdog.py` | Added `_retention_running` flag + outer `try/finally`; `force_prune_now` and `_maybe_run_retention` skip bookkeeping on short-circuit. |
| `scripts/web/blueprints/archive_queue.py` | `POST /api/archive/prune_now` surfaces `status='already_running'` as HTTP 200. |
| `scripts/web/templates/index.html` | Settings JS handles the new status with an info toast. |
| `tests/test_archive_watchdog.py` | New `TestRetentionRunningGuard` class (8 tests); `_reset_module_state()` resets the flag. |

## Acceptance criteria (from issue #91)

- ✅ Concurrent `force_prune_now()` while a watchdog-driven prune is in-flight returns immediately (no 60-second block) with a clear status (`status='already_running'`, message in body).
- ✅ Existing `test_force_prune_now_*` tests still pass — verified, all 50 prior watchdog tests green.
- ✅ New regression test (`test_concurrent_threaded_call_short_circuits`) simulates two simultaneous `_run_retention_prune` calls in real threads and asserts the second one short-circuits without acquiring the lock or running the walk.

## Test results

- Full suite: **747 passed, 3 skipped** (8 new tests added).
- App import smoke test: passes (`from web_control import app`).
- Syntax checks: pass on both modified Python files.

## Safety

- ✅ Boot path / `present_usb.sh` / USB gadget binding **untouched**.
- ✅ No mount/umount/loop-device operations introduced or modified.
- ✅ No new config values; uses the existing `_state_lock`.
- ✅ Lock held only for the microsecond-scale check-and-set + clear — no long critical sections.
- ✅ Flag release tested on every error path: normal completion, walk exception, `acquire_task` failure, and `release_task` is NOT called for a slot we never held.

## Verification on Pi (post-merge)

After `git pull` + `sudo systemctl restart gadget_web.service`:

1. Click Settings → Storage → **Prune now** rapidly twice. Either click should now return promptly; if the first is still in flight, the second shows the new info toast immediately.
2. Trigger a disk-critical condition while a manual prune is running (rare; only relevant if disk is near full). The `_maybe_trigger_critical_cleanup` daemon thread should log "skipped — another prune is already in flight" instead of stacking 60-s waits.
3. `journalctl -u gadget_web.service -f` should show the new INFO line `archive_retention: skipped — another prune is already in flight (returning status='already_running')` for short-circuited callers.
