### PR TITLE
Phase 2.1: Single safe-delete doorway for archived videos (closes p2-1 of #97)

### DIFF
--- a/scripts/web/blueprints/videos.py
+++ b/scripts/web/blueprints/videos.py
@@ -474,20 +474,30 @@ def delete_event(folder, event_name):
 
     try:
         if folder_structure == 'flat':
-            # RecentClips: Delete all videos matching the session timestamp
-            from services.file_safety import is_protected_file
+            # RecentClips / ArchivedClips: delete all videos matching the
+            # session timestamp. ArchivedClips lives on the SD card and IS
+            # an archived video — route through the single Phase 2.1 doorway
+            # so the protected-file guard cannot be bypassed. RecentClips is
+            # on the read-only USB mount in present mode, but we still go
+            # through the helper for uniformity and so the IMG-protection
+            # contract is enforced everywhere.
+            from services.file_safety import (
+                safe_delete_archive_video, DeleteOutcome,
+            )
             session_videos = get_session_videos(folder_path, event_name)
             for video in session_videos:
-                try:
-                    if is_protected_file(video['path']):
-                        logger.error("BLOCKED deletion of protected file: %s", video['path'])
-                        error_count += 1
-                        continue
-                    os.remove(video['path'])
+                result = safe_delete_archive_video(video['path'])
+                if result.outcome is DeleteOutcome.DELETED:
                     deleted_count += 1
                     deleted_files.append(video['name'])
-                except OSError as e:
-                    logger.error(f"Failed to delete {video['path']}: {e}")
+                elif result.outcome is DeleteOutcome.PROTECTED:
+                    # Helper already logged the BLOCKED warning.
+                    error_count += 1
+                else:
+                    logger.error(
+                        "Failed to delete %s: %s",
+                        video['path'], result.outcome.value,
+                    )
                     error_count += 1
         else:
             # SavedClips/SentryClips: Delete the entire event folder

--- a/scripts/web/services/archive_watchdog.py
+++ b/scripts/web/services/archive_watchdog.py
@@ -633,10 +633,13 @@ def _delete_one_mp4(path: str, db_path: str) -> int:
     Routes the actual delete through
     :func:`services.file_safety.safe_delete_archive_video` — the single
     doorway that enforces the protected-file guard (Phase 2.1).
+    Geodata is reconciled only when the helper reports
+    :data:`DeleteOutcome.DELETED` (so a 0-byte clip that was actually
+    removed is still reconciled even though ``bytes_freed`` is 0).
     """
-    from services.file_safety import safe_delete_archive_video
-    freed = safe_delete_archive_video(path)
-    if freed == 0:
+    from services.file_safety import safe_delete_archive_video, DeleteOutcome
+    result = safe_delete_archive_video(path)
+    if result.outcome is not DeleteOutcome.DELETED:
         return 0
     # Reconcile geodata (best-effort — failure here doesn't undo the delete).
     try:
@@ -647,7 +650,7 @@ def _delete_one_mp4(path: str, db_path: str) -> int:
             "archive_retention: purge_deleted_videos failed for %s: %s",
             path, e,
         )
-    return freed
+    return result.bytes_freed
 
 
 def _run_retention_prune(archive_root: str, db_path: str,

--- a/scripts/web/services/archive_watchdog.py
+++ b/scripts/web/services/archive_watchdog.py
@@ -629,17 +629,14 @@ def _delete_one_mp4(path: str, db_path: str) -> int:
     indexed_files row WITHOUT touching trips/waypoints/events. See the
     docstring on ``purge_deleted_videos`` for why that contract is
     load-bearing.
+
+    Routes the actual delete through
+    :func:`services.file_safety.safe_delete_archive_video` — the single
+    doorway that enforces the protected-file guard (Phase 2.1).
     """
-    try:
-        size = os.path.getsize(path)
-    except OSError:
-        size = 0
-    try:
-        os.remove(path)
-    except OSError as e:
-        logger.warning(
-            "archive_retention: failed to remove %s: %s", path, e,
-        )
+    from services.file_safety import safe_delete_archive_video
+    freed = safe_delete_archive_video(path)
+    if freed == 0:
         return 0
     # Reconcile geodata (best-effort — failure here doesn't undo the delete).
     try:
@@ -650,7 +647,7 @@ def _delete_one_mp4(path: str, db_path: str) -> int:
             "archive_retention: purge_deleted_videos failed for %s: %s",
             path, e,
         )
-    return int(size)
+    return freed
 
 
 def _run_retention_prune(archive_root: str, db_path: str,

--- a/scripts/web/services/cleanup_service.py
+++ b/scripts/web/services/cleanup_service.py
@@ -418,17 +418,22 @@ class CleanupService:
         for video in cleanup_plan['files']:
             try:
                 if not dry_run:
-                    from services.file_safety import safe_delete_archive_video
-                    freed = safe_delete_archive_video(video['path'])
-                    if freed == 0:
-                        # Either protected (already logged) or missing/failed.
-                        # Distinguish for the user-facing error list.
-                        from services.file_safety import is_protected_file
-                        if is_protected_file(video['path']):
-                            errors.append(f"BLOCKED: {video['path']} is a protected file")
-                        else:
-                            errors.append(f"Skipped (missing or unwritable): {video['path']}")
+                    from services.file_safety import (
+                        safe_delete_archive_video, DeleteOutcome,
+                    )
+                    result = safe_delete_archive_video(video['path'])
+                    if result.outcome is DeleteOutcome.PROTECTED:
+                        # Helper already logged the BLOCKED warning;
+                        # surface the user-facing reason.
+                        errors.append(f"BLOCKED: {video['path']} is a protected file")
                         continue
+                    if result.outcome is DeleteOutcome.MISSING:
+                        errors.append(f"Skipped (missing): {video['path']}")
+                        continue
+                    if result.outcome is DeleteOutcome.ERROR:
+                        errors.append(f"Skipped (unwritable): {video['path']}")
+                        continue
+                    # outcome is DELETED
                     logger.info(f"Deleted: {video['path']}")
                 else:
                     logger.info(f"[DRY RUN] Would delete: {video['path']}")

--- a/scripts/web/services/cleanup_service.py
+++ b/scripts/web/services/cleanup_service.py
@@ -418,11 +418,17 @@ class CleanupService:
         for video in cleanup_plan['files']:
             try:
                 if not dry_run:
-                    from services.file_safety import is_protected_file
-                    if is_protected_file(video['path']):
-                        errors.append(f"BLOCKED: {video['path']} is a protected file")
+                    from services.file_safety import safe_delete_archive_video
+                    freed = safe_delete_archive_video(video['path'])
+                    if freed == 0:
+                        # Either protected (already logged) or missing/failed.
+                        # Distinguish for the user-facing error list.
+                        from services.file_safety import is_protected_file
+                        if is_protected_file(video['path']):
+                            errors.append(f"BLOCKED: {video['path']} is a protected file")
+                        else:
+                            errors.append(f"Skipped (missing or unwritable): {video['path']}")
                         continue
-                    os.remove(video['path'])
                     logger.info(f"Deleted: {video['path']}")
                 else:
                     logger.info(f"[DRY RUN] Would delete: {video['path']}")

--- a/scripts/web/services/file_safety.py
+++ b/scripts/web/services/file_safety.py
@@ -79,6 +79,58 @@ def safe_remove(path: str) -> bool:
         return False
 
 
+def safe_delete_archive_video(path: str) -> int:
+    """The single doorway for deleting an archived video file.
+
+    Every code path in TeslaUSB that deletes a clip from the local archive
+    (retention prune, size trim, free-space trim, corrupt-file purge,
+    non-driving prune, watchdog retention, manual cleanup) MUST go through
+    this function. Calling ``os.remove`` / ``os.unlink`` directly on
+    archive files is a contract violation — past data-loss incidents were
+    caused by a delete path that bypassed the protected-file check.
+
+    The helper:
+
+    * Refuses to delete any file flagged by :func:`is_protected_file`
+      (currently: ``*.img`` files inside ``GADGET_DIR``).
+    * Reads the file size BEFORE removing so the caller can update its
+      bytes-freed accounting.
+    * Swallows ``OSError`` (including FileNotFoundError) and returns 0
+      so loops over many candidate files don't blow up on transient races.
+
+    Geodata reconciliation (``mapping_service.purge_deleted_videos``) is
+    intentionally NOT done here — it would create a circular-import risk
+    and the May 7 contract requires the caller to control which rows get
+    NULL'd. Callers that hold a list of successfully-deleted paths should
+    call ``purge_deleted_videos`` themselves after the loop finishes.
+
+    Args:
+        path: Absolute path to the archived video to delete.
+
+    Returns:
+        Byte count of the deleted file, or 0 if the file was protected,
+        missing, or removal failed for any other reason. A ``> 0`` return
+        means the file was definitively removed from disk.
+    """
+    if is_protected_file(path):
+        return 0
+    try:
+        size = os.path.getsize(path)
+    except OSError:
+        # Missing or stat failure — nothing to delete.
+        return 0
+    try:
+        os.remove(path)
+    except FileNotFoundError:
+        return 0
+    except OSError as e:
+        logger.warning(
+            "safe_delete_archive_video: failed to remove %s: %s", path, e,
+        )
+        return 0
+    return int(size)
+
+
 def safe_rmtree(path: str) -> bool:
     """Remove a directory tree only if it contains no protected files.
 

--- a/scripts/web/services/file_safety.py
+++ b/scripts/web/services/file_safety.py
@@ -9,6 +9,8 @@ Every code path that deletes files MUST call is_protected_file() first.
 
 import logging
 import os
+from enum import Enum
+from typing import NamedTuple
 
 logger = logging.getLogger(__name__)
 
@@ -79,56 +81,96 @@ def safe_remove(path: str) -> bool:
         return False
 
 
-def safe_delete_archive_video(path: str) -> int:
+class DeleteOutcome(Enum):
+    """Three-valued result for :func:`safe_delete_archive_video`.
+
+    Distinguishes the three semantically-different "did not delete"
+    cases so callers can react appropriately without re-probing the
+    filesystem (which would also double-log the BLOCKED warning).
+    """
+
+    DELETED = "deleted"      # File was removed from disk.
+    PROTECTED = "protected"  # is_protected_file refused (e.g. *.img).
+    MISSING = "missing"      # File didn't exist (FileNotFoundError).
+    ERROR = "error"          # Other OSError (permissions, I/O, etc.).
+
+
+class DeleteResult(NamedTuple):
+    """Outcome + bytes freed for :func:`safe_delete_archive_video`.
+
+    ``outcome`` carries the ternary state; ``bytes_freed`` is the size
+    of the deleted file (only meaningful when outcome is DELETED, but
+    will be 0 for an actually-deleted 0-byte file too — callers should
+    use ``outcome is DeleteOutcome.DELETED`` for the boolean test, not
+    ``bytes_freed > 0``).
+    """
+
+    outcome: "DeleteOutcome"
+    bytes_freed: int
+
+
+def safe_delete_archive_video(path: str) -> DeleteResult:
     """The single doorway for deleting an archived video file.
 
     Every code path in TeslaUSB that deletes a clip from the local archive
     (retention prune, size trim, free-space trim, corrupt-file purge,
-    non-driving prune, watchdog retention, manual cleanup) MUST go through
-    this function. Calling ``os.remove`` / ``os.unlink`` directly on
-    archive files is a contract violation — past data-loss incidents were
-    caused by a delete path that bypassed the protected-file check.
+    non-driving prune, watchdog retention, manual cleanup, video-panel
+    delete) MUST go through this function. Calling ``os.remove`` /
+    ``os.unlink`` directly on archive files is a contract violation —
+    past data-loss incidents were caused by a delete path that bypassed
+    the protected-file check.
 
     The helper:
 
     * Refuses to delete any file flagged by :func:`is_protected_file`
-      (currently: ``*.img`` files inside ``GADGET_DIR``).
+      (currently: ``*.img`` files inside ``GADGET_DIR``) — returns
+      ``DeleteOutcome.PROTECTED``.
     * Reads the file size BEFORE removing so the caller can update its
       bytes-freed accounting.
-    * Swallows ``OSError`` (including FileNotFoundError) and returns 0
-      so loops over many candidate files don't blow up on transient races.
+    * Returns ``DeleteOutcome.MISSING`` for ``FileNotFoundError`` so
+      loops over many candidate files don't blow up on transient races.
+    * Returns ``DeleteOutcome.ERROR`` (with a WARNING log) for other
+      ``OSError`` so callers can surface "skipped (unwritable)" without
+      re-probing the filesystem.
 
-    Geodata reconciliation (``mapping_service.purge_deleted_videos``) is
-    intentionally NOT done here — it would create a circular-import risk
-    and the May 7 contract requires the caller to control which rows get
-    NULL'd. Callers that hold a list of successfully-deleted paths should
-    call ``purge_deleted_videos`` themselves after the loop finishes.
+    Geodata reconciliation (``mapping_service.purge_deleted_videos``)
+    is intentionally NOT done here — it would create a circular-import
+    risk and the May 7 contract requires the caller to control which
+    rows get NULL'd. Callers that hold a list of
+    successfully-deleted paths should call ``purge_deleted_videos``
+    themselves after the loop finishes.
 
     Args:
         path: Absolute path to the archived video to delete.
 
     Returns:
-        Byte count of the deleted file, or 0 if the file was protected,
-        missing, or removal failed for any other reason. A ``> 0`` return
-        means the file was definitively removed from disk.
+        :class:`DeleteResult` with ``outcome`` and ``bytes_freed``.
+        ``bytes_freed`` is the file size at the moment of deletion;
+        ``0`` for any non-DELETED outcome (and also for a real 0-byte
+        delete, so use ``outcome is DeleteOutcome.DELETED`` for the
+        boolean test).
     """
     if is_protected_file(path):
-        return 0
+        return DeleteResult(DeleteOutcome.PROTECTED, 0)
     try:
         size = os.path.getsize(path)
-    except OSError:
-        # Missing or stat failure — nothing to delete.
-        return 0
+    except FileNotFoundError:
+        return DeleteResult(DeleteOutcome.MISSING, 0)
+    except OSError as e:
+        logger.warning(
+            "safe_delete_archive_video: stat failed for %s: %s", path, e,
+        )
+        return DeleteResult(DeleteOutcome.ERROR, 0)
     try:
         os.remove(path)
     except FileNotFoundError:
-        return 0
+        return DeleteResult(DeleteOutcome.MISSING, 0)
     except OSError as e:
         logger.warning(
             "safe_delete_archive_video: failed to remove %s: %s", path, e,
         )
-        return 0
-    return int(size)
+        return DeleteResult(DeleteOutcome.ERROR, 0)
+    return DeleteResult(DeleteOutcome.DELETED, int(size))
 
 
 def safe_rmtree(path: str) -> bool:

--- a/scripts/web/services/video_archive_service.py
+++ b/scripts/web/services/video_archive_service.py
@@ -381,6 +381,7 @@ def _prune_non_driving_archives() -> int:
     # Second pass: delete all clips (any camera) whose timestamp prefix
     # is marked for deletion. Side/back cams without a front-cam decision
     # are NEVER deleted here — only positive evidence drives deletion.
+    from services.file_safety import safe_delete_archive_video
     deleted = 0
     deleted_paths: List[str] = []
     for name in names:
@@ -392,12 +393,9 @@ def _prune_non_driving_archives() -> int:
         if decision.get(ts_key) is not False:
             continue
         fpath = os.path.join(ARCHIVE_DIR, name)
-        try:
-            os.unlink(fpath)
+        if safe_delete_archive_video(fpath) > 0:
             deleted += 1
             deleted_paths.append(fpath)
-        except OSError:
-            continue
 
     if deleted:
         logger.info(
@@ -520,6 +518,7 @@ def _purge_corrupt_archives() -> int:
     if not os.path.isdir(ARCHIVE_DIR):
         return 0
 
+    from services.file_safety import safe_delete_archive_video
     removed = 0
     try:
         for name in os.listdir(ARCHIVE_DIR):
@@ -529,11 +528,8 @@ def _purge_corrupt_archives() -> int:
             if not os.path.isfile(fpath):
                 continue
             if not _is_complete_mp4(fpath):
-                try:
-                    os.unlink(fpath)
+                if safe_delete_archive_video(fpath) > 0:
                     removed += 1
-                except OSError:
-                    continue
     except OSError:
         pass
 
@@ -599,6 +595,7 @@ def _enforce_retention() -> None:
 
 def _delete_files_older_than(cutoff_timestamp: float) -> List[str]:
     """Delete archived files older than the cutoff. Returns deleted paths."""
+    from services.file_safety import safe_delete_archive_video
     deleted: List[str] = []
     if not os.path.isdir(ARCHIVE_DIR):
         return deleted
@@ -610,8 +607,8 @@ def _delete_files_older_than(cutoff_timestamp: float) -> List[str]:
                 continue
             try:
                 if os.stat(fpath).st_mtime < cutoff_timestamp:
-                    os.unlink(fpath)
-                    deleted.append(fpath)
+                    if safe_delete_archive_video(fpath) > 0:
+                        deleted.append(fpath)
             except OSError:
                 continue
     except OSError:
@@ -625,18 +622,16 @@ def _delete_files_older_than(cutoff_timestamp: float) -> List[str]:
 
 def _trim_archive_to_size(max_bytes: int) -> List[str]:
     """Delete oldest files until archive is under max_bytes. Returns deleted paths."""
+    from services.file_safety import safe_delete_archive_video
     files = _get_archived_files_sorted()
     total_size = sum(s for _, s, _ in files)
     deleted: List[str] = []
 
     while total_size > max_bytes and files:
         fpath, fsize, _ = files.pop(0)  # oldest first
-        try:
-            os.unlink(fpath)
+        if safe_delete_archive_video(fpath) > 0:
             total_size -= fsize
             deleted.append(fpath)
-        except OSError:
-            continue
 
     if deleted:
         logger.info("Retention: deleted %d files to stay under %d GB",
@@ -650,6 +645,7 @@ def _trim_archive_for_free_space(min_free_bytes: int) -> List[str]:
     Returns the deleted paths so callers can do a targeted geodata
     purge instead of a full-tree scan.
     """
+    from services.file_safety import safe_delete_archive_video
     files = _get_archived_files_sorted()
     deleted: List[str] = []
 
@@ -661,11 +657,8 @@ def _trim_archive_for_free_space(min_free_bytes: int) -> List[str]:
         if usage.free >= min_free_bytes:
             break
         fpath, _, _ = files.pop(0)
-        try:
-            os.unlink(fpath)
+        if safe_delete_archive_video(fpath) > 0:
             deleted.append(fpath)
-        except OSError:
-            continue
 
     if deleted:
         logger.info("Retention: deleted %d files to maintain %d GB free",

--- a/scripts/web/services/video_archive_service.py
+++ b/scripts/web/services/video_archive_service.py
@@ -381,7 +381,7 @@ def _prune_non_driving_archives() -> int:
     # Second pass: delete all clips (any camera) whose timestamp prefix
     # is marked for deletion. Side/back cams without a front-cam decision
     # are NEVER deleted here — only positive evidence drives deletion.
-    from services.file_safety import safe_delete_archive_video
+    from services.file_safety import safe_delete_archive_video, DeleteOutcome
     deleted = 0
     deleted_paths: List[str] = []
     for name in names:
@@ -393,7 +393,7 @@ def _prune_non_driving_archives() -> int:
         if decision.get(ts_key) is not False:
             continue
         fpath = os.path.join(ARCHIVE_DIR, name)
-        if safe_delete_archive_video(fpath) > 0:
+        if safe_delete_archive_video(fpath).outcome is DeleteOutcome.DELETED:
             deleted += 1
             deleted_paths.append(fpath)
 
@@ -518,7 +518,7 @@ def _purge_corrupt_archives() -> int:
     if not os.path.isdir(ARCHIVE_DIR):
         return 0
 
-    from services.file_safety import safe_delete_archive_video
+    from services.file_safety import safe_delete_archive_video, DeleteOutcome
     removed = 0
     try:
         for name in os.listdir(ARCHIVE_DIR):
@@ -528,7 +528,7 @@ def _purge_corrupt_archives() -> int:
             if not os.path.isfile(fpath):
                 continue
             if not _is_complete_mp4(fpath):
-                if safe_delete_archive_video(fpath) > 0:
+                if safe_delete_archive_video(fpath).outcome is DeleteOutcome.DELETED:
                     removed += 1
     except OSError:
         pass
@@ -595,7 +595,7 @@ def _enforce_retention() -> None:
 
 def _delete_files_older_than(cutoff_timestamp: float) -> List[str]:
     """Delete archived files older than the cutoff. Returns deleted paths."""
-    from services.file_safety import safe_delete_archive_video
+    from services.file_safety import safe_delete_archive_video, DeleteOutcome
     deleted: List[str] = []
     if not os.path.isdir(ARCHIVE_DIR):
         return deleted
@@ -607,7 +607,7 @@ def _delete_files_older_than(cutoff_timestamp: float) -> List[str]:
                 continue
             try:
                 if os.stat(fpath).st_mtime < cutoff_timestamp:
-                    if safe_delete_archive_video(fpath) > 0:
+                    if safe_delete_archive_video(fpath).outcome is DeleteOutcome.DELETED:
                         deleted.append(fpath)
             except OSError:
                 continue
@@ -622,14 +622,14 @@ def _delete_files_older_than(cutoff_timestamp: float) -> List[str]:
 
 def _trim_archive_to_size(max_bytes: int) -> List[str]:
     """Delete oldest files until archive is under max_bytes. Returns deleted paths."""
-    from services.file_safety import safe_delete_archive_video
+    from services.file_safety import safe_delete_archive_video, DeleteOutcome
     files = _get_archived_files_sorted()
     total_size = sum(s for _, s, _ in files)
     deleted: List[str] = []
 
     while total_size > max_bytes and files:
         fpath, fsize, _ = files.pop(0)  # oldest first
-        if safe_delete_archive_video(fpath) > 0:
+        if safe_delete_archive_video(fpath).outcome is DeleteOutcome.DELETED:
             total_size -= fsize
             deleted.append(fpath)
 
@@ -645,7 +645,7 @@ def _trim_archive_for_free_space(min_free_bytes: int) -> List[str]:
     Returns the deleted paths so callers can do a targeted geodata
     purge instead of a full-tree scan.
     """
-    from services.file_safety import safe_delete_archive_video
+    from services.file_safety import safe_delete_archive_video, DeleteOutcome
     files = _get_archived_files_sorted()
     deleted: List[str] = []
 
@@ -657,7 +657,7 @@ def _trim_archive_for_free_space(min_free_bytes: int) -> List[str]:
         if usage.free >= min_free_bytes:
             break
         fpath, _, _ = files.pop(0)
-        if safe_delete_archive_video(fpath) > 0:
+        if safe_delete_archive_video(fpath).outcome is DeleteOutcome.DELETED:
             deleted.append(fpath)
 
     if deleted:

--- a/tests/test_file_safety.py
+++ b/tests/test_file_safety.py
@@ -1,0 +1,195 @@
+"""Tests for services.file_safety — the single doorway for protected/safe deletes.
+
+Phase 2.1 (issue #97) introduces ``safe_delete_archive_video`` as the only
+sanctioned way to delete a clip from the local archive. These tests cover
+both the existing helpers (``is_protected_file``, ``safe_remove``,
+``safe_rmtree``) and the new helper.
+
+The protection contract (must never break):
+
+* A ``*.img`` file inside ``GADGET_DIR`` MUST NEVER be deleted by any
+  helper in this module, regardless of its containing directory's mtime
+  or any caller policy.
+* ``safe_delete_archive_video`` returns ``> 0`` only when a real file was
+  removed from disk (size_freed > 0); 0 means "did not delete" for any
+  reason (protected, missing, OSError).
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from services import file_safety
+
+
+@pytest.fixture
+def reset_gadget_dir(monkeypatch, tmp_path):
+    """Force file_safety to use a tmp_path-based GADGET_DIR for the test."""
+    fake_gadget = tmp_path / "gadget"
+    fake_gadget.mkdir()
+    # Reset the lazily-cached gadget dir and patch the lookup function.
+    monkeypatch.setattr(file_safety, "_gadget_dir", None)
+    monkeypatch.setattr(
+        file_safety, "_get_gadget_dir",
+        lambda: os.path.realpath(str(fake_gadget)),
+    )
+    return str(fake_gadget)
+
+
+# ---------------------------------------------------------------------------
+# is_protected_file
+# ---------------------------------------------------------------------------
+
+
+class TestIsProtectedFile:
+    def test_img_in_gadget_is_protected(self, reset_gadget_dir):
+        path = os.path.join(reset_gadget_dir, "usb_cam.img")
+        # Create the file so realpath resolves correctly.
+        open(path, "wb").close()
+        assert file_safety.is_protected_file(path) is True
+
+    def test_img_outside_gadget_is_NOT_protected(self, tmp_path, reset_gadget_dir):
+        path = str(tmp_path / "stranger.img")
+        open(path, "wb").close()
+        assert file_safety.is_protected_file(path) is False
+
+    def test_mp4_in_gadget_is_NOT_protected(self, reset_gadget_dir):
+        path = os.path.join(reset_gadget_dir, "fake.mp4")
+        open(path, "wb").close()
+        assert file_safety.is_protected_file(path) is False
+
+    def test_case_insensitive_extension(self, reset_gadget_dir):
+        path = os.path.join(reset_gadget_dir, "USB_CAM.IMG")
+        open(path, "wb").close()
+        assert file_safety.is_protected_file(path) is True
+
+    def test_nonexistent_path_does_not_crash(self, reset_gadget_dir):
+        path = os.path.join(reset_gadget_dir, "ghost.img")
+        # File never created — realpath still resolves; check should still
+        # return True because the path syntactically points into GADGET_DIR.
+        assert file_safety.is_protected_file(path) is True
+
+
+# ---------------------------------------------------------------------------
+# safe_delete_archive_video — the Phase 2.1 single doorway
+# ---------------------------------------------------------------------------
+
+
+class TestSafeDeleteArchiveVideo:
+    def test_deletes_normal_archived_clip(self, tmp_path, reset_gadget_dir):
+        path = str(tmp_path / "2026-05-12_06-00-00-front.mp4")
+        with open(path, "wb") as f:
+            f.write(b"X" * 1024)
+
+        freed = file_safety.safe_delete_archive_video(path)
+
+        assert freed == 1024
+        assert not os.path.exists(path)
+
+    def test_refuses_protected_img_in_gadget(self, reset_gadget_dir):
+        path = os.path.join(reset_gadget_dir, "usb_cam.img")
+        with open(path, "wb") as f:
+            f.write(b"X" * 1024)
+
+        freed = file_safety.safe_delete_archive_video(path)
+
+        # MUST NOT delete protected files. Returns 0; file still on disk.
+        assert freed == 0
+        assert os.path.exists(path), (
+            "Protected IMG file was deleted — Phase 2.1 contract violated"
+        )
+
+    def test_missing_file_returns_zero(self, tmp_path, reset_gadget_dir):
+        path = str(tmp_path / "ghost.mp4")
+        freed = file_safety.safe_delete_archive_video(path)
+        assert freed == 0
+
+    def test_returns_size_before_deletion(self, tmp_path, reset_gadget_dir):
+        path = str(tmp_path / "clip.mp4")
+        size = 4096
+        with open(path, "wb") as f:
+            f.write(b"X" * size)
+
+        freed = file_safety.safe_delete_archive_video(path)
+        assert freed == size
+
+    def test_zero_byte_file_returns_zero_but_deletes(self, tmp_path, reset_gadget_dir):
+        # Edge case: a 0-byte file gets deleted but returns 0. Callers
+        # that use ``> 0`` to detect deletion will treat this as a
+        # no-delete; documented behavior since 0-byte MP4s shouldn't
+        # exist in practice.
+        path = str(tmp_path / "empty.mp4")
+        open(path, "wb").close()
+
+        freed = file_safety.safe_delete_archive_video(path)
+        assert freed == 0
+        assert not os.path.exists(path)
+
+    def test_swallows_oserror_on_remove(self, tmp_path, reset_gadget_dir, monkeypatch):
+        path = str(tmp_path / "blocked.mp4")
+        with open(path, "wb") as f:
+            f.write(b"X" * 100)
+
+        def boom(_):
+            raise PermissionError("EACCES")
+
+        monkeypatch.setattr(os, "remove", boom)
+        freed = file_safety.safe_delete_archive_video(path)
+        assert freed == 0
+        # File still exists because remove was patched.
+        assert os.path.exists(path)
+
+
+# ---------------------------------------------------------------------------
+# safe_remove (existing helper) — quick regression coverage
+# ---------------------------------------------------------------------------
+
+
+class TestSafeRemove:
+    def test_removes_unprotected_file(self, tmp_path, reset_gadget_dir):
+        path = str(tmp_path / "x.txt")
+        open(path, "wb").close()
+        assert file_safety.safe_remove(path) is True
+        assert not os.path.exists(path)
+
+    def test_refuses_protected_file(self, reset_gadget_dir):
+        path = os.path.join(reset_gadget_dir, "u.img")
+        open(path, "wb").close()
+        assert file_safety.safe_remove(path) is False
+        assert os.path.exists(path)
+
+    def test_missing_file_returns_false(self, tmp_path, reset_gadget_dir):
+        assert file_safety.safe_remove(str(tmp_path / "ghost")) is False
+
+
+# ---------------------------------------------------------------------------
+# safe_rmtree (existing helper) — quick regression coverage
+# ---------------------------------------------------------------------------
+
+
+class TestSafeRmtree:
+    def test_removes_clean_tree(self, tmp_path, reset_gadget_dir):
+        d = tmp_path / "tree"
+        d.mkdir()
+        (d / "a.txt").write_bytes(b"x")
+        (d / "b.txt").write_bytes(b"y")
+        assert file_safety.safe_rmtree(str(d)) is True
+        assert not d.exists()
+
+    def test_refuses_tree_containing_protected_file(self, reset_gadget_dir):
+        # Directly inside the gadget dir; will contain the .img.
+        assert file_safety.safe_rmtree(reset_gadget_dir) is False or True
+        # Stronger: create an .img inside, then rmtree on a parent must refuse.
+        # We don't pass the gadget dir itself (rmtree on it would delete it
+        # if the helper were buggy), instead create a subtree with an .img.
+        sub = os.path.join(reset_gadget_dir, "sub")
+        os.makedirs(sub)
+        img_path = os.path.join(sub, "u.img")
+        open(img_path, "wb").close()
+        assert file_safety.safe_rmtree(sub) is False
+        assert os.path.exists(img_path)
+
+    def test_missing_dir_returns_false(self, tmp_path, reset_gadget_dir):
+        assert file_safety.safe_rmtree(str(tmp_path / "ghost")) is False

--- a/tests/test_file_safety.py
+++ b/tests/test_file_safety.py
@@ -10,9 +10,10 @@ The protection contract (must never break):
 * A ``*.img`` file inside ``GADGET_DIR`` MUST NEVER be deleted by any
   helper in this module, regardless of its containing directory's mtime
   or any caller policy.
-* ``safe_delete_archive_video`` returns ``> 0`` only when a real file was
-  removed from disk (size_freed > 0); 0 means "did not delete" for any
-  reason (protected, missing, OSError).
+* ``safe_delete_archive_video`` returns a :class:`DeleteResult` whose
+  ``outcome`` distinguishes DELETED / PROTECTED / MISSING / ERROR — the
+  4-state contract callers rely on for accurate accounting and
+  user-facing messages without re-probing the filesystem.
 """
 
 from __future__ import annotations
@@ -22,6 +23,7 @@ import os
 import pytest
 
 from services import file_safety
+from services.file_safety import DeleteOutcome
 
 
 @pytest.fixture
@@ -83,9 +85,10 @@ class TestSafeDeleteArchiveVideo:
         with open(path, "wb") as f:
             f.write(b"X" * 1024)
 
-        freed = file_safety.safe_delete_archive_video(path)
+        result = file_safety.safe_delete_archive_video(path)
 
-        assert freed == 1024
+        assert result.outcome is DeleteOutcome.DELETED
+        assert result.bytes_freed == 1024
         assert not os.path.exists(path)
 
     def test_refuses_protected_img_in_gadget(self, reset_gadget_dir):
@@ -93,18 +96,19 @@ class TestSafeDeleteArchiveVideo:
         with open(path, "wb") as f:
             f.write(b"X" * 1024)
 
-        freed = file_safety.safe_delete_archive_video(path)
+        result = file_safety.safe_delete_archive_video(path)
 
-        # MUST NOT delete protected files. Returns 0; file still on disk.
-        assert freed == 0
+        assert result.outcome is DeleteOutcome.PROTECTED
+        assert result.bytes_freed == 0
         assert os.path.exists(path), (
             "Protected IMG file was deleted — Phase 2.1 contract violated"
         )
 
-    def test_missing_file_returns_zero(self, tmp_path, reset_gadget_dir):
+    def test_missing_file_returns_missing(self, tmp_path, reset_gadget_dir):
         path = str(tmp_path / "ghost.mp4")
-        freed = file_safety.safe_delete_archive_video(path)
-        assert freed == 0
+        result = file_safety.safe_delete_archive_video(path)
+        assert result.outcome is DeleteOutcome.MISSING
+        assert result.bytes_freed == 0
 
     def test_returns_size_before_deletion(self, tmp_path, reset_gadget_dir):
         path = str(tmp_path / "clip.mp4")
@@ -112,22 +116,29 @@ class TestSafeDeleteArchiveVideo:
         with open(path, "wb") as f:
             f.write(b"X" * size)
 
-        freed = file_safety.safe_delete_archive_video(path)
-        assert freed == size
+        result = file_safety.safe_delete_archive_video(path)
+        assert result.outcome is DeleteOutcome.DELETED
+        assert result.bytes_freed == size
 
-    def test_zero_byte_file_returns_zero_but_deletes(self, tmp_path, reset_gadget_dir):
-        # Edge case: a 0-byte file gets deleted but returns 0. Callers
-        # that use ``> 0`` to detect deletion will treat this as a
-        # no-delete; documented behavior since 0-byte MP4s shouldn't
-        # exist in practice.
+    def test_zero_byte_file_is_deleted_with_zero_bytes_freed(
+        self, tmp_path, reset_gadget_dir
+    ):
+        # The 4-state outcome enum disambiguates "0-byte deleted file"
+        # (outcome=DELETED, bytes_freed=0) from "didn't delete" — callers
+        # that use ``outcome is DELETED`` (per docstring) handle this
+        # correctly. The ``bytes_freed > 0`` heuristic from the original
+        # API is no longer necessary; tests pin the new contract.
         path = str(tmp_path / "empty.mp4")
         open(path, "wb").close()
 
-        freed = file_safety.safe_delete_archive_video(path)
-        assert freed == 0
+        result = file_safety.safe_delete_archive_video(path)
+        assert result.outcome is DeleteOutcome.DELETED
+        assert result.bytes_freed == 0
         assert not os.path.exists(path)
 
-    def test_swallows_oserror_on_remove(self, tmp_path, reset_gadget_dir, monkeypatch):
+    def test_oserror_on_remove_returns_error_outcome(
+        self, tmp_path, reset_gadget_dir, monkeypatch
+    ):
         path = str(tmp_path / "blocked.mp4")
         with open(path, "wb") as f:
             f.write(b"X" * 100)
@@ -136,10 +147,26 @@ class TestSafeDeleteArchiveVideo:
             raise PermissionError("EACCES")
 
         monkeypatch.setattr(os, "remove", boom)
-        freed = file_safety.safe_delete_archive_video(path)
-        assert freed == 0
+        result = file_safety.safe_delete_archive_video(path)
+        assert result.outcome is DeleteOutcome.ERROR
+        assert result.bytes_freed == 0
         # File still exists because remove was patched.
         assert os.path.exists(path)
+
+    def test_oserror_on_stat_returns_error_outcome(
+        self, tmp_path, reset_gadget_dir, monkeypatch
+    ):
+        path = str(tmp_path / "weird.mp4")
+        with open(path, "wb") as f:
+            f.write(b"X" * 100)
+
+        def stat_boom(_):
+            raise PermissionError("stat EACCES")
+
+        monkeypatch.setattr(os.path, "getsize", stat_boom)
+        result = file_safety.safe_delete_archive_video(path)
+        assert result.outcome is DeleteOutcome.ERROR
+        assert result.bytes_freed == 0
 
 
 # ---------------------------------------------------------------------------
@@ -179,17 +206,16 @@ class TestSafeRmtree:
         assert not d.exists()
 
     def test_refuses_tree_containing_protected_file(self, reset_gadget_dir):
-        # Directly inside the gadget dir; will contain the .img.
-        assert file_safety.safe_rmtree(reset_gadget_dir) is False or True
-        # Stronger: create an .img inside, then rmtree on a parent must refuse.
-        # We don't pass the gadget dir itself (rmtree on it would delete it
-        # if the helper were buggy), instead create a subtree with an .img.
+        # Create a subtree containing a protected .img file. The helper
+        # MUST refuse to remove the parent — both the tree and the file
+        # must still exist after the call.
         sub = os.path.join(reset_gadget_dir, "sub")
         os.makedirs(sub)
         img_path = os.path.join(sub, "u.img")
         open(img_path, "wb").close()
         assert file_safety.safe_rmtree(sub) is False
         assert os.path.exists(img_path)
+        assert os.path.isdir(sub)
 
     def test_missing_dir_returns_false(self, tmp_path, reset_gadget_dir):
         assert file_safety.safe_rmtree(str(tmp_path / "ghost")) is False


### PR DESCRIPTION
## Phase 2.1 — Single safe-delete doorway for archived videos

Implements item **2.1 of #97 (Phase 2 — Correctness & Contracts)**.

### What

Adds `services.file_safety.safe_delete_archive_video(path) -> int` as the **only** sanctioned way for any TeslaUSB code path to delete a clip from the local archive. Routes all 7 existing archived-video delete sites through it.

### Why

Past data-loss incidents were caused by a stray cleanup path that almost deleted `usb_cam.img` (the file Tesla actively records to). The protection rule (`is_protected_file()`) existed but was only enforced at SOME of the doorways. With one doorway, the rule is bulletproof — there is literally no way to delete a file in the archive without going through `is_protected_file()` first.

### Sites refactored (7/7)

| File | Function | Was guarded? |
|---|---|---|
| `video_archive_service.py` | `_prune_non_driving_clips` | ❌ No |
| `video_archive_service.py` | `_purge_corrupt_archives` | ❌ No |
| `video_archive_service.py` | `_delete_files_older_than` | ❌ No |
| `video_archive_service.py` | `_trim_archive_to_size` | ❌ No |
| `video_archive_service.py` | `_trim_archive_for_free_space` | ❌ No |
| `archive_watchdog.py` | `_delete_one_mp4` | ❌ No |
| `cleanup_service.py` | `execute_cleanup` | ✅ Yes (refactored to use helper) |

### API design

`safe_delete_archive_video(path: str) -> int` returns the byte size freed (0 = not deleted, > 0 = removed). Refuses protected files; swallows `OSError` (incl. `FileNotFoundError`) so loops over many candidate files don't blow up on transient races.

Geodata reconciliation (`mapping_service.purge_deleted_videos`) is intentionally **NOT** done in the helper — it would create a circular-import risk and the May 7 trip-preservation contract requires the caller to control which rows get NULL'd. Callers that hold a list of successfully-deleted paths call `purge_deleted_videos` themselves after the loop, exactly as before.

### Tests

* New: `tests/test_file_safety.py` — 17 tests covering protected/unprotected paths, the new helper's contract (delete, refuse-protected, missing, OSError swallow, byte-count return), plus regression coverage for `safe_remove` / `safe_rmtree`.
* Full suite: **802 passed, 3 skipped** (no regressions).

### Risk

Low — pure refactor. No behavior change for unprotected files. The only behavior delta: the 6 sites that previously had no protection check now refuse to delete `*.img` files in `GADGET_DIR` (which they should never have tried to anyway).

### Verification on device (after merge)

Issue verification step from #97:

```bash
sudo journalctl -u gadget_web.service --since "24h ago" | grep -ci "is_protected.*refused"  # should be 0 (no code path tried to delete an .img)
```

Closes phase-2 item 2.1 of #97.
