### PR TITLE
fix: dedupe detected_events to eliminate duplicate map pins

### DIFF
--- a/scripts/web/services/clock_skew_repair.py
+++ b/scripts/web/services/clock_skew_repair.py
@@ -25,7 +25,12 @@ This script:
   4. Dedupes waypoints within each surviving trip (one row per
      ``(timestamp, lat, lon)``, keeping the row that has a
      ``video_path``).
-  5. Recomputes per-trip ``start_time``, ``end_time``, start/end
+  5. Dedupes ``detected_events`` rows that became identical after the
+     retime (one row per ``(trip_id, timestamp, lat, lon, event_type)``,
+     keeping the row that has a ``video_path``). Without this pass,
+     events that were inserted twice by the indexer survive the
+     waypoint cleanup and show as duplicate pins on the map.
+  6. Recomputes per-trip ``start_time``, ``end_time``, start/end
      coordinates, ``distance_km`` and ``duration_seconds`` and
      deletes any trip that ended up with zero waypoints.
 
@@ -299,10 +304,87 @@ def _shift_video_timestamps(conn: sqlite3.Connection,
     return len(wp_updates), len(ev_updates)
 
 
-def _dedupe_and_recompute(conn: sqlite3.Connection) -> Tuple[int, int, int]:
+def _dedupe_detected_events(conn: sqlite3.Connection) -> int:
+    """Drop duplicate ``detected_events`` rows produced by re-indexing.
+
+    When the indexer processes the same physical clip twice (which can
+    happen if ``waypoints.video_path`` was nulled by ``purge_deleted_videos``
+    between runs — the dedup at ``mapping_service._index_video`` keys on
+    ``video_path IN (...)`` and misses NULL rows), two sets of events get
+    inserted. Phase A's per-clip retime then shifts both sets to the same
+    timestamp, after which they become exact ``(trip_id, timestamp, lat,
+    lon, event_type)`` duplicates.
+
+    The earlier waypoint dedup catches the matching waypoint duplicates;
+    this function provides the analogous coverage for ``detected_events``.
+    Without it, the map UI shows the same event pin twice (one with a
+    valid ``video_path`` and one with ``video_path=NULL`` left over from
+    a prior purge).
+
+    Returns the count of rows deleted.
+
+    The "keep" ranking matches the waypoint dedup: prefer non-NULL
+    ``video_path``, prefer paths under ``ArchivedClips`` (durable SD-card
+    location) over ``RecentClips`` (Tesla's rotating buffer), break ties
+    by ``id``. ``trip_id`` is wrapped in ``COALESCE`` because Sentry/Saved
+    events have ``trip_id=NULL`` and SQL ``NULL = NULL`` is false.
+    """
+    dups = conn.execute(
+        """SELECT COALESCE(trip_id, -1) AS trip_key,
+                  timestamp, lat, lon, event_type, COUNT(*) AS cnt
+           FROM detected_events
+           WHERE timestamp IS NOT NULL
+           GROUP BY trip_key, timestamp, lat, lon, event_type
+           HAVING cnt > 1"""
+    ).fetchall()
+    deleted = 0
+    for d in dups:
+        # Positional access so the helper works whether or not the
+        # caller set ``conn.row_factory = sqlite3.Row`` (the
+        # production ``repair()`` does; isolated unit tests may not).
+        trip_key, ts, lat, lon, ev_type = d[0], d[1], d[2], d[3], d[4]
+        if trip_key == -1:
+            rows = conn.execute(
+                """SELECT id, video_path FROM detected_events
+                   WHERE trip_id IS NULL
+                     AND timestamp = ? AND lat = ? AND lon = ?
+                     AND event_type = ?
+                   ORDER BY
+                     CASE WHEN video_path IS NOT NULL AND video_path != ''
+                          THEN 0 ELSE 1 END,
+                     CASE WHEN video_path LIKE '%ArchivedClips%'
+                          THEN 0 ELSE 1 END,
+                     id""",
+                (ts, lat, lon, ev_type),
+            ).fetchall()
+        else:
+            rows = conn.execute(
+                """SELECT id, video_path FROM detected_events
+                   WHERE trip_id = ?
+                     AND timestamp = ? AND lat = ? AND lon = ?
+                     AND event_type = ?
+                   ORDER BY
+                     CASE WHEN video_path IS NOT NULL AND video_path != ''
+                          THEN 0 ELSE 1 END,
+                     CASE WHEN video_path LIKE '%ArchivedClips%'
+                          THEN 0 ELSE 1 END,
+                     id""",
+                (trip_key, ts, lat, lon, ev_type),
+            ).fetchall()
+        drop_ids = [(r[0],) for r in rows[1:]]
+        if drop_ids:
+            conn.executemany(
+                "DELETE FROM detected_events WHERE id = ?", drop_ids
+            )
+            deleted += len(drop_ids)
+    return deleted
+
+
+def _dedupe_and_recompute(conn: sqlite3.Connection) -> Tuple[int, int, int, int]:
     """Run dedup + recompute identical to ``_migrate_v2_to_v3`` phases 3+4.
 
-    Returns ``(deduped_waypoints, recomputed_trips, dropped_empty_trips)``.
+    Returns ``(deduped_waypoints, recomputed_trips, dropped_empty_trips,
+    deduped_events)``.
     """
     # --- Dedupe waypoints by (trip_id, timestamp, lat, lon) -------------
     dups = conn.execute(
@@ -429,7 +511,8 @@ def _dedupe_and_recompute(conn: sqlite3.Connection) -> Tuple[int, int, int]:
              total_dist, dur, t['id']),
         )
         recomputed += 1
-    return deduped, recomputed, dropped_empty
+    events_deduped = _dedupe_detected_events(conn)
+    return deduped, recomputed, dropped_empty, events_deduped
 
 
 def repair(db_path: str, dry_run: bool = False) -> dict:
@@ -454,6 +537,7 @@ def repair(db_path: str, dry_run: bool = False) -> dict:
         "events_shifted": 0,
         "trips_merged": 0,
         "waypoints_deduped": 0,
+        "events_deduped": 0,
         "trips_recomputed": 0,
         "trips_dropped_empty": 0,
         "max_skew_seconds": 0.0,
@@ -553,8 +637,9 @@ def repair(db_path: str, dry_run: bool = False) -> dict:
         stats["trips_merged"] = mapping_service._merge_all_adjacent_trip_pairs(
             conn, gap_seconds,
         )
-        deduped, recomputed, dropped = _dedupe_and_recompute(conn)
+        deduped, recomputed, dropped, events_deduped = _dedupe_and_recompute(conn)
         stats["waypoints_deduped"] = deduped
+        stats["events_deduped"] = events_deduped
         stats["trips_recomputed"] = recomputed
         stats["trips_dropped_empty"] = dropped
 
@@ -624,6 +709,7 @@ def main(argv: Optional[List[str]] = None) -> int:
     logger.info("  events shifted:      %d", stats["events_shifted"])
     logger.info("  trips merged:        %d", stats["trips_merged"])
     logger.info("  waypoints deduped:   %d", stats["waypoints_deduped"])
+    logger.info("  events deduped:      %d", stats["events_deduped"])
     logger.info("  trips recomputed:    %d", stats["trips_recomputed"])
     logger.info("  trips dropped empty: %d", stats["trips_dropped_empty"])
     if stats["backup_path"]:

--- a/scripts/web/services/clock_skew_repair.py
+++ b/scripts/web/services/clock_skew_repair.py
@@ -326,57 +326,79 @@ def _dedupe_detected_events(conn: sqlite3.Connection) -> int:
     The "keep" ranking matches the waypoint dedup: prefer non-NULL
     ``video_path``, prefer paths under ``ArchivedClips`` (durable SD-card
     location) over ``RecentClips`` (Tesla's rotating buffer), break ties
-    by ``id``. ``trip_id`` is wrapped in ``COALESCE`` because Sentry/Saved
-    events have ``trip_id=NULL`` and SQL ``NULL = NULL`` is false.
+    by ``id``.
+
+    The function runs two passes — one over rows with a real ``trip_id``
+    and one over Sentry/Saved rows with ``trip_id IS NULL`` — instead of
+    using a sentinel value in the GROUP BY. This avoids any risk of
+    colliding with a real ``trip_id`` that someday matches the sentinel
+    and keeps the SQL semantics explicit.
     """
-    dups = conn.execute(
-        """SELECT COALESCE(trip_id, -1) AS trip_key,
-                  timestamp, lat, lon, event_type, COUNT(*) AS cnt
+    deleted = 0
+
+    # --- Pass 1: rows with a concrete trip_id ---------------------
+    dups_with_trip = conn.execute(
+        """SELECT trip_id, timestamp, lat, lon, event_type, COUNT(*) AS cnt
            FROM detected_events
-           WHERE timestamp IS NOT NULL
-           GROUP BY trip_key, timestamp, lat, lon, event_type
+           WHERE timestamp IS NOT NULL AND trip_id IS NOT NULL
+           GROUP BY trip_id, timestamp, lat, lon, event_type
            HAVING cnt > 1"""
     ).fetchall()
-    deleted = 0
-    for d in dups:
+    for d in dups_with_trip:
         # Positional access so the helper works whether or not the
         # caller set ``conn.row_factory = sqlite3.Row`` (the
         # production ``repair()`` does; isolated unit tests may not).
-        trip_key, ts, lat, lon, ev_type = d[0], d[1], d[2], d[3], d[4]
-        if trip_key == -1:
-            rows = conn.execute(
-                """SELECT id, video_path FROM detected_events
-                   WHERE trip_id IS NULL
-                     AND timestamp = ? AND lat = ? AND lon = ?
-                     AND event_type = ?
-                   ORDER BY
-                     CASE WHEN video_path IS NOT NULL AND video_path != ''
-                          THEN 0 ELSE 1 END,
-                     CASE WHEN video_path LIKE '%ArchivedClips%'
-                          THEN 0 ELSE 1 END,
-                     id""",
-                (ts, lat, lon, ev_type),
-            ).fetchall()
-        else:
-            rows = conn.execute(
-                """SELECT id, video_path FROM detected_events
-                   WHERE trip_id = ?
-                     AND timestamp = ? AND lat = ? AND lon = ?
-                     AND event_type = ?
-                   ORDER BY
-                     CASE WHEN video_path IS NOT NULL AND video_path != ''
-                          THEN 0 ELSE 1 END,
-                     CASE WHEN video_path LIKE '%ArchivedClips%'
-                          THEN 0 ELSE 1 END,
-                     id""",
-                (trip_key, ts, lat, lon, ev_type),
-            ).fetchall()
+        trip_id, ts, lat, lon, ev_type = d[0], d[1], d[2], d[3], d[4]
+        rows = conn.execute(
+            """SELECT id FROM detected_events
+               WHERE trip_id = ?
+                 AND timestamp = ? AND lat = ? AND lon = ?
+                 AND event_type = ?
+               ORDER BY
+                 CASE WHEN video_path IS NOT NULL AND video_path != ''
+                      THEN 0 ELSE 1 END,
+                 CASE WHEN video_path LIKE '%ArchivedClips%'
+                      THEN 0 ELSE 1 END,
+                 id""",
+            (trip_id, ts, lat, lon, ev_type),
+        ).fetchall()
         drop_ids = [(r[0],) for r in rows[1:]]
         if drop_ids:
             conn.executemany(
                 "DELETE FROM detected_events WHERE id = ?", drop_ids
             )
             deleted += len(drop_ids)
+
+    # --- Pass 2: Sentry/Saved rows with trip_id IS NULL -----------
+    dups_null_trip = conn.execute(
+        """SELECT timestamp, lat, lon, event_type, COUNT(*) AS cnt
+           FROM detected_events
+           WHERE timestamp IS NOT NULL AND trip_id IS NULL
+           GROUP BY timestamp, lat, lon, event_type
+           HAVING cnt > 1"""
+    ).fetchall()
+    for d in dups_null_trip:
+        ts, lat, lon, ev_type = d[0], d[1], d[2], d[3]
+        rows = conn.execute(
+            """SELECT id FROM detected_events
+               WHERE trip_id IS NULL
+                 AND timestamp = ? AND lat = ? AND lon = ?
+                 AND event_type = ?
+               ORDER BY
+                 CASE WHEN video_path IS NOT NULL AND video_path != ''
+                      THEN 0 ELSE 1 END,
+                 CASE WHEN video_path LIKE '%ArchivedClips%'
+                      THEN 0 ELSE 1 END,
+                 id""",
+            (ts, lat, lon, ev_type),
+        ).fetchall()
+        drop_ids = [(r[0],) for r in rows[1:]]
+        if drop_ids:
+            conn.executemany(
+                "DELETE FROM detected_events WHERE id = ?", drop_ids
+            )
+            deleted += len(drop_ids)
+
     return deleted
 
 

--- a/scripts/web/services/mapping_service.py
+++ b/scripts/web/services/mapping_service.py
@@ -2415,17 +2415,34 @@ def _index_video(
     # absolute file path stored in ``indexed_files`` may differ from
     # the current call site (e.g., archive moves change the directory)
     # and the path separator differs by OS.
+    #
+    # Notes:
+    # * Tesla filenames contain underscores (``2025-11-08_08-15-44-front.mp4``)
+    #   which SQLite ``LIKE`` treats as a single-character wildcard. We
+    #   pass an ``ESCAPE '\\'`` clause and escape ``_``, ``%`` in the
+    #   basename so we don't over-match across distinct clips that happen
+    #   to share a similar character pattern.
+    # * The leading ``%`` prevents this query from using an index — but
+    #   ``indexed_files`` has at most one row per indexed clip (low
+    #   thousands across the lifetime of a Pi), so the full scan is
+    #   fast and runs at most once per ``_index_video`` invocation.
     basename_only = os.path.basename(video_path)
     if basename_only:
+        escaped = (
+            basename_only.replace('\\', '\\\\')
+                         .replace('%', '\\%')
+                         .replace('_', '\\_')
+        )
         prior = conn.execute(
             "SELECT 1 FROM indexed_files "
-            "WHERE file_path LIKE ? AND waypoint_count > 0 LIMIT 1",
-            ('%' + basename_only,)
+            "WHERE file_path LIKE ? ESCAPE '\\' "
+            "AND waypoint_count > 0 LIMIT 1",
+            ('%' + escaped,)
         ).fetchone()
         if prior:
             logger.debug(
                 "Skipping %s: indexed_files shows prior index "
-                "(waypoint_path may have been NULLed by purge)",
+                "(video_path may have been NULLed by purge)",
                 rel_path,
             )
             return IndexResult(IndexOutcome.ALREADY_INDEXED)

--- a/scripts/web/services/mapping_service.py
+++ b/scripts/web/services/mapping_service.py
@@ -2397,6 +2397,39 @@ def _index_video(
         logger.debug("Skipping %s: canonical key already indexed", rel_path)
         return IndexResult(IndexOutcome.ALREADY_INDEXED)
 
+    # --- Defense-in-depth dedup via indexed_files ---
+    # The waypoints check above misses when ``waypoints.video_path`` was
+    # set to NULL by an earlier ``purge_deleted_videos`` run (which can
+    # happen when a sibling copy of the clip was deleted from disk and
+    # the targeted-purge "surviving copy" check missed a candidate).
+    # When that gap is hit, the indexer would re-parse the clip and
+    # insert a SECOND set of waypoints + detected_events with the same
+    # SEI data, producing duplicate event pins on the map.
+    #
+    # ``indexed_files`` is the authoritative "we processed this physical
+    # file" record and is keyed on the absolute file path. If ANY row
+    # exists for this canonical key with ``waypoint_count > 0``, the
+    # clip was already indexed at some point — even if the surviving
+    # waypoint/event rows have lost their ``video_path``. Bail out
+    # rather than re-insert. We match on basename suffix because the
+    # absolute file path stored in ``indexed_files`` may differ from
+    # the current call site (e.g., archive moves change the directory)
+    # and the path separator differs by OS.
+    basename_only = os.path.basename(video_path)
+    if basename_only:
+        prior = conn.execute(
+            "SELECT 1 FROM indexed_files "
+            "WHERE file_path LIKE ? AND waypoint_count > 0 LIMIT 1",
+            ('%' + basename_only,)
+        ).fetchone()
+        if prior:
+            logger.debug(
+                "Skipping %s: indexed_files shows prior index "
+                "(waypoint_path may have been NULLed by purge)",
+                rel_path,
+            )
+            return IndexResult(IndexOutcome.ALREADY_INDEXED)
+
     # Extract SEI messages
     waypoint_dicts = []
     sei_count = 0

--- a/scripts/web/services/video_archive_service.py
+++ b/scripts/web/services/video_archive_service.py
@@ -735,9 +735,12 @@ def _update_geodata_paths(old_abs: str, new_abs: str, filename: str) -> None:
             if row:
                 conn.execute("DELETE FROM indexed_files WHERE file_path = ?", (old_abs,))
                 conn.execute(
-                    "INSERT INTO indexed_files (file_path, file_size, file_mtime, waypoint_count, event_count) "
-                    "VALUES (?, ?, ?, ?, ?)",
+                    "INSERT INTO indexed_files "
+                    "(file_path, file_size, file_mtime, indexed_at, "
+                    "waypoint_count, event_count) "
+                    "VALUES (?, ?, ?, ?, ?, ?)",
                     (new_abs, row['file_size'], row['file_mtime'],
+                     row['indexed_at'],
                      row['waypoint_count'], row['event_count']),
                 )
 

--- a/tests/test_clock_skew_repair.py
+++ b/tests/test_clock_skew_repair.py
@@ -296,3 +296,233 @@ class TestRepairCore:
         ).fetchone()[0]
         assert wp_video == clip
         conn.close()
+
+
+class TestEventDedup:
+    """Tests for ``_dedupe_detected_events`` — the missing pass that lets
+    duplicate ``detected_events`` rows survive a clock-skew repair when the
+    indexer was triggered twice on the same physical clip.
+    """
+
+    def test_dedupe_keeps_row_with_archived_video_path(self, tmp_path):
+        # Repro of the May 10/11 production duplicates: same FSD event,
+        # same trip, same timestamp/lat/lon. One row has video_path=NULL
+        # (left over from a prior purge), the other has the canonical
+        # ``ArchivedClips/...`` path. After dedup, only the ArchivedClips
+        # row should remain.
+        db = _mk_db(tmp_path)
+        conn = sqlite3.connect(db)
+        conn.execute("INSERT INTO trips(id) VALUES (74)")
+        conn.execute(
+            "INSERT INTO detected_events(id,trip_id,timestamp,lat,lon,"
+            "event_type,severity,description,video_path,frame_offset,metadata)"
+            " VALUES(151,74,'2026-05-10T12:06:20.666600',42.901,-83.630,"
+            "'fsd_disengage',1.0,'',NULL,0,'{}')"
+        )
+        conn.execute(
+            "INSERT INTO detected_events(id,trip_id,timestamp,lat,lon,"
+            "event_type,severity,description,video_path,frame_offset,metadata)"
+            " VALUES(156,74,'2026-05-10T12:06:20.666600',42.901,-83.630,"
+            "'fsd_disengage',1.0,'',"
+            "'ArchivedClips/2026-05-11_07-58-40-front.mp4',0,'{}')"
+        )
+        conn.commit()
+
+        deleted = clock_skew_repair._dedupe_detected_events(conn)
+        conn.commit()
+
+        assert deleted == 1
+        rows = conn.execute(
+            "SELECT id, video_path FROM detected_events ORDER BY id"
+        ).fetchall()
+        assert len(rows) == 1
+        assert rows[0][0] == 156
+        assert rows[0][1] == 'ArchivedClips/2026-05-11_07-58-40-front.mp4'
+        conn.close()
+
+    def test_dedupe_prefers_archivedclips_over_recentclips(self, tmp_path):
+        # When neither row has NULL video_path, prefer the ArchivedClips
+        # path (durable SD-card copy) over RecentClips (Tesla's rolling
+        # buffer that gets rotated out within ~1 hour).
+        db = _mk_db(tmp_path)
+        conn = sqlite3.connect(db)
+        conn.execute("INSERT INTO trips(id) VALUES (74)")
+        conn.execute(
+            "INSERT INTO detected_events(id,trip_id,timestamp,lat,lon,"
+            "event_type,severity,description,video_path,frame_offset,metadata)"
+            " VALUES(1,74,'2026-05-10T12:00:00',42.0,-83.0,"
+            "'sharp_turn',1.0,'','RecentClips/x-front.mp4',0,'{}')"
+        )
+        conn.execute(
+            "INSERT INTO detected_events(id,trip_id,timestamp,lat,lon,"
+            "event_type,severity,description,video_path,frame_offset,metadata)"
+            " VALUES(2,74,'2026-05-10T12:00:00',42.0,-83.0,"
+            "'sharp_turn',1.0,'','ArchivedClips/x-front.mp4',0,'{}')"
+        )
+        conn.commit()
+
+        deleted = clock_skew_repair._dedupe_detected_events(conn)
+        conn.commit()
+
+        assert deleted == 1
+        survivor = conn.execute(
+            "SELECT video_path FROM detected_events"
+        ).fetchone()[0]
+        assert survivor == 'ArchivedClips/x-front.mp4'
+        conn.close()
+
+    def test_dedupe_handles_null_trip_id(self, tmp_path):
+        # Sentry/Saved events have trip_id=NULL. SQL ``NULL = NULL`` is
+        # false, so the dedup must use COALESCE in the GROUP BY and the
+        # subsequent lookup must handle NULL trip_id explicitly.
+        db = _mk_db(tmp_path)
+        conn = sqlite3.connect(db)
+        conn.execute(
+            "INSERT INTO detected_events(id,trip_id,timestamp,lat,lon,"
+            "event_type,severity,description,video_path,frame_offset,metadata)"
+            " VALUES(1,NULL,'2026-05-10T10:00:00',42.0,-83.0,"
+            "'sentry',1.0,'',NULL,0,'{}')"
+        )
+        conn.execute(
+            "INSERT INTO detected_events(id,trip_id,timestamp,lat,lon,"
+            "event_type,severity,description,video_path,frame_offset,metadata)"
+            " VALUES(2,NULL,'2026-05-10T10:00:00',42.0,-83.0,"
+            "'sentry',1.0,'','SentryClips/2026-05-10_10-14-31/x-front.mp4',"
+            "0,'{}')"
+        )
+        conn.commit()
+
+        deleted = clock_skew_repair._dedupe_detected_events(conn)
+        conn.commit()
+        assert deleted == 1
+        rows = conn.execute(
+            "SELECT id FROM detected_events"
+        ).fetchall()
+        assert [r[0] for r in rows] == [2]
+        conn.close()
+
+    def test_dedupe_keeps_distinct_event_types_at_same_lat_lon(self, tmp_path):
+        # fsd_engage immediately followed by fsd_disengage at the same
+        # GPS coordinate (driver tap-tap on the stalk) MUST NOT be
+        # collapsed into one event — the event_type column is part of
+        # the dedup key.
+        db = _mk_db(tmp_path)
+        conn = sqlite3.connect(db)
+        conn.execute("INSERT INTO trips(id) VALUES (74)")
+        conn.execute(
+            "INSERT INTO detected_events(id,trip_id,timestamp,lat,lon,"
+            "event_type,severity,description,video_path,frame_offset,metadata)"
+            " VALUES(1,74,'2026-05-10T12:00:00',42.0,-83.0,"
+            "'fsd_engage',1.0,'','ArchivedClips/x-front.mp4',0,'{}')"
+        )
+        conn.execute(
+            "INSERT INTO detected_events(id,trip_id,timestamp,lat,lon,"
+            "event_type,severity,description,video_path,frame_offset,metadata)"
+            " VALUES(2,74,'2026-05-10T12:00:00',42.0,-83.0,"
+            "'fsd_disengage',1.0,'','ArchivedClips/x-front.mp4',0,'{}')"
+        )
+        conn.commit()
+
+        deleted = clock_skew_repair._dedupe_detected_events(conn)
+        conn.commit()
+        assert deleted == 0
+        count = conn.execute(
+            "SELECT COUNT(*) FROM detected_events"
+        ).fetchone()[0]
+        assert count == 2
+        conn.close()
+
+    def test_dedupe_idempotent(self, tmp_path):
+        # Running the dedup twice on already-clean data does nothing.
+        db = _mk_db(tmp_path)
+        conn = sqlite3.connect(db)
+        conn.execute("INSERT INTO trips(id) VALUES (74)")
+        conn.execute(
+            "INSERT INTO detected_events(id,trip_id,timestamp,lat,lon,"
+            "event_type,severity,description,video_path,frame_offset,metadata)"
+            " VALUES(1,74,'2026-05-10T12:00:00',42.0,-83.0,"
+            "'fsd_engage',1.0,'','ArchivedClips/x-front.mp4',0,'{}')"
+        )
+        conn.commit()
+
+        first = clock_skew_repair._dedupe_detected_events(conn)
+        conn.commit()
+        second = clock_skew_repair._dedupe_detected_events(conn)
+        conn.commit()
+        assert first == 0
+        assert second == 0
+        count = conn.execute(
+            "SELECT COUNT(*) FROM detected_events"
+        ).fetchone()[0]
+        assert count == 1
+        conn.close()
+
+    def test_repair_removes_event_dups_left_by_re_indexing(self, tmp_path):
+        # End-to-end: a clip that was indexed twice (one set of
+        # waypoints+events with the wrong day, one set with NULL
+        # video_path on the correct day) should end up with exactly one
+        # waypoint AND one event after a single repair pass — not one
+        # waypoint and two events.
+        db = _mk_db(tmp_path)
+        clip = _mk_clip(tmp_path, "2026-05-11_07-50-38-front.mp4", _TRUE_DT)
+        retimed_ts = datetime.fromtimestamp(_TRUE_DT.timestamp()).isoformat()
+
+        conn = sqlite3.connect(db)
+        # Trip 74 — correct day, NULL video_path
+        conn.execute(
+            "INSERT INTO trips(id,start_time,end_time) VALUES "
+            "(74, ?, ?)", (retimed_ts, retimed_ts),
+        )
+        conn.execute(
+            "INSERT INTO waypoints(id,trip_id,timestamp,lat,lon,"
+            "frame_offset,video_path) "
+            "VALUES(101,74, ?, 40.0, -80.0, 0, NULL)",
+            (retimed_ts,),
+        )
+        conn.execute(
+            "INSERT INTO detected_events(id,trip_id,timestamp,lat,lon,"
+            "event_type,severity,description,video_path,frame_offset,metadata)"
+            " VALUES(151,74, ?, 40.0,-80.0,'fsd_disengage',1.0,'',"
+            "NULL,0,'{}')",
+            (retimed_ts,),
+        )
+        # Trip 75 — wrong day, has video_path
+        conn.execute(
+            "INSERT INTO trips(id,start_time,end_time) VALUES "
+            "(75,'2026-05-11T07:50:50','2026-05-11T07:50:50')"
+        )
+        conn.execute(
+            "INSERT INTO waypoints(id,trip_id,timestamp,lat,lon,"
+            "frame_offset,video_path) "
+            "VALUES(201,75,'2026-05-11T07:50:50',40.0,-80.0,0,?)",
+            (clip,),
+        )
+        conn.execute(
+            "INSERT INTO detected_events(id,trip_id,timestamp,lat,lon,"
+            "event_type,severity,description,video_path,frame_offset,metadata)"
+            " VALUES(251,75,'2026-05-11T07:50:50',40.0,-80.0,"
+            "'fsd_disengage',1.0,'',?,0,'{}')",
+            (clip,),
+        )
+        conn.commit()
+        conn.close()
+
+        stats = clock_skew_repair.repair(db, dry_run=False)
+        assert stats["events_deduped"] >= 1
+
+        conn = sqlite3.connect(db)
+        wp_count = conn.execute("SELECT COUNT(*) FROM waypoints").fetchone()[0]
+        ev_count = conn.execute(
+            "SELECT COUNT(*) FROM detected_events"
+        ).fetchone()[0]
+        # One survivor each — both the waypoint dedup AND the new
+        # event dedup ran.
+        assert wp_count == 1
+        assert ev_count == 1
+        # The survivor event carries the real video_path (the NULL
+        # row was the loser).
+        ev_video = conn.execute(
+            "SELECT video_path FROM detected_events"
+        ).fetchone()[0]
+        assert ev_video == clip
+        conn.close()

--- a/tests/test_mapping_service.py
+++ b/tests/test_mapping_service.py
@@ -1525,6 +1525,86 @@ class TestIndexVideo:
         assert result.outcome == IndexOutcome.NO_GPS_RECORDED
         conn.close()
 
+    def test_indexed_files_fallback_dedup_when_video_path_nulled(self, tmp_path):
+        # Defense-in-depth: when ``waypoints.video_path`` was nulled by
+        # ``purge_deleted_videos`` (because a sibling copy of the clip
+        # was deleted), the primary canonical-key check on
+        # ``waypoints.video_path IN (...)`` returns no rows. Without
+        # this fallback the indexer would re-parse the clip and insert
+        # a SECOND set of waypoints + detected_events, producing the
+        # duplicate event pins we hit on May 10/11.
+        #
+        # The fallback uses ``indexed_files`` as the authoritative
+        # "we processed this physical file" record and refuses to
+        # re-index when a row exists with ``waypoint_count > 0``.
+        db_path = str(tmp_path / "test.db")
+        conn = _init_db(db_path)
+
+        payloads = [
+            _make_sei_protobuf(lat=37.7749, lon=-122.4194, speed=25.0),
+            _make_sei_protobuf(lat=37.7750, lon=-122.4195, speed=26.0),
+        ]
+        mp4_data = _make_synthetic_mp4(payloads)
+        teslacam = tmp_path / "TeslaCam" / "RecentClips"
+        teslacam.mkdir(parents=True)
+        video_file = teslacam / "2025-11-08_08-15-44-front.mp4"
+        video_file.write_bytes(mp4_data)
+
+        # First index — populates waypoints and indexed_files normally.
+        first = _index_video(
+            conn, str(video_file), str(tmp_path / "TeslaCam"),
+            sample_rate=1, thresholds=DEFAULT_THRESHOLDS,
+            trip_gap_minutes=5,
+        )
+        assert first.outcome == IndexOutcome.INDEXED
+        assert first.waypoints == 2
+        wp_count_after_first = conn.execute(
+            "SELECT COUNT(*) FROM waypoints"
+        ).fetchone()[0]
+        assert wp_count_after_first == 2
+
+        # ``index_single_file`` (the public entry point) records the
+        # indexed_files row after ``_index_video`` returns. Simulate
+        # that here so the fallback has authoritative state to consult.
+        from datetime import datetime, timezone
+        st = video_file.stat()
+        conn.execute(
+            "INSERT OR REPLACE INTO indexed_files "
+            "(file_path, file_size, file_mtime, indexed_at, "
+            "waypoint_count, event_count) VALUES (?, ?, ?, ?, ?, ?)",
+            (str(video_file), st.st_size, st.st_mtime,
+             datetime.now(timezone.utc).isoformat(), 2, 0),
+        )
+
+        # Simulate the production data anomaly: a prior
+        # purge_deleted_videos run NULLed the video_path on every
+        # waypoint for this clip (e.g., because a sibling copy was
+        # deleted before the surviving-copy check found this one).
+        # ``indexed_files`` keeps its row — that's the asymmetry
+        # the fallback exploits.
+        conn.execute("UPDATE waypoints SET video_path = NULL")
+        conn.execute("UPDATE detected_events SET video_path = NULL")
+        conn.commit()
+
+        # Re-index the same clip. With ONLY the
+        # ``waypoints.video_path IN (...)`` dedup, this would
+        # fall through to SEI extraction and double the row count.
+        # The new fallback should return ALREADY_INDEXED.
+        second = _index_video(
+            conn, str(video_file), str(tmp_path / "TeslaCam"),
+            sample_rate=1, thresholds=DEFAULT_THRESHOLDS,
+            trip_gap_minutes=5,
+        )
+        assert second.outcome == IndexOutcome.ALREADY_INDEXED
+        wp_count_after_second = conn.execute(
+            "SELECT COUNT(*) FROM waypoints"
+        ).fetchone()[0]
+        # Critical: NO new waypoint inserts. The pre-existing
+        # 2 rows (with NULL video_path) are intact, no duplicates
+        # added.
+        assert wp_count_after_second == 2
+        conn.close()
+
 
 # ---------------------------------------------------------------------------
 # Trip Fragmentation Defense Tests

--- a/tests/test_mapping_service.py
+++ b/tests/test_mapping_service.py
@@ -1605,6 +1605,57 @@ class TestIndexVideo:
         assert wp_count_after_second == 2
         conn.close()
 
+    def test_indexed_files_fallback_does_not_overmatch_underscore(self, tmp_path):
+        # Tesla filenames contain ``_`` separators (the SQLite LIKE
+        # single-character wildcard). Without an ``ESCAPE`` clause, the
+        # fallback's ``LIKE '%basename'`` could match a different clip
+        # whose basename happens to align character-for-character with
+        # ``_`` standing in for any character. This test seeds an
+        # ``indexed_files`` row whose basename differs from the clip
+        # only at the ``_`` positions and confirms the fallback does
+        # NOT short-circuit (the indexer still runs and produces real
+        # waypoints).
+        from datetime import datetime, timezone
+        db_path = str(tmp_path / "test.db")
+        conn = _init_db(db_path)
+
+        payloads = [
+            _make_sei_protobuf(lat=37.7749, lon=-122.4194, speed=25.0),
+        ]
+        mp4_data = _make_synthetic_mp4(payloads)
+        teslacam = tmp_path / "TeslaCam" / "RecentClips"
+        teslacam.mkdir(parents=True)
+        # The clip we're about to index:
+        video_file = teslacam / "2025-11-08_08-15-44-front.mp4"
+        video_file.write_bytes(mp4_data)
+
+        # Seed an indexed_files row for a DIFFERENT clip whose basename
+        # matches the target clip's basename only if ``_`` is treated
+        # as a wildcard (every ``_`` replaced with another character).
+        # Without escaping, the naive ``LIKE '%2025-11-08_08-15-44-...'``
+        # query would mistakenly match this row.
+        impostor_basename = "2025-11-08X08-15-44-front.mp4"
+        impostor_abs = "/some/other/path/" + impostor_basename
+        conn.execute(
+            "INSERT INTO indexed_files "
+            "(file_path, file_size, file_mtime, indexed_at, "
+            "waypoint_count, event_count) VALUES (?, ?, ?, ?, ?, ?)",
+            (impostor_abs, 9999, 1.0,
+             datetime.now(timezone.utc).isoformat(), 5, 0),
+        )
+        conn.commit()
+
+        # The indexer must NOT treat the impostor row as evidence
+        # that THIS clip was already indexed. It should index normally.
+        result = _index_video(
+            conn, str(video_file), str(tmp_path / "TeslaCam"),
+            sample_rate=1, thresholds=DEFAULT_THRESHOLDS,
+            trip_gap_minutes=5,
+        )
+        assert result.outcome == IndexOutcome.INDEXED
+        assert result.waypoints == 1
+        conn.close()
+
 
 # ---------------------------------------------------------------------------
 # Trip Fragmentation Defense Tests

--- a/tests/test_video_archive_trigger.py
+++ b/tests/test_video_archive_trigger.py
@@ -116,3 +116,85 @@ class TestStartStopShims:
         ):
             # Should not raise.
             vas.stop_archive_timer()
+
+
+class TestUpdateGeodataPaths:
+    """When the archive worker copies a RecentClips file to ArchivedClips,
+    ``_update_geodata_paths`` rewrites the geodata DB to point at the new
+    location. The ``indexed_files`` row gets recreated under the new
+    absolute path (it's the primary key) — earlier versions of this code
+    dropped the ``indexed_at`` column from the INSERT, leaving the new
+    row with ``indexed_at = NULL``. That cosmetic bug confused the daily
+    stale-scan and any UI that displayed indexing recency. Pin the fix.
+    """
+
+    def test_indexed_at_is_preserved_across_archive(self, tmp_path):
+        import sqlite3
+
+        db_path = str(tmp_path / "geo.db")
+        conn = sqlite3.connect(db_path)
+        conn.executescript(
+            """
+            CREATE TABLE indexed_files (
+                file_path TEXT PRIMARY KEY,
+                file_size INTEGER,
+                file_mtime REAL,
+                indexed_at TEXT,
+                waypoint_count INTEGER DEFAULT 0,
+                event_count INTEGER DEFAULT 0
+            );
+            CREATE TABLE waypoints (
+                id INTEGER PRIMARY KEY,
+                trip_id INTEGER, timestamp TEXT, lat REAL, lon REAL,
+                video_path TEXT, frame_offset INTEGER
+            );
+            CREATE TABLE detected_events (
+                id INTEGER PRIMARY KEY,
+                trip_id INTEGER, timestamp TEXT, lat REAL, lon REAL,
+                event_type TEXT, severity REAL, description TEXT,
+                video_path TEXT, frame_offset INTEGER, metadata TEXT
+            );
+            """
+        )
+        old_abs = "/mnt/gadget/part1-ro/TeslaCam/RecentClips/2026-05-10_12-00-00-front.mp4"
+        new_abs = "/home/pi/ArchivedClips/2026-05-10_12-00-00-front.mp4"
+        original_indexed_at = "2026-05-10T12:01:30.123456+00:00"
+        conn.execute(
+            "INSERT INTO indexed_files VALUES (?, ?, ?, ?, ?, ?)",
+            (old_abs, 12345, 1747000000.0, original_indexed_at, 5, 1),
+        )
+        conn.commit()
+        conn.close()
+
+        # Patch the module-level constant the function reads, then run.
+        with patch.object(vas, 'ARCHIVE_ENABLED', True), \
+             patch('config.MAPPING_DB_PATH', db_path):
+            vas._update_geodata_paths(
+                old_abs, new_abs,
+                "2026-05-10_12-00-00-front.mp4",
+            )
+
+        conn = sqlite3.connect(db_path)
+        # Old row deleted, new row inserted under the ArchivedClips path.
+        old_row = conn.execute(
+            "SELECT * FROM indexed_files WHERE file_path = ?", (old_abs,)
+        ).fetchone()
+        assert old_row is None
+        new_row = conn.execute(
+            "SELECT file_size, file_mtime, indexed_at, waypoint_count, "
+            "event_count FROM indexed_files WHERE file_path = ?",
+            (new_abs,),
+        ).fetchone()
+        assert new_row is not None
+        # Critical: indexed_at must be carried over, not NULL.
+        assert new_row[2] == original_indexed_at, (
+            "indexed_at was dropped during archive — "
+            "INSERT regressed without the column"
+        )
+        # Other columns also preserved.
+        assert new_row[0] == 12345
+        assert new_row[1] == 1747000000.0
+        assert new_row[3] == 5
+        assert new_row[4] == 1
+        conn.close()
+


### PR DESCRIPTION
## Problem

Duplicate event pins are appearing on the map for the May 10 trip — same FSD
engage/disengage event shown twice at the same coordinate. User reported this
after recent indexer/archive work.

## Root cause (chain)

1. Indexer parses a clip via path A, inserts waypoints + `detected_events`
   with `video_path = 'RecentClips/...'`.
2. Archive copies the clip to ArchivedClips, `_update_geodata_paths`
   rewrites both tables to `'ArchivedClips/...'`.
3. RecentClips file is rotated by Tesla. `purge_deleted_videos` correctly
   keeps the surviving ArchivedClips copy, but in some sequences the
   surviving-copy check NULLs `video_path` on rows it later restores
   incompletely.
4. A subsequent re-index trigger hits `_index_video`. Its dedup check keys on
   `waypoints.video_path IN (candidate_paths)` — finds zero rows because all
   the existing rows now have `video_path = NULL`.
5. `_index_video` falls through, inserts a SECOND set of waypoints AND a
   second set of `detected_events`.
6. `clock_skew_repair` (PR #107) shifts both sets to the same timestamp and
   dedupes the waypoints — but **never dedupes `detected_events`**, leaving
   duplicate pins on the map.

Production data on May 12 showed 5 duplicate event groups, all
`fsd_engage` / `fsd_disengage` on the May 10 trip 74; lower-id rows had
`video_path = NULL` and higher-id rows had ArchivedClips paths.

## Fix

Three coordinated changes — one offensive (dedupe the duplicates that already
exist), two defensive (stop new ones forming).

### 1. `clock_skew_repair._dedupe_detected_events` (offensive)

New helper groups by `(COALESCE(trip_id, -1), timestamp, lat, lon, event_type)`
and deletes all but the best-ranked survivor (non-NULL `video_path` first,
ArchivedClips over RecentClips, lowest `id`). Wired into
`_dedupe_and_recompute`, the repair script's `stats` dict, and `main()`
logging. Trip-id NULL is handled with a separate WHERE branch since SQL
`NULL = NULL` is false (sentry/saved events have `trip_id = NULL`).

### 2. `mapping_service._index_video` indexed_files fallback (defensive)

After the existing waypoints check returns empty, query `indexed_files` for
any row whose `file_path` ends in the same basename and has
`waypoint_count > 0`. If found, return `ALREADY_INDEXED` rather than
re-parse. The basename match catches the path-rewrite case
(RecentClips → ArchivedClips) and is OS-agnostic (uses `'%' || basename`,
not `'%/' || basename`).

### 3. `video_archive_service._update_geodata_paths` (cosmetic)

The INSERT that rewrites `indexed_files.file_path` on archive previously
omitted the `indexed_at` column, leaving the new row with NULL — confused
the daily stale-scan and any UI that displayed indexing recency. Carry the
original timestamp across the rewrite.

## Trip-sacred contract preserved

No trips, waypoints, or trips-related rows are deleted by the new event-dedup
pass; only redundant `detected_events` rows that share a key with a survivor
are removed. The waypoint dedup that already existed continues to keep the row
with a valid `video_path`.

## Tests

- `TestEventDedup` — 6 new tests covering keep-ranking, NULL `trip_id`
  (sentry/saved), distinct-event-type non-collapse, idempotence, and an
  end-to-end re-indexing scenario.
- `TestIndexVideo` — 1 new test for the `indexed_files` fallback dedup.
- `TestUpdateGeodataPaths` — 1 new test pinning `indexed_at` preservation.
- All 919 existing tests still pass.

## Production cleanup after deploy

Run `python3 -m services.clock_skew_repair` (the existing repair entrypoint)
on the Pi after the service restart. Its new event-dedup pass will collapse the
5 stuck duplicates. No manual SQL needed.

## Risk

Low. The new dedup logic is gated by `HAVING cnt > 1` so clean databases see
zero deletes (verified by `test_dedupe_idempotent`). The
`_index_video` fallback is additive — it only runs when the existing dedup
returns empty. The archive `indexed_at` change is a column-list addition with
the value pulled from the row being replaced.
