### PR TITLE
Fix false 'Video file not found' toast on map video overlay close

### DIFF
--- a/scripts/web/templates/mapping.html
+++ b/scripts/web/templates/mapping.html
@@ -2631,9 +2631,15 @@ function openVideoOverlay(waypoint, clickPoint, routeWps) {
     const video = document.getElementById('overlayVideo');
     video.src = `/videos/stream/${waypoint.video_path}`;
 
-    // Handle video load error — file may no longer exist on disk
+    // Handle video load error — file may no longer exist on disk.
+    // NOTE: check the raw src ATTRIBUTE, not the .src property. The property
+    // resolves an empty/missing attribute against the document base URL
+    // (e.g. https://host/mapping), which is non-empty and would slip past a
+    // .src-based guard, surfacing a false "video not found" toast when the
+    // overlay is closed or the element is detached mid-load.
     video.addEventListener('error', function onError() {
-        if (!video.src || video.src.endsWith('/')) return;
+        const rawSrc = video.getAttribute('src');
+        if (!rawSrc) return;
         if (typeof showToast === 'function') {
             showToast('Video file not found — Tesla may have overwritten it.', 'warning');
         }
@@ -2945,7 +2951,15 @@ function closeVideoOverlay() {
         const video = existing.querySelector('video');
         if (video) {
             video.removeEventListener('timeupdate', onOverlayTimeUpdate);
-            video.pause(); video.src = '';
+            video.pause();
+            // Properly abort any pending load. Setting src='' resolves to
+            // the document base URL (e.g. https://host/mapping) and the
+            // browser then tries to load THAT as a video, fails, and fires
+            // a spurious 'error' event that surfaced a false "video file
+            // not found" toast every time the overlay was closed. The HTML5
+            // standard reset is removeAttribute('src') + load().
+            video.removeAttribute('src');
+            video.load();
         }
         existing.remove();
     }


### PR DESCRIPTION
## Problem

When closing the map video overlay (clicking the ✕ button or otherwise dismissing it), users always saw a `Video file not found — Tesla may have overwritten it.` toast — even though the file existed and had just played without issue.

## Root Cause

`closeVideoOverlay()` cleared the source with `video.src = ''`. Per the HTML spec, assigning the empty string to `src` resolves the URL against the document base, so `video.src` becomes the page URL itself (e.g. `https://cybertruckusb.local/mapping`). The browser then tries to load THAT page as a video, fails, and fires an `error` event.

The error handler's guard read the **resolved** `video.src` property — now non-empty (the page URL) — so the guard slipped past and the toast fired on every close.

```js
// Before — bug
video.pause(); video.src = '';            // → triggers spurious 'error' event

// And the error guard:
if (!video.src || video.src.endsWith('/')) return;  // .src is the page URL → guard misses
```

## Fix

**1.** `closeVideoOverlay()` now uses the HTML5-standard reset that properly aborts a pending load without firing an error event:

```js
video.pause();
video.removeAttribute('src');
video.load();
```

**2.** Defense-in-depth — the error handler now reads the **raw attribute** via `getAttribute('src')` (which is truly empty when unset) instead of the resolved `.src` property, so any future detach-mid-load condition can't surface a false toast either.

## Files Changed

- `scripts/web/templates/mapping.html` — `closeVideoOverlay()` and the error-listener guard inside `openVideoOverlay()`.

## Testing

- Verified the new toast appears only on a genuine 404 (manually streamed a known-deleted clip).
- Verified normal play → close cycle no longer shows a toast.
- Camera switching and clip navigation paths unaffected (they assign a real URL to `src` rather than clearing it).
- Deployed to live Pi (`cybertruckusb.local`); HTTP 200 after restart, behavior confirmed.

## Risk

Very low. Single-template change, scoped to the overlay close path. No backend, no schema, no service-config changes. Standard HTML5 media reset pattern.
