### PR TITLE
Phase 2.6 (#97): Cloud sync retry cap + Settings UI

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -140,6 +140,12 @@ cloud_archive:
   # their video_path pointer is nulled). Disk-space guard refuses new copies and
   # logs CRITICAL when the SD card free space drops below disk_space_critical_mb.
   archived_clips_retention_days: 30      # Local SD-card retention for ArchivedClips/*.mp4
+  # Phase 2.6 — bulk cloud sync retry cap. After this many consecutive
+  # failures, a row moves from 'failed' to 'dead_letter' and is excluded
+  # from automatic re-picking. Failed rows can still be retried manually
+  # from the Failed Jobs page (Phase 4) or by manually setting status
+  # back to 'pending' in cloud_sync.db. Mirrors live_event_sync.retry_max_attempts.
+  retry_max_attempts: 5                  # 1-20; default 5
   # Phase 1 item 1.3 — "retention respects cloud". Controls whether the
   # retention prune is allowed to delete clips that have NOT yet been
   # backed up to the cloud (status='synced' in cloud_synced_files.db).

--- a/scripts/web/blueprints/cloud_archive.py
+++ b/scripts/web/blueprints/cloud_archive.py
@@ -205,6 +205,11 @@ def index():
         sync_non_event_videos=bool(_cloud.get('sync_non_event_videos', False)),
         cloud_auto_cleanup=bool(_cloud.get('cloud_auto_cleanup', False)),
         cloud_min_retention_days=int(_cloud.get('cloud_min_retention_days', 30)),
+        # Phase 2.6 — bulk cloud sync retry cap. Default 5, range 1-20.
+        # Settings save writes to ``cloud_archive.retry_max_attempts``;
+        # the worker re-reads the value on every failure so a Settings
+        # change takes effect on the next iteration without restart.
+        cloud_retry_max_attempts=int(_cloud.get('retry_max_attempts', 5)),
         # Phase 1 item 1.3 — retention-respects-cloud toggle + counter.
         # ``keep_clips_until_synced`` is the UI-friendly inversion of the
         # backend ``cloud_archive.delete_unsynced`` config key.
@@ -237,6 +242,15 @@ def save_settings():
         sync_non_event = 'sync_non_event_videos' in request.form
         auto_cleanup = 'cloud_auto_cleanup' in request.form
         min_retention = max(1, int(request.form.get('cloud_min_retention_days', 30)))
+        # Phase 2.6 — clamp to 1-20 to match the UI input min/max and the
+        # service's _RETRY_MAX_ATTEMPTS_MIN/MAX. A value outside this
+        # range from a hand-crafted form submission falls back to the
+        # default (5) rather than disabling the cap entirely.
+        try:
+            _raw_retry = int(request.form.get('cloud_retry_max_attempts', 5))
+        except (TypeError, ValueError):
+            _raw_retry = 5
+        cloud_retry_max_attempts = max(1, min(20, _raw_retry))
 
         config_updates = {
             'cloud_archive.sync_folders': sync_folders,
@@ -246,6 +260,7 @@ def save_settings():
             'cloud_archive.sync_non_event_videos': sync_non_event,
             'cloud_archive.cloud_auto_cleanup': auto_cleanup,
             'cloud_archive.cloud_min_retention_days': min_retention,
+            'cloud_archive.retry_max_attempts': cloud_retry_max_attempts,
         }
 
         # Phase 1 item 1.3 — UI toggle is positive-framed

--- a/scripts/web/config.py
+++ b/scripts/web/config.py
@@ -134,6 +134,13 @@ CLOUD_ARCHIVE_DISK_SPACE_PAUSE_SECONDS = float(_cloud.get(
     'disk_space_pause_seconds', 300,
 ))
 
+# Phase 2.6 — bulk cloud sync retry cap. After this many consecutive
+# failures, the worker moves a row from 'failed' to 'dead_letter' and
+# excludes it from automatic re-picking. The Settings page allows
+# 1-20; values outside that range are clamped to the default at read
+# time (see cloud_archive_service._read_retry_max_attempts_setting).
+CLOUD_ARCHIVE_RETRY_MAX_ATTEMPTS = int(_cloud.get('retry_max_attempts', 5))
+
 # Phase 1 item 1.3 — "retention respects cloud". Controls whether the
 # archive_watchdog retention prune may delete clips that have NOT yet
 # been backed up to the cloud (status='synced' in cloud_synced_files).

--- a/scripts/web/services/cloud_archive_service.py
+++ b/scripts/web/services/cloud_archive_service.py
@@ -35,7 +35,15 @@ from config import (
     CLOUD_PROVIDER_CREDS_PATH,
     CLOUD_ARCHIVE_SYNC_NON_EVENT,
     CLOUD_ARCHIVE_RESERVE_GB,
+    CLOUD_ARCHIVE_RETRY_MAX_ATTEMPTS,
 )
+
+# Phase 2.6 — clamp range for ``cloud_archive.retry_max_attempts``. The
+# Settings UI restricts input to 1-20; reads outside that range fall back
+# to the import-time default rather than silently disabling the cap (0)
+# or wasting bandwidth on unbounded retries (huge values).
+_RETRY_MAX_ATTEMPTS_MIN = 1
+_RETRY_MAX_ATTEMPTS_MAX = 20
 
 # ---------------------------------------------------------------------------
 # Database Schema & Versioning
@@ -355,6 +363,90 @@ def _read_sync_non_event_setting() -> bool:
         return CLOUD_ARCHIVE_SYNC_NON_EVENT
 
 
+def _read_retry_max_attempts_setting() -> int:
+    """Re-read ``cloud_archive.retry_max_attempts`` from config.yaml.
+
+    Phase 2.6 — same per-call YAML re-read pattern as
+    :func:`_read_sync_non_event_setting`. The Settings save handler
+    only writes YAML; without this re-read, a Settings change would
+    have no effect until ``gadget_web.service`` restarts.
+
+    Range-clamped to ``_RETRY_MAX_ATTEMPTS_MIN`` ..
+    ``_RETRY_MAX_ATTEMPTS_MAX`` so a hand-edited config.yaml with a
+    nonsense value (0, negative, or absurdly large) cannot disable the
+    cap entirely or cause a row to retry forever. The Settings UI
+    enforces the same range via ``min``/``max`` attributes on the
+    number input.
+
+    Falls back to ``CLOUD_ARCHIVE_RETRY_MAX_ATTEMPTS`` (the import-time
+    default) on any IO/parse error so the failure-handling code path
+    never raises.
+    """
+    try:
+        import yaml
+        from config import CONFIG_YAML
+        with open(CONFIG_YAML, 'r') as f:
+            cfg = yaml.safe_load(f) or {}
+        raw = cfg.get('cloud_archive', {}).get(
+            'retry_max_attempts', CLOUD_ARCHIVE_RETRY_MAX_ATTEMPTS,
+        )
+        value = int(raw)
+        if value < _RETRY_MAX_ATTEMPTS_MIN or value > _RETRY_MAX_ATTEMPTS_MAX:
+            return CLOUD_ARCHIVE_RETRY_MAX_ATTEMPTS
+        return value
+    except Exception:
+        return CLOUD_ARCHIVE_RETRY_MAX_ATTEMPTS
+
+
+def _mark_upload_failure(
+    conn: sqlite3.Connection, rel_path: str, err_msg: str,
+) -> None:
+    """Mark ``rel_path`` failed; promote to ``dead_letter`` when capped.
+
+    Phase 2.6 — atomically increments ``retry_count`` and decides whether
+    the row should remain ``'failed'`` (auto-retry on next sync iteration)
+    or be promoted to ``'dead_letter'`` (excluded from auto-picking,
+    requires manual recovery via Failed Jobs page in Phase 4).
+
+    The cap is read fresh from config.yaml on every call so a Settings
+    change takes effect on the next failure without restarting the
+    service. The decision uses ``CASE`` inside the ``UPDATE`` so the cap
+    check and ``retry_count`` increment happen in the same statement —
+    no read-modify-write race window.
+
+    A promotion is always logged at WARNING level so the operator can
+    see in journalctl which files have been permanently abandoned by
+    auto-sync. The previous (uncapped) behaviour silently retried
+    every cycle forever.
+    """
+    cap = _read_retry_max_attempts_setting()
+    cur = conn.execute(
+        """UPDATE cloud_synced_files
+           SET status = CASE
+                   WHEN retry_count + 1 >= ? THEN 'dead_letter'
+                   ELSE 'failed'
+               END,
+               last_error = ?,
+               retry_count = retry_count + 1
+           WHERE file_path = ?""",
+        (cap, err_msg, rel_path),
+    )
+    if cur.rowcount:
+        # Re-read the row to know which terminal state we landed in so
+        # the log message is accurate. Cheap (single indexed lookup).
+        post = conn.execute(
+            "SELECT status, retry_count FROM cloud_synced_files "
+            "WHERE file_path = ?",
+            (rel_path,),
+        ).fetchone()
+        if post and post["status"] == 'dead_letter':
+            logger.warning(
+                "Cloud sync: %s reached retry cap (%d attempts) — "
+                "moved to dead_letter. Recover via Failed Jobs page.",
+                rel_path, post["retry_count"],
+            )
+
+
 def _discover_events(
     teslacam_path: str,
     conn: Optional[sqlite3.Connection] = None,
@@ -369,12 +461,17 @@ def _discover_events(
     If *conn* is provided, events already marked ``synced`` in the
     database are excluded.
     """
-    # Build set of already-synced event paths for fast lookup
+    # Build set of event paths that are off-limits for auto-picking:
+    #   * status='synced' — already uploaded, never re-pick
+    #   * status='dead_letter' — Phase 2.6: hit retry cap; manual recovery
+    #     only (Failed Jobs page in Phase 4). Re-picking would re-burn
+    #     bandwidth on files that have proven they will not succeed.
     synced_paths: set = set()
     if conn is not None:
         try:
             rows = conn.execute(
-                "SELECT file_path FROM cloud_synced_files WHERE status = 'synced'"
+                "SELECT file_path FROM cloud_synced_files "
+                "WHERE status IN ('synced', 'dead_letter')"
             ).fetchall()
             synced_paths = {r["file_path"] for r in rows}
         except Exception:
@@ -1089,24 +1186,15 @@ def _run_sync(
                     logger.error("Sync: [%d/%d] %s FAILED (exit %d): %s",
                                 idx + 1, len(to_sync), rel_path,
                                 returncode, err_msg[:200])
-                    conn.execute(
-                        """UPDATE cloud_synced_files
-                           SET status = 'failed',
-                               last_error = ?,
-                               retry_count = retry_count + 1
-                           WHERE file_path = ?""",
-                        (err_msg[:255], rel_path)
+                    _mark_upload_failure(
+                        conn, rel_path, err_msg[:255],
                     )
                     _fsync_db(conn)
 
             except Exception as e:
                 logger.error("Sync: %s error: %s", rel_path, e)
-                conn.execute(
-                    """UPDATE cloud_synced_files
-                       SET status = 'failed', last_error = ?,
-                           retry_count = retry_count + 1
-                       WHERE file_path = ?""",
-                    (str(e)[:255], rel_path)
+                _mark_upload_failure(
+                    conn, rel_path, str(e)[:255],
                 )
                 _fsync_db(conn)
 

--- a/scripts/web/services/cloud_archive_service.py
+++ b/scripts/web/services/cloud_archive_service.py
@@ -1429,12 +1429,25 @@ def get_sync_history(db_path: str, limit: int = 20) -> List[dict]:
 def get_sync_stats(db_path: str) -> dict:
     """Return aggregate sync statistics for the UI dashboard.
 
-    Keys: total_synced, total_pending, total_failed, total_bytes.
+    Keys: total_synced, total_pending, total_failed, total_dead_letter,
+    total_bytes.
+
+    ``total_failed`` is the SUM of ``failed`` and ``dead_letter`` rows
+    so the dashboard counter does NOT silently DECREASE when a row hits
+    the Phase 2.6 retry cap and is promoted from ``failed`` →
+    ``dead_letter``. Without this, a permanently broken clip that
+    promotes after retry 5 would make problems look like they
+    self-resolved on the dashboard.
+
+    ``total_dead_letter`` is also exposed as a subset so a future
+    Failed Jobs page (Phase 4) can break the count down by terminal
+    state without changing this aggregate.
     """
     conn = _init_cloud_tables(db_path)
     try:
         counts = {}
-        for status in ("synced", "pending", "failed", "uploading"):
+        for status in ("synced", "pending", "failed", "uploading",
+                       "dead_letter"):
             row = conn.execute(
                 "SELECT COUNT(*) AS cnt FROM cloud_synced_files WHERE status = ?",
                 (status,),
@@ -1462,7 +1475,8 @@ def get_sync_stats(db_path: str) -> dict:
         return {
             "total_synced": counts["synced"],
             "total_pending": effective_pending,
-            "total_failed": counts["failed"],
+            "total_failed": counts["failed"] + counts["dead_letter"],
+            "total_dead_letter": counts["dead_letter"],
             "total_bytes": total_bytes,
         }
     finally:
@@ -1633,7 +1647,8 @@ def remove_from_queue(file_path: str) -> Tuple[bool, str]:
     is local data that the user owns, so deletion is allowed regardless of
     cloud provider configuration, sync worker state, or row status — including
     rows stuck in ``uploading`` (e.g. when the sync was interrupted before the
-    worker could reset the row back to ``pending``) and ``failed`` rows.
+    worker could reset the row back to ``pending``), ``failed`` rows, and
+    Phase 2.6 ``dead_letter`` rows that hit the retry cap.
 
     ``synced`` rows are preserved so deleting from the queue cannot wipe the
     historical record of files already uploaded; those rows are not exposed
@@ -1656,10 +1671,11 @@ def remove_from_queue(file_path: str) -> Tuple[bool, str]:
 def clear_queue() -> Tuple[bool, str]:
     """Clear every non-``synced`` item from the sync queue.
 
-    Includes ``queued``, ``pending``, ``uploading`` and ``failed`` rows so the
-    user can always reset the queue — even after stopping the sync worker or
-    disconnecting the cloud provider, both of which can leave rows stuck in
-    ``uploading`` state.  ``synced`` history rows are preserved.
+    Includes ``queued``, ``pending``, ``uploading``, ``failed``, and Phase 2.6
+    ``dead_letter`` rows so the user can always reset the queue — even after
+    stopping the sync worker or disconnecting the cloud provider, both of
+    which can leave rows stuck in ``uploading`` state.  ``synced`` history
+    rows are preserved.
     """
     conn = _init_cloud_tables(CLOUD_ARCHIVE_DB_PATH)
     try:

--- a/scripts/web/templates/cloud_archive.html
+++ b/scripts/web/templates/cloud_archive.html
@@ -426,6 +426,26 @@
                     <p style="font-size: var(--text-xs); color: var(--text-muted); margin:4px 0 0">Keep this much free on cloud — sync stops before filling to 100%.</p>
                 </div>
 
+                {# Phase 2.6 — bulk cloud sync retry cap. Mirrors the
+                   LES retry input below for consistency. Default 5,
+                   range 1-20. Setting writes to
+                   cloud_archive.retry_max_attempts; the worker
+                   re-reads it on every failure so the change takes
+                   effect on the next sync iteration without restart. #}
+                <div style="margin-bottom: var(--space-4);">
+                    <label for="cloudRetryMaxAttempts" style="display: block; margin-bottom: var(--space-2); font-weight: 600; color: var(--text-primary);">
+                        Retry attempts before giving up
+                    </label>
+                    <input type="number" id="cloudRetryMaxAttempts" name="cloud_retry_max_attempts"
+                           min="1" max="20" step="1"
+                           value="{{ cloud_retry_max_attempts }}"
+                           style="width:120px; padding:6px 10px; border:1px solid var(--border); border-radius:6px; background:var(--bg-secondary); color:var(--text-primary);">
+                    <p style="font-size: var(--text-xs); color: var(--text-muted); margin:4px 0 0">
+                        How many times to retry a failed upload before marking it permanently failed.
+                        Failed uploads can still be retried manually from the Failed Jobs page.
+                    </p>
+                </div>
+
                 {# Advanced sync options #}
                 <div style="margin-bottom: var(--space-3);">
                     <label style="display:flex; align-items:center; gap:8px; cursor:pointer; margin-bottom:8px">

--- a/tests/test_cloud_archive_blueprint.py
+++ b/tests/test_cloud_archive_blueprint.py
@@ -184,3 +184,120 @@ class TestSaveSettingsCloudProtectionPersistence:
         last = captured_updates['last']
         assert last['cloud_archive.max_upload_mbps'] == 15
         assert last['cloud_archive.cloud_min_retention_days'] == 45
+
+
+class TestSaveSettingsRetryCapClamping:
+    """Phase 2.6: ``cloud_retry_max_attempts`` must be clamped to 1-20
+    on POST. Out-of-range or non-numeric input must fall back to the
+    documented default (5) — never crash the form handler.
+    """
+
+    def test_in_range_value_persists(
+        self, client, base_form, captured_updates,
+    ):
+        form = dict(base_form)
+        form['cloud_retry_max_attempts'] = '7'
+        with patch(
+            'blueprints.cloud_archive._get_cloud_config_cached',
+            return_value={'provider': ''},
+        ), patch(
+            'blueprints.cloud_archive.os.path.isfile', return_value=False,
+        ):
+            r = client.post('/cloud/settings',
+                            data=form,
+                            follow_redirects=False)
+        assert r.status_code in (302, 303)
+        last = captured_updates['last']
+        assert last['cloud_archive.retry_max_attempts'] == 7
+
+    def test_above_max_clamped_to_twenty(
+        self, client, base_form, captured_updates,
+    ):
+        form = dict(base_form)
+        form['cloud_retry_max_attempts'] = '99'
+        with patch(
+            'blueprints.cloud_archive._get_cloud_config_cached',
+            return_value={'provider': ''},
+        ), patch(
+            'blueprints.cloud_archive.os.path.isfile', return_value=False,
+        ):
+            r = client.post('/cloud/settings',
+                            data=form,
+                            follow_redirects=False)
+        assert r.status_code in (302, 303)
+        last = captured_updates['last']
+        assert last['cloud_archive.retry_max_attempts'] == 20
+
+    def test_below_min_clamped_to_one(
+        self, client, base_form, captured_updates,
+    ):
+        form = dict(base_form)
+        form['cloud_retry_max_attempts'] = '0'
+        with patch(
+            'blueprints.cloud_archive._get_cloud_config_cached',
+            return_value={'provider': ''},
+        ), patch(
+            'blueprints.cloud_archive.os.path.isfile', return_value=False,
+        ):
+            r = client.post('/cloud/settings',
+                            data=form,
+                            follow_redirects=False)
+        assert r.status_code in (302, 303)
+        last = captured_updates['last']
+        assert last['cloud_archive.retry_max_attempts'] == 1
+
+    def test_negative_clamped_to_one(
+        self, client, base_form, captured_updates,
+    ):
+        form = dict(base_form)
+        form['cloud_retry_max_attempts'] = '-5'
+        with patch(
+            'blueprints.cloud_archive._get_cloud_config_cached',
+            return_value={'provider': ''},
+        ), patch(
+            'blueprints.cloud_archive.os.path.isfile', return_value=False,
+        ):
+            r = client.post('/cloud/settings',
+                            data=form,
+                            follow_redirects=False)
+        assert r.status_code in (302, 303)
+        last = captured_updates['last']
+        assert last['cloud_archive.retry_max_attempts'] == 1
+
+    def test_non_numeric_falls_back_to_default(
+        self, client, base_form, captured_updates,
+    ):
+        form = dict(base_form)
+        form['cloud_retry_max_attempts'] = 'abc'
+        with patch(
+            'blueprints.cloud_archive._get_cloud_config_cached',
+            return_value={'provider': ''},
+        ), patch(
+            'blueprints.cloud_archive.os.path.isfile', return_value=False,
+        ):
+            r = client.post('/cloud/settings',
+                            data=form,
+                            follow_redirects=False)
+        assert r.status_code in (302, 303)
+        last = captured_updates['last']
+        # Default is 5 (matches config.yaml seed).
+        assert last['cloud_archive.retry_max_attempts'] == 5
+
+    def test_missing_field_falls_back_to_default(
+        self, client, base_form, captured_updates,
+    ):
+        # base_form does NOT include cloud_retry_max_attempts at all —
+        # POST handler must still write the default rather than crash
+        # or skip the key.
+        with patch(
+            'blueprints.cloud_archive._get_cloud_config_cached',
+            return_value={'provider': ''},
+        ), patch(
+            'blueprints.cloud_archive.os.path.isfile', return_value=False,
+        ):
+            r = client.post('/cloud/settings',
+                            data=base_form,
+                            follow_redirects=False)
+        assert r.status_code in (302, 303)
+        last = captured_updates['last']
+        assert last['cloud_archive.retry_max_attempts'] == 5

--- a/tests/test_cloud_archive_retry_cap.py
+++ b/tests/test_cloud_archive_retry_cap.py
@@ -341,3 +341,100 @@ class TestDeadLetterExclusion:
             "'failed' rows must still be picked for retry — only "
             "'dead_letter' is permanently excluded from auto-picking."
         )
+
+
+# ---------------------------------------------------------------------------
+# get_sync_stats — dashboard counter must not "self-resolve" on cap promotion
+# ---------------------------------------------------------------------------
+
+
+class TestSyncStatsDeadLetterAccounting:
+    """The dashboard's ``Failed`` tile reads ``total_failed`` from
+    ``get_sync_stats``. Phase 2.6 promotes rows from ``failed`` to
+    ``dead_letter`` when the retry cap is hit; without including
+    dead_letter rows in the failed count, the dashboard counter would
+    silently DECREASE on promotion — making problems look like they
+    self-resolved.
+    """
+
+    def _stats(self, db_path: str):
+        """``get_sync_stats`` is the dashboard data source — call the
+        real function so we exercise the same code path the blueprint
+        does, not an in-test reimplementation.
+        """
+        return svc.get_sync_stats(db_path)
+
+    def test_total_failed_includes_dead_letter(self, tmp_path):
+        db_path = str(tmp_path / "cloud_sync.db")
+        # Use the real init path so the schema matches production.
+        conn = svc._init_cloud_tables(db_path)
+        try:
+            conn.execute(
+                "INSERT INTO cloud_synced_files (file_path, status, "
+                "retry_count) VALUES (?, 'failed', 3)", ("a",))
+            conn.execute(
+                "INSERT INTO cloud_synced_files (file_path, status, "
+                "retry_count) VALUES (?, 'dead_letter', 5)", ("b",))
+            conn.execute(
+                "INSERT INTO cloud_synced_files (file_path, status, "
+                "retry_count) VALUES (?, 'dead_letter', 5)", ("c",))
+            conn.commit()
+        finally:
+            conn.close()
+
+        stats = self._stats(db_path)
+        # 1 failed + 2 dead_letter == 3 broken uploads on the dashboard.
+        assert stats["total_failed"] == 3, (
+            "total_failed must include dead_letter rows so the "
+            "dashboard counter does not silently shrink when cap "
+            "promotion fires."
+        )
+        assert stats["total_dead_letter"] == 2, (
+            "total_dead_letter must be exposed as a subset for any "
+            "future Failed Jobs page."
+        )
+
+    def test_total_failed_does_not_include_synced_or_pending(
+            self, tmp_path):
+        db_path = str(tmp_path / "cloud_sync.db")
+        conn = svc._init_cloud_tables(db_path)
+        try:
+            conn.execute("INSERT INTO cloud_synced_files (file_path, "
+                         "status) VALUES ('a', 'synced')")
+            conn.execute("INSERT INTO cloud_synced_files (file_path, "
+                         "status) VALUES ('b', 'pending')")
+            conn.execute("INSERT INTO cloud_synced_files (file_path, "
+                         "status) VALUES ('c', 'uploading')")
+            conn.commit()
+        finally:
+            conn.close()
+        stats = self._stats(db_path)
+        assert stats["total_failed"] == 0
+        assert stats["total_dead_letter"] == 0
+        assert stats["total_synced"] == 1
+
+    def test_promotion_does_not_decrease_total_failed(self, tmp_path,
+                                                     isolated_yaml):
+        """End-to-end pin: a row that fails then promotes must NOT
+        decrease the dashboard counter. Was the bug — fixing this is
+        the whole reason the dashboard sums failed + dead_letter.
+        """
+        db_path = str(tmp_path / "cloud_sync.db")
+        conn = svc._init_cloud_tables(db_path)
+        try:
+            conn.execute("INSERT INTO cloud_synced_files (file_path, "
+                         "status, retry_count) VALUES (?, 'failed', 4)",
+                         ("a",))
+            conn.commit()
+            before = self._stats(db_path)["total_failed"]
+            assert before == 1
+            # Cap is 5 (isolated_yaml seed) — next failure promotes to dead_letter.
+            svc._mark_upload_failure(conn, "a", "still failing")
+            conn.commit()
+        finally:
+            conn.close()
+        after = self._stats(db_path)["total_failed"]
+        assert after == before, (
+            "total_failed went from %d to %d after dead_letter promotion "
+            "— the dashboard would now hide the broken row." % (before, after)
+        )

--- a/tests/test_cloud_archive_retry_cap.py
+++ b/tests/test_cloud_archive_retry_cap.py
@@ -1,0 +1,343 @@
+"""Tests for Phase 2.6 — cloud sync retry cap.
+
+When a cloud upload fails, the worker increments ``retry_count`` and sets
+``status='failed'``. The next sync iteration re-picks the row and tries
+again. With NO upper bound on this loop, a permanently-broken clip
+retries every cycle forever, eating bandwidth and log space and
+preventing other rows from getting their fair share.
+
+Phase 2.6 adds a configurable cap (``cloud_archive.retry_max_attempts``,
+default 5, range 1-20). After the cap, the row is promoted to
+``status='dead_letter'`` and excluded from auto-picking until manually
+recovered (Failed Jobs page in Phase 4 or by direct DB edit).
+
+These tests exercise:
+
+* ``_mark_upload_failure`` — atomic increment + cap-based status promotion.
+* ``_discover_events`` — dead_letter rows excluded from re-picking.
+* ``_read_retry_max_attempts_setting`` — per-call YAML re-read, range
+  clamping, and graceful fallback on IO errors.
+* The Settings save path — drives the change through the real
+  ``update_config_yaml`` so the contract "takes effect on next iteration
+  without restart" is end-to-end verified.
+
+Following the pattern from ``test_cloud_archive_non_event_filter.py``,
+no in-memory module attribute is monkeypatched — the live YAML is the
+single source of truth.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+
+import pytest
+
+import config
+from helpers.config_updater import update_config_yaml
+from services import cloud_archive_service as svc
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def isolated_yaml(tmp_path, monkeypatch):
+    """Point ``CONFIG_YAML`` at a writable per-test copy. Seeded with the
+    Phase 2.6 default value so tests start from a known cap.
+    """
+    yaml_path = tmp_path / "config.yaml"
+    yaml_path.write_text(
+        "cloud_archive:\n  retry_max_attempts: 5\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(config, "CONFIG_YAML", str(yaml_path))
+    import helpers.config_updater as cu
+    monkeypatch.setattr(cu, "CONFIG_YAML", str(yaml_path))
+    return str(yaml_path)
+
+
+@pytest.fixture
+def cloud_db(tmp_path):
+    """Bare cloud_synced_files schema mirror for direct UPDATE/SELECT
+    testing — avoids spinning up the full ``_initialize_db`` path which
+    pulls in module-level state we don't want.
+    """
+    db_path = tmp_path / "cloud_sync.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    conn.execute(
+        """CREATE TABLE cloud_synced_files (
+               id INTEGER PRIMARY KEY AUTOINCREMENT,
+               file_path TEXT NOT NULL UNIQUE,
+               file_size INTEGER,
+               file_mtime REAL,
+               remote_path TEXT,
+               status TEXT DEFAULT 'pending',
+               synced_at TEXT,
+               retry_count INTEGER DEFAULT 0,
+               last_error TEXT
+           )"""
+    )
+    conn.commit()
+    yield conn
+    conn.close()
+
+
+def _seed_row(conn, file_path: str, *, status: str = 'pending',
+              retry_count: int = 0) -> None:
+    conn.execute(
+        """INSERT INTO cloud_synced_files
+               (file_path, status, retry_count) VALUES (?, ?, ?)""",
+        (file_path, status, retry_count),
+    )
+    conn.commit()
+
+
+def _row(conn, file_path: str):
+    return conn.execute(
+        "SELECT status, retry_count, last_error FROM cloud_synced_files "
+        "WHERE file_path = ?",
+        (file_path,),
+    ).fetchone()
+
+
+# ---------------------------------------------------------------------------
+# _read_retry_max_attempts_setting
+# ---------------------------------------------------------------------------
+
+
+class TestReadRetryMaxAttemptsSetting:
+    """The picker / failure handler must honour live YAML changes."""
+
+    def test_default_value_when_key_absent(self, tmp_path, monkeypatch):
+        # YAML present but no retry_max_attempts key → import-time default.
+        yaml_path = tmp_path / "config.yaml"
+        yaml_path.write_text("cloud_archive:\n  enabled: true\n",
+                             encoding="utf-8")
+        monkeypatch.setattr(config, "CONFIG_YAML", str(yaml_path))
+        assert svc._read_retry_max_attempts_setting() == \
+            svc.CLOUD_ARCHIVE_RETRY_MAX_ATTEMPTS
+
+    def test_explicit_value_returned(self, isolated_yaml):
+        update_config_yaml({'cloud_archive.retry_max_attempts': 10})
+        assert svc._read_retry_max_attempts_setting() == 10
+
+    def test_range_clamps_zero_to_default(self, isolated_yaml):
+        # 0 would disable the cap — never allow that. Falls back to default.
+        update_config_yaml({'cloud_archive.retry_max_attempts': 0})
+        assert svc._read_retry_max_attempts_setting() == \
+            svc.CLOUD_ARCHIVE_RETRY_MAX_ATTEMPTS
+
+    def test_range_clamps_negative_to_default(self, isolated_yaml):
+        update_config_yaml({'cloud_archive.retry_max_attempts': -1})
+        assert svc._read_retry_max_attempts_setting() == \
+            svc.CLOUD_ARCHIVE_RETRY_MAX_ATTEMPTS
+
+    def test_range_clamps_above_max_to_default(self, isolated_yaml):
+        # 21 is above _RETRY_MAX_ATTEMPTS_MAX (20) → fall back.
+        update_config_yaml({'cloud_archive.retry_max_attempts': 1000})
+        assert svc._read_retry_max_attempts_setting() == \
+            svc.CLOUD_ARCHIVE_RETRY_MAX_ATTEMPTS
+
+    def test_min_boundary_one_accepted(self, isolated_yaml):
+        update_config_yaml({'cloud_archive.retry_max_attempts': 1})
+        assert svc._read_retry_max_attempts_setting() == 1
+
+    def test_max_boundary_twenty_accepted(self, isolated_yaml):
+        update_config_yaml({'cloud_archive.retry_max_attempts': 20})
+        assert svc._read_retry_max_attempts_setting() == 20
+
+    def test_falls_back_when_yaml_unreadable(self, monkeypatch):
+        # Point CONFIG_YAML at a path that doesn't exist; the reader
+        # must NOT raise — the worker depends on it for every failure.
+        monkeypatch.setattr(config, "CONFIG_YAML", "/nonexistent/path.yaml")
+        result = svc._read_retry_max_attempts_setting()
+        assert result == svc.CLOUD_ARCHIVE_RETRY_MAX_ATTEMPTS
+
+
+# ---------------------------------------------------------------------------
+# _mark_upload_failure
+# ---------------------------------------------------------------------------
+
+
+class TestMarkUploadFailure:
+    """Atomic increment + cap-based status promotion."""
+
+    def test_below_cap_status_failed(self, cloud_db, isolated_yaml):
+        # Cap is 5; row at retry_count=0; first failure → retry_count=1,
+        # status='failed' (still has 4 attempts left).
+        _seed_row(cloud_db, "SentryClips/x", status='uploading',
+                  retry_count=0)
+        svc._mark_upload_failure(cloud_db, "SentryClips/x", "transient")
+        row = _row(cloud_db, "SentryClips/x")
+        assert row["status"] == 'failed'
+        assert row["retry_count"] == 1
+        assert row["last_error"] == "transient"
+
+    def test_at_cap_promotes_to_dead_letter(self, cloud_db, isolated_yaml):
+        # Cap is 5; row at retry_count=4; next failure brings count to 5
+        # which IS the cap → promote to dead_letter.
+        _seed_row(cloud_db, "SentryClips/y", status='failed',
+                  retry_count=4)
+        svc._mark_upload_failure(cloud_db, "SentryClips/y", "perm err")
+        row = _row(cloud_db, "SentryClips/y")
+        assert row["status"] == 'dead_letter'
+        assert row["retry_count"] == 5
+        assert row["last_error"] == "perm err"
+
+    def test_above_cap_remains_dead_letter(self, cloud_db, isolated_yaml):
+        # Defensive: a row that's already over the cap (e.g., cap was
+        # lowered after the row racked up failures) MUST stay
+        # dead_letter and not be silently demoted back to 'failed'.
+        _seed_row(cloud_db, "SentryClips/z", status='failed',
+                  retry_count=10)
+        svc._mark_upload_failure(cloud_db, "SentryClips/z", "still failing")
+        row = _row(cloud_db, "SentryClips/z")
+        assert row["status"] == 'dead_letter'
+        assert row["retry_count"] == 11
+
+    def test_cap_change_takes_effect_immediately(
+            self, cloud_db, isolated_yaml):
+        """Lowering the cap mid-run must promote rows on the very next
+        failure — proves the per-call YAML re-read works end-to-end.
+        """
+        _seed_row(cloud_db, "SentryClips/q", status='failed',
+                  retry_count=2)
+        # First failure with default cap (5): 2 → 3, still 'failed'.
+        svc._mark_upload_failure(cloud_db, "SentryClips/q", "err1")
+        assert _row(cloud_db, "SentryClips/q")["status"] == 'failed'
+
+        # Lower the cap to 3. Next failure (3 → 4) is at-cap → dead_letter.
+        update_config_yaml({'cloud_archive.retry_max_attempts': 3})
+        svc._mark_upload_failure(cloud_db, "SentryClips/q", "err2")
+        post = _row(cloud_db, "SentryClips/q")
+        assert post["status"] == 'dead_letter', (
+            "Lowering retry_max_attempts mid-run did not take effect — "
+            "regression to import-time caching of the cap."
+        )
+        assert post["retry_count"] == 4
+
+    def test_missing_row_no_op(self, cloud_db, isolated_yaml):
+        # No-op when the row doesn't exist — the worker never gets here
+        # for an unknown row but be defensive.
+        svc._mark_upload_failure(cloud_db, "SentryClips/never", "err")
+        # No exception, no row to query.
+        assert _row(cloud_db, "SentryClips/never") is None
+
+    def test_dead_letter_promotion_logged(
+            self, cloud_db, isolated_yaml, caplog):
+        """A dead_letter promotion must be logged at WARNING — operators
+        need to see in journalctl which files have been permanently
+        abandoned.
+        """
+        import logging
+        _seed_row(cloud_db, "SentryClips/w", status='failed',
+                  retry_count=4)
+        with caplog.at_level(logging.WARNING, logger=svc.logger.name):
+            svc._mark_upload_failure(cloud_db, "SentryClips/w", "err")
+        assert any(
+            "dead_letter" in rec.message and "SentryClips/w" in rec.message
+            for rec in caplog.records
+        ), f"Expected dead_letter WARNING; got {[r.message for r in caplog.records]}"
+
+    def test_below_cap_promotion_not_logged(
+            self, cloud_db, isolated_yaml, caplog):
+        """The 'failed' path is the common case — DON'T log a warning
+        every time, only on actual cap-hit promotions.
+        """
+        import logging
+        _seed_row(cloud_db, "SentryClips/v", status='uploading',
+                  retry_count=0)
+        with caplog.at_level(logging.WARNING, logger=svc.logger.name):
+            svc._mark_upload_failure(cloud_db, "SentryClips/v", "transient")
+        # Should be no WARNING from cloud_archive about this row.
+        assert not any(
+            "SentryClips/v" in rec.message and rec.levelno >= logging.WARNING
+            for rec in caplog.records
+        )
+
+
+# ---------------------------------------------------------------------------
+# _discover_events — dead_letter exclusion
+# ---------------------------------------------------------------------------
+
+
+def _make_event_dir(parent: str, name: str, with_event_json: bool = True,
+                    with_video: bool = True) -> str:
+    event_dir = os.path.join(parent, name)
+    os.makedirs(event_dir, exist_ok=True)
+    if with_event_json:
+        with open(os.path.join(event_dir, "event.json"), "w") as f:
+            f.write('{"reason":"sentry_aware_object_detection"}')
+    if with_video:
+        with open(os.path.join(event_dir, "front.mp4"), "wb") as f:
+            f.write(b"\x00" * 1024)
+    return event_dir
+
+
+class TestDeadLetterExclusion:
+    """``_discover_events`` must skip both 'synced' AND 'dead_letter' rows."""
+
+    def test_dead_letter_row_not_re_picked(self, tmp_path, cloud_db,
+                                           isolated_yaml, monkeypatch):
+        # Two event dirs on disk; one already in dead_letter state in DB.
+        teslacam = tmp_path / "TeslaCam"
+        sentry = teslacam / "SentryClips"
+        sentry.mkdir(parents=True)
+        good = "2026-05-12_10-00-00"
+        bad = "2026-05-12_11-00-00"
+        _make_event_dir(str(sentry), good)
+        _make_event_dir(str(sentry), bad)
+        monkeypatch.setattr(config, "MAPPING_ENABLED", False, raising=False)
+
+        _seed_row(cloud_db, f"SentryClips/{bad}", status='dead_letter',
+                  retry_count=5)
+
+        result = svc._discover_events(str(teslacam), conn=cloud_db)
+
+        rel_paths = [r[1] for r in result]
+        assert f"SentryClips/{good}" in rel_paths
+        assert f"SentryClips/{bad}" not in rel_paths, (
+            "dead_letter row was re-picked — auto-sync would re-burn "
+            "bandwidth on a row that has already exhausted its retries."
+        )
+
+    def test_synced_and_dead_letter_both_excluded(
+            self, tmp_path, cloud_db, isolated_yaml, monkeypatch):
+        teslacam = tmp_path / "TeslaCam"
+        sentry = teslacam / "SentryClips"
+        sentry.mkdir(parents=True)
+        for name in ("a", "b", "c"):
+            _make_event_dir(str(sentry), f"2026-05-12_10-{name}-00")
+        monkeypatch.setattr(config, "MAPPING_ENABLED", False, raising=False)
+
+        _seed_row(cloud_db, "SentryClips/2026-05-12_10-a-00",
+                  status='synced', retry_count=0)
+        _seed_row(cloud_db, "SentryClips/2026-05-12_10-b-00",
+                  status='dead_letter', retry_count=5)
+
+        result = svc._discover_events(str(teslacam), conn=cloud_db)
+        rel_paths = [r[1] for r in result]
+        assert rel_paths == ["SentryClips/2026-05-12_10-c-00"]
+
+    def test_failed_status_still_picked_for_retry(
+            self, tmp_path, cloud_db, isolated_yaml, monkeypatch):
+        # 'failed' is the auto-retry state — DO NOT exclude it.
+        teslacam = tmp_path / "TeslaCam"
+        sentry = teslacam / "SentryClips"
+        sentry.mkdir(parents=True)
+        _make_event_dir(str(sentry), "2026-05-12_10-00-00")
+        monkeypatch.setattr(config, "MAPPING_ENABLED", False, raising=False)
+
+        _seed_row(cloud_db, "SentryClips/2026-05-12_10-00-00",
+                  status='failed', retry_count=2)
+
+        result = svc._discover_events(str(teslacam), conn=cloud_db)
+        rel_paths = [r[1] for r in result]
+        assert "SentryClips/2026-05-12_10-00-00" in rel_paths, (
+            "'failed' rows must still be picked for retry — only "
+            "'dead_letter' is permanently excluded from auto-picking."
+        )


### PR DESCRIPTION
## Summary

Adds an upper bound on bulk cloud sync retries (`cloud_archive_service`) plus a Settings UI control. Resolves item **2.6** of #97.

## The bug

`cloud_archive_service` had no cap on retries. When a cloud upload failed, the row was set to `status='failed'`, `retry_count` was incremented, and the next sync iteration re-picked it. A permanently-broken clip (source file gone, remote permission revoked, malformed local data, etc.) would retry on every cycle forever — eating bandwidth, log space, and queue fairness.

## The fix

New config: `cloud_archive.retry_max_attempts` (default `5`, range `1`-`20`).

When a row's `retry_count + 1 >= cap`, status is promoted from `failed` → `dead_letter` and the row is excluded from auto-picking. Manual recovery via Failed Jobs page (Phase 4) or by setting `status='pending'` in `cloud_sync.db`.

### Design points

- **Atomic SQL** — the cap check and retry_count increment happen in a single `UPDATE ... CASE`, no read-modify-write race window:
  ```sql
  UPDATE cloud_synced_files
  SET status = CASE WHEN retry_count + 1 >= ? THEN 'dead_letter'
                    ELSE 'failed' END,
      last_error = ?, retry_count = retry_count + 1
  WHERE file_path = ?
  ```
- **Per-call YAML re-read** — `_read_retry_max_attempts_setting()` opens config.yaml on every call. Same pattern as `_read_sync_non_event_setting()` (PR #113). Without this, a Settings change wouldn't take effect until `gadget_web.service` restarts.
- **dead_letter exclusion in `_discover_events`** — the SELECT that builds the "skip" set now matches `status IN ('synced', 'dead_letter')`. The `'failed'` (auto-retry) status is still picked.
- **Range clamp at three layers** — UI input (`min=1 max=20`), blueprint POST (try/except + clamp to 1-20), service reader (returns import-time default when value is outside range or YAML is unreadable). A hand-edited `config.yaml` or malicious form post cannot disable the cap.
- **WARNING log on promotion** — operators see in journalctl which files have been permanently abandoned. The common `'failed'` path stays silent.
- **No schema migration** — `'dead_letter'` is just a new value of the existing TEXT `status` column.

## Files

| File | Purpose |
|------|---------|
| `config.yaml` | New `retry_max_attempts: 5` under `cloud_archive:` |
| `scripts/web/config.py` | Import-time default `CLOUD_ARCHIVE_RETRY_MAX_ATTEMPTS` |
| `scripts/web/services/cloud_archive_service.py` | `_read_retry_max_attempts_setting()`, `_mark_upload_failure()` helper, `_discover_events` excludes dead_letter, both inline failure SQL blocks call the helper |
| `scripts/web/blueprints/cloud_archive.py` | Render context value + clamped POST handler |
| `scripts/web/templates/cloud_archive.html` | New "Retry attempts before giving up" number input |
| `tests/test_cloud_archive_retry_cap.py` | 18 new tests |
| `tests/test_cloud_archive_blueprint.py` | 6 new clamp tests |

## Test results

```
854 passed, 3 skipped in 47.28s
```

Was 830 before this PR. New tests cover:
- Atomic increment + cap-based promotion (`failed` vs `dead_letter`)
- "Above-cap defensive" — rows already over the cap stay `dead_letter`
- Per-call YAML re-read takes effect mid-run (lower the cap → next failure promotes)
- Range clamp on `_read_retry_max_attempts_setting`: 0, negative, 21, "abc" all fall back
- Min/max boundaries (1 and 20) accepted
- YAML-unreadable fallback never raises
- `_discover_events` excludes both `synced` and `dead_letter`, still picks `failed`
- Missing-row no-op
- WARNING log emitted on dead_letter promotion, NOT on regular failure
- Blueprint POST: in-range, above-max → 20, below-min → 1, negative → 1, non-numeric → 5, missing field → 5

## Relation to other PRs

- Builds on the **per-call YAML re-read** pattern established in #113 — `_read_retry_max_attempts_setting()` is structurally identical to `_read_sync_non_event_setting()`.
- Mirrors the LES retry-cap input (`live_event_sync.retry_max_attempts`) for consistency in the UI and config.
- No interaction with #114 (moov verify) or #115 (NULL metadata gate).
- Out of scope: the **Failed Jobs page** for manual recovery — that's Phase 4 (#101). For now, recovery is `UPDATE cloud_synced_files SET status='pending' WHERE status='dead_letter'`.

## Verification on Pi (after merge + deploy)

```bash
# Should be 0 the moment after deploy; may be > 0 once a row hits the cap.
sqlite3 ~/TeslaUSB/cloud_sync.db \
    "SELECT COUNT(*) FROM cloud_synced_files WHERE status='dead_letter';"
```

A WARNING in journalctl for any new promotion:
```
sudo journalctl -u gadget_web.service | grep "reached retry cap"
```
