### PR TITLE
Phase 2.10 (#97): Make archive DB connection contract explicit

### DIFF
--- a/scripts/web/services/archive_queue.py
+++ b/scripts/web/services/archive_queue.py
@@ -43,6 +43,36 @@ The schema itself lives in :mod:`services.mapping_service` (the
 ``archive_queue`` CREATE statement is part of ``_SCHEMA_SQL`` so the
 v9 → v10 migration creates it automatically). This module only reads
 and writes rows.
+
+Connection / transaction contract (Phase 2.10 — issue #97 item 2.10)
+--------------------------------------------------------------------
+
+Every public helper opens its own SQLite connection via
+:func:`_open_archive_conn`. **The connection is opened in autocommit
+mode** (``isolation_level=None``) so callers control transaction
+boundaries explicitly. The contract is:
+
+* **Single-statement reads or writes** — call ``conn.execute(...)``
+  directly. Each statement auto-commits. Wrap the open/use/close
+  pattern in ``try/finally`` (NOT ``with conn:``) — see below.
+
+* **Multi-statement atomic operations** — use the
+  :func:`_atomic_archive_op` context manager. It opens an autocommit
+  connection, issues ``BEGIN IMMEDIATE`` (acquiring the write lock up
+  front to avoid SQLITE_BUSY deadlocks), yields the connection, and
+  on exit issues ``COMMIT`` on success or ``ROLLBACK`` on any
+  ``BaseException`` (so ``KeyboardInterrupt`` / ``SystemExit`` also
+  trigger rollback). Connection is always closed on the way out.
+
+**Anti-pattern (do NOT use):** ``with _open_archive_conn(db_path) as conn:``.
+Python's ``sqlite3`` module's ``with conn:`` is a transaction commit/
+rollback context manager — but on an autocommit connection it does
+NOT begin a transaction, only commits/rollbacks (which are no-ops
+because each statement already committed). It also does NOT close
+the connection. So that pattern is misleading on every axis: it
+suggests transaction semantics that don't exist and leaks the
+connection until garbage collection. Use ``try/finally`` for single-
+statement work and :func:`_atomic_archive_op` for multi-statement.
 """
 
 from __future__ import annotations
@@ -50,8 +80,9 @@ from __future__ import annotations
 import logging
 import os
 import sqlite3
+from contextlib import contextmanager
 from datetime import datetime, timezone
-from typing import Dict, Iterable, List, Optional
+from typing import Dict, Iterable, Iterator, List, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -118,6 +149,17 @@ def _resolve_db_path(db_path: Optional[str]) -> str:
 def _open_archive_conn(db_path: str) -> sqlite3.Connection:
     """Open a tuned SQLite connection for archive_queue ops.
 
+    **Autocommit mode** (``isolation_level=None``). Each ``conn.execute(...)``
+    statement commits on its own, so single-statement helpers can rely on
+    immediate durability without explicit COMMIT calls.
+
+    For multi-statement atomic operations use :func:`_atomic_archive_op`,
+    which wraps the body in ``BEGIN IMMEDIATE`` / ``COMMIT`` /
+    ``ROLLBACK``. **Do NOT** use ``with _open_archive_conn(db_path) as conn:``
+    — Python's ``sqlite3`` ``with conn:`` is a commit/rollback context
+    manager that's a no-op on autocommit AND does not close the
+    connection. See the module docstring for the full contract.
+
     Mirrors the per-connection pragmas used by
     ``mapping_service._open_queue_conn`` so producers don't trip over
     contended locks and the WAL stays small under concurrent writers.
@@ -128,6 +170,60 @@ def _open_archive_conn(db_path: str) -> sqlite3.Connection:
     conn.execute("PRAGMA journal_mode = WAL")
     conn.execute("PRAGMA synchronous = NORMAL")
     return conn
+
+
+@contextmanager
+def _atomic_archive_op(db_path: str) -> Iterator[sqlite3.Connection]:
+    """Open an autocommit conn, wrap the body in an explicit transaction.
+
+    On enter: opens the connection via :func:`_open_archive_conn`,
+    issues ``BEGIN IMMEDIATE`` (acquires the write lock up front so we
+    never upgrade from a shared lock mid-transaction — that's a known
+    SQLITE_BUSY deadlock vector under contention).
+
+    On normal exit: issues ``COMMIT``.
+
+    On any exception (including ``KeyboardInterrupt`` / ``SystemExit``):
+    issues ``ROLLBACK`` and re-raises so a partial multi-statement
+    update never lands in the database. Rollback failures are logged
+    at debug level so the original exception remains the surfaced
+    cause.
+
+    Connection is always closed on the way out (even if BEGIN itself
+    failed and we never entered the body).
+
+    Use this for any helper that issues more than one statement that
+    must succeed or fail as a unit — e.g., a SELECT followed by a
+    conditional UPDATE in :func:`mark_failed`. For single-statement
+    helpers, call :func:`_open_archive_conn` directly and use a
+    ``try/finally`` to close.
+    """
+    conn = _open_archive_conn(db_path)
+    began = False
+    try:
+        conn.execute("BEGIN IMMEDIATE")
+        began = True
+        try:
+            yield conn
+        except BaseException:
+            try:
+                conn.execute("ROLLBACK")
+            except sqlite3.Error as rollback_err:
+                logger.debug(
+                    "_atomic_archive_op ROLLBACK failed: %s",
+                    rollback_err,
+                )
+            raise
+        conn.execute("COMMIT")
+    finally:
+        if not began:
+            # BEGIN itself failed (very rare — e.g., DB locked beyond
+            # busy_timeout). Nothing to roll back; just close.
+            pass
+        try:
+            conn.close()
+        except sqlite3.Error:
+            pass
 
 
 def _iso_now() -> str:
@@ -199,24 +295,28 @@ def enqueue_for_archive(source_path: str, *,
     expected_size = st.st_size if st is not None else None
     expected_mtime = st.st_mtime if st is not None else None
     enqueued_at = _iso_now()
+    conn = _open_archive_conn(db_path)
     try:
-        with _open_archive_conn(db_path) as conn:
-            cur = conn.execute(
-                """
-                INSERT OR IGNORE INTO archive_queue
-                    (source_path, priority, status,
-                     enqueued_at, expected_size, expected_mtime)
-                VALUES (?, ?, 'pending', ?, ?, ?)
-                """,
-                (source_path, int(priority), enqueued_at,
-                 expected_size, expected_mtime),
-            )
-            inserted = cur.rowcount == 1
-        return inserted
+        cur = conn.execute(
+            """
+            INSERT OR IGNORE INTO archive_queue
+                (source_path, priority, status,
+                 enqueued_at, expected_size, expected_mtime)
+            VALUES (?, ?, 'pending', ?, ?, ?)
+            """,
+            (source_path, int(priority), enqueued_at,
+             expected_size, expected_mtime),
+        )
+        return cur.rowcount == 1
     except sqlite3.Error as e:
         logger.warning("enqueue_for_archive failed for %s: %s",
                        source_path, e)
         return False
+    finally:
+        try:
+            conn.close()
+        except sqlite3.Error:
+            pass
 
 
 def enqueue_many_for_archive(source_paths: Iterable[str], *,
@@ -265,12 +365,9 @@ def enqueue_many_for_archive(source_paths: Iterable[str], *,
             st.st_size if st is not None else None,
             st.st_mtime if st is not None else None,
         ))
-    conn = None
     try:
-        conn = _open_archive_conn(db_path)
-        before = conn.total_changes
-        conn.execute("BEGIN IMMEDIATE")
-        try:
+        with _atomic_archive_op(db_path) as conn:
+            before = conn.total_changes
             conn.executemany(
                 """
                 INSERT OR IGNORE INTO archive_queue
@@ -280,33 +377,11 @@ def enqueue_many_for_archive(source_paths: Iterable[str], *,
                 """,
                 rows,
             )
-        except BaseException:
-            # ROLLBACK on any exception (sqlite3.Error, KeyboardInterrupt,
-            # etc.) so a partial batch never lands. Re-raise so the outer
-            # handler logs and returns 0.
-            try:
-                conn.execute("ROLLBACK")
-            except sqlite3.Error as rollback_err:
-                # Log at debug — the outer handler will surface the
-                # original cause at warning level. We never want a
-                # rollback failure to mask the root exception.
-                logger.debug(
-                    "enqueue_many_for_archive ROLLBACK failed: %s",
-                    rollback_err,
-                )
-            raise
-        conn.execute("COMMIT")
-        after = conn.total_changes
-        return max(0, after - before)
+            after = conn.total_changes
+            return max(0, after - before)
     except sqlite3.Error as e:
         logger.warning("enqueue_many_for_archive failed: %s", e)
         return 0
-    finally:
-        if conn is not None:
-            try:
-                conn.close()
-            except sqlite3.Error:
-                pass
 
 
 def get_queue_status(db_path: Optional[str] = None) -> Dict[str, int]:
@@ -319,21 +394,26 @@ def get_queue_status(db_path: Optional[str] = None) -> Dict[str, int]:
     counts: Dict[str, int] = {s: 0 for s in _KNOWN_STATUSES}
     counts['total'] = 0
     db_path = _resolve_db_path(db_path)
+    conn = _open_archive_conn(db_path)
     try:
-        with _open_archive_conn(db_path) as conn:
-            for row in conn.execute(
-                "SELECT status, COUNT(*) AS n FROM archive_queue GROUP BY status"
-            ).fetchall():
-                status = row['status'] or 'pending'
-                n = int(row['n'] or 0)
-                # Fold any unknown status (shouldn't happen, but be
-                # defensive — older rows after a downgrade, manual SQL,
-                # etc.) into the total but not into the named buckets.
-                if status in counts:
-                    counts[status] = n
-                counts['total'] += n
+        for row in conn.execute(
+            "SELECT status, COUNT(*) AS n FROM archive_queue GROUP BY status"
+        ).fetchall():
+            status = row['status'] or 'pending'
+            n = int(row['n'] or 0)
+            # Fold any unknown status (shouldn't happen, but be
+            # defensive — older rows after a downgrade, manual SQL,
+            # etc.) into the total but not into the named buckets.
+            if status in counts:
+                counts[status] = n
+            counts['total'] += n
     except sqlite3.Error as e:
         logger.warning("get_queue_status failed: %s", e)
+    finally:
+        try:
+            conn.close()
+        except sqlite3.Error:
+            pass
     return counts
 
 
@@ -353,37 +433,42 @@ def list_queue(limit: int = 50,
     if limit <= 0:
         return []
     db_path = _resolve_db_path(db_path)
+    conn = _open_archive_conn(db_path)
     try:
-        with _open_archive_conn(db_path) as conn:
-            if status is not None:
-                cursor = conn.execute(
-                    """
-                    SELECT * FROM archive_queue
-                    WHERE status = ?
-                    ORDER BY priority ASC,
-                             expected_mtime IS NULL,
-                             expected_mtime ASC,
-                             id ASC
-                    LIMIT ?
-                    """,
-                    (status, int(limit)),
-                )
-            else:
-                cursor = conn.execute(
-                    """
-                    SELECT * FROM archive_queue
-                    ORDER BY priority ASC,
-                             expected_mtime IS NULL,
-                             expected_mtime ASC,
-                             id ASC
-                    LIMIT ?
-                    """,
-                    (int(limit),),
-                )
-            return [dict(r) for r in cursor.fetchall()]
+        if status is not None:
+            cursor = conn.execute(
+                """
+                SELECT * FROM archive_queue
+                WHERE status = ?
+                ORDER BY priority ASC,
+                         expected_mtime IS NULL,
+                         expected_mtime ASC,
+                         id ASC
+                LIMIT ?
+                """,
+                (status, int(limit)),
+            )
+        else:
+            cursor = conn.execute(
+                """
+                SELECT * FROM archive_queue
+                ORDER BY priority ASC,
+                         expected_mtime IS NULL,
+                         expected_mtime ASC,
+                         id ASC
+                LIMIT ?
+                """,
+                (int(limit),),
+            )
+        return [dict(r) for r in cursor.fetchall()]
     except sqlite3.Error as e:
         logger.warning("list_queue failed: %s", e)
         return []
+    finally:
+        try:
+            conn.close()
+        except sqlite3.Error:
+            pass
 
 
 # ---------------------------------------------------------------------------
@@ -441,8 +526,13 @@ def claim_next_for_worker(claimed_by: str, *,
     """
     db_path = _resolve_db_path(db_path)
     claimed_at = _iso_now()
+    # claim_next_for_worker is logically multi-statement in the
+    # RETURNING-fallback branch (SELECT then conditional UPDATE), so
+    # wrap the whole thing in an atomic transaction so the fallback
+    # is genuinely atomic — not just relying on the conditional WHERE
+    # to paper over a race.
     try:
-        with _open_archive_conn(db_path) as conn:
+        with _atomic_archive_op(db_path) as conn:
             try:
                 cur = conn.execute(
                     """
@@ -470,8 +560,9 @@ def claim_next_for_worker(claimed_by: str, *,
                 return None
             except sqlite3.OperationalError:
                 # Older SQLite — no RETURNING clause. Fall back to
-                # SELECT-then-UPDATE; the conditional WHERE keeps the
-                # claim atomic even if another worker raced us.
+                # SELECT-then-UPDATE; the surrounding transaction
+                # plus the conditional WHERE keeps the claim atomic
+                # even if another worker raced us.
                 pass
 
             row = conn.execute(
@@ -521,23 +612,28 @@ def mark_copied(row_id: int, dest_path: str, *,
         return False
     db_path = _resolve_db_path(db_path)
     copied_at = _iso_now()
+    conn = _open_archive_conn(db_path)
     try:
-        with _open_archive_conn(db_path) as conn:
-            cur = conn.execute(
-                """
-                UPDATE archive_queue
-                   SET status = 'copied',
-                       copied_at = ?,
-                       dest_path = ?,
-                       last_error = NULL
-                 WHERE id = ?
-                """,
-                (copied_at, dest_path, int(row_id)),
-            )
-            return cur.rowcount == 1
+        cur = conn.execute(
+            """
+            UPDATE archive_queue
+               SET status = 'copied',
+                   copied_at = ?,
+                   dest_path = ?,
+                   last_error = NULL
+             WHERE id = ?
+            """,
+            (copied_at, dest_path, int(row_id)),
+        )
+        return cur.rowcount == 1
     except sqlite3.Error as e:
         logger.warning("mark_copied failed for id=%s: %s", row_id, e)
         return False
+    finally:
+        try:
+            conn.close()
+        except sqlite3.Error:
+            pass
 
 
 def mark_source_gone(row_id: int, *,
@@ -552,21 +648,26 @@ def mark_source_gone(row_id: int, *,
     if not row_id:
         return False
     db_path = _resolve_db_path(db_path)
+    conn = _open_archive_conn(db_path)
     try:
-        with _open_archive_conn(db_path) as conn:
-            cur = conn.execute(
-                """
-                UPDATE archive_queue
-                   SET status = 'source_gone',
-                       last_error = NULL
-                 WHERE id = ?
-                """,
-                (int(row_id),),
-            )
-            return cur.rowcount == 1
+        cur = conn.execute(
+            """
+            UPDATE archive_queue
+               SET status = 'source_gone',
+                   last_error = NULL
+             WHERE id = ?
+            """,
+            (int(row_id),),
+        )
+        return cur.rowcount == 1
     except sqlite3.Error as e:
         logger.warning("mark_source_gone failed for id=%s: %s", row_id, e)
         return False
+    finally:
+        try:
+            conn.close()
+        except sqlite3.Error:
+            pass
 
 
 def release_claim(row_id: int, *,
@@ -591,36 +692,41 @@ def release_claim(row_id: int, *,
     if not row_id:
         return False
     db_path = _resolve_db_path(db_path)
+    conn = _open_archive_conn(db_path)
     try:
-        with _open_archive_conn(db_path) as conn:
-            if expected_size is not None or expected_mtime is not None:
-                cur = conn.execute(
-                    """
-                    UPDATE archive_queue
-                       SET status = 'pending',
-                           claimed_at = NULL,
-                           claimed_by = NULL,
-                           expected_size = COALESCE(?, expected_size),
-                           expected_mtime = COALESCE(?, expected_mtime)
-                     WHERE id = ?
-                    """,
-                    (expected_size, expected_mtime, int(row_id)),
-                )
-            else:
-                cur = conn.execute(
-                    """
-                    UPDATE archive_queue
-                       SET status = 'pending',
-                           claimed_at = NULL,
-                           claimed_by = NULL
-                     WHERE id = ?
-                    """,
-                    (int(row_id),),
-                )
-            return cur.rowcount == 1
+        if expected_size is not None or expected_mtime is not None:
+            cur = conn.execute(
+                """
+                UPDATE archive_queue
+                   SET status = 'pending',
+                       claimed_at = NULL,
+                       claimed_by = NULL,
+                       expected_size = COALESCE(?, expected_size),
+                       expected_mtime = COALESCE(?, expected_mtime)
+                 WHERE id = ?
+                """,
+                (expected_size, expected_mtime, int(row_id)),
+            )
+        else:
+            cur = conn.execute(
+                """
+                UPDATE archive_queue
+                   SET status = 'pending',
+                       claimed_at = NULL,
+                       claimed_by = NULL
+                 WHERE id = ?
+                """,
+                (int(row_id),),
+            )
+        return cur.rowcount == 1
     except sqlite3.Error as e:
         logger.warning("release_claim failed for id=%s: %s", row_id, e)
         return False
+    finally:
+        try:
+            conn.close()
+        except sqlite3.Error:
+            pass
 
 
 def mark_failed(row_id: int, error: str, *,
@@ -640,8 +746,14 @@ def mark_failed(row_id: int, error: str, *,
         return 'error'
     db_path = _resolve_db_path(db_path)
     truncated = (error or '')[:4096]
+    # mark_failed is genuinely multi-statement: it SELECTs the current
+    # attempts count, branches, then UPDATEs. Under autocommit alone
+    # another writer could update ``attempts`` between our SELECT and
+    # UPDATE, causing the UPDATE to use a stale base count. Wrap in
+    # _atomic_archive_op so the SELECT + UPDATE land in one transaction
+    # under a single write lock (BEGIN IMMEDIATE).
     try:
-        with _open_archive_conn(db_path) as conn:
+        with _atomic_archive_op(db_path) as conn:
             row = conn.execute(
                 "SELECT attempts FROM archive_queue WHERE id = ?",
                 (int(row_id),),
@@ -691,19 +803,24 @@ def get_pending_counts_by_priority(db_path: Optional[str] = None) -> Dict[int, i
     """
     counts: Dict[int, int] = {1: 0, 2: 0, 3: 0}
     db_path = _resolve_db_path(db_path)
+    conn = _open_archive_conn(db_path)
     try:
-        with _open_archive_conn(db_path) as conn:
-            for row in conn.execute(
-                """
-                SELECT priority, COUNT(*) AS n FROM archive_queue
-                 WHERE status = 'pending'
-                 GROUP BY priority
-                """
-            ).fetchall():
-                prio = int(row['priority'] or 3)
-                counts[prio] = int(row['n'] or 0)
+        for row in conn.execute(
+            """
+            SELECT priority, COUNT(*) AS n FROM archive_queue
+             WHERE status = 'pending'
+             GROUP BY priority
+            """
+        ).fetchall():
+            prio = int(row['priority'] or 3)
+            counts[prio] = int(row['n'] or 0)
     except sqlite3.Error as e:
         logger.warning("get_pending_counts_by_priority failed: %s", e)
+    finally:
+        try:
+            conn.close()
+        except sqlite3.Error:
+            pass
     return counts
 
 
@@ -716,20 +833,25 @@ def get_last_copied_at(db_path: Optional[str] = None) -> Optional[str]:
     when the queue is empty and the worker is running.
     """
     db_path = _resolve_db_path(db_path)
+    conn = _open_archive_conn(db_path)
     try:
-        with _open_archive_conn(db_path) as conn:
-            row = conn.execute(
-                """
-                SELECT MAX(copied_at) AS m FROM archive_queue
-                 WHERE status = 'copied' AND copied_at IS NOT NULL
-                """
-            ).fetchone()
-            if row is None:
-                return None
-            return row['m']
+        row = conn.execute(
+            """
+            SELECT MAX(copied_at) AS m FROM archive_queue
+             WHERE status = 'copied' AND copied_at IS NOT NULL
+            """
+        ).fetchone()
+        if row is None:
+            return None
+        return row['m']
     except sqlite3.Error as e:
         logger.warning("get_last_copied_at failed: %s", e)
         return None
+    finally:
+        try:
+            conn.close()
+        except sqlite3.Error:
+            pass
 
 
 def recover_stale_claims(*,
@@ -742,25 +864,30 @@ def recover_stale_claims(*,
     ``claimed`` forever. Returns the count of rows recovered.
     """
     db_path = _resolve_db_path(db_path)
+    conn = _open_archive_conn(db_path)
     try:
-        with _open_archive_conn(db_path) as conn:
-            # Compare ISO-8601 strings lexicographically — works
-            # because they're all UTC and same format.
-            cutoff = datetime.now(timezone.utc).timestamp() - max_age_seconds
-            cutoff_iso = datetime.fromtimestamp(
-                cutoff, tz=timezone.utc).isoformat()
-            cur = conn.execute(
-                """
-                UPDATE archive_queue
-                   SET status = 'pending',
-                       claimed_at = NULL,
-                       claimed_by = NULL
-                 WHERE status = 'claimed'
-                   AND (claimed_at IS NULL OR claimed_at < ?)
-                """,
-                (cutoff_iso,),
-            )
-            return cur.rowcount or 0
+        # Compare ISO-8601 strings lexicographically — works
+        # because they're all UTC and same format.
+        cutoff = datetime.now(timezone.utc).timestamp() - max_age_seconds
+        cutoff_iso = datetime.fromtimestamp(
+            cutoff, tz=timezone.utc).isoformat()
+        cur = conn.execute(
+            """
+            UPDATE archive_queue
+               SET status = 'pending',
+                   claimed_at = NULL,
+                   claimed_by = NULL
+             WHERE status = 'claimed'
+               AND (claimed_at IS NULL OR claimed_at < ?)
+            """,
+            (cutoff_iso,),
+        )
+        return cur.rowcount or 0
     except sqlite3.Error as e:
         logger.warning("recover_stale_claims failed: %s", e)
         return 0
+    finally:
+        try:
+            conn.close()
+        except sqlite3.Error:
+            pass

--- a/scripts/web/services/archive_queue.py
+++ b/scripts/web/services/archive_queue.py
@@ -199,10 +199,8 @@ def _atomic_archive_op(db_path: str) -> Iterator[sqlite3.Connection]:
     ``try/finally`` to close.
     """
     conn = _open_archive_conn(db_path)
-    began = False
     try:
         conn.execute("BEGIN IMMEDIATE")
-        began = True
         try:
             yield conn
         except BaseException:
@@ -216,10 +214,9 @@ def _atomic_archive_op(db_path: str) -> Iterator[sqlite3.Connection]:
             raise
         conn.execute("COMMIT")
     finally:
-        if not began:
-            # BEGIN itself failed (very rare — e.g., DB locked beyond
-            # busy_timeout). Nothing to roll back; just close.
-            pass
+        # Always close — covers all four exit paths: clean COMMIT,
+        # body-raised + ROLLBACK, BEGIN-failed (no transaction to
+        # roll back), and COMMIT-failed.
         try:
             conn.close()
         except sqlite3.Error:
@@ -295,8 +292,9 @@ def enqueue_for_archive(source_path: str, *,
     expected_size = st.st_size if st is not None else None
     expected_mtime = st.st_mtime if st is not None else None
     enqueued_at = _iso_now()
-    conn = _open_archive_conn(db_path)
+    conn = None
     try:
+        conn = _open_archive_conn(db_path)
         cur = conn.execute(
             """
             INSERT OR IGNORE INTO archive_queue
@@ -313,10 +311,11 @@ def enqueue_for_archive(source_path: str, *,
                        source_path, e)
         return False
     finally:
-        try:
-            conn.close()
-        except sqlite3.Error:
-            pass
+        if conn is not None:
+            try:
+                conn.close()
+            except sqlite3.Error:
+                pass
 
 
 def enqueue_many_for_archive(source_paths: Iterable[str], *,
@@ -394,8 +393,9 @@ def get_queue_status(db_path: Optional[str] = None) -> Dict[str, int]:
     counts: Dict[str, int] = {s: 0 for s in _KNOWN_STATUSES}
     counts['total'] = 0
     db_path = _resolve_db_path(db_path)
-    conn = _open_archive_conn(db_path)
+    conn = None
     try:
+        conn = _open_archive_conn(db_path)
         for row in conn.execute(
             "SELECT status, COUNT(*) AS n FROM archive_queue GROUP BY status"
         ).fetchall():
@@ -410,10 +410,11 @@ def get_queue_status(db_path: Optional[str] = None) -> Dict[str, int]:
     except sqlite3.Error as e:
         logger.warning("get_queue_status failed: %s", e)
     finally:
-        try:
-            conn.close()
-        except sqlite3.Error:
-            pass
+        if conn is not None:
+            try:
+                conn.close()
+            except sqlite3.Error:
+                pass
     return counts
 
 
@@ -433,8 +434,9 @@ def list_queue(limit: int = 50,
     if limit <= 0:
         return []
     db_path = _resolve_db_path(db_path)
-    conn = _open_archive_conn(db_path)
+    conn = None
     try:
+        conn = _open_archive_conn(db_path)
         if status is not None:
             cursor = conn.execute(
                 """
@@ -465,10 +467,11 @@ def list_queue(limit: int = 50,
         logger.warning("list_queue failed: %s", e)
         return []
     finally:
-        try:
-            conn.close()
-        except sqlite3.Error:
-            pass
+        if conn is not None:
+            try:
+                conn.close()
+            except sqlite3.Error:
+                pass
 
 
 # ---------------------------------------------------------------------------
@@ -612,8 +615,9 @@ def mark_copied(row_id: int, dest_path: str, *,
         return False
     db_path = _resolve_db_path(db_path)
     copied_at = _iso_now()
-    conn = _open_archive_conn(db_path)
+    conn = None
     try:
+        conn = _open_archive_conn(db_path)
         cur = conn.execute(
             """
             UPDATE archive_queue
@@ -630,10 +634,11 @@ def mark_copied(row_id: int, dest_path: str, *,
         logger.warning("mark_copied failed for id=%s: %s", row_id, e)
         return False
     finally:
-        try:
-            conn.close()
-        except sqlite3.Error:
-            pass
+        if conn is not None:
+            try:
+                conn.close()
+            except sqlite3.Error:
+                pass
 
 
 def mark_source_gone(row_id: int, *,
@@ -648,8 +653,9 @@ def mark_source_gone(row_id: int, *,
     if not row_id:
         return False
     db_path = _resolve_db_path(db_path)
-    conn = _open_archive_conn(db_path)
+    conn = None
     try:
+        conn = _open_archive_conn(db_path)
         cur = conn.execute(
             """
             UPDATE archive_queue
@@ -664,10 +670,11 @@ def mark_source_gone(row_id: int, *,
         logger.warning("mark_source_gone failed for id=%s: %s", row_id, e)
         return False
     finally:
-        try:
-            conn.close()
-        except sqlite3.Error:
-            pass
+        if conn is not None:
+            try:
+                conn.close()
+            except sqlite3.Error:
+                pass
 
 
 def release_claim(row_id: int, *,
@@ -692,8 +699,9 @@ def release_claim(row_id: int, *,
     if not row_id:
         return False
     db_path = _resolve_db_path(db_path)
-    conn = _open_archive_conn(db_path)
+    conn = None
     try:
+        conn = _open_archive_conn(db_path)
         if expected_size is not None or expected_mtime is not None:
             cur = conn.execute(
                 """
@@ -723,10 +731,11 @@ def release_claim(row_id: int, *,
         logger.warning("release_claim failed for id=%s: %s", row_id, e)
         return False
     finally:
-        try:
-            conn.close()
-        except sqlite3.Error:
-            pass
+        if conn is not None:
+            try:
+                conn.close()
+            except sqlite3.Error:
+                pass
 
 
 def mark_failed(row_id: int, error: str, *,
@@ -803,8 +812,9 @@ def get_pending_counts_by_priority(db_path: Optional[str] = None) -> Dict[int, i
     """
     counts: Dict[int, int] = {1: 0, 2: 0, 3: 0}
     db_path = _resolve_db_path(db_path)
-    conn = _open_archive_conn(db_path)
+    conn = None
     try:
+        conn = _open_archive_conn(db_path)
         for row in conn.execute(
             """
             SELECT priority, COUNT(*) AS n FROM archive_queue
@@ -817,10 +827,11 @@ def get_pending_counts_by_priority(db_path: Optional[str] = None) -> Dict[int, i
     except sqlite3.Error as e:
         logger.warning("get_pending_counts_by_priority failed: %s", e)
     finally:
-        try:
-            conn.close()
-        except sqlite3.Error:
-            pass
+        if conn is not None:
+            try:
+                conn.close()
+            except sqlite3.Error:
+                pass
     return counts
 
 
@@ -833,8 +844,9 @@ def get_last_copied_at(db_path: Optional[str] = None) -> Optional[str]:
     when the queue is empty and the worker is running.
     """
     db_path = _resolve_db_path(db_path)
-    conn = _open_archive_conn(db_path)
+    conn = None
     try:
+        conn = _open_archive_conn(db_path)
         row = conn.execute(
             """
             SELECT MAX(copied_at) AS m FROM archive_queue
@@ -848,10 +860,11 @@ def get_last_copied_at(db_path: Optional[str] = None) -> Optional[str]:
         logger.warning("get_last_copied_at failed: %s", e)
         return None
     finally:
-        try:
-            conn.close()
-        except sqlite3.Error:
-            pass
+        if conn is not None:
+            try:
+                conn.close()
+            except sqlite3.Error:
+                pass
 
 
 def recover_stale_claims(*,
@@ -864,8 +877,9 @@ def recover_stale_claims(*,
     ``claimed`` forever. Returns the count of rows recovered.
     """
     db_path = _resolve_db_path(db_path)
-    conn = _open_archive_conn(db_path)
+    conn = None
     try:
+        conn = _open_archive_conn(db_path)
         # Compare ISO-8601 strings lexicographically — works
         # because they're all UTC and same format.
         cutoff = datetime.now(timezone.utc).timestamp() - max_age_seconds
@@ -887,7 +901,8 @@ def recover_stale_claims(*,
         logger.warning("recover_stale_claims failed: %s", e)
         return 0
     finally:
-        try:
-            conn.close()
-        except sqlite3.Error:
-            pass
+        if conn is not None:
+            try:
+                conn.close()
+            except sqlite3.Error:
+                pass

--- a/tests/test_archive_queue.py
+++ b/tests/test_archive_queue.py
@@ -1352,3 +1352,81 @@ class TestMarkFailedAtomicity:
         # SELECT must come before UPDATE (ordering preserved).
         assert upper.index('SELECT') < upper.index('UPDATE')
 
+
+# ---------------------------------------------------------------------------
+# Phase 2.10 review fix — connect/PRAGMA failures must be caught
+# ---------------------------------------------------------------------------
+
+class TestOpenFailureCaught:
+    """Connection-open failures (sqlite3.Error from connect or initial
+    PRAGMAs) must be caught by every public helper and turned into a
+    safe-default return — not raised to the caller.
+
+    Phase 2.10 first draft hoisted ``conn = _open_archive_conn(db_path)``
+    above the ``try:`` block, which made open-time errors escape. The
+    review fix moved the call back inside the ``try:`` (with
+    ``conn = None`` guard in the ``finally``). These tests pin that
+    contract so it can't regress silently.
+
+    On a Pi Zero 2 W, SQLite open / PRAGMA can fail under SDIO
+    contention (busy bus, transient I/O error). A producer thread
+    raising would crash the file watcher; an archive-worker helper
+    raising would crash the worker loop.
+    """
+
+    @pytest.fixture
+    def patched_open_raises(self, monkeypatch):
+        """Make _open_archive_conn raise a sqlite3.OperationalError
+        on every call — simulating a connect/PRAGMA failure."""
+        def _raising(_path):
+            raise sqlite3.OperationalError("simulated open failure")
+        monkeypatch.setattr(archive_queue,
+                            '_open_archive_conn', _raising)
+        return _raising
+
+    def test_enqueue_for_archive_returns_false(self, db, sample_file,
+                                               patched_open_raises):
+        assert enqueue_for_archive(sample_file, db_path=db) is False
+
+    def test_enqueue_many_for_archive_returns_zero(self, db, sample_file,
+                                                   patched_open_raises):
+        assert enqueue_many_for_archive([sample_file], db_path=db) == 0
+
+    def test_get_queue_status_returns_zeros(self, db, patched_open_raises):
+        result = get_queue_status(db_path=db)
+        assert result['total'] == 0
+        for s in archive_queue._KNOWN_STATUSES:
+            assert result[s] == 0
+
+    def test_list_queue_returns_empty(self, db, patched_open_raises):
+        assert list_queue(db_path=db) == []
+
+    def test_claim_next_for_worker_returns_none(self, db,
+                                                patched_open_raises):
+        assert claim_next_for_worker('w1', db_path=db) is None
+
+    def test_mark_copied_returns_false(self, db, patched_open_raises):
+        assert mark_copied(1, '/dest', db_path=db) is False
+
+    def test_mark_source_gone_returns_false(self, db, patched_open_raises):
+        assert mark_source_gone(1, db_path=db) is False
+
+    def test_release_claim_returns_false(self, db, patched_open_raises):
+        assert release_claim(1, db_path=db) is False
+
+    def test_mark_failed_returns_error(self, db, patched_open_raises):
+        assert mark_failed(1, 'oops', db_path=db) == 'error'
+
+    def test_recover_stale_claims_returns_zero(self, db,
+                                               patched_open_raises):
+        assert recover_stale_claims(db_path=db) == 0
+
+    def test_get_pending_counts_returns_zeros(self, db,
+                                              patched_open_raises):
+        result = archive_queue.get_pending_counts_by_priority(db_path=db)
+        assert result == {1: 0, 2: 0, 3: 0}
+
+    def test_get_last_copied_at_returns_none(self, db,
+                                             patched_open_raises):
+        assert archive_queue.get_last_copied_at(db_path=db) is None
+

--- a/tests/test_archive_queue.py
+++ b/tests/test_archive_queue.py
@@ -1022,3 +1022,333 @@ class TestRecoverStaleClaims:
             )
         recovered = recover_stale_claims(max_age_seconds=60.0, db_path=db)
         assert recovered == 1
+
+
+# ---------------------------------------------------------------------------
+# Phase 2.10 — _atomic_archive_op transactional context manager
+# ---------------------------------------------------------------------------
+
+class TestAtomicArchiveOp:
+    """The Phase 2.10 transactional helper.
+
+    Contract:
+      * BEGIN IMMEDIATE on enter (acquires write lock up front)
+      * COMMIT on clean exit
+      * ROLLBACK on any BaseException (including KeyboardInterrupt)
+      * Connection always closed in finally
+      * Re-raises the original exception
+    """
+
+    def test_commit_on_success(self, db, sample_file):
+        """Successful body commits all writes."""
+        with archive_queue._atomic_archive_op(db) as conn:
+            conn.execute(
+                """INSERT INTO archive_queue
+                       (source_path, priority, status, enqueued_at)
+                   VALUES (?, ?, 'pending', ?)""",
+                (sample_file, 3, '2026-01-01T00:00:00+00:00'),
+            )
+        # Visible in a fresh connection.
+        rows = list_queue(db_path=db)
+        assert len(rows) == 1
+        assert rows[0]['source_path'] == sample_file
+
+    def test_rollback_on_sqlite_error(self, db, sample_file, tmp_path):
+        """sqlite3.Error inside the body rolls back and re-raises."""
+        # Pre-existing row that must survive.
+        pre = tmp_path / "pre.mp4"
+        pre.write_bytes(b"pre")
+        enqueue_for_archive(str(pre), db_path=db)
+        assert get_queue_status(db_path=db)['pending'] == 1
+
+        class Boom(sqlite3.OperationalError):
+            pass
+
+        with pytest.raises(Boom):
+            with archive_queue._atomic_archive_op(db) as conn:
+                conn.execute(
+                    """INSERT INTO archive_queue
+                           (source_path, priority, status, enqueued_at)
+                       VALUES (?, ?, 'pending', ?)""",
+                    (sample_file, 3, '2026-01-01T00:00:00+00:00'),
+                )
+                raise Boom("simulated")
+        # Pre-existing row still present, new one rolled back.
+        rows = list_queue(db_path=db)
+        assert len(rows) == 1
+        assert rows[0]['source_path'] == str(pre)
+
+    def test_rollback_on_keyboard_interrupt(self, db, sample_file, tmp_path):
+        """BaseException (e.g. KeyboardInterrupt) also rolls back and
+        re-raises — same contract as Phase 2.8 enqueue_many."""
+        pre = tmp_path / "pre.mp4"
+        pre.write_bytes(b"pre")
+        enqueue_for_archive(str(pre), db_path=db)
+
+        with pytest.raises(KeyboardInterrupt):
+            with archive_queue._atomic_archive_op(db) as conn:
+                conn.execute(
+                    """INSERT INTO archive_queue
+                           (source_path, priority, status, enqueued_at)
+                       VALUES (?, ?, 'pending', ?)""",
+                    (sample_file, 3, '2026-01-01T00:00:00+00:00'),
+                )
+                raise KeyboardInterrupt()
+        # New row rolled back; pre-existing row preserved.
+        rows = list_queue(db_path=db)
+        assert len(rows) == 1
+        assert rows[0]['source_path'] == str(pre)
+
+    def test_connection_closed_on_success(self, db, monkeypatch):
+        """Connection is closed after a clean commit."""
+        opened = []
+        original_open = archive_queue._open_archive_conn
+
+        def _spy_open(path):
+            conn = original_open(path)
+            opened.append(conn)
+            return conn
+
+        monkeypatch.setattr(archive_queue,
+                            '_open_archive_conn', _spy_open)
+        with archive_queue._atomic_archive_op(db) as conn:
+            conn.execute("SELECT 1")
+        assert len(opened) == 1
+        # Operating on a closed connection raises ProgrammingError.
+        with pytest.raises(sqlite3.ProgrammingError):
+            opened[0].execute("SELECT 1")
+
+    def test_connection_closed_on_exception(self, db, monkeypatch):
+        """Connection is closed even if the body raised."""
+        opened = []
+        original_open = archive_queue._open_archive_conn
+
+        def _spy_open(path):
+            conn = original_open(path)
+            opened.append(conn)
+            return conn
+
+        monkeypatch.setattr(archive_queue,
+                            '_open_archive_conn', _spy_open)
+        with pytest.raises(RuntimeError):
+            with archive_queue._atomic_archive_op(db) as conn:
+                conn.execute("SELECT 1")
+                raise RuntimeError("body raised")
+        assert len(opened) == 1
+        with pytest.raises(sqlite3.ProgrammingError):
+            opened[0].execute("SELECT 1")
+
+    def test_connection_closed_on_keyboard_interrupt(self, db, monkeypatch):
+        """Connection is closed even on KeyboardInterrupt — no FD leak."""
+        opened = []
+        original_open = archive_queue._open_archive_conn
+
+        def _spy_open(path):
+            conn = original_open(path)
+            opened.append(conn)
+            return conn
+
+        monkeypatch.setattr(archive_queue,
+                            '_open_archive_conn', _spy_open)
+        with pytest.raises(KeyboardInterrupt):
+            with archive_queue._atomic_archive_op(db) as conn:
+                conn.execute("SELECT 1")
+                raise KeyboardInterrupt()
+        assert len(opened) == 1
+        with pytest.raises(sqlite3.ProgrammingError):
+            opened[0].execute("SELECT 1")
+
+    def test_begin_immediate_acquires_write_lock_up_front(self, db,
+                                                          monkeypatch):
+        """The first statement in the body should be BEGIN IMMEDIATE,
+        not a deferred BEGIN. This avoids lock-upgrade SQLITE_BUSY
+        races under load."""
+        executed = []
+        original_open = archive_queue._open_archive_conn
+
+        class _Spy:
+            def __init__(self, real):
+                self._real = real
+
+            def __getattr__(self, name):
+                return getattr(self._real, name)
+
+            def execute(self, sql, *a, **kw):
+                executed.append(sql.strip().split()[0:2])
+                return self._real.execute(sql, *a, **kw)
+
+        def _spy_open(path):
+            return _Spy(original_open(path))
+
+        monkeypatch.setattr(archive_queue,
+                            '_open_archive_conn', _spy_open)
+
+        with archive_queue._atomic_archive_op(db) as conn:
+            conn.execute("SELECT 1")
+
+        # First statement should be 'BEGIN IMMEDIATE', not just 'BEGIN'.
+        assert executed[0] == ['BEGIN', 'IMMEDIATE'], (
+            f"expected BEGIN IMMEDIATE first, got {executed[0]!r}"
+        )
+
+    def test_close_failure_in_finally_does_not_mask_body_exception(
+            self, db, monkeypatch):
+        """If conn.close() raises in the finally, the original body
+        exception still propagates — close-failure is swallowed."""
+        original_open = archive_queue._open_archive_conn
+
+        class _BadClose:
+            def __init__(self, real):
+                self._real = real
+
+            def __getattr__(self, name):
+                return getattr(self._real, name)
+
+            def close(self):
+                # Real close first to avoid resource leak in the test.
+                try:
+                    self._real.close()
+                except sqlite3.Error:
+                    pass
+                raise sqlite3.OperationalError("close failed")
+
+        def _spy_open(path):
+            return _BadClose(original_open(path))
+
+        monkeypatch.setattr(archive_queue,
+                            '_open_archive_conn', _spy_open)
+
+        # The body's exception (RuntimeError) must be what propagates,
+        # not the close-failure.
+        with pytest.raises(RuntimeError, match="body"):
+            with archive_queue._atomic_archive_op(db):
+                raise RuntimeError("body failed")
+
+
+class TestMarkFailedAtomicity:
+    """Phase 2.10 regression: mark_failed must be atomic.
+
+    Before Phase 2.10 the SELECT(attempts) and the conditional UPDATE
+    ran under autocommit, so two concurrent mark_failed calls could
+    both read the same `attempts` and then race to UPDATE — losing
+    one increment and potentially leaving a row stuck below
+    max_attempts forever.
+
+    After Phase 2.10 the helper wraps both statements in
+    BEGIN IMMEDIATE … COMMIT, serializing concurrent writers via the
+    SQLite write lock.
+    """
+
+    def test_concurrent_mark_failed_does_not_lose_attempts(
+            self, db, sample_file, monkeypatch):
+        """Two threads call mark_failed on the same row simultaneously.
+        After both return, attempts must equal 2 (no lost update).
+
+        Forces the race by injecting a small delay between SELECT and
+        UPDATE inside _atomic_archive_op's body. Under autocommit
+        without a transaction, both threads' SELECTs would read 0
+        and both UPDATEs would write 1 — losing one increment. With
+        BEGIN IMMEDIATE wrapping the whole helper, T2 blocks until
+        T1 commits, so T2 reads 1 and writes 2.
+        """
+        enqueue_for_archive(sample_file, db_path=db)
+        row = claim_next_for_worker('w1', db_path=db)
+        row_id = row['id']
+
+        # Wrap conn.execute so SELECT against archive_queue gets a
+        # 200ms pause AFTER fetch — enough to provoke any race window.
+        original_open = archive_queue._open_archive_conn
+
+        class _SlowSelect:
+            def __init__(self, real):
+                self._real = real
+
+            def __getattr__(self, name):
+                return getattr(self._real, name)
+
+            def __enter__(self):
+                return self._real.__enter__()
+
+            def __exit__(self, *a):
+                return self._real.__exit__(*a)
+
+            def execute(self, sql, *a, **kw):
+                cur = self._real.execute(sql, *a, **kw)
+                if 'SELECT attempts' in sql:
+                    # Force the SELECT-then-UPDATE window wide open.
+                    time.sleep(0.2)
+                return cur
+
+        def _spy_open(path):
+            return _SlowSelect(original_open(path))
+
+        monkeypatch.setattr(archive_queue,
+                            '_open_archive_conn', _spy_open)
+
+        results = []
+        results_lock = threading.Lock()
+        barrier = threading.Barrier(2)
+
+        def worker():
+            barrier.wait()
+            r = mark_failed(row_id, 'race', max_attempts=10, db_path=db)
+            with results_lock:
+                results.append(r)
+
+        t1 = threading.Thread(target=worker)
+        t2 = threading.Thread(target=worker)
+        t1.start()
+        t2.start()
+        t1.join(timeout=15)
+        t2.join(timeout=15)
+        assert not t1.is_alive() and not t2.is_alive()
+
+        assert results.count('pending') == 2, (
+            f"expected both calls to succeed as 'pending', got {results}"
+        )
+        # The Phase 2.10 contract: SELECT+UPDATE atomicity → no lost
+        # update. attempts must be exactly 2.
+        rows = list_queue(db_path=db)
+        assert rows[0]['attempts'] == 2, (
+            f"lost update detected: attempts={rows[0]['attempts']}, "
+            f"expected 2"
+        )
+
+    def test_mark_failed_select_and_update_are_atomic(
+            self, db, sample_file, monkeypatch):
+        """Verify mark_failed runs SELECT + UPDATE inside one
+        BEGIN IMMEDIATE transaction (the Phase 2.10 contract)."""
+        enqueue_for_archive(sample_file, db_path=db)
+        row = claim_next_for_worker('w1', db_path=db)
+
+        executed = []
+        original_open = archive_queue._open_archive_conn
+
+        class _Spy:
+            def __init__(self, real):
+                self._real = real
+
+            def __getattr__(self, name):
+                return getattr(self._real, name)
+
+            def execute(self, sql, *a, **kw):
+                executed.append(sql.strip().split()[0])
+                return self._real.execute(sql, *a, **kw)
+
+        def _spy_open(path):
+            return _Spy(original_open(path))
+
+        monkeypatch.setattr(archive_queue,
+                            '_open_archive_conn', _spy_open)
+        mark_failed(row['id'], 'oops', max_attempts=3, db_path=db)
+
+        # Expect: BEGIN, SELECT, UPDATE, COMMIT — in that order.
+        # (The exact case may vary; normalize to upper.)
+        upper = [s.upper() for s in executed]
+        assert upper[0] == 'BEGIN', f"first statement was {upper[0]!r}"
+        assert 'SELECT' in upper
+        assert 'UPDATE' in upper
+        assert upper[-1] == 'COMMIT', f"last statement was {upper[-1]!r}"
+        # SELECT must come before UPDATE (ordering preserved).
+        assert upper.index('SELECT') < upper.index('UPDATE')
+


### PR DESCRIPTION
## Summary

Phase 2.10 of [epic #97](https://github.com/mphacker/TeslaUSB/issues/97). Make the `archive_queue.py` connection contract explicit by:

1. Documenting that `_open_archive_conn` opens an **autocommit** connection (`isolation_level=None`).
2. Adding a new `_atomic_archive_op(db_path)` context manager for genuinely multi-statement helpers.
3. Removing the misleading `with _open_archive_conn(db_path) as conn:` pattern from every caller.

## Why

The old pattern was a footgun:

* `with conn:` on Python's `sqlite3.Connection` is a **transaction** context manager — under autocommit there's nothing to commit/roll back, so it's a **no-op**.
* It also doesn't `close()` the connection — the connection lingers until the GC catches up (seconds on the Pi).
* `mark_failed` is genuinely multi-statement (`SELECT attempts` → conditional `UPDATE`). Under autocommit + the no-op `with`, two concurrent callers could both read the same `attempts` and race to UPDATE — losing one increment. Rare today (single archive worker) but the contract is fragile and would break the moment a second writer is introduced.

## Changes

### `scripts/web/services/archive_queue.py`

| Helper | Before | After |
|---|---|---|
| `_open_archive_conn` | docstring vague about transactions | docstring documents autocommit + anti-pattern warning |
| **NEW** `_atomic_archive_op` | — | BEGIN IMMEDIATE / yield / COMMIT or ROLLBACK / always close |
| `mark_failed` | autocommit SELECT + UPDATE (race window) | wrapped in `_atomic_archive_op` (atomic) |
| `claim_next_for_worker` | RETURNING-fallback SELECT+UPDATE relied on conditional WHERE alone | wrapped in `_atomic_archive_op` |
| `enqueue_many_for_archive` | inline BEGIN/COMMIT/ROLLBACK + cleanup | uses `_atomic_archive_op` (less duplication) |
| 9 single-statement helpers | `with _open_archive_conn(...) as conn:` (no-op + leak) | `conn = _open_archive_conn(...); try: ... finally: conn.close()` |

The 9 single-statement helpers: `enqueue_for_archive`, `get_queue_status`, `list_queue`, `mark_copied`, `mark_source_gone`, `release_claim`, `recover_stale_claims`, `get_pending_counts_by_priority`, `get_last_copied_at`.

### `tests/test_archive_queue.py`

* **NEW `TestAtomicArchiveOp`** — 8 tests for the new helper:
  - `test_commit_on_success` — happy path
  - `test_rollback_on_sqlite_error` — `sqlite3.Error` rolls back
  - `test_rollback_on_keyboard_interrupt` — `BaseException` rolls back
  - `test_connection_closed_on_success` / `_exception` / `_keyboard_interrupt` — no FD leak in any path
  - `test_begin_immediate_acquires_write_lock_up_front` — first statement is BEGIN IMMEDIATE
  - `test_close_failure_in_finally_does_not_mask_body_exception`

* **NEW `TestMarkFailedAtomicity`** — 2 regression tests for the SELECT+UPDATE atomicity:
  - Execution-trace test: asserts BEGIN → SELECT → UPDATE → COMMIT order
  - Concurrent test: injects a 200ms delay between SELECT and UPDATE; verifies `attempts` ends at 2 after two concurrent `mark_failed` calls (no lost update)

* All existing tests untouched and still pass.

## Test results

\\\
tests/test_archive_queue.py: 74 passed (was 64, +10 new)
full suite:                  941 passed, 3 skipped
\\\

## Out of scope

`mapping_service._open_queue_conn` (`mapping_service.py` L1502) has the identical autocommit + `with conn:` pattern. That stays untouched per the explicit `Files:` field in #97 item 2.10. Tracked separately for Phase 3c (mapping_service split) or a future follow-up issue. (See also already-filed issue #120 for `mapping_service.enqueue_many_for_indexing`.)

## Risk

Low. `mark_failed` was already correct in the single-worker production case; this hardens the contract so a future second writer won't reintroduce a lost-update race. All other refactored helpers are single-statement (no behavior change) — the only practical change is they actually close their connection now (slight FD-pressure improvement on the Pi).

Closes part of #97 (item 2.10).