### PR TITLE
Phase 2.3: sync_non_event_videos filter actually filters (closes p2-3 of #97)

### DIFF
--- a/scripts/web/services/cloud_archive_service.py
+++ b/scripts/web/services/cloud_archive_service.py
@@ -410,10 +410,37 @@ def _discover_events(
     except ImportError:
         pass
 
-    # Sort by priority (lower score = sync first)
-    events.sort(key=lambda t: _score_event_priority(t[0]))
+    # Score every candidate once so we can both filter and sort without
+    # invoking the (relatively expensive) scorer twice. Score >= 200 means
+    # neither an event.json trigger nor any waypoint geolocation hit was
+    # found — i.e. routine driving footage.
+    scored: List[Tuple[Tuple[str, str, int], int]] = [
+        (t, _score_event_priority(t[0])) for t in events
+    ]
 
-    return events
+    # Phase 2.3 — When ``sync_non_event_videos`` is False the picker MUST
+    # actually drop the non-event/non-geo tier from the queue (the previous
+    # behaviour merely demoted them to a lower priority, so they still got
+    # uploaded — which silently consumed the user's bandwidth on top of the
+    # event clips they actually wanted backed up). We re-read the flag from
+    # ``config`` on every call so a Settings change takes effect on the
+    # next sync iteration without a service restart.
+    try:
+        from config import CLOUD_ARCHIVE_SYNC_NON_EVENT as _sync_non_event_now
+    except Exception:
+        _sync_non_event_now = CLOUD_ARCHIVE_SYNC_NON_EVENT
+    if not _sync_non_event_now:
+        before = len(scored)
+        scored = [(t, s) for (t, s) in scored if s < 200]
+        dropped = before - len(scored)
+        if dropped:
+            logger.info(
+                "Cloud sync: filtered %d non-event/non-geo clip(s) "
+                "(sync_non_event_videos=false)", dropped,
+            )
+
+    scored.sort(key=lambda x: x[1])
+    return [t for (t, _s) in scored]
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/web/services/cloud_archive_service.py
+++ b/scripts/web/services/cloud_archive_service.py
@@ -323,6 +323,38 @@ def _fsync_db(conn: sqlite3.Connection) -> None:
         pass  # Best-effort; WAL mode provides crash safety regardless
 
 
+def _read_sync_non_event_setting() -> bool:
+    """Re-read ``cloud_archive.sync_non_event_videos`` from config.yaml.
+
+    Phase 2.3 — ``config.CLOUD_ARCHIVE_SYNC_NON_EVENT`` is snapshotted at
+    module-import time, and the Settings save handler at
+    ``cloud_archive.py:_update_config_yaml`` only writes YAML; it does not
+    mutate the config module attribute. Re-importing the symbol therefore
+    returns the stale boot-time value and a Settings toggle has no effect
+    until ``gadget_web.service`` restarts. To honour the documented
+    ""effective on next sync iteration without restart"" contract we read
+    the live YAML directly here.
+
+    ``_discover_events`` runs at most once per sync iteration (minutes
+    apart), so a single ~1ms YAML read is invisible to performance and
+    avoids the heavier ``systemd-run`` restart pattern used by LES.
+
+    On any IO/parse error we fall back to the import-time value so the
+    picker never crashes the worker — matching the safe-default
+    behaviour the rest of the service uses for config edge cases.
+    """
+    try:
+        import yaml
+        from config import CONFIG_YAML
+        with open(CONFIG_YAML, 'r') as f:
+            cfg = yaml.safe_load(f) or {}
+        return bool(
+            cfg.get('cloud_archive', {}).get('sync_non_event_videos', False)
+        )
+    except Exception:
+        return CLOUD_ARCHIVE_SYNC_NON_EVENT
+
+
 def _discover_events(
     teslacam_path: str,
     conn: Optional[sqlite3.Connection] = None,
@@ -422,14 +454,16 @@ def _discover_events(
     # actually drop the non-event/non-geo tier from the queue (the previous
     # behaviour merely demoted them to a lower priority, so they still got
     # uploaded — which silently consumed the user's bandwidth on top of the
-    # event clips they actually wanted backed up). We re-read the flag from
-    # ``config`` on every call so a Settings change takes effect on the
-    # next sync iteration without a service restart.
-    try:
-        from config import CLOUD_ARCHIVE_SYNC_NON_EVENT as _sync_non_event_now
-    except Exception:
-        _sync_non_event_now = CLOUD_ARCHIVE_SYNC_NON_EVENT
-    if not _sync_non_event_now:
+    # event clips they actually wanted backed up).
+    #
+    # We must NOT re-import ``CLOUD_ARCHIVE_SYNC_NON_EVENT`` here: it is
+    # snapshotted at config.py import time and the Settings save handler
+    # only writes YAML — so the import would always return the stale
+    # boot-time value. ``_read_sync_non_event_setting`` reads the live
+    # YAML so a Settings toggle takes effect on the next sync iteration
+    # without a service restart.
+    sync_non_event_now = _read_sync_non_event_setting()
+    if not sync_non_event_now:
         before = len(scored)
         scored = [(t, s) for (t, s) in scored if s < 200]
         dropped = before - len(scored)

--- a/tests/test_cloud_archive_non_event_filter.py
+++ b/tests/test_cloud_archive_non_event_filter.py
@@ -1,0 +1,166 @@
+"""Tests for Phase 2.3 — sync_non_event_videos filter actually filters.
+
+When ``cloud_archive.sync_non_event_videos`` is False (the default), the
+cloud archive sync picker must DROP non-event/non-geo clips from the queue
+entirely — not merely demote them to lower priority. The pre-fix behaviour
+silently uploaded those clips anyway, eating user bandwidth and slowing
+down the upload of the event clips users actually care about.
+
+These tests pin both directions of the toggle:
+
+* ``sync_non_event_videos=False`` → score >= 200 entries dropped, score < 200
+  entries preserved.
+* ``sync_non_event_videos=True`` → all entries preserved (current legacy
+  behaviour kept intact for users who explicitly opt in).
+* The flag is read from ``config`` on every call so Settings changes take
+  effect on the next sync iteration without a service restart.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import List, Tuple
+
+import pytest
+
+import config
+from services import cloud_archive_service as svc
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_event_dir(parent: str, name: str, with_event_json: bool,
+                    with_video: bool = True) -> str:
+    """Create a fake event directory matching Tesla's on-disk layout.
+
+    ``with_event_json=True`` will produce a folder that scores 0 (Tesla
+    event trigger). Otherwise the folder scores 200+ unless geodata.db
+    contains a matching waypoint (which the tests deliberately avoid by
+    disabling MAPPING_ENABLED).
+    """
+    event_dir = os.path.join(parent, name)
+    os.makedirs(event_dir, exist_ok=True)
+    if with_event_json:
+        # Real Tesla event.json — minimal valid JSON with a reason.
+        with open(os.path.join(event_dir, "event.json"), "w") as f:
+            f.write('{"reason":"sentry_aware_object_detection"}')
+    if with_video:
+        # Tesla writes one MP4 per camera per minute; one is enough for the
+        # discover loop's "has_video" check.
+        with open(os.path.join(event_dir, "front.mp4"), "wb") as f:
+            f.write(b"\x00" * 1024)
+    return event_dir
+
+
+@pytest.fixture
+def teslacam_root(tmp_path, monkeypatch):
+    """Build a fake TeslaCam directory with one event clip and one routine
+    (non-event, non-geo) clip in SentryClips. Disables MAPPING_ENABLED so
+    the geolocation tier is unreachable, ensuring routine clips score 200+.
+    """
+    teslacam = tmp_path / "TeslaCam"
+    sentry = teslacam / "SentryClips"
+    sentry.mkdir(parents=True)
+
+    _make_event_dir(str(sentry), "2026-05-12_10-00-00",
+                    with_event_json=True)            # score = 0
+    _make_event_dir(str(sentry), "2026-05-12_11-00-00",
+                    with_event_json=False)           # score >= 200
+
+    # Disable mapping so _score_event_priority can't fall into the
+    # geolocation tier (score 100) and accidentally save the routine clip.
+    monkeypatch.setattr(config, "MAPPING_ENABLED", False, raising=False)
+
+    return str(teslacam)
+
+
+# ---------------------------------------------------------------------------
+# Tests — Phase 2.3
+# ---------------------------------------------------------------------------
+
+class TestSyncNonEventVideosFilter:
+    """``sync_non_event_videos`` must actually drop non-event clips."""
+
+    def test_filter_off_drops_non_event_clips(self, teslacam_root, monkeypatch):
+        """When the flag is False, only the event clip should remain."""
+        monkeypatch.setattr(config, "CLOUD_ARCHIVE_SYNC_NON_EVENT", False)
+        # Module-level binding is read once at import; the picker re-imports
+        # from config on every call, so patching config alone is sufficient
+        # — but we also patch the module binding to defend against any
+        # legacy fallback path.
+        monkeypatch.setattr(svc, "CLOUD_ARCHIVE_SYNC_NON_EVENT", False)
+
+        result = svc._discover_events(teslacam_root, conn=None)
+
+        assert len(result) == 1, (
+            f"Expected only the event clip, got {[r[1] for r in result]}"
+        )
+        assert result[0][1] == "SentryClips/2026-05-12_10-00-00"
+
+    def test_filter_on_keeps_non_event_clips(self, teslacam_root, monkeypatch):
+        """When the flag is True, both clips remain (legacy behaviour)."""
+        monkeypatch.setattr(config, "CLOUD_ARCHIVE_SYNC_NON_EVENT", True)
+        monkeypatch.setattr(svc, "CLOUD_ARCHIVE_SYNC_NON_EVENT", True)
+
+        result = svc._discover_events(teslacam_root, conn=None)
+
+        rel_paths = sorted(r[1] for r in result)
+        assert rel_paths == [
+            "SentryClips/2026-05-12_10-00-00",
+            "SentryClips/2026-05-12_11-00-00",
+        ]
+
+    def test_filter_off_with_only_non_event_clips_returns_empty(
+            self, tmp_path, monkeypatch):
+        """If every candidate is non-event/non-geo, the queue is empty."""
+        teslacam = tmp_path / "TeslaCam"
+        sentry = teslacam / "SentryClips"
+        sentry.mkdir(parents=True)
+        _make_event_dir(str(sentry), "2026-05-12_09-00-00",
+                        with_event_json=False)
+        _make_event_dir(str(sentry), "2026-05-12_10-00-00",
+                        with_event_json=False)
+        monkeypatch.setattr(config, "MAPPING_ENABLED", False, raising=False)
+        monkeypatch.setattr(config, "CLOUD_ARCHIVE_SYNC_NON_EVENT", False)
+        monkeypatch.setattr(svc, "CLOUD_ARCHIVE_SYNC_NON_EVENT", False)
+
+        result = svc._discover_events(str(teslacam), conn=None)
+
+        assert result == []
+
+    def test_filter_change_takes_effect_without_restart(
+            self, teslacam_root, monkeypatch):
+        """Toggling the flag between calls picks up the new value.
+
+        Pins the contract: the picker re-reads ``config`` per call, so a
+        Settings change is honoured on the next sync iteration.
+        """
+        monkeypatch.setattr(config, "CLOUD_ARCHIVE_SYNC_NON_EVENT", False)
+        monkeypatch.setattr(svc, "CLOUD_ARCHIVE_SYNC_NON_EVENT", False)
+        first = svc._discover_events(teslacam_root, conn=None)
+        assert len(first) == 1
+
+        # Flip the flag — no module reload, no service restart.
+        monkeypatch.setattr(config, "CLOUD_ARCHIVE_SYNC_NON_EVENT", True)
+        # Note: NOT updating svc.CLOUD_ARCHIVE_SYNC_NON_EVENT here — the
+        # picker MUST be reading the live ``config`` module, not its own
+        # import-time binding. If this test starts failing, the picker has
+        # silently regressed to import-time caching.
+        second = svc._discover_events(teslacam_root, conn=None)
+        assert len(second) == 2
+
+    def test_filter_logs_drop_count(self, teslacam_root, monkeypatch, caplog):
+        """The filter must log how many clips it dropped (for diagnosis)."""
+        import logging
+        monkeypatch.setattr(config, "CLOUD_ARCHIVE_SYNC_NON_EVENT", False)
+        monkeypatch.setattr(svc, "CLOUD_ARCHIVE_SYNC_NON_EVENT", False)
+
+        with caplog.at_level(logging.INFO, logger=svc.logger.name):
+            svc._discover_events(teslacam_root, conn=None)
+
+        assert any(
+            "filtered 1 non-event" in rec.message
+            for rec in caplog.records
+        ), f"Expected drop-count log line; got {[r.message for r in caplog.records]}"

--- a/tests/test_cloud_archive_non_event_filter.py
+++ b/tests/test_cloud_archive_non_event_filter.py
@@ -6,14 +6,15 @@ entirely — not merely demote them to lower priority. The pre-fix behaviour
 silently uploaded those clips anyway, eating user bandwidth and slowing
 down the upload of the event clips users actually care about.
 
-These tests pin both directions of the toggle:
-
-* ``sync_non_event_videos=False`` → score >= 200 entries dropped, score < 200
-  entries preserved.
-* ``sync_non_event_videos=True`` → all entries preserved (current legacy
-  behaviour kept intact for users who explicitly opt in).
-* The flag is read from ``config`` on every call so Settings changes take
-  effect on the next sync iteration without a service restart.
+These tests pin both directions of the toggle, AND drive the
+config-change path through ``update_config_yaml`` (the real Settings
+save handler) — NOT by monkeypatching the in-memory ``config`` module.
+The first iteration of this PR was caught in review using exactly this
+test technique: monkeypatching ``config.CLOUD_ARCHIVE_SYNC_NON_EVENT``
+masked the fact that the production save handler only writes YAML, so
+the picker had to re-read YAML directly to honour the
+""no-restart-needed"" contract. These tests now exercise that path
+end-to-end.
 """
 
 from __future__ import annotations
@@ -24,6 +25,7 @@ from typing import List, Tuple
 import pytest
 
 import config
+from helpers.config_updater import update_config_yaml
 from services import cloud_archive_service as svc
 
 
@@ -55,6 +57,26 @@ def _make_event_dir(parent: str, name: str, with_event_json: bool,
 
 
 @pytest.fixture
+def isolated_yaml(tmp_path, monkeypatch):
+    """Point ``CONFIG_YAML`` at a writable copy so tests can drive the
+    real ``update_config_yaml`` path without poisoning the repo's
+    config.yaml. Returns the path so individual tests can pre-seed the
+    flag if desired.
+    """
+    yaml_path = tmp_path / "config.yaml"
+    # Minimal config matching the keys the picker reads.
+    yaml_path.write_text(
+        "cloud_archive:\n  sync_non_event_videos: false\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(config, "CONFIG_YAML", str(yaml_path))
+    # Also patch the helper's import-time copy.
+    import helpers.config_updater as cu
+    monkeypatch.setattr(cu, "CONFIG_YAML", str(yaml_path))
+    return str(yaml_path)
+
+
+@pytest.fixture
 def teslacam_root(tmp_path, monkeypatch):
     """Build a fake TeslaCam directory with one event clip and one routine
     (non-event, non-geo) clip in SentryClips. Disables MAPPING_ENABLED so
@@ -83,15 +105,10 @@ def teslacam_root(tmp_path, monkeypatch):
 class TestSyncNonEventVideosFilter:
     """``sync_non_event_videos`` must actually drop non-event clips."""
 
-    def test_filter_off_drops_non_event_clips(self, teslacam_root, monkeypatch):
-        """When the flag is False, only the event clip should remain."""
-        monkeypatch.setattr(config, "CLOUD_ARCHIVE_SYNC_NON_EVENT", False)
-        # Module-level binding is read once at import; the picker re-imports
-        # from config on every call, so patching config alone is sufficient
-        # — but we also patch the module binding to defend against any
-        # legacy fallback path.
-        monkeypatch.setattr(svc, "CLOUD_ARCHIVE_SYNC_NON_EVENT", False)
-
+    def test_filter_off_drops_non_event_clips(
+            self, teslacam_root, isolated_yaml):
+        """Default (flag absent → False): only the event clip remains."""
+        # isolated_yaml seeds sync_non_event_videos: false
         result = svc._discover_events(teslacam_root, conn=None)
 
         assert len(result) == 1, (
@@ -99,10 +116,10 @@ class TestSyncNonEventVideosFilter:
         )
         assert result[0][1] == "SentryClips/2026-05-12_10-00-00"
 
-    def test_filter_on_keeps_non_event_clips(self, teslacam_root, monkeypatch):
+    def test_filter_on_keeps_non_event_clips(
+            self, teslacam_root, isolated_yaml):
         """When the flag is True, both clips remain (legacy behaviour)."""
-        monkeypatch.setattr(config, "CLOUD_ARCHIVE_SYNC_NON_EVENT", True)
-        monkeypatch.setattr(svc, "CLOUD_ARCHIVE_SYNC_NON_EVENT", True)
+        update_config_yaml({'cloud_archive.sync_non_event_videos': True})
 
         result = svc._discover_events(teslacam_root, conn=None)
 
@@ -113,9 +130,9 @@ class TestSyncNonEventVideosFilter:
         ]
 
     def test_filter_off_with_only_non_event_clips_returns_empty(
-            self, tmp_path, monkeypatch):
+            self, tmp_path, isolated_yaml, monkeypatch):
         """If every candidate is non-event/non-geo, the queue is empty."""
-        teslacam = tmp_path / "TeslaCam"
+        teslacam = tmp_path / "TeslaCam2"
         sentry = teslacam / "SentryClips"
         sentry.mkdir(parents=True)
         _make_event_dir(str(sentry), "2026-05-12_09-00-00",
@@ -123,39 +140,47 @@ class TestSyncNonEventVideosFilter:
         _make_event_dir(str(sentry), "2026-05-12_10-00-00",
                         with_event_json=False)
         monkeypatch.setattr(config, "MAPPING_ENABLED", False, raising=False)
-        monkeypatch.setattr(config, "CLOUD_ARCHIVE_SYNC_NON_EVENT", False)
-        monkeypatch.setattr(svc, "CLOUD_ARCHIVE_SYNC_NON_EVENT", False)
 
         result = svc._discover_events(str(teslacam), conn=None)
 
         assert result == []
 
     def test_filter_change_takes_effect_without_restart(
-            self, teslacam_root, monkeypatch):
-        """Toggling the flag between calls picks up the new value.
+            self, teslacam_root, isolated_yaml):
+        """Toggling the flag through the real Settings save path picks up
+        the new value on the next call.
 
-        Pins the contract: the picker re-reads ``config`` per call, so a
-        Settings change is honoured on the next sync iteration.
+        This is THE contract this PR exists to ship: the prior version
+        of the picker re-imported a module attribute from ``config`` —
+        which is set once at import time and is never refreshed by
+        ``update_config_yaml``. Result: a Settings change had no effect
+        until ``gadget_web.service`` was restarted, and a user toggling
+        ``false → true`` would silently keep filtering forever.
+
+        If this test starts failing, the picker has regressed to
+        import-time caching and we'll silently re-introduce the same
+        bug the original review caught.
         """
-        monkeypatch.setattr(config, "CLOUD_ARCHIVE_SYNC_NON_EVENT", False)
-        monkeypatch.setattr(svc, "CLOUD_ARCHIVE_SYNC_NON_EVENT", False)
+        # Seed: flag is off (default), routine clip filtered out.
         first = svc._discover_events(teslacam_root, conn=None)
-        assert len(first) == 1
+        assert len(first) == 1, "expected filter-on by default"
 
-        # Flip the flag — no module reload, no service restart.
-        monkeypatch.setattr(config, "CLOUD_ARCHIVE_SYNC_NON_EVENT", True)
-        # Note: NOT updating svc.CLOUD_ARCHIVE_SYNC_NON_EVENT here — the
-        # picker MUST be reading the live ``config`` module, not its own
-        # import-time binding. If this test starts failing, the picker has
-        # silently regressed to import-time caching.
+        # Drive the change through the EXACT path the Settings handler
+        # uses — no in-memory module mutation, no service restart.
+        update_config_yaml({'cloud_archive.sync_non_event_videos': True})
+
+        # Next call should now include the routine clip.
         second = svc._discover_events(teslacam_root, conn=None)
-        assert len(second) == 2
+        assert len(second) == 2, (
+            "Picker did not pick up the YAML change without restart — "
+            "regression to import-time caching of "
+            "CLOUD_ARCHIVE_SYNC_NON_EVENT."
+        )
 
-    def test_filter_logs_drop_count(self, teslacam_root, monkeypatch, caplog):
+    def test_filter_logs_drop_count(
+            self, teslacam_root, isolated_yaml, caplog):
         """The filter must log how many clips it dropped (for diagnosis)."""
         import logging
-        monkeypatch.setattr(config, "CLOUD_ARCHIVE_SYNC_NON_EVENT", False)
-        monkeypatch.setattr(svc, "CLOUD_ARCHIVE_SYNC_NON_EVENT", False)
 
         with caplog.at_level(logging.INFO, logger=svc.logger.name):
             svc._discover_events(teslacam_root, conn=None)
@@ -164,3 +189,19 @@ class TestSyncNonEventVideosFilter:
             "filtered 1 non-event" in rec.message
             for rec in caplog.records
         ), f"Expected drop-count log line; got {[r.message for r in caplog.records]}"
+
+    def test_picker_falls_back_safely_when_yaml_unreadable(
+            self, teslacam_root, isolated_yaml, monkeypatch):
+        """If YAML read fails, the picker falls back to import-time value
+        rather than crashing the worker.
+
+        Pins the fail-safe contract: the worker thread must keep running
+        even if config.yaml is missing/corrupt/locked at the moment of a
+        sync iteration.
+        """
+        monkeypatch.setattr(config, "CONFIG_YAML", "/nonexistent/path/config.yaml")
+        # Import-time fallback is whatever was loaded at module import
+        # — we don't assert a specific count here, only that the call
+        # doesn't raise.
+        result = svc._discover_events(teslacam_root, conn=None)
+        assert isinstance(result, list)


### PR DESCRIPTION
## Phase 2.3 — sync_non_event_videos filter actually filters (closes p2-3 of #97)

### Problem

The `cloud_archive.sync_non_event_videos` setting (defaults to `false`) is supposed to keep routine driving clips off the cloud upload queue when off. But the picker (`_discover_events`) was only USING the priority score to **sort** — never to filter. Result: with the flag off, routine non-event/non-geo clips were still queued (just at lower priority), silently consuming user bandwidth and burying the event clips users actually wanted backed up.

### Change

* `_discover_events` scores every candidate exactly once (was previously double-scoring during sort), then DROPS score >= 200 entries when `CLOUD_ARCHIVE_SYNC_NON_EVENT` is `False`.
* The flag is **re-read from `config` on every call** so a Settings toggle takes effect on the next sync iteration without a service restart.
* INFO log records the drop count so operators can confirm the filter is working.

### Why filter at `_discover_events` only

`queue_event_for_sync` is called solely from the manual ""Sync this folder"" button (cloud_archive blueprint). That's explicit user intent and should NOT be filtered. The bulk picker is the only place the flag should apply.

### Tests (5 new)

* `test_filter_off_drops_non_event_clips` — pre-fix: 2 entries; post-fix: 1
* `test_filter_on_keeps_non_event_clips` — legacy opt-in path preserved
* `test_filter_off_with_only_non_event_clips_returns_empty` — edge case
* `test_filter_change_takes_effect_without_restart` — pins the per-call re-read contract
* `test_filter_logs_drop_count` — operator visibility contract

Full suite: **811 passed, 3 skipped** (was 806 + 5 new).

### Verification on Pi (after deploy)

* With `cloud_archive.sync_non_event_videos: false` (default), trigger a sync iteration:
  `sudo journalctl -u gadget_web.service --since '5 min ago' | grep 'filtered.*non-event'`
  should report a non-zero count if any routine clips exist on disk.
* The `cloud_synced_files` table should not gain new `queued` rows for routine clips.

### Risk

Trivial — additive filter behind an existing config flag whose default is unchanged. Users with the flag explicitly set to `true` see no change.
