### PR TITLE
Phase 2.5 (#97): Handle NULL expected metadata in stable-write gate

### DIFF
--- a/scripts/web/services/archive_worker.py
+++ b/scripts/web/services/archive_worker.py
@@ -1082,11 +1082,24 @@ def process_one_claim(row: Dict[str, Any], db_path: str,
     age = now_fn() - st.st_mtime
     expected_size = row.get('expected_size')
     expected_mtime = row.get('expected_mtime')
+    # Phase 2.5 — When the queue row has NULL ``expected_size`` /
+    # ``expected_mtime`` (e.g., enqueue happened while Tesla was still
+    # writing and the producer's ``stat()`` raced against the partial
+    # write, OR a legacy schema row predates the metadata columns), we
+    # have NO baseline to compare against. The pre-2.5 code computed
+    # ``metadata_drifted = False`` in that case and FELL THROUGH to the
+    # copy step, potentially copying a half-written file. With moov-
+    # verify (2.4) such files now fail post-copy, but it's wasteful to
+    # do the IO and immediately retry. Treat NULL metadata as
+    # "needs settling check" so the freshness gate fires: defer if the
+    # file is too young, proceed if it has been settled long enough.
+    metadata_unknown = (expected_size is None or expected_mtime is None)
     metadata_drifted = (
         (expected_size is not None and expected_size != st.st_size)
         or (expected_mtime is not None and expected_mtime != st.st_mtime)
     )
-    if age < _STABLE_WRITE_AGE_SECONDS and metadata_drifted:
+    needs_settling_check = metadata_drifted or metadata_unknown
+    if age < _STABLE_WRITE_AGE_SECONDS and needs_settling_check:
         # Update the snapshot so the next pick uses fresh values.
         archive_queue.release_claim(
             row_id,

--- a/tests/test_archive_worker.py
+++ b/tests/test_archive_worker.py
@@ -413,6 +413,151 @@ class TestArchiveWorkerStableGate:
         )
         assert outcome == 'copied'
 
+    # ------------------------------------------------------------------
+    # Phase 2.5 — NULL expected_size / expected_mtime semantics.
+    #
+    # Pre-2.5 behavior: ``metadata_drifted`` was False when both were
+    # None, so the gate skipped and the worker would copy a possibly-
+    # half-written file. With 2.5, NULL metadata is treated as "needs
+    # settling check": defer if young, proceed if settled, refresh
+    # baseline either way so the next claim has something to compare.
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _insert_null_metadata_row(
+        db_path: str, source_path: str, priority: int = 1,
+    ) -> int:
+        """Insert a queue row with NULL expected_size / expected_mtime.
+
+        Mimics the production race condition where the enqueue
+        producer's ``stat()`` raced against Tesla's mid-write (or a
+        legacy schema row predates the columns being populated).
+        """
+        with sqlite3.connect(db_path) as c:
+            cur = c.execute(
+                """INSERT INTO archive_queue
+                       (source_path, priority, status, enqueued_at,
+                        expected_size, expected_mtime)
+                   VALUES (?, ?, 'pending', '2025-01-01T00:00:00+00:00',
+                           NULL, NULL)""",
+                (source_path, int(priority)),
+            )
+            return int(cur.lastrowid)
+
+    def test_null_metadata_with_fresh_file_defers(
+        self, db, archive_root, teslacam_root, make_clip,
+    ):
+        # Fresh file (mtime=now) + NULL expected_size/mtime → MUST be
+        # deferred. Pre-2.5, this case fell through and copied a
+        # potentially half-written file.
+        clip = make_clip(
+            "RecentClips/null-fresh-front.mp4", mtime=time.time(),
+        )
+        self._insert_null_metadata_row(db, clip)
+        row = claim_next_for_worker('w', db_path=db)
+        outcome = archive_worker.process_one_claim(
+            row, db, archive_root, teslacam_root,
+            chunk_size=4096, max_attempts=3,
+        )
+        assert outcome == 'pending', (
+            "NULL metadata + fresh file MUST defer to next iteration; "
+            "pre-2.5 this fell through and could copy a half-written file"
+        )
+        rows = list_queue(db_path=db)
+        assert rows[0]['status'] == 'pending'
+        assert rows[0]['attempts'] == 0  # not burned
+        # Baseline metadata is now populated for the next claim.
+        assert rows[0]['expected_size'] is not None
+        assert rows[0]['expected_mtime'] is not None
+
+    def test_null_metadata_with_settled_file_proceeds(
+        self, db, archive_root, teslacam_root, make_clip,
+    ):
+        # NULL metadata + file that has been quiet for > 5 s →
+        # treat live stat as authoritative and copy. The moov-verify
+        # added in 2.4 catches any structural incompleteness.
+        clip = make_clip(
+            "RecentClips/null-settled-front.mp4", mtime=1000.0,
+        )
+        self._insert_null_metadata_row(db, clip)
+        row = claim_next_for_worker('w', db_path=db)
+        outcome = archive_worker.process_one_claim(
+            row, db, archive_root, teslacam_root,
+            chunk_size=4096, max_attempts=3,
+        )
+        assert outcome == 'copied', (
+            "NULL metadata + settled file should proceed: live stat "
+            "is the authoritative baseline"
+        )
+
+    def test_null_metadata_only_size_null_defers_when_fresh(
+        self, db, archive_root, teslacam_root, make_clip,
+    ):
+        # Defensive: only ONE column NULL (legacy partial-migration
+        # row) should still trigger the settling check, not be
+        # accidentally trusted because the other column matches.
+        clip = make_clip(
+            "RecentClips/null-size-front.mp4", mtime=time.time(),
+        )
+        with sqlite3.connect(db) as c:
+            c.execute(
+                """INSERT INTO archive_queue
+                       (source_path, priority, status, enqueued_at,
+                        expected_size, expected_mtime)
+                   VALUES (?, 1, 'pending', '2025-01-01T00:00:00+00:00',
+                           NULL, ?)""",
+                (clip, os.path.getmtime(clip)),
+            )
+        row = claim_next_for_worker('w', db_path=db)
+        outcome = archive_worker.process_one_claim(
+            row, db, archive_root, teslacam_root,
+            chunk_size=4096, max_attempts=3,
+        )
+        assert outcome == 'pending'
+        rows = list_queue(db_path=db)
+        assert rows[0]['expected_size'] is not None  # refreshed
+
+    def test_null_metadata_eventually_drains_after_settling(
+        self, db, archive_root, teslacam_root, make_clip, monkeypatch,
+    ):
+        # NULL metadata + fresh file → defer. Then simulate the file
+        # settling (mtime moved into the past) and re-claim. The
+        # previous defer populated expected_size/mtime, so the next
+        # claim has a baseline + the file is now stable → copy.
+        clip = make_clip(
+            "RecentClips/null-then-settled-front.mp4",
+            mtime=time.time(),
+        )
+        self._insert_null_metadata_row(db, clip)
+
+        # First claim: NULL + fresh → defer with refreshed metadata.
+        row = claim_next_for_worker('w', db_path=db)
+        assert archive_worker.process_one_claim(
+            row, db, archive_root, teslacam_root,
+            chunk_size=4096, max_attempts=3,
+        ) == 'pending'
+
+        # Simulate Tesla finishing the write: backdate mtime so the
+        # file is now older than the 5-s gate. The size matches what
+        # was just written into expected_size on the defer above.
+        os.utime(clip, (1000.0, 1000.0))
+        # release_claim updates expected_mtime to the live stat at
+        # that moment, so we must also refresh the row's
+        # expected_mtime to the now-backdated value to mimic a normal
+        # later "no drift" pickup.
+        with sqlite3.connect(db) as c:
+            c.execute(
+                "UPDATE archive_queue SET expected_mtime=1000.0 "
+                "WHERE source_path=?",
+                (clip,),
+            )
+
+        row = claim_next_for_worker('w', db_path=db)
+        assert archive_worker.process_one_claim(
+            row, db, archive_root, teslacam_root,
+            chunk_size=4096, max_attempts=3,
+        ) == 'copied'
+
 
 # ---------------------------------------------------------------------------
 # TestArchiveWorkerSourceGone


### PR DESCRIPTION
Closes part of #97 (Phase 2 — Correctness & Coverage, item **2.5 — `p2-stable-write-null-metadata`**).

## Problem

The archive worker's stable-write gate compares the live source `stat()` against the queue row's `expected_size` / `expected_mtime` to detect "Tesla is still writing this file" drift. When **both** of those columns are NULL, the drift comparison produces `False` and the gate **falls through to the copy step** — even when the file is freshly modified and possibly half-written.

Where do NULL columns come from?

1. **Producer race**: `enqueue_for_archive` calls `os.stat(path)` and writes NULL into both columns if `stat()` raises. With Tesla actively writing the file inside the gadget loopback, `stat()` can race against truncation/rename and fail.
2. **Schema migration legacy**: a queue row inserted before the metadata columns existed.

The downstream effect:

- **Pre-2.4 (no moov-verify)**: a half-written file lands in `~/ArchivedClips/`, gets indexed (with errors), shows up in the UI, and refuses to play.
- **Post-2.4 (moov-verify, just merged)**: the moov-verify catches it and re-queues — but only for `.mp4` files. For `.ts` segments and other types, the bug still bites. And even for `.mp4`, we waste a 25-50 MB read+write per attempt before catching it.

## Fix

Treat NULL metadata as "needs settling check" — the same trigger as drifted metadata:

```python
metadata_unknown = (expected_size is None or expected_mtime is None)
metadata_drifted = (
    (expected_size is not None and expected_size != st.st_size)
    or (expected_mtime is not None and expected_mtime != st.st_mtime)
)
needs_settling_check = metadata_drifted or metadata_unknown
if age < _STABLE_WRITE_AGE_SECONDS and needs_settling_check:
    archive_queue.release_claim(
        row_id, expected_size=st.st_size,
        expected_mtime=st.st_mtime, db_path=db_path,
    )
    return 'pending'
```

Behavior matrix:

| metadata    | age       | outcome      |
|-------------|-----------|--------------|
| matches     | < 5 s     | copy         | (unchanged) |
| drifted     | < 5 s     | defer + refresh | (unchanged) |
| **unknown** | **< 5 s** | **defer + refresh** | **(was: copy — BUG)** |
| matches     | >= 5 s    | copy         | (unchanged) |
| drifted     | >= 5 s    | copy         | (unchanged — file is settled) |
| **unknown** | **>= 5 s** | **copy**     | **(live stat is authoritative)** |

The defer path populates the row's `expected_size` / `expected_mtime` from the live `stat()`, so the next claim has a baseline — same machinery the existing drift-detection path already uses.

## Tests

`tests/test_archive_worker.py::TestArchiveWorkerStableGate` — **4 new tests**:

| Test | What it pins |
|---|---|
| `test_null_metadata_with_fresh_file_defers` | The bug fix: NULL + fresh → `'pending'` with refreshed metadata. Pre-2.5 this would copy a half-written file. |
| `test_null_metadata_with_settled_file_proceeds` | The benign case still works: NULL + settled (mtime old) → `'copied'`. |
| `test_null_metadata_only_size_null_defers_when_fresh` | Defensive: a partial-migration row with one column NULL still triggers the gate. |
| `test_null_metadata_eventually_drains_after_settling` | End-to-end: NULL + fresh → defer → file settles → `'copied'`. |

`_insert_null_metadata_row` helper bypasses `enqueue_for_archive` (which always populates metadata) to reproduce the production NULL-row condition.

**Test results:**
```
830 passed, 3 skipped in 47.61s    (was 826 + 4 new)
```

## What changed

| File | Lines |
|---|---|
| `scripts/web/services/archive_worker.py` | +18 / -3 |
| `tests/test_archive_worker.py` | +144 / -1 |

## Coordination contract — preserved

- No new threads, no new task_coordinator entries, no new imports.
- No new IO: the live `stat()` is already done at the top of the gate.
- The `release_claim` call already handles the snapshot refresh — same code path as the existing drift case.

## Risk

Low. The change strictly **tightens** an existing check — pre-2.5, files with NULL metadata were unconditionally trusted; now they undergo the same freshness check that drifted files have always undergone. The only behavior change for files that **would have copied successfully** under the old code is a one-cycle delay (5+ seconds) before they're picked up — and only if they happen to have NULL metadata AND were freshly modified, which is a small fraction of the queue.

Together with #114 (Phase 2.4 moov-verify), this closes the Tesla-still-writing class of partial-copy bugs at the **source** instead of catching them at the **destination**.
