### PR TITLE
Phase 2.7 (#97): Canonicalize cloud_synced_files.file_path

### DIFF
--- a/scripts/web/services/cloud_archive_service.py
+++ b/scripts/web/services/cloud_archive_service.py
@@ -11,6 +11,8 @@ rclone credentials to tmpfs only for the duration of each upload.
 
 import logging
 import os
+import posixpath
+import shutil
 import sqlite3
 import subprocess
 import threading
@@ -70,7 +72,13 @@ def canonical_cloud_path(file_path: str) -> str:
     * ``/`` separators only (Windows backslashes converted defensively).
     * No leading slash.
     * No trailing slash.
-    * No ``//``, ``./``, or ``../`` components.
+    * No ``//`` or ``./`` components.
+    * **No ``..`` components** — these are rejected with ``ValueError``
+      because they have no legitimate place in a cloud-sync row name and
+      ``remove_from_queue`` is reachable from raw user input
+      (``cloud_archive.py`` POST handler), so a ``..`` collapse via
+      ``posixpath.normpath`` could be exploited to reference a row the
+      user shouldn't be able to address.
 
     Absolute paths under any of those known roots have everything before
     the root segment stripped. Examples::
@@ -91,10 +99,26 @@ def canonical_cloud_path(file_path: str) -> str:
 
     Empty / falsy input is returned unchanged so callers can pass
     optional values without a guard.
+
+    Raises:
+        ValueError: if ``file_path`` contains a ``..`` segment.
     """
     if not file_path:
         return file_path
     p = file_path.replace('\\', '/')
+
+    # Reject path-traversal attempts BEFORE any normalization. We check
+    # for the literal '..' segment surrounded by separators (or at the
+    # ends) so a basename like 'foo..bar.mp4' is allowed but
+    # 'ArchivedClips/../foo' is not. Doing this before normpath() is
+    # critical: posixpath.normpath('/x/../etc/passwd') silently
+    # collapses to '/etc/passwd'.
+    for seg in p.split('/'):
+        if seg == '..':
+            raise ValueError(
+                f"Path traversal segment '..' is not permitted in "
+                f"cloud_synced_files.file_path: {file_path!r}"
+            )
 
     # Find a known root segment and strip everything before it. We use
     # find('/<root>/') so 'ArchivedClips' inside a basename doesn't
@@ -115,9 +139,10 @@ def canonical_cloud_path(file_path: str) -> str:
     if stripped is not None:
         p = stripped
 
-    # Normalize separators: collapse //, drop ./ and ../ components,
-    # strip trailing slash. posixpath.normpath does all of this.
-    import posixpath
+    # Normalize separators: collapse //, drop ./ components, strip
+    # trailing slash. posixpath.normpath does all of this; it would
+    # ALSO collapse '..' but we've already rejected those above, so
+    # there's no traversal risk from this call.
     p = posixpath.normpath(p)
 
     if p == '.':
@@ -307,7 +332,6 @@ def _migrate_canonicalize_paths_v2(
     backup_path = f"{db_path}.bak.v2-canonical-paths"
     if not os.path.exists(backup_path):
         try:
-            import shutil
             shutil.copy2(db_path, backup_path)
             # Best-effort: also copy WAL/SHM if they exist, so the
             # backup is a coherent snapshot.
@@ -454,29 +478,45 @@ def _init_cloud_tables(db_path: str) -> sqlite3.Connection:
         # are skipped, and rows that collapse to the same canonical
         # path are merged keeping the higher-priority status (a synced
         # row beats a pending one).
+        #
+        # Atomicity: the migration's UPDATEs/DELETEs and the version
+        # bump that follows MUST commit together. If the migration
+        # raises, we ``conn.rollback()`` to undo any partial rewrites
+        # and SKIP the version bump entirely so the migration retries
+        # on the next process start. The previous behaviour (log and
+        # fall through) left the DB with one rewritten row + the rest
+        # legacy + version=2 — the migration would never run again and
+        # the dedup contract would be silently broken.
+        migration_ok = True
         if current < 2:
             try:
                 _migrate_canonicalize_paths_v2(conn, db_path)
             except Exception as e:
-                # Migration failures should never lock out the service.
-                # Log loudly so an operator notices, but proceed.
+                migration_ok = False
+                try:
+                    conn.rollback()
+                except Exception:
+                    pass
                 logger.error(
-                    "Cloud archive v2 migration failed (%s); leaving "
-                    "rows as-is. New writes will still be canonical.",
-                    e,
+                    "Cloud archive v2 migration failed (%s); rolled "
+                    "back partial rewrites and leaving schema at v%d. "
+                    "Migration will retry on next service start. New "
+                    "writes will still be canonical.",
+                    e, current,
                 )
 
-        conn.execute(
-            "INSERT OR REPLACE INTO module_versions (module, version, updated_at) "
-            "VALUES (?, ?, ?)",
-            (_CLOUD_MODULE, _CLOUD_SCHEMA_VERSION,
-             datetime.now(timezone.utc).isoformat()),
-        )
-        conn.commit()
-        logger.info(
-            "Cloud archive tables initialized (v%d) in %s",
-            _CLOUD_SCHEMA_VERSION, db_path,
-        )
+        if migration_ok:
+            conn.execute(
+                "INSERT OR REPLACE INTO module_versions (module, version, updated_at) "
+                "VALUES (?, ?, ?)",
+                (_CLOUD_MODULE, _CLOUD_SCHEMA_VERSION,
+                 datetime.now(timezone.utc).isoformat()),
+            )
+            conn.commit()
+            logger.info(
+                "Cloud archive tables initialized (v%d) in %s",
+                _CLOUD_SCHEMA_VERSION, db_path,
+            )
 
     # On first DB access after process start, recover any sessions or
     # uploads left in a transient state by a crash or service restart.
@@ -1933,8 +1973,16 @@ def remove_from_queue(file_path: str) -> Tuple[bool, str]:
     the legacy absolute form or the canonical relative form match the
     same row (post-2.7 migration the DB only contains canonical rows,
     but the API can still receive legacy paths).
+
+    A path containing ``..`` segments is rejected via
+    :func:`canonical_cloud_path` (raises ``ValueError``) — caught here
+    and surfaced to the caller as ``(False, "Invalid path")`` so the
+    blueprint returns a sane error to the UI rather than crashing.
     """
-    canonical = canonical_cloud_path(file_path)
+    try:
+        canonical = canonical_cloud_path(file_path)
+    except ValueError:
+        return False, "Invalid path"
     conn = _init_cloud_tables(CLOUD_ARCHIVE_DB_PATH)
     try:
         result = conn.execute(

--- a/scripts/web/services/cloud_archive_service.py
+++ b/scripts/web/services/cloud_archive_service.py
@@ -45,12 +45,95 @@ from config import (
 _RETRY_MAX_ATTEMPTS_MIN = 1
 _RETRY_MAX_ATTEMPTS_MAX = 20
 
+# Phase 2.7 — cloud-path canonicalization. The cloud_synced_files table's
+# ``file_path`` column was historically populated by several call sites
+# with inconsistent forms: relative POSIX (``ArchivedClips/foo.mp4``,
+# ``SentryClips/<event>``) from the bulk worker, but absolute filesystem
+# paths from ``queue_event_for_sync`` (which used ``os.scandir().path``).
+# The mix made dedup checks unreliable, broke ``WHERE file_path = ?``
+# lookups across writers, and produced corrupt rows like
+# ``ArchivedClips/foo.mp4/`` (trailing slash from a stray ``rclone lsf``
+# response). The schema version is bumped to 2 and a one-shot migration
+# rewrites every row to canonical relative form. New writes go through
+# ``canonical_cloud_path`` so this can never regress.
+_KNOWN_CLOUD_ROOTS = ("ArchivedClips", "RecentClips", "SentryClips",
+                      "SavedClips", "TeslaTrackMode")
+
+
+def canonical_cloud_path(file_path: str) -> str:
+    """Normalize a cloud-sync ``file_path`` to canonical relative form.
+
+    The canonical form is a POSIX-style path **relative to one of the
+    well-known TeslaCam folders** (``ArchivedClips``, ``RecentClips``,
+    ``SentryClips``, ``SavedClips``, ``TeslaTrackMode``):
+
+    * ``/`` separators only (Windows backslashes converted defensively).
+    * No leading slash.
+    * No trailing slash.
+    * No ``//``, ``./``, or ``../`` components.
+
+    Absolute paths under any of those known roots have everything before
+    the root segment stripped. Examples::
+
+        /home/pi/ArchivedClips/2026-01-01-front.mp4
+            -> ArchivedClips/2026-01-01-front.mp4
+        /mnt/gadget/part1-ro/TeslaCam/SentryClips/2026-01-01_10-00-00
+            -> SentryClips/2026-01-01_10-00-00
+        ArchivedClips/foo.mp4/      (corrupt trailing slash)
+            -> ArchivedClips/foo.mp4
+        /home/pi/ArchivedClips//bar.mp4
+            -> ArchivedClips/bar.mp4
+
+    Paths that don't contain a known root segment have their leading /
+    and trailing / stripped but are otherwise preserved (this should
+    never happen for legitimate cloud-sync rows; treat such paths as
+    suspect but don't drop them).
+
+    Empty / falsy input is returned unchanged so callers can pass
+    optional values without a guard.
+    """
+    if not file_path:
+        return file_path
+    p = file_path.replace('\\', '/')
+
+    # Find a known root segment and strip everything before it. We use
+    # find('/<root>/') so 'ArchivedClips' inside a basename doesn't
+    # accidentally match (e.g. a hypothetical filename
+    # 'someArchivedClipsthing.mp4' would not be split).
+    stripped = None
+    for root in _KNOWN_CLOUD_ROOTS:
+        # Match 'X/<root>/' so we keep the root segment itself.
+        marker = f"/{root}/"
+        idx = p.find(marker)
+        if idx >= 0:
+            stripped = p[idx + 1:]  # +1 to drop the leading slash
+            break
+        # Or if the whole prefix IS the root (path begins with the root).
+        if p == root or p.startswith(f"{root}/"):
+            stripped = p
+            break
+    if stripped is not None:
+        p = stripped
+
+    # Normalize separators: collapse //, drop ./ and ../ components,
+    # strip trailing slash. posixpath.normpath does all of this.
+    import posixpath
+    p = posixpath.normpath(p)
+
+    if p == '.':
+        return ''
+    # Strip leading slashes (defensive — normpath leaves a single one).
+    while p.startswith('/'):
+        p = p[1:]
+    return p
+
+
 # ---------------------------------------------------------------------------
 # Database Schema & Versioning
 # ---------------------------------------------------------------------------
 
 _CLOUD_MODULE = "cloud_archive"
-_CLOUD_SCHEMA_VERSION = 1
+_CLOUD_SCHEMA_VERSION = 2
 
 _CLOUD_TABLES_SQL = """\
 CREATE TABLE IF NOT EXISTS module_versions (
@@ -170,6 +253,164 @@ def _handle_corrupt_db(db_path: str) -> None:
                 pass
 
 
+# ---------------------------------------------------------------------------
+# Phase 2.7 v2 migration: canonicalize cloud_synced_files.file_path
+# ---------------------------------------------------------------------------
+
+# Status priority for merging two rows that collapse to the same canonical
+# path. Higher value wins. ``synced`` always beats anything else (it's the
+# only state that records a successful upload — losing it would make the
+# bulk worker re-upload). ``dead_letter`` outranks ``failed`` because it
+# represents a row that has already exhausted its automatic retries —
+# demoting it back to ``failed`` would re-burn bandwidth on something
+# the operator has implicitly given up on.
+_MIGRATE_STATUS_PRIORITY = {
+    'synced': 5,
+    'dead_letter': 4,
+    'failed': 3,
+    'uploading': 2,
+    'pending': 1,
+    'queued': 0,
+}
+
+
+def _migrate_canonicalize_paths_v2(
+    conn: sqlite3.Connection, db_path: str,
+) -> Tuple[int, int]:
+    """Rewrite all ``cloud_synced_files.file_path`` rows to canonical form.
+
+    Returns ``(rewrites, merges)`` so the caller can log a summary.
+
+    Strategy:
+    1. Snapshot the DB to ``{db_path}.bak.v2-canonical-paths`` BEFORE
+       any writes. Power-loss during the migration leaves both copies on
+       disk; the operator can ``mv`` the .bak back without losing data.
+    2. Walk every row, compute canonical form via
+       :func:`canonical_cloud_path`.
+    3. If the new path is identical to the old, skip.
+    4. Otherwise attempt the UPDATE. On UNIQUE conflict (another row
+       already has the canonical form), MERGE: keep the row with the
+       higher status priority and delete the loser.
+
+    The whole operation runs inside a single transaction so a crash
+    leaves either the old form or the new form — never a half-migrated
+    mix. SQLite holds the WAL until commit, so an incomplete commit on
+    power-loss replays correctly on next open.
+    """
+    if not os.path.exists(db_path):
+        # In-memory or about-to-be-created DB: nothing to migrate.
+        return (0, 0)
+    # Snapshot first.  shutil.copy2 preserves mtime so the operator
+    # can see when the migration ran. Don't copy-2 over an existing
+    # backup file (a re-attempted migration after a partial crash);
+    # the FIRST snapshot is the source of truth.
+    backup_path = f"{db_path}.bak.v2-canonical-paths"
+    if not os.path.exists(backup_path):
+        try:
+            import shutil
+            shutil.copy2(db_path, backup_path)
+            # Best-effort: also copy WAL/SHM if they exist, so the
+            # backup is a coherent snapshot.
+            for suffix in ("-wal", "-shm"):
+                src = db_path + suffix
+                if os.path.exists(src):
+                    shutil.copy2(src, backup_path + suffix)
+            logger.info(
+                "Cloud archive v2 migration: snapshotted DB to %s",
+                backup_path,
+            )
+        except OSError as e:
+            logger.warning(
+                "Cloud archive v2 migration: backup to %s failed (%s); "
+                "proceeding without snapshot",
+                backup_path, e,
+            )
+
+    rewrites = 0
+    merges = 0
+    # Defensive: tests may pass a connection without row_factory set.
+    # The production caller (_init_cloud_tables) always sets it, but we
+    # don't want this routine to be picky about its connection state.
+    prior_factory = conn.row_factory
+    conn.row_factory = sqlite3.Row
+    try:
+        rows = conn.execute(
+            "SELECT id, file_path, status FROM cloud_synced_files"
+        ).fetchall()
+    finally:
+        conn.row_factory = prior_factory
+
+    for row in rows:
+        new_path = canonical_cloud_path(row["file_path"])
+        if not new_path or new_path == row["file_path"]:
+            continue
+        try:
+            conn.execute(
+                "UPDATE cloud_synced_files SET file_path = ? WHERE id = ?",
+                (new_path, row["id"]),
+            )
+            rewrites += 1
+        except sqlite3.IntegrityError:
+            # Another row already holds the canonical form. Resolve by
+            # status priority: keep the higher-ranked row, delete the
+            # other. Re-run the canonical_cloud_path so we look up by
+            # the same key the conflicting row was inserted with.
+            conn.row_factory = sqlite3.Row
+            try:
+                existing = conn.execute(
+                    "SELECT id, status FROM cloud_synced_files "
+                    "WHERE file_path = ?",
+                    (new_path,),
+                ).fetchone()
+            finally:
+                conn.row_factory = prior_factory
+            if existing is None:
+                # Defensive: the conflict row vanished mid-migration
+                # (parallel writer? shouldn't happen — service is
+                # single-threaded for this DB). Try the update again.
+                conn.execute(
+                    "UPDATE cloud_synced_files SET file_path = ? WHERE id = ?",
+                    (new_path, row["id"]),
+                )
+                rewrites += 1
+                continue
+            existing_pri = _MIGRATE_STATUS_PRIORITY.get(
+                existing["status"], 0,
+            )
+            our_pri = _MIGRATE_STATUS_PRIORITY.get(row["status"], 0)
+            if our_pri > existing_pri:
+                # Promote ours: delete existing, retry the rename.
+                conn.execute(
+                    "DELETE FROM cloud_synced_files WHERE id = ?",
+                    (existing["id"],),
+                )
+                conn.execute(
+                    "UPDATE cloud_synced_files SET file_path = ? WHERE id = ?",
+                    (new_path, row["id"]),
+                )
+            else:
+                # Keep existing: drop our duplicate.
+                conn.execute(
+                    "DELETE FROM cloud_synced_files WHERE id = ?",
+                    (row["id"],),
+                )
+            merges += 1
+            logger.info(
+                "Cloud archive v2 migration: merged duplicate row "
+                "old=%r new=%r (kept status=%s)",
+                row["file_path"], new_path,
+                existing["status"] if our_pri <= existing_pri
+                else row["status"],
+            )
+
+    if rewrites or merges:
+        logger.info(
+            "Cloud archive v2 migration: rewrote %d row(s), merged %d duplicate(s)",
+            rewrites, merges,
+        )
+    return (rewrites, merges)
+
+
 def _init_cloud_tables(db_path: str) -> sqlite3.Connection:
     """Open the cloud sync database and ensure all tables exist.
 
@@ -205,9 +446,25 @@ def _init_cloud_tables(db_path: str) -> sqlite3.Connection:
     if current < _CLOUD_SCHEMA_VERSION:
         conn.executescript(_CLOUD_TABLES_SQL)
 
-        # Future migrations would go here:
-        # if current < 2:
-        #     conn.execute("ALTER TABLE cloud_synced_files ADD COLUMN ...")
+        # Phase 2.7 (v2) — canonicalize all cloud_synced_files.file_path
+        # values. Mixed forms (relative POSIX from the bulk worker,
+        # absolute from queue_event_for_sync, plus rare corrupt rows
+        # like trailing-slash) made dedup unreliable across writers.
+        # The migration is idempotent: rows already in canonical form
+        # are skipped, and rows that collapse to the same canonical
+        # path are merged keeping the higher-priority status (a synced
+        # row beats a pending one).
+        if current < 2:
+            try:
+                _migrate_canonicalize_paths_v2(conn, db_path)
+            except Exception as e:
+                # Migration failures should never lock out the service.
+                # Log loudly so an operator notices, but proceed.
+                logger.error(
+                    "Cloud archive v2 migration failed (%s); leaving "
+                    "rows as-is. New writes will still be canonical.",
+                    e,
+                )
 
         conn.execute(
             "INSERT OR REPLACE INTO module_versions (module, version, updated_at) "
@@ -495,7 +752,7 @@ def _discover_events(
             if not os.path.isdir(event_dir):
                 continue  # Skip flat files — events only
 
-            rel_path = f"{folder}/{entry}"
+            rel_path = canonical_cloud_path(f"{folder}/{entry}")
 
             # Skip events already confirmed synced
             if rel_path in synced_paths:
@@ -527,7 +784,7 @@ def _discover_events(
                 for f in sorted(os.listdir(ARCHIVE_DIR)):
                     fpath = os.path.join(ARCHIVE_DIR, f)
                     if os.path.isfile(fpath) and f.lower().endswith(('.mp4', '.ts')):
-                        rel_path = f"ArchivedClips/{f}"
+                        rel_path = canonical_cloud_path(f"ArchivedClips/{f}")
                         if rel_path in synced_paths:
                             continue
                         fsize = os.path.getsize(fpath)
@@ -703,7 +960,7 @@ def _reconcile_with_remote(
                 continue
 
             for dirname in remote_dirs:
-                rel_path = f"{folder}/{dirname}"
+                rel_path = canonical_cloud_path(f"{folder}/{dirname}")
                 remote_dest = f"teslausb:{remote_path}/{rel_path}"
 
                 # Update existing pending/failed entries
@@ -745,9 +1002,18 @@ def _reconcile_with_remote(
             capture_output=True, text=True, timeout=60,
         )
         if result.returncode == 0:
-            remote_files = {f.strip() for f in result.stdout.strip().split('\n') if f.strip()}
+            # Strip trailing slashes too — rclone lsf may return directory
+            # entries when a folder gets mistakenly created on the remote
+            # (PRE-2.7 this produced corrupt rows like
+            # ``ArchivedClips/foo.mp4/`` that broke later dedup checks).
+            remote_files = {
+                f.strip().rstrip('/')
+                for f in result.stdout.strip().split('\n') if f.strip()
+            }
             for filename in remote_files:
-                rel_path = f"ArchivedClips/{filename}"
+                if not filename:
+                    continue
+                rel_path = canonical_cloud_path(f"ArchivedClips/{filename}")
                 remote_dest = f"teslausb:{remote_path}/{rel_path}"
 
                 cur = conn.execute(
@@ -1593,10 +1859,18 @@ def queue_event_for_sync(folder: str, event_name: str, priority: bool = False) -
         queued = 0
         for entry in os.scandir(event_dir):
             if entry.name.lower().endswith('.mp4') and event_name in entry.name:
-                # Check if already synced or uploading
+                # Phase 2.7 — store and look up by canonical relative
+                # path. Pre-2.7 this used ``entry.path`` (an absolute
+                # filesystem path) which was inconsistent with the bulk
+                # worker's relative ``f"{folder}/{event_dir}"`` form.
+                # The canonical form is what the bulk worker stores AND
+                # what the v2 migration rewrote existing rows to, so
+                # this lookup now sees the same row the worker created
+                # and the dedup check actually dedups.
+                canonical = canonical_cloud_path(entry.path)
                 existing = conn.execute(
                     "SELECT status FROM cloud_synced_files WHERE file_path = ?",
-                    (entry.path,)
+                    (canonical,)
                 ).fetchone()
                 if existing and existing['status'] in ('synced', 'uploading'):
                     continue
@@ -1606,7 +1880,7 @@ def queue_event_for_sync(folder: str, event_name: str, priority: bool = False) -
                     """INSERT OR REPLACE INTO cloud_synced_files
                        (file_path, file_size, file_mtime, status, retry_count)
                        VALUES (?, ?, ?, 'queued', 0)""",
-                    (entry.path, stat.st_size, stat.st_mtime)
+                    (canonical, stat.st_size, stat.st_mtime)
                 )
                 queued += 1
 
@@ -1653,12 +1927,19 @@ def remove_from_queue(file_path: str) -> Tuple[bool, str]:
     ``synced`` rows are preserved so deleting from the queue cannot wipe the
     historical record of files already uploaded; those rows are not exposed
     via :func:`get_sync_queue` anyway.
+
+    The ``file_path`` argument is canonicalized via
+    :func:`canonical_cloud_path` before lookup so callers passing either
+    the legacy absolute form or the canonical relative form match the
+    same row (post-2.7 migration the DB only contains canonical rows,
+    but the API can still receive legacy paths).
     """
+    canonical = canonical_cloud_path(file_path)
     conn = _init_cloud_tables(CLOUD_ARCHIVE_DB_PATH)
     try:
         result = conn.execute(
             "DELETE FROM cloud_synced_files WHERE file_path = ? AND status != 'synced'",
-            (file_path,),
+            (canonical,),
         )
         conn.commit()
         if result.rowcount:

--- a/tests/test_cloud_archive_canonicalization.py
+++ b/tests/test_cloud_archive_canonicalization.py
@@ -171,6 +171,47 @@ class TestCanonicalCloudPathSlashes:
         assert canonical_cloud_path(".") == ""
 
 
+class TestCanonicalCloudPathRejectsTraversal:
+    """``..`` segments are rejected with ``ValueError`` BEFORE
+    posixpath.normpath has a chance to silently collapse them. This
+    matters because ``remove_from_queue`` is reachable from raw user
+    input via the cloud_archive blueprint.
+    """
+
+    def test_dotdot_in_middle_raises(self):
+        with pytest.raises(ValueError, match="traversal"):
+            canonical_cloud_path("ArchivedClips/../etc/passwd")
+
+    def test_dotdot_at_start_raises(self):
+        with pytest.raises(ValueError, match="traversal"):
+            canonical_cloud_path("../ArchivedClips/foo.mp4")
+
+    def test_dotdot_in_absolute_path_raises(self):
+        # The classic exploit: /a/../b becomes /b after normpath,
+        # potentially letting an attacker reference a row they
+        # shouldn't be able to address. Must raise.
+        with pytest.raises(ValueError, match="traversal"):
+            canonical_cloud_path(
+                "/home/pi/ArchivedClips/../../../etc/passwd"
+            )
+
+    def test_dotdot_basename_substring_allowed(self):
+        # A literal '..' inside a basename (e.g. 'foo..bar.mp4') is
+        # NOT a traversal — the segment check only matches '..' as a
+        # full path component.
+        assert canonical_cloud_path("ArchivedClips/foo..bar.mp4") == \
+            "ArchivedClips/foo..bar.mp4"
+
+    def test_single_dot_basename_allowed(self):
+        # 'a.b' is fine; only the literal segment '..' is rejected.
+        assert canonical_cloud_path("ArchivedClips/a.b.mp4") == \
+            "ArchivedClips/a.b.mp4"
+
+    def test_dotdot_at_end_raises(self):
+        with pytest.raises(ValueError, match="traversal"):
+            canonical_cloud_path("ArchivedClips/foo/..")
+
+
 class TestCanonicalCloudPathUnknownRoots:
     """Paths that don't contain a known root segment are still cleaned
     of the leading slash and trailing slash, but otherwise preserved."""
@@ -738,3 +779,148 @@ class TestSchemaVersionBump:
             assert paths == ["ArchivedClips/already.mp4", "ArchivedClips/clip.mp4"]
         finally:
             new_conn.close()
+
+
+class TestMigrationAtomicity:
+    """If the migration raises mid-flight, ALL partial rewrites must be
+    rolled back AND the version must NOT be bumped, so the migration
+    retries on the next process start.
+
+    Pre-fix, ``_init_cloud_tables`` swallowed the exception with
+    ``logger.error`` and fell through to the version bump, leaving the
+    DB with a few rewritten rows + the rest legacy + version=2 — the
+    migration would never run again and the dedup contract would be
+    silently broken on every cloud sync from then on.
+    """
+
+    def test_exception_rolls_back_all_rewrites(self, tmp_path, monkeypatch):
+        # Build a v1 DB with several rows that need rewriting.
+        db = tmp_path / "cloud.db"
+        conn = _seed_cloud_db(db, [
+            ("/home/pi/ArchivedClips/clip_a.mp4", "pending", 0),
+            ("/home/pi/ArchivedClips/clip_b.mp4", "pending", 0),
+            ("/home/pi/ArchivedClips/clip_c.mp4", "pending", 0),
+        ])
+        conn.execute(
+            "CREATE TABLE module_versions "
+            "(module TEXT PRIMARY KEY, version INTEGER NOT NULL, updated_at TEXT)"
+        )
+        conn.execute(
+            "INSERT INTO module_versions (module, version, updated_at) "
+            "VALUES ('cloud_archive', 1, '2026-01-01T00:00:00')"
+        )
+        conn.commit()
+        conn.close()
+
+        # Patch the migration helper to rewrite one row, then raise.
+        original = svc._migrate_canonicalize_paths_v2
+
+        def faulty_migration(c, path):
+            # Simulate "first row rewritten OK, then an unexpected
+            # error from row 2 onwards" — the exact failure mode the
+            # reviewer demonstrated.
+            c.row_factory = sqlite3.Row
+            c.execute(
+                "UPDATE cloud_synced_files SET file_path = ? WHERE id = 1",
+                ("ArchivedClips/clip_a.mp4",),
+            )
+            raise RuntimeError("simulated migration crash")
+
+        monkeypatch.setattr(svc, "_migrate_canonicalize_paths_v2", faulty_migration)
+
+        new_conn = svc._init_cloud_tables(str(db))
+        try:
+            # Version MUST stay at 1 — migration retries on next start.
+            ver = new_conn.execute(
+                "SELECT version FROM module_versions WHERE module = 'cloud_archive'"
+            ).fetchone()[0]
+            assert ver == 1, (
+                f"Version was bumped to {ver} despite migration failure — "
+                "migration won't retry and dedup is broken"
+            )
+
+            # All three rows must still be in their original (legacy)
+            # form — the partial rewrite of clip_a was rolled back.
+            paths = sorted(
+                r[0] for r in new_conn.execute(
+                    "SELECT file_path FROM cloud_synced_files"
+                )
+            )
+            assert paths == [
+                "/home/pi/ArchivedClips/clip_a.mp4",
+                "/home/pi/ArchivedClips/clip_b.mp4",
+                "/home/pi/ArchivedClips/clip_c.mp4",
+            ], "Partial rewrites were not rolled back"
+        finally:
+            new_conn.close()
+
+        # Restore the real migration and verify it runs successfully on
+        # the next call (proves the retry actually happens).
+        monkeypatch.setattr(svc, "_migrate_canonicalize_paths_v2", original)
+        # Reset startup_recovery_done so _init_cloud_tables re-runs the
+        # version block without the cached side-effect.
+        monkeypatch.setattr(svc, "_startup_recovery_done", False)
+        retry_conn = svc._init_cloud_tables(str(db))
+        try:
+            ver = retry_conn.execute(
+                "SELECT version FROM module_versions WHERE module = 'cloud_archive'"
+            ).fetchone()[0]
+            assert ver == 2
+            paths = sorted(
+                r[0] for r in retry_conn.execute(
+                    "SELECT file_path FROM cloud_synced_files"
+                )
+            )
+            assert paths == [
+                "ArchivedClips/clip_a.mp4",
+                "ArchivedClips/clip_b.mp4",
+                "ArchivedClips/clip_c.mp4",
+            ]
+        finally:
+            retry_conn.close()
+
+
+class TestRemoveFromQueueRejectsTraversal:
+    """``remove_from_queue`` is reachable from raw user input via the
+    cloud_archive blueprint POST handler. A ``..`` segment must surface
+    as a graceful ``(False, "Invalid path")`` result, NOT crash the
+    request handler."""
+
+    def test_dotdot_returns_invalid_path(self, tmp_path, monkeypatch):
+        db = tmp_path / "cloud_sync.db"
+        monkeypatch.setattr(svc, "CLOUD_ARCHIVE_DB_PATH", str(db))
+        # Materialise the schema so the call gets past _init_cloud_tables.
+        conn = svc._init_cloud_tables(str(db))
+        conn.close()
+
+        ok, msg = svc.remove_from_queue("ArchivedClips/../etc/passwd")
+        assert ok is False
+        assert msg == "Invalid path"
+
+    def test_dotdot_does_not_delete_anything(self, tmp_path, monkeypatch):
+        # Defense in depth: prove the early-return short-circuits any
+        # DELETE. Seed an unrelated row and verify it survives.
+        db = tmp_path / "cloud_sync.db"
+        monkeypatch.setattr(svc, "CLOUD_ARCHIVE_DB_PATH", str(db))
+        conn = svc._init_cloud_tables(str(db))
+        conn.execute(
+            "INSERT INTO cloud_synced_files (file_path, status, retry_count) "
+            "VALUES (?, 'pending', 0)",
+            ("ArchivedClips/etc",),  # Plausible victim
+        )
+        conn.commit()
+        conn.close()
+
+        ok, msg = svc.remove_from_queue("ArchivedClips/../etc")
+        assert ok is False
+        assert msg == "Invalid path"
+
+        conn2 = sqlite3.connect(str(db))
+        try:
+            count = conn2.execute(
+                "SELECT COUNT(*) FROM cloud_synced_files"
+            ).fetchone()[0]
+            assert count == 1, "remove_from_queue deleted a row despite returning Invalid path"
+        finally:
+            conn2.close()
+

--- a/tests/test_cloud_archive_canonicalization.py
+++ b/tests/test_cloud_archive_canonicalization.py
@@ -1,0 +1,740 @@
+"""Tests for Phase 2.7 — cloud_synced_files.file_path canonicalization.
+
+Pre-2.7 the cloud_synced_files table stored ``file_path`` in inconsistent
+forms across writers:
+
+* The bulk worker wrote relative POSIX (``ArchivedClips/foo.mp4``,
+  ``SentryClips/2026-01-01_10-00-00``).
+* :func:`cloud_archive_service.queue_event_for_sync` wrote absolute
+  filesystem paths from ``os.scandir().path`` (e.g.
+  ``/mnt/gadget/part1-ro/TeslaCam/SentryClips/2026-01-01_10-00-00``).
+* :func:`cloud_archive_service._reconcile_with_remote` mostly stripped
+  trailing slashes from ``rclone lsf`` output but missed one branch,
+  producing corrupt rows like ``ArchivedClips/foo.mp4/``.
+
+The mismatch broke dedup checks across writers and meant a row queued via
+the UI button could never be matched against the bulk worker's row of the
+same event.
+
+Phase 2.7 introduces:
+
+1. A pure :func:`canonical_cloud_path` helper that normalises any input
+   form (absolute or relative; with or without trailing slashes; with
+   Windows backslashes; with redundant ``./`` or ``//``) to a single
+   canonical relative POSIX path beneath the well-known TeslaCam roots.
+2. A one-shot v2 schema migration that rewrites every existing
+   ``cloud_synced_files`` row to canonical form, snapshotting the DB
+   first and merging duplicate rows by status priority.
+3. Defensive wrapping of every INSERT / SELECT / UPDATE / DELETE
+   ``file_path`` site so future writers can never reintroduce the
+   mismatch.
+
+These tests cover the helper, the migration (including the duplicate
+merge logic), the snapshot, idempotence, and the dedup fix in
+``queue_event_for_sync``.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import sqlite3
+from unittest import mock
+
+import pytest
+
+from services import cloud_archive_service as svc
+from services.cloud_archive_service import canonical_cloud_path
+
+
+# ---------------------------------------------------------------------------
+# canonical_cloud_path: pure-function unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestCanonicalCloudPathBasics:
+    """Forms that already match the canonical contract pass through."""
+
+    def test_empty_string_passthrough(self):
+        assert canonical_cloud_path("") == ""
+
+    def test_none_returns_falsy(self):
+        # canonical_cloud_path treats falsy inputs as a no-op so callers
+        # don't need a guard. We don't care if it returns the input or
+        # an empty string — only that it doesn't raise.
+        result = canonical_cloud_path(None)  # type: ignore[arg-type]
+        assert not result
+
+    def test_already_canonical_archived(self):
+        assert canonical_cloud_path("ArchivedClips/2026-01-01-front.mp4") == \
+            "ArchivedClips/2026-01-01-front.mp4"
+
+    def test_already_canonical_sentry_event(self):
+        assert canonical_cloud_path("SentryClips/2026-01-01_10-00-00") == \
+            "SentryClips/2026-01-01_10-00-00"
+
+    def test_already_canonical_saved_event(self):
+        assert canonical_cloud_path("SavedClips/2026-02-15_18-30-45") == \
+            "SavedClips/2026-02-15_18-30-45"
+
+    def test_root_only_passthrough(self):
+        # Just the root segment alone is technically valid — preserve it.
+        assert canonical_cloud_path("ArchivedClips") == "ArchivedClips"
+
+
+class TestCanonicalCloudPathAbsoluteStripping:
+    """Absolute paths under known roots have everything before the root
+    stripped."""
+
+    def test_archive_dir_absolute(self):
+        # The local archive lives at ~pi/ArchivedClips; the canonical
+        # form drops everything up to and including the path component
+        # before the root.
+        assert canonical_cloud_path("/home/pi/ArchivedClips/2026-01-01-front.mp4") == \
+            "ArchivedClips/2026-01-01-front.mp4"
+
+    def test_present_mode_sentry_absolute(self):
+        # /mnt/gadget/part1-ro/TeslaCam/SentryClips/<event> — the
+        # form actually written by queue_event_for_sync's
+        # ``os.scandir().path``.
+        assert canonical_cloud_path(
+            "/mnt/gadget/part1-ro/TeslaCam/SentryClips/2026-01-01_10-00-00"
+        ) == "SentryClips/2026-01-01_10-00-00"
+
+    def test_edit_mode_sentry_absolute(self):
+        # /mnt/gadget/part1/TeslaCam/SentryClips/... (RW mount form).
+        assert canonical_cloud_path(
+            "/mnt/gadget/part1/TeslaCam/SentryClips/2026-01-01_10-00-00"
+        ) == "SentryClips/2026-01-01_10-00-00"
+
+    def test_saved_clips_absolute(self):
+        assert canonical_cloud_path(
+            "/mnt/gadget/part1-ro/TeslaCam/SavedClips/2026-02-15_18-30-45"
+        ) == "SavedClips/2026-02-15_18-30-45"
+
+    def test_recent_clips_absolute(self):
+        assert canonical_cloud_path(
+            "/mnt/gadget/part1-ro/TeslaCam/RecentClips/2026-03-01_09-15-00-front.mp4"
+        ) == "RecentClips/2026-03-01_09-15-00-front.mp4"
+
+    def test_track_mode_absolute(self):
+        assert canonical_cloud_path(
+            "/mnt/gadget/part1-ro/TeslaCam/TeslaTrackMode/session1"
+        ) == "TeslaTrackMode/session1"
+
+    def test_event_with_video_file(self):
+        # Some absolute paths are deeper than just the event dir —
+        # /mnt/.../SentryClips/<event>/front.mp4.
+        assert canonical_cloud_path(
+            "/mnt/gadget/part1-ro/TeslaCam/SentryClips/2026-01-01_10-00-00/front.mp4"
+        ) == "SentryClips/2026-01-01_10-00-00/front.mp4"
+
+
+class TestCanonicalCloudPathSlashes:
+    """Slash defects: leading, trailing, doubled, and Windows backslashes."""
+
+    def test_strip_trailing_slash(self):
+        # The exact production-corruption pattern that motivated 2.7.
+        assert canonical_cloud_path("ArchivedClips/2026-04-07_13-56-53-back.mp4/") == \
+            "ArchivedClips/2026-04-07_13-56-53-back.mp4"
+
+    def test_strip_double_trailing_slash(self):
+        assert canonical_cloud_path("ArchivedClips/foo.mp4//") == \
+            "ArchivedClips/foo.mp4"
+
+    def test_strip_leading_slash(self):
+        assert canonical_cloud_path("/ArchivedClips/foo.mp4") == \
+            "ArchivedClips/foo.mp4"
+
+    def test_collapse_double_slash(self):
+        assert canonical_cloud_path("ArchivedClips//foo.mp4") == \
+            "ArchivedClips/foo.mp4"
+
+    def test_collapse_triple_slash(self):
+        assert canonical_cloud_path("ArchivedClips///foo.mp4") == \
+            "ArchivedClips/foo.mp4"
+
+    def test_windows_backslashes(self):
+        assert canonical_cloud_path("ArchivedClips\\foo.mp4") == \
+            "ArchivedClips/foo.mp4"
+
+    def test_mixed_separators(self):
+        assert canonical_cloud_path("ArchivedClips\\sub/foo.mp4") == \
+            "ArchivedClips/sub/foo.mp4"
+
+    def test_dot_components_collapsed(self):
+        assert canonical_cloud_path("ArchivedClips/./foo.mp4") == \
+            "ArchivedClips/foo.mp4"
+
+    def test_only_dot_returns_empty(self):
+        # posixpath.normpath('.') is '.'; we map that to ''.
+        assert canonical_cloud_path(".") == ""
+
+
+class TestCanonicalCloudPathUnknownRoots:
+    """Paths that don't contain a known root segment are still cleaned
+    of the leading slash and trailing slash, but otherwise preserved."""
+
+    def test_unknown_root_keeps_relative(self):
+        # No known root: this should not crash but also shouldn't try to
+        # invent one. The path just gets cleaned.
+        assert canonical_cloud_path("/some/random/path.mp4") == \
+            "some/random/path.mp4"
+
+    def test_unknown_root_keeps_subdir(self):
+        assert canonical_cloud_path("custom/folder/clip.mp4") == \
+            "custom/folder/clip.mp4"
+
+    def test_basename_substring_doesnt_match(self):
+        # 'someArchivedClipsthing.mp4' contains the substring
+        # 'ArchivedClips' but is not actually under the root. The
+        # canonical helper must NOT match substrings — only path
+        # segments. We use find('/<root>/') in the implementation, so a
+        # bare basename without surrounding slashes does NOT match.
+        # Result: leading slash stripped, otherwise unchanged.
+        assert canonical_cloud_path(
+            "/home/pi/someArchivedClipsthing.mp4"
+        ) == "home/pi/someArchivedClipsthing.mp4"
+
+
+# ---------------------------------------------------------------------------
+# v2 migration: cloud_synced_files row rewriting
+# ---------------------------------------------------------------------------
+
+
+def _seed_cloud_db(db_path, rows):
+    """Create a v1-shaped DB and INSERT the given (file_path, status,
+    retry_count) tuples. Returns the connection (caller closes)."""
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        """CREATE TABLE cloud_synced_files (
+               id INTEGER PRIMARY KEY AUTOINCREMENT,
+               file_path TEXT NOT NULL UNIQUE,
+               file_size INTEGER,
+               file_mtime REAL,
+               remote_path TEXT,
+               status TEXT DEFAULT 'pending',
+               synced_at TEXT,
+               retry_count INTEGER DEFAULT 0,
+               last_error TEXT
+           )"""
+    )
+    for fp, status, retry in rows:
+        conn.execute(
+            "INSERT INTO cloud_synced_files (file_path, status, retry_count) "
+            "VALUES (?, ?, ?)",
+            (fp, status, retry),
+        )
+    conn.commit()
+    return conn
+
+
+class TestMigrationCanonicalizesPaths:
+    """v2 migration rewrites mixed-form rows to canonical form."""
+
+    def test_absolute_path_rewritten(self, tmp_path):
+        db = tmp_path / "cloud.db"
+        conn = _seed_cloud_db(db, [
+            ("/mnt/gadget/part1-ro/TeslaCam/SentryClips/event_a", "pending", 0),
+        ])
+        try:
+            rewrites, merges = svc._migrate_canonicalize_paths_v2(conn, str(db))
+            conn.commit()
+            assert rewrites == 1
+            assert merges == 0
+            row = conn.execute(
+                "SELECT file_path FROM cloud_synced_files"
+            ).fetchone()
+            assert row[0] == "SentryClips/event_a"
+        finally:
+            conn.close()
+
+    def test_trailing_slash_rewritten(self, tmp_path):
+        # The exact production corruption row.
+        db = tmp_path / "cloud.db"
+        conn = _seed_cloud_db(db, [
+            ("ArchivedClips/2026-04-07_13-56-53-back.mp4/", "synced", 0),
+        ])
+        try:
+            rewrites, _ = svc._migrate_canonicalize_paths_v2(conn, str(db))
+            conn.commit()
+            assert rewrites == 1
+            row = conn.execute(
+                "SELECT file_path FROM cloud_synced_files"
+            ).fetchone()
+            assert row[0] == "ArchivedClips/2026-04-07_13-56-53-back.mp4"
+        finally:
+            conn.close()
+
+    def test_canonical_rows_unchanged(self, tmp_path):
+        db = tmp_path / "cloud.db"
+        conn = _seed_cloud_db(db, [
+            ("ArchivedClips/clip_a.mp4", "synced", 0),
+            ("SentryClips/event_b", "pending", 1),
+            ("SavedClips/event_c", "failed", 3),
+        ])
+        try:
+            rewrites, merges = svc._migrate_canonicalize_paths_v2(conn, str(db))
+            conn.commit()
+            assert rewrites == 0
+            assert merges == 0
+            paths = sorted(
+                r[0] for r in conn.execute(
+                    "SELECT file_path FROM cloud_synced_files"
+                )
+            )
+            assert paths == [
+                "ArchivedClips/clip_a.mp4",
+                "SavedClips/event_c",
+                "SentryClips/event_b",
+            ]
+        finally:
+            conn.close()
+
+    def test_mixed_batch(self, tmp_path):
+        db = tmp_path / "cloud.db"
+        conn = _seed_cloud_db(db, [
+            ("ArchivedClips/already_canonical.mp4", "synced", 0),
+            ("/home/pi/ArchivedClips/abs_archive.mp4", "pending", 0),
+            ("/mnt/gadget/part1-ro/TeslaCam/SentryClips/abs_sentry", "pending", 2),
+            ("SavedClips/saved_canonical/", "failed", 4),
+        ])
+        try:
+            rewrites, merges = svc._migrate_canonicalize_paths_v2(conn, str(db))
+            conn.commit()
+            assert rewrites == 3  # three needed rewriting
+            assert merges == 0  # no collisions
+            paths = sorted(
+                r[0] for r in conn.execute(
+                    "SELECT file_path FROM cloud_synced_files"
+                )
+            )
+            assert paths == [
+                "ArchivedClips/abs_archive.mp4",
+                "ArchivedClips/already_canonical.mp4",
+                "SavedClips/saved_canonical",
+                "SentryClips/abs_sentry",
+            ]
+        finally:
+            conn.close()
+
+
+class TestMigrationDuplicateMerging:
+    """When two rows collapse to the same canonical path, the higher-
+    priority status wins."""
+
+    def test_synced_beats_pending(self, tmp_path):
+        # Synced was inserted first (legacy bulk worker), pending added
+        # later by queue_event_for_sync — both refer to the same event
+        # but the synced form is canonical and the pending form is
+        # absolute. After migration we should keep the synced row.
+        db = tmp_path / "cloud.db"
+        conn = _seed_cloud_db(db, [
+            ("SentryClips/event_x", "synced", 0),
+            ("/mnt/gadget/part1-ro/TeslaCam/SentryClips/event_x", "pending", 0),
+        ])
+        try:
+            rewrites, merges = svc._migrate_canonicalize_paths_v2(conn, str(db))
+            conn.commit()
+            assert merges == 1
+            rows = conn.execute(
+                "SELECT file_path, status FROM cloud_synced_files"
+            ).fetchall()
+            assert len(rows) == 1
+            assert rows[0][0] == "SentryClips/event_x"
+            assert rows[0][1] == "synced"
+        finally:
+            conn.close()
+
+    def test_synced_beats_dead_letter(self, tmp_path):
+        db = tmp_path / "cloud.db"
+        conn = _seed_cloud_db(db, [
+            ("/mnt/gadget/part1-ro/TeslaCam/SentryClips/event_y", "dead_letter", 5),
+            ("SentryClips/event_y", "synced", 0),
+        ])
+        try:
+            _, merges = svc._migrate_canonicalize_paths_v2(conn, str(db))
+            conn.commit()
+            assert merges == 1
+            rows = conn.execute(
+                "SELECT file_path, status FROM cloud_synced_files"
+            ).fetchall()
+            assert len(rows) == 1
+            assert rows[0][1] == "synced"
+        finally:
+            conn.close()
+
+    def test_dead_letter_beats_failed(self, tmp_path):
+        # Dead-letter is the operator's "give up" decision — demoting it
+        # back to failed would re-enqueue an upload that has already
+        # exhausted its retries.
+        db = tmp_path / "cloud.db"
+        conn = _seed_cloud_db(db, [
+            ("ArchivedClips/clip_z.mp4", "failed", 3),
+            ("/home/pi/ArchivedClips/clip_z.mp4", "dead_letter", 5),
+        ])
+        try:
+            _, merges = svc._migrate_canonicalize_paths_v2(conn, str(db))
+            conn.commit()
+            assert merges == 1
+            rows = conn.execute(
+                "SELECT file_path, status FROM cloud_synced_files"
+            ).fetchall()
+            assert len(rows) == 1
+            assert rows[0][1] == "dead_letter"
+        finally:
+            conn.close()
+
+    def test_failed_beats_pending(self, tmp_path):
+        db = tmp_path / "cloud.db"
+        conn = _seed_cloud_db(db, [
+            ("ArchivedClips/clip_w.mp4", "pending", 0),
+            ("/home/pi/ArchivedClips/clip_w.mp4", "failed", 2),
+        ])
+        try:
+            _, merges = svc._migrate_canonicalize_paths_v2(conn, str(db))
+            conn.commit()
+            assert merges == 1
+            rows = conn.execute(
+                "SELECT file_path, status FROM cloud_synced_files"
+            ).fetchall()
+            assert len(rows) == 1
+            assert rows[0][1] == "failed"
+        finally:
+            conn.close()
+
+
+class TestMigrationSnapshot:
+    """The DB is snapshotted to ``.bak.v2-canonical-paths`` BEFORE any
+    writes. A power-loss mid-migration leaves both files on disk."""
+
+    def test_backup_file_created(self, tmp_path):
+        db = tmp_path / "cloud.db"
+        conn = _seed_cloud_db(db, [
+            ("/home/pi/ArchivedClips/clip.mp4", "pending", 0),
+        ])
+        try:
+            assert not (tmp_path / "cloud.db.bak.v2-canonical-paths").exists()
+            svc._migrate_canonicalize_paths_v2(conn, str(db))
+            conn.commit()
+            assert (tmp_path / "cloud.db.bak.v2-canonical-paths").exists()
+        finally:
+            conn.close()
+
+    def test_backup_preserves_original_rows(self, tmp_path):
+        # The backup is taken before any UPDATEs; opening it should
+        # reveal the un-canonicalized form.
+        db = tmp_path / "cloud.db"
+        conn = _seed_cloud_db(db, [
+            ("/home/pi/ArchivedClips/clip.mp4", "pending", 0),
+        ])
+        try:
+            svc._migrate_canonicalize_paths_v2(conn, str(db))
+            conn.commit()
+        finally:
+            conn.close()
+
+        # Live DB is canonicalized.
+        live = sqlite3.connect(str(db))
+        try:
+            paths = [r[0] for r in live.execute(
+                "SELECT file_path FROM cloud_synced_files"
+            )]
+            assert paths == ["ArchivedClips/clip.mp4"]
+        finally:
+            live.close()
+
+        # Backup retains original.
+        backup = sqlite3.connect(str(tmp_path / "cloud.db.bak.v2-canonical-paths"))
+        try:
+            paths = [r[0] for r in backup.execute(
+                "SELECT file_path FROM cloud_synced_files"
+            )]
+            assert paths == ["/home/pi/ArchivedClips/clip.mp4"]
+        finally:
+            backup.close()
+
+    def test_backup_not_overwritten_on_repeat(self, tmp_path):
+        # If the migration is re-run (e.g. after a partial crash where
+        # rewrites started but version wasn't bumped), we must NOT
+        # overwrite the existing backup with a half-migrated copy.
+        db = tmp_path / "cloud.db"
+        conn = _seed_cloud_db(db, [
+            ("/home/pi/ArchivedClips/clip_a.mp4", "pending", 0),
+        ])
+        try:
+            svc._migrate_canonicalize_paths_v2(conn, str(db))
+            conn.commit()
+        finally:
+            conn.close()
+
+        backup_path = tmp_path / "cloud.db.bak.v2-canonical-paths"
+        first_mtime = backup_path.stat().st_mtime
+
+        # Insert new (already-canonical) row, then re-run.
+        conn2 = sqlite3.connect(str(db))
+        try:
+            conn2.execute(
+                "INSERT INTO cloud_synced_files (file_path, status, retry_count) "
+                "VALUES (?, ?, ?)",
+                ("ArchivedClips/clip_b.mp4", "pending", 0),
+            )
+            conn2.commit()
+            # Sleep 1.1s so any new copy would have a different mtime.
+            import time
+            time.sleep(1.1)
+            svc._migrate_canonicalize_paths_v2(conn2, str(db))
+            conn2.commit()
+        finally:
+            conn2.close()
+
+        # Backup mtime must not have changed.
+        assert backup_path.stat().st_mtime == first_mtime
+
+
+class TestMigrationIdempotent:
+    """Running the migration twice on already-canonical data is a no-op."""
+
+    def test_second_run_no_changes(self, tmp_path):
+        db = tmp_path / "cloud.db"
+        conn = _seed_cloud_db(db, [
+            ("ArchivedClips/clip.mp4", "synced", 0),
+            ("SentryClips/event_a", "pending", 0),
+        ])
+        try:
+            r1, m1 = svc._migrate_canonicalize_paths_v2(conn, str(db))
+            r2, m2 = svc._migrate_canonicalize_paths_v2(conn, str(db))
+            conn.commit()
+            assert r1 == 0 and m1 == 0
+            assert r2 == 0 and m2 == 0
+        finally:
+            conn.close()
+
+    def test_empty_db(self, tmp_path):
+        db = tmp_path / "cloud.db"
+        conn = _seed_cloud_db(db, [])
+        try:
+            r, m = svc._migrate_canonicalize_paths_v2(conn, str(db))
+            assert r == 0
+            assert m == 0
+        finally:
+            conn.close()
+
+
+# ---------------------------------------------------------------------------
+# queue_event_for_sync: dedup against the bulk worker's canonical row
+# ---------------------------------------------------------------------------
+
+
+class TestQueueEventForSyncCanonicalDedup:
+    """The dedup check + INSERT in ``queue_event_for_sync`` must use the
+    canonical form so it matches the bulk worker's row."""
+
+    def test_dedup_skips_already_synced_canonical_row(self, tmp_path, monkeypatch):
+        # Set up a fake TeslaCam tree on disk so os.scandir finds files.
+        teslacam = tmp_path / "TeslaCam"
+        sentry = teslacam / "SentryClips" / "event_q"
+        sentry.mkdir(parents=True)
+        # File name MUST contain the event name — queue_event_for_sync
+        # filters with ``event_name in entry.name`` (Tesla writes per-
+        # camera files prefixed with the event timestamp).
+        clip = sentry / "event_q-front.mp4"
+        clip.write_bytes(b"x" * 100)
+
+        # Patch get_teslacam_path to return our fake.
+        monkeypatch.setattr(
+            "services.video_service.get_teslacam_path",
+            lambda: str(teslacam),
+        )
+
+        db = tmp_path / "cloud_sync.db"
+        # Seed a canonical synced row for the same clip.
+        canonical = canonical_cloud_path(str(clip))
+        assert canonical.startswith("SentryClips/event_q/")
+
+        # Use _init_cloud_tables so the schema is bootstrapped properly.
+        monkeypatch.setattr(
+            svc, "CLOUD_ARCHIVE_DB_PATH", str(db),
+        )
+        conn = svc._init_cloud_tables(str(db))
+        conn.execute(
+            "INSERT INTO cloud_synced_files (file_path, status, retry_count) "
+            "VALUES (?, 'synced', 0)",
+            (canonical,),
+        )
+        conn.commit()
+        conn.close()
+
+        ok, msg = svc.queue_event_for_sync("SentryClips", "event_q")
+        assert ok
+
+        # The synced row should still be the only row, with status synced.
+        conn2 = sqlite3.connect(str(db))
+        try:
+            rows = conn2.execute(
+                "SELECT file_path, status FROM cloud_synced_files"
+            ).fetchall()
+            assert len(rows) == 1
+            assert rows[0][0] == canonical
+            assert rows[0][1] == "synced"
+        finally:
+            conn2.close()
+
+    def test_inserts_canonical_form_not_absolute(self, tmp_path, monkeypatch):
+        teslacam = tmp_path / "TeslaCam"
+        sentry = teslacam / "SentryClips" / "event_r"
+        sentry.mkdir(parents=True)
+        clip = sentry / "event_r-front.mp4"
+        clip.write_bytes(b"x" * 100)
+
+        monkeypatch.setattr(
+            "services.video_service.get_teslacam_path",
+            lambda: str(teslacam),
+        )
+        db = tmp_path / "cloud_sync.db"
+        monkeypatch.setattr(svc, "CLOUD_ARCHIVE_DB_PATH", str(db))
+
+        ok, msg = svc.queue_event_for_sync("SentryClips", "event_r")
+        assert ok
+
+        conn = sqlite3.connect(str(db))
+        try:
+            rows = conn.execute(
+                "SELECT file_path, status FROM cloud_synced_files"
+            ).fetchall()
+            assert len(rows) == 1
+            # Critical: must NOT contain the tmp_path absolute prefix.
+            assert not rows[0][0].startswith(str(tmp_path))
+            assert not rows[0][0].startswith("/")
+            # Must start with the canonical SentryClips/ root.
+            assert rows[0][0].startswith("SentryClips/event_r/")
+            assert rows[0][1] == "queued"
+        finally:
+            conn.close()
+
+
+# ---------------------------------------------------------------------------
+# remove_from_queue: canonical lookup
+# ---------------------------------------------------------------------------
+
+
+class TestRemoveFromQueueCanonical:
+    """``remove_from_queue`` canonicalizes its input so callers passing
+    legacy absolute paths still match canonical rows."""
+
+    def test_remove_with_absolute_path_matches_canonical_row(
+        self, tmp_path, monkeypatch
+    ):
+        db = tmp_path / "cloud_sync.db"
+        monkeypatch.setattr(svc, "CLOUD_ARCHIVE_DB_PATH", str(db))
+        conn = svc._init_cloud_tables(str(db))
+        conn.execute(
+            "INSERT INTO cloud_synced_files (file_path, status, retry_count) "
+            "VALUES (?, 'pending', 0)",
+            ("SentryClips/event_s",),
+        )
+        conn.commit()
+        conn.close()
+
+        ok, msg = svc.remove_from_queue(
+            "/mnt/gadget/part1-ro/TeslaCam/SentryClips/event_s"
+        )
+        assert ok
+        assert msg == "Removed from queue"
+
+        conn2 = sqlite3.connect(str(db))
+        try:
+            rows = conn2.execute(
+                "SELECT COUNT(*) FROM cloud_synced_files"
+            ).fetchone()
+            assert rows[0] == 0
+        finally:
+            conn2.close()
+
+    def test_remove_with_canonical_path_works(self, tmp_path, monkeypatch):
+        db = tmp_path / "cloud_sync.db"
+        monkeypatch.setattr(svc, "CLOUD_ARCHIVE_DB_PATH", str(db))
+        conn = svc._init_cloud_tables(str(db))
+        conn.execute(
+            "INSERT INTO cloud_synced_files (file_path, status, retry_count) "
+            "VALUES (?, 'failed', 3)",
+            ("ArchivedClips/clip.mp4",),
+        )
+        conn.commit()
+        conn.close()
+
+        ok, msg = svc.remove_from_queue("ArchivedClips/clip.mp4")
+        assert ok and msg == "Removed from queue"
+
+    def test_remove_preserves_synced_rows(self, tmp_path, monkeypatch):
+        # The protection that synced rows are NOT deleted by
+        # remove_from_queue must still work after canonicalization.
+        db = tmp_path / "cloud_sync.db"
+        monkeypatch.setattr(svc, "CLOUD_ARCHIVE_DB_PATH", str(db))
+        conn = svc._init_cloud_tables(str(db))
+        conn.execute(
+            "INSERT INTO cloud_synced_files (file_path, status, retry_count) "
+            "VALUES (?, 'synced', 0)",
+            ("ArchivedClips/clip.mp4",),
+        )
+        conn.commit()
+        conn.close()
+
+        ok, msg = svc.remove_from_queue("ArchivedClips/clip.mp4")
+        assert ok and msg == "Not in queue"
+
+        conn2 = sqlite3.connect(str(db))
+        try:
+            rows = conn2.execute(
+                "SELECT COUNT(*) FROM cloud_synced_files"
+            ).fetchone()
+            assert rows[0] == 1
+        finally:
+            conn2.close()
+
+
+# ---------------------------------------------------------------------------
+# Schema version bump and migration wiring
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaVersionBump:
+    def test_schema_version_is_2(self):
+        assert svc._CLOUD_SCHEMA_VERSION == 2
+
+    def test_init_cloud_tables_runs_migration_on_v1_db(self, tmp_path):
+        # Build a DB at v1 with mixed-form rows, then call
+        # _init_cloud_tables and verify the rows are canonical and the
+        # version is bumped to 2.
+        db = tmp_path / "cloud.db"
+        conn = _seed_cloud_db(db, [
+            ("/home/pi/ArchivedClips/clip.mp4", "pending", 0),
+            ("ArchivedClips/already.mp4", "synced", 0),
+        ])
+        # Mark as v1 in module_versions so _init_cloud_tables sees a
+        # legacy DB.
+        conn.execute(
+            "CREATE TABLE module_versions "
+            "(module TEXT PRIMARY KEY, version INTEGER NOT NULL, updated_at TEXT)"
+        )
+        conn.execute(
+            "INSERT INTO module_versions (module, version, updated_at) "
+            "VALUES ('cloud_archive', 1, '2026-01-01T00:00:00')"
+        )
+        conn.commit()
+        conn.close()
+
+        new_conn = svc._init_cloud_tables(str(db))
+        try:
+            ver = new_conn.execute(
+                "SELECT version FROM module_versions WHERE module = 'cloud_archive'"
+            ).fetchone()[0]
+            assert ver == 2
+            paths = sorted(
+                r[0] for r in new_conn.execute(
+                    "SELECT file_path FROM cloud_synced_files"
+                )
+            )
+            assert paths == ["ArchivedClips/already.mp4", "ArchivedClips/clip.mp4"]
+        finally:
+            new_conn.close()

--- a/tests/test_cloud_archive_queue.py
+++ b/tests/test_cloud_archive_queue.py
@@ -72,30 +72,30 @@ class TestRemoveFromQueue:
     """remove_from_queue must succeed for any non-synced row."""
 
     def test_removes_queued_row(self, db):
-        _insert_row(db, "/path/clip.mp4", "queued")
-        ok, _ = svc.remove_from_queue("/path/clip.mp4")
+        _insert_row(db, "path/clip.mp4", "queued")
+        ok, _ = svc.remove_from_queue("path/clip.mp4")
         assert ok is True
         assert _row_count(db) == 0
 
     def test_removes_pending_row(self, db):
-        _insert_row(db, "/path/clip.mp4", "pending")
-        ok, _ = svc.remove_from_queue("/path/clip.mp4")
+        _insert_row(db, "path/clip.mp4", "pending")
+        ok, _ = svc.remove_from_queue("path/clip.mp4")
         assert ok is True
         assert _row_count(db) == 0
 
     def test_removes_uploading_row(self, db):
         """Reproduction for issue #67: 'uploading' rows stuck after
         ``stop_sync`` + provider disconnect must still be deletable."""
-        _insert_row(db, "/path/clip.mp4", "uploading")
-        ok, _ = svc.remove_from_queue("/path/clip.mp4")
+        _insert_row(db, "path/clip.mp4", "uploading")
+        ok, _ = svc.remove_from_queue("path/clip.mp4")
         assert ok is True
         assert _row_count(db) == 0
 
     def test_removes_failed_row(self, db):
         """Failed rows from a disconnected/unreachable provider must be
         deletable."""
-        _insert_row(db, "/path/clip.mp4", "failed")
-        ok, _ = svc.remove_from_queue("/path/clip.mp4")
+        _insert_row(db, "path/clip.mp4", "failed")
+        ok, _ = svc.remove_from_queue("path/clip.mp4")
         assert ok is True
         assert _row_count(db) == 0
 
@@ -103,8 +103,8 @@ class TestRemoveFromQueue:
         """Synced rows are historical records and must NOT be deletable
         through the queue API (they're not exposed via get_sync_queue
         either)."""
-        _insert_row(db, "/path/clip.mp4", "synced")
-        ok, _ = svc.remove_from_queue("/path/clip.mp4")
+        _insert_row(db, "path/clip.mp4", "synced")
+        ok, _ = svc.remove_from_queue("path/clip.mp4")
         # Returns success ("not in queue") but the synced row stays.
         assert ok is True
         assert _row_count(db, "synced") == 1
@@ -113,7 +113,7 @@ class TestRemoveFromQueue:
         """Removing a path that isn't in the queue is a no-op success —
         the UI should never see an error for a row that was already
         cleaned up by the worker."""
-        ok, msg = svc.remove_from_queue("/never/queued.mp4")
+        ok, msg = svc.remove_from_queue("never/queued.mp4")
         assert ok is True
         assert "queue" in msg.lower()
 
@@ -121,16 +121,16 @@ class TestRemoveFromQueue:
         """The local queue is local data — clearing the cloud provider
         from config.yaml must not prevent deletion."""
         monkeypatch.setattr(svc, "CLOUD_ARCHIVE_PROVIDER", "")
-        _insert_row(db, "/path/clip.mp4", "uploading")
-        ok, _ = svc.remove_from_queue("/path/clip.mp4")
+        _insert_row(db, "path/clip.mp4", "uploading")
+        ok, _ = svc.remove_from_queue("path/clip.mp4")
         assert ok is True
         assert _row_count(db) == 0
 
     def test_only_targets_named_path(self, db):
         """remove_from_queue must not touch other rows."""
-        _insert_row(db, "/a/clip.mp4", "uploading")
-        _insert_row(db, "/b/clip.mp4", "uploading")
-        ok, _ = svc.remove_from_queue("/a/clip.mp4")
+        _insert_row(db, "a/clip.mp4", "uploading")
+        _insert_row(db, "b/clip.mp4", "uploading")
+        ok, _ = svc.remove_from_queue("a/clip.mp4")
         assert ok is True
         assert _row_count(db) == 1
         conn = sqlite3.connect(db)
@@ -138,7 +138,7 @@ class TestRemoveFromQueue:
             "SELECT file_path FROM cloud_synced_files"
         ).fetchone()
         conn.close()
-        assert row[0] == "/b/clip.mp4"
+        assert row[0] == "b/clip.mp4"
 
 
 # ---------------------------------------------------------------------------
@@ -150,10 +150,10 @@ class TestClearQueue:
 
     def test_clears_mixed_statuses(self, db):
         """All four queue statuses must be cleared in a single call."""
-        _insert_row(db, "/a.mp4", "queued")
-        _insert_row(db, "/b.mp4", "pending")
-        _insert_row(db, "/c.mp4", "uploading")
-        _insert_row(db, "/d.mp4", "failed")
+        _insert_row(db, "a.mp4", "queued")
+        _insert_row(db, "b.mp4", "pending")
+        _insert_row(db, "c.mp4", "uploading")
+        _insert_row(db, "d.mp4", "failed")
         ok, msg = svc.clear_queue()
         assert ok is True
         assert "4" in msg
@@ -163,9 +163,9 @@ class TestClearQueue:
         """Synced rows are historical records — clear_queue must leave
         them alone so the dashboard's 'total synced' counter stays
         accurate."""
-        _insert_row(db, "/a.mp4", "queued")
-        _insert_row(db, "/b.mp4", "uploading")
-        _insert_row(db, "/c.mp4", "synced")
+        _insert_row(db, "a.mp4", "queued")
+        _insert_row(db, "b.mp4", "uploading")
+        _insert_row(db, "c.mp4", "synced")
         ok, _ = svc.clear_queue()
         assert ok is True
         assert _row_count(db) == 1
@@ -175,8 +175,8 @@ class TestClearQueue:
         """Reproduction for issue #67: clearing the queue must work even
         after the cloud provider has been disconnected."""
         monkeypatch.setattr(svc, "CLOUD_ARCHIVE_PROVIDER", "")
-        _insert_row(db, "/a.mp4", "uploading")
-        _insert_row(db, "/b.mp4", "queued")
+        _insert_row(db, "a.mp4", "uploading")
+        _insert_row(db, "b.mp4", "queued")
         ok, _ = svc.clear_queue()
         assert ok is True
         assert _row_count(db) == 0
@@ -197,14 +197,14 @@ class TestGetSyncQueueAfterDelete:
     def test_uploading_row_disappears_from_queue_after_delete(self, db):
         """The original bug from issue #67: an 'uploading' row was
         visible in get_sync_queue but invisible to the delete API."""
-        _insert_row(db, "/stuck.mp4", "uploading")
+        _insert_row(db, "stuck.mp4", "uploading")
 
         before = svc.get_sync_queue()
         assert before["total"] == 1
-        assert before["queue"][0]["file_path"] == "/stuck.mp4"
+        assert before["queue"][0]["file_path"] == "stuck.mp4"
         assert before["queue"][0]["status"] == "uploading"
 
-        ok, _ = svc.remove_from_queue("/stuck.mp4")
+        ok, _ = svc.remove_from_queue("stuck.mp4")
         assert ok is True
 
         after = svc.get_sync_queue()


### PR DESCRIPTION
Closes part of #97 (item 2.7 — cloud-path canonicalization).

## Problem

Pre-2.7 the `cloud_synced_files` table stored `file_path` in three inconsistent forms across writers:

| Writer | Form | Example |
|---|---|---|
| `_discover_events` (bulk worker) | relative POSIX | `SentryClips/2026-01-01_10-00-00` |
| `queue_event_for_sync` (manual UI) | **absolute** filesystem path | `/mnt/gadget/part1-ro/TeslaCam/SentryClips/2026-01-01_10-00-00` |
| `_reconcile_with_remote` (rclone-sync) | mostly relative; one branch left **trailing slashes** | `ArchivedClips/foo.mp4/` |

The mismatch broke dedup checks: a row queued via the UI button could never match the bulk worker's row of the same event because `WHERE file_path = ?` compared apples to oranges. One corrupt trailing-slash row was found in production.

## Fix

1. **`canonical_cloud_path(file_path)`** — pure helper that normalises any input form (absolute / relative; trailing slashes; backslashes; `./` or `//`) to a single canonical relative POSIX path beneath the well-known TeslaCam roots (`ArchivedClips`, `RecentClips`, `SentryClips`, `SavedClips`, `TeslaTrackMode`). Substring matches inside basenames are explicitly rejected — uses `/<root>/` segment matching so `someArchivedClipsthing.mp4` doesn't accidentally match the `ArchivedClips` root.
2. **v2 schema migration** (`_migrate_canonicalize_paths_v2`):
   - **Snapshots** the DB to `{db_path}.bak.v2-canonical-paths` BEFORE any writes (power-loss leaves both files on disk so an operator can `mv` the .bak back).
   - Walks every row, rewrites to canonical, and on UNIQUE conflict **MERGES** the duplicate by status priority: `synced > dead_letter > failed > uploading > pending > queued`. (`synced` always wins so we never re-burn bandwidth on something already uploaded; `dead_letter` outranks `failed` because dead-letter is the operator's "give up" decision and demoting it would re-enqueue an exhausted row.)
   - Wrapped in the same transaction the version-bump uses, so a crash leaves either the old or new form (never half-migrated) and the version is only bumped on full success.
   - Idempotent: re-running on an already-canonical DB is a no-op (`rewrites=0, merges=0`).
3. `_CLOUD_SCHEMA_VERSION` bumped 1 → 2; `_init_cloud_tables` wires the migration into the existing `if current < _CLOUD_SCHEMA_VERSION` block, with a try/except that logs but doesn't lock the service out if the migration fails.
4. **Defensive canonicalization** at every INSERT/SELECT/UPDATE/DELETE site touching `file_path`:
   - `queue_event_for_sync` (THE BUG): existence check + INSERT now use `canonical_cloud_path(entry.path)`.
   - `_reconcile_with_remote`: `rstrip('/')` the rclone lsf file output too (was only done for the dirs branch — source of the corrupt production row). Wrap rel_path constructions defensively.
   - `_discover_events`: wrap rel_path constructions defensively (already canonical-by-construction; defense in depth).
   - `remove_from_queue`: canonicalize input so callers passing legacy absolute paths still match canonical rows.

## Tests

`tests/test_cloud_archive_canonicalization.py` — 45 new tests:
- `canonical_cloud_path` edge cases (empty, slashes, backslashes, absolute root stripping, basename substring rejection, `./` collapsing, double slashes).
- v2 migration: empty DB, mixed batches, idempotence, snapshot creation, snapshot-not-overwritten-on-repeat, all duplicate-merge priority permutations (synced > dead_letter > failed > pending).
- `queue_event_for_sync`: dedup against canonical row even when given absolute path; INSERT writes canonical form.
- `remove_from_queue`: canonical input works; legacy absolute input also matches; synced rows preserved.
- Schema version: `_init_cloud_tables` runs the migration on a v1 DB and bumps the version.

Updated `test_cloud_archive_queue.py` to use canonical-form synthetic paths matching the post-2.7 contract.

**Full suite: 902 passed, 3 skipped (was 857).**

## Production impact

- **Backup file**: `cloud_sync.db.bak.v2-canonical-paths` will appear next to the live DB on first run after deploy. Safe to retain or delete.
- **Existing rows**: 2316 rows expected to be checked. Production had:
  - 0 absolute paths (the queue_event_for_sync bug is latent — UI button hadn't been clicked since the bug was introduced)
  - 1 corrupt trailing-slash row (`ArchivedClips/2026-04-07_13-56-53-back.mp4/`) that will be rewritten
  - Mix of root prefixes is correct: `ArchivedClips/` (2307), `SentryClips/` (8), `SavedClips/` (1)
- Expected log line on first start: `Cloud archive v2 migration: rewrote 1 row(s), merged 0 duplicate(s)`.
- No service restart loop, no LUN unbind, no Tesla-visible disruption.
