### PR TITLE
Phase 3a.1 (#98 / closes #91): Unify retention into archive_watchdog

### DIFF
--- a/scripts/web/blueprints/cloud_archive.py
+++ b/scripts/web/blueprints/cloud_archive.py
@@ -666,6 +666,17 @@ def api_archive_cleanup():
     ``_enforce_retention`` cascade has been deleted — retention is
     owned by ``archive_watchdog``.
 
+    HTTP contract preserved across the refactor:
+      * 200 + ``{"success": True, "result": {...}}`` on a successful
+        prune (including the watchdog's ``status='already_running'``
+        short-circuit, which is a normal control-flow signal — NOT
+        an error).
+      * 500 + ``{"success": False, "message": ...}`` when the
+        retention call itself fails. The shim swallows the
+        underlying exception and returns a structured error dict
+        with an ``error`` key; we re-raise that as a 500 so external
+        callers / automation that key on HTTP status keep working.
+
     New callers should use ``POST /api/archive/prune_now`` directly;
     this endpoint is kept for backwards compatibility with any
     external automation.
@@ -673,10 +684,23 @@ def api_archive_cleanup():
     from services.video_archive_service import trigger_archive_cleanup
     try:
         result = trigger_archive_cleanup()
-        return jsonify({"success": True, "result": result})
     except Exception as exc:
         logger.exception("Failed to run archive cleanup")
         return jsonify({"success": False, "message": str(exc)}), 500
+
+    if isinstance(result, dict) and result.get("error"):
+        # The shim handled the exception internally and returned a
+        # structured error dict. Surface this as the legacy 500 so
+        # callers that check HTTP status (or the top-level
+        # ``success`` flag) continue to treat watchdog crashes as
+        # failures, not silent successes.
+        return jsonify({
+            "success": False,
+            "message": result["error"],
+            "result": result,
+        }), 500
+
+    return jsonify({"success": True, "result": result})
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/web/blueprints/cloud_archive.py
+++ b/scripts/web/blueprints/cloud_archive.py
@@ -657,7 +657,19 @@ def api_queue_clear():
 
 @cloud_archive_bp.route('/api/archive_cleanup', methods=['POST'])
 def api_archive_cleanup():
-    """Manually trigger smart archive cleanup."""
+    """Manually trigger archive retention prune.
+
+    Phase 3a (#98 / closes #91): this endpoint is now a thin wrapper
+    around ``archive_watchdog.force_prune_now`` (via the
+    ``video_archive_service.trigger_archive_cleanup`` shim). The legacy
+    ``smart_cleanup_archive`` / ``_proactive_retention`` /
+    ``_enforce_retention`` cascade has been deleted — retention is
+    owned by ``archive_watchdog``.
+
+    New callers should use ``POST /api/archive/prune_now`` directly;
+    this endpoint is kept for backwards compatibility with any
+    external automation.
+    """
     from services.video_archive_service import trigger_archive_cleanup
     try:
         result = trigger_archive_cleanup()

--- a/scripts/web/services/cleanup_service.py
+++ b/scripts/web/services/cleanup_service.py
@@ -1,6 +1,21 @@
-"""
-Cleanup Service for TeslaUSB
-Handles automatic cleanup of old video recordings with safety mechanisms.
+"""Cleanup Service for TeslaUSB — USB-partition video cleanup.
+
+Manages retention of videos that live INSIDE the USB drive image
+(``RecentClips/``, ``SavedClips/``, ``SentryClips/``,
+``EncryptedClips/`` on the part1 filesystem that the gadget exposes
+to Tesla). These deletions happen via the partition mount path
+(present mode: USB RO mount + ``quick_edit_part2`` is NOT used here;
+edit mode: RW mount). Per-folder policies are tracked in
+``cleanup_config.json``.
+
+**Scope boundary (Phase 3a / #98):** This service NEVER touches the
+SD-card ``ArchivedClips/`` folder. Retention of archived clips on the
+Pi's SD card is owned by ``services.archive_watchdog`` —
+``archive_watchdog.force_prune_now`` is the synchronous entry point
+and it honors the ``cloud_archive.delete_unsynced`` toggle, the
+``_retention_running`` duplicate-trigger guard, and the "trips are
+sacred" invariant. Any new "delete archived clips" code path belongs
+in ``archive_watchdog``, never here.
 """
 
 import os

--- a/scripts/web/services/video_archive_service.py
+++ b/scripts/web/services/video_archive_service.py
@@ -44,7 +44,7 @@ that callers still depend on:
 * ``get_archive_status()`` — ``GET /api/recent_archive/status``
   (polled by the NM dispatcher to know when archiving has drained
   before triggering cloud sync). Bridges to ``archive_worker.get_status``.
-* ``trigger_archive_cleanup()`` — ``POST /api/archive_cleanup``
+* ``trigger_archive_cleanup()`` — ``POST /cloud/api/archive_cleanup``
   legacy endpoint; one-line wrapper for
   ``archive_watchdog.force_prune_now``. New callers should use
   ``POST /api/archive/prune_now`` directly.
@@ -181,7 +181,7 @@ def trigger_archive_now() -> bool:
 def trigger_archive_cleanup() -> Dict[str, Any]:
     """Phase 3a (#98 / closes #91): one-line wrapper for ``force_prune_now``.
 
-    Backwards-compatible entry point for ``POST /api/archive_cleanup``
+    Backwards-compatible entry point for ``POST /cloud/api/archive_cleanup``
     that previously called the legacy ``smart_cleanup_archive`` /
     ``_proactive_retention`` / ``_enforce_retention`` cascade. All
     three of those are gone — retention is owned by

--- a/scripts/web/services/video_archive_service.py
+++ b/scripts/web/services/video_archive_service.py
@@ -1,139 +1,139 @@
-"""
-TeslaUSB RecentClips Archive Service.
+"""Phase 2b/3a compatibility shim for the queue-driven archive subsystem.
 
-Copies RecentClips from the read-only USB mount to the Pi's SD card
-before Tesla's 1-hour circular buffer deletes them. Zero USB disruption —
-the gadget stays connected and Tesla continues recording.
+The legacy timer-based ``video_archive_service`` was a ~900 LOC module
+that owned three responsibilities:
 
-Designed for Pi Zero 2 W (512 MB RAM): copies one file at a time using
-buffered 64 KB I/O, with generator-based scanning and memory pressure
-monitoring between files.
+1. Periodically scanning ``RecentClips/`` and copying new files to
+   ``ArchivedClips/``.
+2. A "smart cleanup" + "proactive retention" + "enforce retention" trio
+   that decided which archived files to delete and when.
+3. Path-fixup helpers used by the timer loop after each copy.
+
+All three responsibilities now live elsewhere (Phase 2b + Phase 3a):
+
+* **Archiving** — ``services.archive_worker`` (queue-driven, single
+  worker thread, dead-letter aware). Producers enqueue via
+  ``archive_queue.enqueue_for_archive`` from ``file_watcher_service`` /
+  ``mapping_service`` boot scan; the worker drains one file at a time
+  with stable-write gating, atomic copy, throttling, and recovery.
+
+* **Retention** — ``services.archive_watchdog`` is the single
+  authoritative retention system. ``archive_watchdog.force_prune_now``
+  is the synchronous entry point and is exposed at
+  ``POST /api/archive/prune_now``. It honors the
+  ``cloud_archive.delete_unsynced`` toggle (Phase 1 #95), the
+  ``_retention_running`` duplicate-trigger guard (Phase 3a / #91), and
+  the "trips are sacred" invariant — it deletes only ``indexed_files``
+  rows and NULLs the ``waypoints.video_path`` / ``detected_events.video_path``
+  pointer. Existing ``trips`` / ``waypoints`` / ``detected_events``
+  records are preserved.
+
+* **Path fixup** — Replaced by re-enqueueing the archived file into
+  ``indexing_queue`` (``mapping_service.enqueue_for_indexing``); the
+  indexer rewrites the canonical path on its next pass and
+  ``purge_deleted_videos`` removes the stale USB-side row.
+
+This module is kept for backwards compatibility with the public API
+that callers still depend on:
+
+* ``start_archive_timer()`` / ``stop_archive_timer()`` —
+  ``web_control.startup`` / shutdown handlers; delegate to the worker.
+* ``trigger_archive_now()`` — ``POST /api/recent_archive/trigger``
+  (the NM dispatcher's WiFi-up entry point) and ``base.html`` /
+  ``index.html`` UI buttons. Wakes the worker.
+* ``get_archive_status()`` — ``GET /api/recent_archive/status``
+  (polled by the NM dispatcher to know when archiving has drained
+  before triggering cloud sync). Bridges to ``archive_worker.get_status``.
+* ``trigger_archive_cleanup()`` — ``POST /api/archive_cleanup``
+  legacy endpoint; one-line wrapper for
+  ``archive_watchdog.force_prune_now``. New callers should use
+  ``POST /api/archive/prune_now`` directly.
+
+This module should NOT grow. Anything new belongs in ``archive_worker``,
+``archive_watchdog``, or ``archive_queue``.
 """
+
+from __future__ import annotations
 
 import logging
-import os
-import shutil
 import threading
-import time
-from datetime import datetime, timezone, timedelta
-from typing import Dict, List, Optional, Tuple
+from typing import Any, Dict
+
+from config import ARCHIVE_ENABLED
 
 logger = logging.getLogger(__name__)
 
-# ---------------------------------------------------------------------------
-# Configuration (lazy-loaded from config.py)
-# ---------------------------------------------------------------------------
-
-from config import (
-    ARCHIVE_DIR,
-    ARCHIVE_ENABLED,
-    ARCHIVE_RETENTION_DAYS,
-    ARCHIVE_MIN_FREE_SPACE_GB,
-    ARCHIVE_MAX_SIZE_GB,
-    ARCHIVE_ONLY_DRIVING,
-)
 
 # ---------------------------------------------------------------------------
-# Constants
-# ---------------------------------------------------------------------------
-
-# Minimum file age before copying (seconds). Files younger than this are
-# assumed to still be actively written by Tesla and skipped this cycle.
-# Tesla's RecentClips are ~60 s long, so by 90 s the clip is finalized.
-# The real safety net against partial reads is ``_is_complete_mp4`` (the
-# moov-atom check at line 405 / 585) — this age gate is belt-and-suspenders
-# and a cheap fast-path that avoids running the moov scan on actively-rotating
-# files. Lowered from 300 s in #70 (was the dominant source of archive lag).
-_MIN_FILE_AGE_SECONDS = 90  # 1.5 minutes — see comment above
-
-# Buffered copy chunk size — keeps memory usage predictable on Pi Zero 2 W
-_COPY_CHUNK_SIZE = 65536  # 64 KB
-
-# I/O throttle: max bytes per second during copy. The archive reads from
-# the same SD card that the USB gadget uses for Tesla. Copying too fast
-# starves the gadget (endpoint stalls) and can trigger a watchdog reboot.
-# 2 MB/s leaves ample bandwidth for the gadget (~20-30 MB/s SD card).
-_MAX_COPY_BYTES_PER_SEC = 2 * 1024 * 1024  # 2 MB/s
-
-# Minimum available RAM+swap (bytes) to continue archiving
-_MIN_MEMORY_BYTES = 50 * 1024 * 1024  # 50 MB
-
-# Pause between file copies to let the system breathe
-_INTER_FILE_SLEEP = 2.0  # 2 seconds
-
-# Max files to copy per archive cycle. Prevents a large backlog from
-# monopolising I/O and RAM for the whole archive interval, which can
-# starve the web server and trigger the hardware watchdog on Pi Zero 2 W.
-# Remaining files are picked up in the next cycle.
-_MAX_FILES_PER_CYCLE = 50
-
-# Grace period before pruning a clip as "non-driving". Gives the indexer
-# time to extract GPS from the clip and the trip detector time to
-# consolidate sequential waypoints into a trip. Clips younger than this
-# are kept regardless of whether they fall in a known trip range — they
-# may be from a drive that hasn't been indexed yet.
-_PRUNE_GRACE_SECONDS = 6 * 3600  # 6 hours
-
-# ---------------------------------------------------------------------------
-# Background Thread State
+# Module state
 # ---------------------------------------------------------------------------
 #
-# Phase 2b (issue #76): the legacy ``_archive_thread`` periodic timer
-# is gone — the archive flow now runs entirely inside
-# ``services.archive_worker``. ``_archive_cancel`` is kept so
-# ``stop_archive_timer`` and any retention helper that still consults
-# it (defensive abort flag) keep working unchanged.
+# The Phase 2b worker is the single archive thread. ``_archive_cancel``
+# is kept as a no-op compatibility flag for any caller that still
+# checks it (defensive abort signal). The worker has its own
+# ``_stop_event`` and ignores this flag.
 _archive_cancel = threading.Event()
-
-_status: Dict = {
-    "running": False,
-    "progress": "",
-    "files_total": 0,
-    "files_done": 0,
-    "bytes_copied": 0,
-    "current_file": "",
-    "started_at": None,
-    "last_run": None,
-    "last_run_files": 0,
-    "archive_size_mb": 0,
-    "error": None,
-}
 
 
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
 
+def get_archive_status() -> Dict[str, Any]:
+    """Return current archive status — bridge to ``archive_worker.get_status``.
 
-def get_archive_status() -> dict:
-    """Return current archive status (safe to call from any thread)."""
-    return dict(_status)
+    The dispatcher (``helpers/refresh_cloud_token.py``) polls this
+    endpoint and waits for ``running == False`` before kicking cloud
+    sync. In the queue-driven architecture the worker is always
+    "alive" once started, so ``running`` is True iff there is work
+    in flight (an active file being copied, or pending rows in
+    the queue).
 
+    Returns a dict with the legacy field names the dispatcher and UI
+    code paths expect, augmented with the worker's structured
+    snapshot for any new caller that wants more detail.
+    """
+    legacy: Dict[str, Any] = {
+        "running": False,
+        "current_file": "",
+        "queue_depth": 0,
+        "worker_running": False,
+        "last_outcome": None,
+        "error": None,
+    }
+    try:
+        from services import archive_worker
+        snap = archive_worker.get_status()
+    except Exception as e:  # noqa: BLE001 — status must never raise
+        logger.debug("get_archive_status: archive_worker unavailable: %s", e)
+        legacy["error"] = str(e)
+        return legacy
 
-def get_archive_dir() -> str:
-    """Return the archive directory path."""
-    return ARCHIVE_DIR
+    queue_depth = int(snap.get("queue_depth", 0) or 0)
+    active_file = snap.get("active_file") or ""
+    worker_running = bool(snap.get("worker_running"))
+    legacy.update({
+        "running": bool(worker_running and (active_file or queue_depth > 0)),
+        "current_file": active_file,
+        "queue_depth": queue_depth,
+        "worker_running": worker_running,
+        "last_outcome": snap.get("last_outcome"),
+        "claimed_count": int(snap.get("claimed_count", 0) or 0),
+        "dead_letter_count": int(snap.get("dead_letter_count", 0) or 0),
+        "copied_count": int(snap.get("copied_count", 0) or 0),
+        "paused": bool(snap.get("paused")),
+        "idle": bool(snap.get("idle")),
+    })
+    return legacy
 
 
 def start_archive_timer() -> None:
-    """Phase 2b (issue #76): Legacy timer is gone — start the worker instead.
+    """Phase 2b shim: ensure the archive worker is running.
 
-    Pre-Phase-2b this spun up ``_archive_timer_loop`` which woke every
-    ``ARCHIVE_INTERVAL_MINUTES`` and walked the RO RecentClips folder.
-    The Phase 2b architecture is queue-driven: the
-    ``archive_producer`` thread (started by ``web_control.startup``)
-    enqueues into ``archive_queue`` from inotify + a 60-second rescan,
-    and the ``archive_worker`` thread drains the queue one file at a
-    time with stable-write gating, atomic copy, and dead-letter
-    handling.
-
-    This shim stays callable so existing call sites in
-    ``web_control.startup`` keep working without a flag dance, but
-    delegates to :func:`services.archive_worker.ensure_worker_started`.
-    The retention/cleanup cascade that used to run after each timer
-    tick is now driven by the periodic ``smart_cleanup_archive`` call
-    that runs from elsewhere (and from the manual cleanup endpoint);
-    see :func:`trigger_archive_cleanup`.
+    Callers in ``web_control.startup`` rely on this being a no-op when
+    ``ARCHIVE_ENABLED`` is False. A worker startup failure is logged
+    but never raised — gadget_web's main thread must not crash on a
+    background-subsystem error.
     """
     if not ARCHIVE_ENABLED:
         logger.info("RecentClips archive is disabled in config")
@@ -141,12 +141,14 @@ def start_archive_timer() -> None:
     try:
         from services import archive_worker
         archive_worker.ensure_worker_started()
-    except Exception as e:  # noqa: BLE001 — never let startup raise here
-        logger.warning("archive_worker.ensure_worker_started failed: %s", e)
+    except Exception as e:  # noqa: BLE001
+        logger.warning(
+            "archive_worker.ensure_worker_started failed: %s", e,
+        )
 
 
 def stop_archive_timer() -> None:
-    """Phase 2b: stop the new archive worker (no legacy timer to cancel)."""
+    """Phase 2b shim: stop the archive worker on service shutdown."""
     _archive_cancel.set()
     try:
         from services import archive_worker
@@ -156,24 +158,18 @@ def stop_archive_timer() -> None:
 
 
 def trigger_archive_now() -> bool:
-    """Wake the Phase 2b archive worker (was: spawn a one-shot timer thread).
+    """Wake the archive worker — used by NM dispatcher + UI buttons.
 
-    Returns True if a wake was issued (ARCHIVE_ENABLED and the worker
-    accepted the call), False if archiving is disabled or the worker
-    couldn't be started. The actual draining happens asynchronously in
-    the worker thread.
-
-    Compatibility shim: callers (notably the NM dispatcher's
-    ``/api/recent_archive/trigger`` endpoint and the legacy duplicate-
-    guard tests) get a True/False return that tracks "did we kick the
-    worker?" rather than the old "did we start a thread?" — which is
-    semantically equivalent for every external caller.
+    Returns True if the worker was woken (``ARCHIVE_ENABLED`` is True
+    and the worker accepted the call), False if archiving is disabled
+    or the worker raised. Worker-side exceptions MUST NOT propagate
+    — the dispatcher treats False as "no archive in flight" and
+    moves on to the cloud-sync trigger.
     """
     if not ARCHIVE_ENABLED:
         return False
     try:
         from services import archive_worker
-        # Lazy-start the worker if it isn't running yet.
         archive_worker.ensure_worker_started()
         archive_worker.wake()
         return True
@@ -182,924 +178,35 @@ def trigger_archive_now() -> bool:
         return False
 
 
-# ---------------------------------------------------------------------------
-# Phase 2b (issue #76): the legacy ``_archive_timer_loop`` /
-# ``_run_archive`` / ``_do_archive_work`` / ``_discover_new_files``
-# code paths have been removed in favor of the queue-driven
-# ``archive_producer`` + ``archive_worker`` pair.
-#
-# The retention/cleanup helpers below (``_purge_corrupt_archives``,
-# ``_prune_non_driving_archives``, ``_enforce_retention``,
-# ``smart_cleanup_archive``, ``trigger_archive_cleanup``) remain
-# callable from the API/cleanup endpoints — they don't depend on the
-# old timer loop and operate purely on ``ARCHIVE_DIR``.
-# ---------------------------------------------------------------------------
+def trigger_archive_cleanup() -> Dict[str, Any]:
+    """Phase 3a (#98 / closes #91): one-line wrapper for ``force_prune_now``.
 
+    Backwards-compatible entry point for ``POST /api/archive_cleanup``
+    that previously called the legacy ``smart_cleanup_archive`` /
+    ``_proactive_retention`` / ``_enforce_retention`` cascade. All
+    three of those are gone — retention is owned by
+    ``services.archive_watchdog`` and the synchronous entry point is
+    ``archive_watchdog.force_prune_now``.
 
-def _get_driving_time_ranges() -> Optional[List[Tuple[float, float]]]:
-    """Load trip time ranges from geodata.db.
+    The watchdog's ``_retention_running`` guard means this call
+    returns immediately (with ``status='already_running'``) if a prune
+    is already in flight, so the request thread no longer block-waits
+    up to 60 s on the ``task_coordinator`` 'retention' slot.
 
-    Returns a sorted list of (start_epoch, end_epoch) tuples, or None
-    if the database is unavailable (fall back to archiving everything).
+    New callers should use ``POST /api/archive/prune_now`` directly;
+    this shim is kept so the existing endpoint and any external
+    automation continue to work.
     """
     try:
-        from config import MAPPING_ENABLED, MAPPING_DB_PATH
-        if not MAPPING_ENABLED:
-            return None
-        if not os.path.isfile(MAPPING_DB_PATH):
-            return None
-
-        import sqlite3
-        conn = sqlite3.connect(MAPPING_DB_PATH, timeout=5)
-        conn.row_factory = sqlite3.Row
-        try:
-            rows = conn.execute(
-                "SELECT start_time, end_time FROM trips ORDER BY start_time"
-            ).fetchall()
-            if not rows:
-                return None  # No trips indexed yet — archive everything
-
-            ranges = []
-            _PADDING = 120  # 2 min padding around each trip
-            for r in rows:
-                try:
-                    st = datetime.fromisoformat(r['start_time']).timestamp() - _PADDING
-                    et = datetime.fromisoformat(r['end_time']).timestamp() + _PADDING
-                    ranges.append((st, et))
-                except (ValueError, TypeError):
-                    continue
-            return ranges if ranges else None
-        finally:
-            conn.close()
-    except Exception as e:
-        logger.debug("Could not load driving ranges: %s", e)
-        return None
-
-
-def _timestamp_from_filename(name: str) -> Optional[float]:
-    """Extract epoch timestamp from Tesla filename like '2026-04-08_20-00-03-front.mp4'."""
-    try:
-        # First 19 chars: '2026-04-08_20-00-03'
-        ts_str = os.path.basename(name)[:19]
-        dt = datetime.strptime(ts_str, '%Y-%m-%d_%H-%M-%S')
-        return dt.timestamp()
-    except (ValueError, IndexError):
-        return None
-
-
-def _is_during_driving(clip_ts: float, ranges: List[Tuple[float, float]]) -> bool:
-    """Return True if clip_ts falls within any driving time range."""
-    for start, end in ranges:
-        if start <= clip_ts <= end:
-            return True
-        if start > clip_ts:
-            break  # Ranges are sorted — no need to check further
-    return False
-
-
-def _prune_non_driving_archives() -> int:
-    """Delete archived clips that the indexer has positively identified
-    as containing no GPS data and no detected events.
-
-    Honors the ARCHIVE_ONLY_DRIVING flag — does nothing if False.
-
-    A clip is DELETED only when there is positive evidence it isn't a
-    drive. Specifically, the front-camera clip must have an
-    ``indexed_files`` row (so we know the indexer processed it) with
-    ``waypoint_count == 0`` AND ``event_count == 0`` (so we know the
-    extraction succeeded but found nothing). Clips that have never been
-    indexed are kept unconditionally — we never delete on the absence of
-    evidence, only on the presence of contrary evidence.
-
-    A clip is also KEPT if any of:
-      - It's younger than the grace period (give the indexer time)
-      - Its timestamp falls within any known trip range (with padding)
-      - It has waypoints in geodata.db (proven driving)
-      - It has detected events in geodata.db (saved/sentry events)
-
-    Decisions are made per timestamp prefix (YYYY-MM-DD_HH-MM-SS) so all
-    six cameras for one recording moment are kept or deleted together.
-    The front-camera clip is the source of truth (only front-cam is
-    indexed); sibling cameras follow the front-cam decision. Side cameras
-    that exist as orphans (no front-cam) are left alone — we only delete
-    on positive evidence.
-
-    Returns the number of files deleted.
-    """
-    if not ARCHIVE_ONLY_DRIVING:
-        return 0
-    if not os.path.isdir(ARCHIVE_DIR):
-        return 0
-
-    driving_ranges = _get_driving_time_ranges()
-    if driving_ranges is None:
-        return 0  # No trips yet — leave clips so they can be indexed
-
-    # Build:
-    #   keep_basenames        — clips with positive driving/event evidence
-    #   proven_non_driving    — front-cam basenames the indexer proved have
-    #                            no GPS and no events (safe to delete)
-    keep_basenames = set()
-    proven_non_driving = set()
-    try:
-        from config import MAPPING_ENABLED, MAPPING_DB_PATH
-        if not (MAPPING_ENABLED and os.path.isfile(MAPPING_DB_PATH)):
-            return 0
-        import sqlite3
-        conn = sqlite3.connect(MAPPING_DB_PATH, timeout=10)
-        try:
-            for row in conn.execute(
-                "SELECT DISTINCT video_path FROM waypoints "
-                "WHERE lat != 0 AND lon != 0"
-            ):
-                if row[0]:
-                    keep_basenames.add(os.path.basename(row[0]))
-            for row in conn.execute(
-                "SELECT DISTINCT video_path FROM detected_events"
-            ):
-                if row[0]:
-                    keep_basenames.add(os.path.basename(row[0]))
-            for row in conn.execute(
-                "SELECT file_path FROM indexed_files "
-                "WHERE waypoint_count = 0 AND event_count = 0"
-            ):
-                if not row[0]:
-                    continue
-                basename = os.path.basename(row[0])
-                if basename.endswith('-front.mp4'):
-                    proven_non_driving.add(basename)
-        finally:
-            conn.close()
-    except Exception as e:
-        logger.debug("prune: failed loading classification sets: %s", e)
-        return 0  # Can't determine safely — don't prune this cycle
-
-    cutoff = time.time() - _PRUNE_GRACE_SECONDS
-
-    try:
-        names = list(os.listdir(ARCHIVE_DIR))
-    except OSError:
-        return 0
-
-    # Decide per timestamp prefix using the front-camera clip
-    decision: Dict[str, bool] = {}  # ts_prefix -> True (keep) / False (delete)
-    for name in names:
-        if not name.lower().endswith('.mp4'):
-            continue
-        if not name.endswith('-front.mp4'):
-            continue
-
-        clip_ts = _timestamp_from_filename(name)
-        if clip_ts is None:
-            continue
-        ts_key = name[:19]
-
-        # Grace period — keep recent clips no matter what
-        if clip_ts > cutoff:
-            decision[ts_key] = True
-            continue
-
-        # Indexer found waypoints/events for this clip
-        if name in keep_basenames:
-            decision[ts_key] = True
-            continue
-
-        # Falls inside a known driving trip's time window
-        if _is_during_driving(clip_ts, driving_ranges):
-            decision[ts_key] = True
-            continue
-
-        # Only DELETE when we have positive evidence that the indexer
-        # processed this clip and found neither GPS nor events. Without
-        # that evidence (no indexed_files row at all), keep the clip so
-        # the indexer can try again on a future run.
-        if name in proven_non_driving:
-            decision[ts_key] = False
-        else:
-            decision[ts_key] = True
-
-    # Second pass: delete all clips (any camera) whose timestamp prefix
-    # is marked for deletion. Side/back cams without a front-cam decision
-    # are NEVER deleted here — only positive evidence drives deletion.
-    from services.file_safety import safe_delete_archive_video, DeleteOutcome
-    deleted = 0
-    deleted_paths: List[str] = []
-    for name in names:
-        if not name.lower().endswith('.mp4'):
-            continue
-        if len(name) < 19:
-            continue
-        ts_key = name[:19]
-        if decision.get(ts_key) is not False:
-            continue
-        fpath = os.path.join(ARCHIVE_DIR, name)
-        if safe_delete_archive_video(fpath).outcome is DeleteOutcome.DELETED:
-            deleted += 1
-            deleted_paths.append(fpath)
-
-    if deleted:
-        logger.info(
-            "Prune: deleted %d archived clips with positive non-driving evidence",
-            deleted,
+        from services import archive_watchdog
+        return archive_watchdog.force_prune_now()
+    except Exception as e:  # noqa: BLE001
+        logger.exception(
+            "trigger_archive_cleanup: archive_watchdog.force_prune_now failed",
         )
-        # Targeted geodata purge for the exact files we just deleted.
-        try:
-            from config import MAPPING_ENABLED, MAPPING_DB_PATH
-            if MAPPING_ENABLED and os.path.isfile(MAPPING_DB_PATH):
-                from services.mapping_service import purge_deleted_videos
-                purge_deleted_videos(
-                    MAPPING_DB_PATH, deleted_paths=deleted_paths,
-                )
-        except Exception as e:
-            logger.debug("Prune geodata purge failed: %s", e)
-
-    return deleted
-
-
-# ---------------------------------------------------------------------------
-# MP4 Validation
-# ---------------------------------------------------------------------------
-
-
-def _is_complete_mp4(filepath: str) -> bool:
-    """Check if an MP4 file has both ftyp and moov boxes (is complete).
-
-    Tesla writes the moov atom at the END of the file. If the file was
-    copied while Tesla was still recording, the moov box will be missing
-    and the file is unplayable.
-    """
-    try:
-        with open(filepath, 'rb') as f:
-            header = f.read(12)
-            if len(header) < 12 or b'ftyp' not in header:
-                return False
-
-            # Scan for moov box — read box headers sequentially
-            f.seek(0)
-            file_size = os.path.getsize(filepath)
-            pos = 0
-            while pos < file_size - 8:
-                f.seek(pos)
-                box_header = f.read(8)
-                if len(box_header) < 8:
-                    break
-                box_size = int.from_bytes(box_header[:4], 'big')
-                box_type = box_header[4:8]
-
-                if box_type == b'moov':
-                    return True
-
-                if box_size < 8:
-                    break  # Invalid box
-                pos += box_size
-
-            return False  # moov not found
-    except (OSError, IOError):
-        return False
-
-
-# ---------------------------------------------------------------------------
-# File Copy
-# ---------------------------------------------------------------------------
-
-
-def _buffered_copy(src: str, dst: str) -> None:
-    """Copy a file using rate-limited buffered reads.
-
-    Throttled to _MAX_COPY_BYTES_PER_SEC to avoid saturating the SD card
-    I/O bus. The USB gadget shares the same bus — unthrottled copies cause
-    endpoint stalls (dwc2 ep1in stalled) and can trigger watchdog reboots.
-    """
-    dst_tmp = dst + ".tmp"
-    try:
-        bytes_this_second = 0
-        second_start = time.monotonic()
-
-        with open(src, "rb") as fin, open(dst_tmp, "wb") as fout:
-            while True:
-                chunk = fin.read(_COPY_CHUNK_SIZE)
-                if not chunk:
-                    break
-                fout.write(chunk)
-                bytes_this_second += len(chunk)
-
-                # Rate limiting: sleep if we've exceeded the budget for this second
-                elapsed = time.monotonic() - second_start
-                if bytes_this_second >= _MAX_COPY_BYTES_PER_SEC:
-                    sleep_for = 1.0 - elapsed
-                    if sleep_for > 0:
-                        time.sleep(sleep_for)
-                    bytes_this_second = 0
-                    second_start = time.monotonic()
-
-            fout.flush()
-            os.fsync(fout.fileno())
-        os.replace(dst_tmp, dst)
-    except Exception:
-        # Clean up partial file
-        try:
-            os.unlink(dst_tmp)
-        except OSError:
-            pass
-        raise
-
-
-# ---------------------------------------------------------------------------
-# Corrupt File Cleanup
-# ---------------------------------------------------------------------------
-
-
-def _purge_corrupt_archives() -> int:
-    """Remove archived MP4 files that are incomplete (no moov box).
-
-    These result from copying files that Tesla was still writing.
-    Returns the count of files removed.
-    """
-    if not os.path.isdir(ARCHIVE_DIR):
-        return 0
-
-    from services.file_safety import safe_delete_archive_video, DeleteOutcome
-    removed = 0
-    try:
-        for name in os.listdir(ARCHIVE_DIR):
-            if not name.lower().endswith('.mp4'):
-                continue
-            fpath = os.path.join(ARCHIVE_DIR, name)
-            if not os.path.isfile(fpath):
-                continue
-            if not _is_complete_mp4(fpath):
-                if safe_delete_archive_video(fpath).outcome is DeleteOutcome.DELETED:
-                    removed += 1
-    except OSError:
-        pass
-
-    if removed:
-        logger.info("Purged %d corrupt/incomplete archived files", removed)
-    return removed
-
-
-# ---------------------------------------------------------------------------
-# Retention Enforcement
-# ---------------------------------------------------------------------------
-
-
-def _enforce_retention() -> None:
-    """Delete oldest archived files when limits are exceeded.
-
-    Enforcement cascade (highest priority first):
-    1. min_free_space_gb — hard floor, protects OS and IMG growth
-    2. max_size_gb — cap on archive folder size
-    3. retention_days — age-based cleanup
-
-    After deleting files, purges stale entries from geodata.db so the
-    map page doesn't show ghost trips with missing video files. The
-    purge is targeted (the exact files we just deleted) rather than a
-    full-tree scan — much cheaper on a Pi with thousands of clips.
-    """
-    if not os.path.isdir(ARCHIVE_DIR):
-        return
-
-    deleted_paths: List[str] = []
-
-    # Age-based cleanup first (cheapest — no disk usage calculation)
-    if ARCHIVE_RETENTION_DAYS > 0:
-        cutoff = time.time() - (ARCHIVE_RETENTION_DAYS * 86400)
-        deleted_paths.extend(_delete_files_older_than(cutoff))
-
-    # Size-based cleanup (only when a hard cap is set)
-    if ARCHIVE_MAX_SIZE_GB > 0:
-        max_bytes = ARCHIVE_MAX_SIZE_GB * 1024 * 1024 * 1024
-        deleted_paths.extend(_trim_archive_to_size(max_bytes))
-
-    # Free-space floor
-    min_free_bytes = ARCHIVE_MIN_FREE_SPACE_GB * 1024 * 1024 * 1024
-    deleted_paths.extend(_trim_archive_for_free_space(min_free_bytes))
-
-    # Targeted geodata purge for the exact files we just deleted.
-    if deleted_paths:
-        try:
-            from config import MAPPING_ENABLED, MAPPING_DB_PATH
-            if MAPPING_ENABLED and os.path.isfile(MAPPING_DB_PATH):
-                from services.mapping_service import purge_deleted_videos
-                result = purge_deleted_videos(
-                    MAPPING_DB_PATH, deleted_paths=deleted_paths,
-                )
-                purged = result.get('purged_files', 0)
-                if purged:
-                    logger.info(
-                        "Retention: purged %d stale geodata entries", purged,
-                    )
-        except Exception as e:
-            logger.debug("Retention geodata purge failed (non-fatal): %s", e)
-
-
-def _delete_files_older_than(cutoff_timestamp: float) -> List[str]:
-    """Delete archived files older than the cutoff. Returns deleted paths."""
-    from services.file_safety import safe_delete_archive_video, DeleteOutcome
-    deleted: List[str] = []
-    if not os.path.isdir(ARCHIVE_DIR):
-        return deleted
-
-    try:
-        for name in os.listdir(ARCHIVE_DIR):
-            fpath = os.path.join(ARCHIVE_DIR, name)
-            if not os.path.isfile(fpath):
-                continue
-            try:
-                if os.stat(fpath).st_mtime < cutoff_timestamp:
-                    if safe_delete_archive_video(fpath).outcome is DeleteOutcome.DELETED:
-                        deleted.append(fpath)
-            except OSError:
-                continue
-    except OSError:
-        pass
-
-    if deleted:
-        logger.info("Retention: deleted %d files older than %d days",
-                     len(deleted), ARCHIVE_RETENTION_DAYS)
-    return deleted
-
-
-def _trim_archive_to_size(max_bytes: int) -> List[str]:
-    """Delete oldest files until archive is under max_bytes. Returns deleted paths."""
-    from services.file_safety import safe_delete_archive_video, DeleteOutcome
-    files = _get_archived_files_sorted()
-    total_size = sum(s for _, s, _ in files)
-    deleted: List[str] = []
-
-    while total_size > max_bytes and files:
-        fpath, fsize, _ = files.pop(0)  # oldest first
-        if safe_delete_archive_video(fpath).outcome is DeleteOutcome.DELETED:
-            total_size -= fsize
-            deleted.append(fpath)
-
-    if deleted:
-        logger.info("Retention: deleted %d files to stay under %d GB",
-                     len(deleted), ARCHIVE_MAX_SIZE_GB)
-    return deleted
-
-
-def _trim_archive_for_free_space(min_free_bytes: int) -> List[str]:
-    """Delete oldest archived files until SD card has enough free space.
-
-    Returns the deleted paths so callers can do a targeted geodata
-    purge instead of a full-tree scan.
-    """
-    from services.file_safety import safe_delete_archive_video, DeleteOutcome
-    files = _get_archived_files_sorted()
-    deleted: List[str] = []
-
-    while files:
-        try:
-            usage = shutil.disk_usage(ARCHIVE_DIR)
-        except OSError:
-            break
-        if usage.free >= min_free_bytes:
-            break
-        fpath, _, _ = files.pop(0)
-        if safe_delete_archive_video(fpath).outcome is DeleteOutcome.DELETED:
-            deleted.append(fpath)
-
-    if deleted:
-        logger.info("Retention: deleted %d files to maintain %d GB free",
-                     len(deleted), ARCHIVE_MIN_FREE_SPACE_GB)
-    return deleted
-
-
-def _get_archived_files_sorted() -> List[Tuple[str, int, float]]:
-    """Return list of (path, size, mtime) sorted oldest first."""
-    files = []
-    if not os.path.isdir(ARCHIVE_DIR):
-        return files
-
-    try:
-        for name in os.listdir(ARCHIVE_DIR):
-            fpath = os.path.join(ARCHIVE_DIR, name)
-            if not os.path.isfile(fpath):
-                continue
-            try:
-                st = os.stat(fpath)
-                files.append((fpath, st.st_size, st.st_mtime))
-            except OSError:
-                continue
-    except OSError:
-        pass
-
-    files.sort(key=lambda x: x[2])  # oldest first
-    return files
-
-
-# ---------------------------------------------------------------------------
-# Geodata DB Path Updates
-# ---------------------------------------------------------------------------
-
-
-def _update_geodata_paths(old_abs: str, new_abs: str, filename: str) -> None:
-    """Update geodata.db to point at the archived copy of a video.
-
-    When a RecentClips file is archived to the SD card, we update the DB
-    paths rather than re-indexing (the GPS data is already extracted).
-
-    - indexed_files.file_path: absolute path (primary key — requires delete+insert)
-    - waypoints.video_path: relative path (e.g. "RecentClips/...-front.mp4")
-    - detected_events.video_path: same relative format
-
-    Uses the canonical-key candidate paths so we update every form the DB
-    might have stored (bare basename, RecentClips/<basename>) and never
-    accidentally match an unrelated path that simply happens to contain
-    the basename as a substring.
-    """
-    try:
-        import sqlite3
-        from config import MAPPING_DB_PATH
-        from services.mapping_service import canonical_key, candidate_db_paths
-
-        if not os.path.isfile(MAPPING_DB_PATH):
-            return
-
-        conn = sqlite3.connect(MAPPING_DB_PATH, timeout=10)
-        conn.row_factory = sqlite3.Row
-
-        try:
-            basename = os.path.basename(filename)
-            new_rel = f"ArchivedClips/{basename}"
-            old_paths = candidate_db_paths(canonical_key(basename))
-            placeholders = ','.join('?' * len(old_paths))
-
-            # Update indexed_files (file_path is PRIMARY KEY, so delete+insert)
-            row = conn.execute(
-                "SELECT * FROM indexed_files WHERE file_path = ?",
-                (old_abs,)
-            ).fetchone()
-
-            if row:
-                conn.execute("DELETE FROM indexed_files WHERE file_path = ?", (old_abs,))
-                conn.execute(
-                    "INSERT INTO indexed_files "
-                    "(file_path, file_size, file_mtime, indexed_at, "
-                    "waypoint_count, event_count) "
-                    "VALUES (?, ?, ?, ?, ?, ?)",
-                    (new_abs, row['file_size'], row['file_mtime'],
-                     row['indexed_at'],
-                     row['waypoint_count'], row['event_count']),
-                )
-
-            # Update waypoints.video_path — exact-match every candidate form
-            # except the new path itself (avoid no-op self-update churn).
-            non_archive = [p for p in old_paths if p != new_rel]
-            if non_archive:
-                non_archive_placeholders = ','.join('?' * len(non_archive))
-                conn.execute(
-                    f"UPDATE waypoints SET video_path = ? "
-                    f"WHERE video_path IN ({non_archive_placeholders})",
-                    (new_rel, *non_archive),
-                )
-                conn.execute(
-                    f"UPDATE detected_events SET video_path = ? "
-                    f"WHERE video_path IN ({non_archive_placeholders})",
-                    (new_rel, *non_archive),
-                )
-
-            conn.commit()
-        finally:
-            conn.close()
-
-    except Exception as e:
-        # Non-fatal — the file is archived even if DB update fails.
-        # The purge logic will fix paths on the next full scan.
-        logger.debug("Failed to update geodata paths for %s: %s", filename, e)
-
-
-# ---------------------------------------------------------------------------
-# System Checks
-# ---------------------------------------------------------------------------
-
-
-def _check_memory() -> bool:
-    """Return True if enough memory is available to continue archiving."""
-    try:
-        with open("/proc/meminfo", "r") as f:
-            mem = {}
-            for line in f:
-                parts = line.split()
-                if len(parts) >= 2:
-                    mem[parts[0].rstrip(":")] = int(parts[1]) * 1024  # kB → bytes
-        available = mem.get("MemAvailable", 0) + mem.get("SwapFree", 0)
-        return available > _MIN_MEMORY_BYTES
-    except (OSError, ValueError):
-        return True  # Assume OK if we can't read meminfo
-
-
-def _check_disk_space() -> bool:
-    """Return True if archive can continue (space limits OK).
-
-    When ``ARCHIVE_MAX_SIZE_GB`` is 0 (the default), the archive grows
-    freely — the only constraint is ``ARCHIVE_MIN_FREE_SPACE_GB`` which
-    reserves space for the OS and other services.  A non-zero value
-    imposes a hard cap on the archive folder itself.
-    """
-    # Check SD card free space (always enforced)
-    try:
-        usage = shutil.disk_usage(ARCHIVE_DIR)
-        min_free = ARCHIVE_MIN_FREE_SPACE_GB * 1024 * 1024 * 1024
-        if usage.free < min_free:
-            return False
-    except OSError:
-        return False
-
-    # Optional hard cap on archive folder size (0 = no cap)
-    if ARCHIVE_MAX_SIZE_GB > 0:
-        max_bytes = ARCHIVE_MAX_SIZE_GB * 1024 * 1024 * 1024
-        archive_size = _get_archive_size()
-        if archive_size >= max_bytes:
-            return False
-
-    return True
-
-
-def _proactive_retention() -> None:
-    """Run retention early when free space is getting low.
-
-    Triggers at 2× the ``min_free_space_gb`` floor so there is always a
-    buffer before the hard limit is reached.  This avoids the scenario
-    where we hit the floor mid-copy and have to stop.  Uses the smart
-    cleanup path (deletes least-valuable files first) when available,
-    falling back to age-based + oldest-first retention.
-    """
-    try:
-        usage = shutil.disk_usage(ARCHIVE_DIR)
-    except OSError:
-        return
-
-    soft_threshold = ARCHIVE_MIN_FREE_SPACE_GB * 2 * 1024 * 1024 * 1024
-    if usage.free >= soft_threshold:
-        return  # Plenty of space — nothing to do
-
-    free_gb = usage.free / (1024 ** 3)
-    target_gb = ARCHIVE_MIN_FREE_SPACE_GB * 2
-    logger.info(
-        "Proactive retention: %.1f GB free < %.0f GB soft threshold, cleaning up",
-        free_gb, target_gb,
-    )
-
-    # Try smart cleanup first (deletes least-valuable files)
-    try:
-        result = smart_cleanup_archive(
-            ARCHIVE_DIR,
-            min_free_gb=target_gb,
-            max_size_gb=ARCHIVE_MAX_SIZE_GB,
-        )
-        if result["deleted_count"]:
-            logger.info(
-                "Proactive retention: smart cleanup freed %.1f MB (%d files)",
-                result["freed_bytes"] / (1024 * 1024), result["deleted_count"],
-            )
-            return
-    except Exception as e:
-        logger.debug("Smart cleanup unavailable, using basic retention: %s", e)
-
-    # Fall back to basic retention (oldest-first)
-    _trim_archive_for_free_space(int(target_gb * 1024 ** 3))
-
-
-def _get_archive_size() -> int:
-    """Return total size of archived files in bytes."""
-    total = 0
-    if not os.path.isdir(ARCHIVE_DIR):
-        return 0
-    try:
-        for name in os.listdir(ARCHIVE_DIR):
-            fpath = os.path.join(ARCHIVE_DIR, name)
-            try:
-                if os.path.isfile(fpath):
-                    total += os.stat(fpath).st_size
-            except OSError:
-                continue
-    except OSError:
-        pass
-    return total
-
-
-def _update_archive_size() -> None:
-    """Update the status dict with current archive size."""
-    size = _get_archive_size()
-    _status["archive_size_mb"] = round(size / (1024 * 1024), 1)
-
-
-# ---------------------------------------------------------------------------
-# Path Resolution
-# ---------------------------------------------------------------------------
-
-
-def _get_teslacam_ro_path() -> Optional[str]:
-    """Get the TeslaCam read-only mount path (present mode only)."""
-    from services.mode_service import current_mode
-    from config import MNT_DIR, RO_MNT_DIR
-
-    mode = current_mode()
-    if mode == "present":
-        ro_path = os.path.join(RO_MNT_DIR, "part1-ro", "TeslaCam")
-        if os.path.isdir(ro_path):
-            return ro_path
-    elif mode == "edit":
-        # In edit mode, RecentClips is at the RW mount path
-        rw_path = os.path.join(MNT_DIR, "part1", "TeslaCam")
-        if os.path.isdir(rw_path):
-            return rw_path
-    return None
-
-
-# ---------------------------------------------------------------------------
-# Smart Archive Cleanup
-# ---------------------------------------------------------------------------
-
-
-def smart_cleanup_archive(
-    archive_dir: str,
-    min_free_gb: float = 10.0,
-    max_size_gb: float = 50.0,
-) -> dict:
-    """Smart cleanup of ArchivedClips when SD card space is low.
-
-    Priority order for deletion:
-    1. Videos without events AND without GPS coordinates (least valuable)
-    2. Oldest videos (by file modification time)
-    Never: Delete videos that are queued for or currently syncing to cloud.
-
-    Returns dict with deleted_count, freed_bytes, and details.
-    """
-    import sqlite3
-    from services.file_safety import safe_remove
-
-    result = {
-        "deleted_count": 0,
-        "freed_bytes": 0,
-        "skipped_cloud_queue": 0,
-        "details": [],
-    }
-
-    if not os.path.isdir(archive_dir):
-        return result
-
-    # Check if cleanup is needed
-    try:
-        usage = shutil.disk_usage(archive_dir)
-    except OSError:
-        logger.warning("Smart cleanup: cannot read disk usage for %s", archive_dir)
-        return result
-
-    free_gb = usage.free / (1024 ** 3)
-    archive_size = _get_archive_size()
-    archive_gb = archive_size / (1024 ** 3)
-
-    if free_gb >= min_free_gb and (max_size_gb <= 0 or archive_gb <= max_size_gb):
-        logger.debug("Smart cleanup: no action needed (%.1f GB free, %.1f GB archive)", free_gb, archive_gb)
-        return result
-
-    logger.info(
-        "Smart cleanup: starting (%.1f GB free < %.1f GB min, or %.1f GB archive > %.1f GB max)",
-        free_gb, min_free_gb, archive_gb, max_size_gb,
-    )
-
-    # Scan all .mp4 files
-    files_to_score = []
-    try:
-        for entry in os.scandir(archive_dir):
-            if not entry.name.lower().endswith('.mp4'):
-                continue
-            try:
-                st = entry.stat()
-                files_to_score.append({
-                    "path": entry.path,
-                    "name": entry.name,
-                    "size": st.st_size,
-                    "mtime": st.st_mtime,
-                })
-            except OSError:
-                continue
-    except OSError:
-        logger.warning("Smart cleanup: cannot scan %s", archive_dir)
-        return result
-
-    if not files_to_score:
-        return result
-
-    # Check geodata.db for GPS data and events
-    geo_db_path = None
-    try:
-        from config import MAPPING_DB_PATH
-        if os.path.isfile(MAPPING_DB_PATH):
-            geo_db_path = MAPPING_DB_PATH
-    except Exception:
-        pass
-
-    files_with_gps = set()
-    files_with_events = set()
-    if geo_db_path:
-        try:
-            conn = sqlite3.connect(geo_db_path, timeout=5)
-            conn.row_factory = sqlite3.Row
-            try:
-                for f in files_to_score:
-                    row = conn.execute(
-                        "SELECT 1 FROM waypoints WHERE video_path LIKE ? LIMIT 1",
-                        ('%' + f["name"] + '%',)
-                    ).fetchone()
-                    if row:
-                        files_with_gps.add(f["name"])
-            except sqlite3.OperationalError:
-                pass  # Table may not exist
-
-            try:
-                for f in files_to_score:
-                    row = conn.execute(
-                        "SELECT 1 FROM detected_events WHERE video_path LIKE ? LIMIT 1",
-                        ('%' + f["name"] + '%',)
-                    ).fetchone()
-                    if row:
-                        files_with_events.add(f["name"])
-            except sqlite3.OperationalError:
-                pass  # Table may not exist
-            conn.close()
-        except Exception:
-            logger.debug("Smart cleanup: could not query geodata.db")
-
-    # Check cloud sync status - skip files queued/uploading
-    cloud_queued_files = set()
-    try:
-        from config import CLOUD_ARCHIVE_DB_PATH
-        if os.path.isfile(CLOUD_ARCHIVE_DB_PATH):
-            cconn = sqlite3.connect(CLOUD_ARCHIVE_DB_PATH, timeout=5)
-            cconn.row_factory = sqlite3.Row
-            try:
-                for f in files_to_score:
-                    row = cconn.execute(
-                        "SELECT status FROM cloud_synced_files WHERE file_path LIKE ? AND status IN ('queued', 'uploading', 'pending') LIMIT 1",
-                        ('%' + f["name"] + '%',)
-                    ).fetchone()
-                    if row:
-                        cloud_queued_files.add(f["name"])
-            except sqlite3.OperationalError:
-                pass
-            cconn.close()
-    except Exception:
-        pass
-
-    # Assign scores and filter out cloud-queued files
-    scored = []
-    for f in files_to_score:
-        name = f["name"]
-        if name in cloud_queued_files:
-            result["skipped_cloud_queue"] += 1
-            continue
-
-        has_gps = name in files_with_gps
-        has_events = name in files_with_events
-        score = 0
-        if has_gps:
-            score += 50
-        if has_events:
-            score += 50
-        scored.append((score, f["mtime"], f))
-
-    # Sort: lowest score first, then oldest first within same score
-    scored.sort(key=lambda x: (x[0], x[1]))
-
-    # Delete files until space constraints are met
-    min_free_bytes = int(min_free_gb * 1024 ** 3)
-    max_archive_bytes = int(max_size_gb * 1024 ** 3) if max_size_gb > 0 else 0
-
-    for _score, _mtime, f in scored:
-        # Recheck conditions
-        try:
-            current_usage = shutil.disk_usage(archive_dir)
-            current_free = current_usage.free
-        except OSError:
-            break
-
-        current_archive_size = archive_size - result["freed_bytes"]
-        size_ok = (max_archive_bytes <= 0) or (current_archive_size <= max_archive_bytes)
-        if current_free >= min_free_bytes and size_ok:
-            break
-
-        if safe_remove(f["path"]):
-            result["deleted_count"] += 1
-            result["freed_bytes"] += f["size"]
-            result["details"].append(f["name"])
-            logger.info("Smart cleanup: deleted %s (score=%d, size=%d)", f["name"], _score, f["size"])
-
-    if result["deleted_count"]:
-        logger.info(
-            "Smart cleanup: deleted %d files, freed %.1f MB (skipped %d cloud-queued)",
-            result["deleted_count"],
-            result["freed_bytes"] / (1024 * 1024),
-            result["skipped_cloud_queue"],
-        )
-        _update_archive_size()
-
-    return result
-
-
-def trigger_archive_cleanup() -> dict:
-    """Manually trigger archive cleanup. Returns result."""
-    return smart_cleanup_archive(ARCHIVE_DIR, ARCHIVE_MIN_FREE_SPACE_GB, ARCHIVE_MAX_SIZE_GB)
+        return {
+            "deleted_count": 0,
+            "freed_bytes": 0,
+            "scanned": 0,
+            "error": str(e),
+        }

--- a/tests/test_cloud_archive_blueprint.py
+++ b/tests/test_cloud_archive_blueprint.py
@@ -301,3 +301,120 @@ class TestSaveSettingsRetryCapClamping:
         assert r.status_code in (302, 303)
         last = captured_updates['last']
         assert last['cloud_archive.retry_max_attempts'] == 5
+
+
+class TestArchiveCleanupHttpContract:
+    """Phase 3a.1 (#98 / closes #91) post-review fix: ``POST /api/archive_cleanup``
+    must preserve the legacy 500-on-error HTTP contract that the endpoint
+    advertised before the refactor.
+
+    Before the refactor: ``trigger_archive_cleanup`` raised on watchdog
+    failure; the blueprint's outer ``try/except`` produced HTTP 500.
+    After the refactor: the shim swallows watchdog exceptions and
+    returns ``{'error': '...'}``; the blueprint must convert that
+    structured error back into an HTTP 500 so external automation /
+    front-end code that keys on the status code keeps working.
+
+    Successful runs (including the watchdog's ``status='already_running'``
+    short-circuit, which is normal control flow, not an error) MUST
+    return HTTP 200.
+    """
+
+    def test_successful_prune_returns_200(self, client):
+        with patch(
+            'services.video_archive_service.trigger_archive_cleanup',
+            return_value={
+                'deleted_count': 7,
+                'freed_bytes': 1_400_000,
+                'scanned': 100,
+                'kept_unsynced_count': 0,
+                'duration_seconds': 0.42,
+            },
+        ):
+            r = client.post('/cloud/api/archive_cleanup')
+        assert r.status_code == 200
+        body = r.get_json()
+        assert body['success'] is True
+        assert body['result']['deleted_count'] == 7
+        assert body['result']['freed_bytes'] == 1_400_000
+
+    def test_already_running_returns_200(self, client):
+        # The watchdog's ``_retention_running`` guard short-circuits with
+        # a synthetic summary carrying ``status='already_running'``.
+        # That's a normal control-flow signal — NOT an error — so the
+        # endpoint MUST return 200 so the front end can render
+        # "Cleanup already in progress" instead of an error toast.
+        with patch(
+            'services.video_archive_service.trigger_archive_cleanup',
+            return_value={
+                'deleted_count': 0,
+                'freed_bytes': 0,
+                'scanned': 0,
+                'status': 'already_running',
+                'duration_seconds': 0.001,
+            },
+        ):
+            r = client.post('/cloud/api/archive_cleanup')
+        assert r.status_code == 200
+        body = r.get_json()
+        assert body['success'] is True
+        assert body['result']['status'] == 'already_running'
+
+    def test_watchdog_error_dict_returns_500(self, client):
+        # The shim catches watchdog exceptions and converts them to
+        # ``{'error': '<exc>', ...}``. The blueprint MUST translate
+        # that back into an HTTP 500 + ``success=False`` so the legacy
+        # contract is preserved. Without this translation, callers
+        # would treat watchdog crashes as silent successes.
+        with patch(
+            'services.video_archive_service.trigger_archive_cleanup',
+            return_value={
+                'deleted_count': 0,
+                'freed_bytes': 0,
+                'scanned': 0,
+                'error': 'watchdog raised: synthetic',
+            },
+        ):
+            r = client.post('/cloud/api/archive_cleanup')
+        assert r.status_code == 500
+        body = r.get_json()
+        assert body['success'] is False
+        assert 'synthetic' in body['message']
+        # The structured error dict is preserved in the response so
+        # debuggers can see the full context (cutoff, scanned, etc.).
+        assert body['result']['error'] == 'watchdog raised: synthetic'
+
+    def test_watchdog_not_started_returns_500(self, client):
+        # ``force_prune_now`` returns ``{'error': 'watchdog not started', ...}``
+        # without raising when the daemon isn't running. Per the legacy
+        # contract this is still an error condition (the user clicked
+        # "Run cleanup now" and nothing happened), so 500 is correct.
+        with patch(
+            'services.video_archive_service.trigger_archive_cleanup',
+            return_value={
+                'deleted_count': 0,
+                'freed_bytes': 0,
+                'scanned': 0,
+                'error': 'watchdog not started',
+            },
+        ):
+            r = client.post('/cloud/api/archive_cleanup')
+        assert r.status_code == 500
+        body = r.get_json()
+        assert body['success'] is False
+        assert body['message'] == 'watchdog not started'
+
+    def test_unexpected_exception_returns_500(self, client):
+        # Defense in depth: even if the shim itself raises (e.g.
+        # ImportError on the local import), the endpoint's outer
+        # try/except must still return a clean 500 rather than
+        # leaking a traceback.
+        with patch(
+            'services.video_archive_service.trigger_archive_cleanup',
+            side_effect=RuntimeError("synthetic"),
+        ):
+            r = client.post('/cloud/api/archive_cleanup')
+        assert r.status_code == 500
+        body = r.get_json()
+        assert body['success'] is False
+        assert 'synthetic' in body['message']

--- a/tests/test_video_archive_trigger.py
+++ b/tests/test_video_archive_trigger.py
@@ -1,18 +1,25 @@
-"""Tests for the Phase 2b ``video_archive_service`` shims (issue #76).
+"""Tests for the Phase 2b/3a ``video_archive_service`` shim layer.
 
-The legacy ``_archive_timer_loop`` periodic thread + ``_archive_pending``
-duplicate-guard pattern is gone. ``video_archive_service`` is now a thin
-compatibility layer over ``archive_worker``:
+Phase 2b (issue #76) replaced the legacy ``_archive_timer_loop`` /
+``_run_archive`` / ``_archive_pending`` duplicate-guard internals with
+the queue-driven ``archive_worker``. Phase 3a (issue #98 / closes #91)
+deletes the legacy retention cascade — ``smart_cleanup_archive``,
+``_proactive_retention``, ``_enforce_retention``, ``_purge_corrupt_archives``,
+``_prune_non_driving_archives``, ``_update_geodata_paths``, and the
+helper ladder beneath them — and rewires
+``trigger_archive_cleanup`` to a one-line wrapper around
+``archive_watchdog.force_prune_now``.
 
-* ``start_archive_timer()`` → ``archive_worker.ensure_worker_started()``
-* ``stop_archive_timer()``  → ``archive_worker.stop_worker()``
-* ``trigger_archive_now()`` → ``archive_worker.wake()``
+These tests pin the surviving public API:
 
-The old tests asserted on the deleted internals (``_run_archive``,
-``_archive_pending``, ``_archive_timer_loop``, the ionice-on-the-process
-bug). Those are no longer reachable code paths and have been deleted.
-The Phase 2b worker has its own pause/resume/wake/dead-letter test
-coverage in ``test_archive_worker.py``.
+* ``trigger_archive_now`` — wakes the worker, swallows worker exceptions
+* ``start_archive_timer`` / ``stop_archive_timer`` — delegate to the
+  worker's lifecycle, swallow exceptions
+* ``get_archive_status`` — bridges to ``archive_worker.get_status`` and
+  reports a backwards-compatible ``running`` flag for the dispatcher
+* ``trigger_archive_cleanup`` — Phase 3a wrapper for
+  ``archive_watchdog.force_prune_now``; passes through the watchdog's
+  ``status='already_running'`` short-circuit
 """
 
 from unittest.mock import patch
@@ -86,15 +93,28 @@ class TestStartStopShims:
     delegations to the worker; the legacy internal thread is gone."""
 
     def test_start_archive_timer_starts_worker(self):
+        vas.ARCHIVE_ENABLED = True
         with patch(
             'services.archive_worker.ensure_worker_started',
         ) as mock_start:
             vas.start_archive_timer()
             mock_start.assert_called_once()
 
+    def test_start_archive_timer_disabled_does_not_start_worker(self):
+        # When ARCHIVE_ENABLED is False, start should be a no-op.
+        # Importantly, it must NOT call ensure_worker_started — the
+        # worker shouldn't even be initialised when archiving is off.
+        vas.ARCHIVE_ENABLED = False
+        with patch(
+            'services.archive_worker.ensure_worker_started',
+        ) as mock_start:
+            vas.start_archive_timer()
+            mock_start.assert_not_called()
+
     def test_start_archive_timer_swallows_worker_failure(self):
         # Same resilience contract as trigger_archive_now: a worker
         # startup failure must not crash gadget_web's main thread.
+        vas.ARCHIVE_ENABLED = True
         with patch(
             'services.archive_worker.ensure_worker_started',
             side_effect=RuntimeError("synthetic"),
@@ -118,83 +138,235 @@ class TestStartStopShims:
             vas.stop_archive_timer()
 
 
-class TestUpdateGeodataPaths:
-    """When the archive worker copies a RecentClips file to ArchivedClips,
-    ``_update_geodata_paths`` rewrites the geodata DB to point at the new
-    location. The ``indexed_files`` row gets recreated under the new
-    absolute path (it's the primary key) — earlier versions of this code
-    dropped the ``indexed_at`` column from the INSERT, leaving the new
-    row with ``indexed_at = NULL``. That cosmetic bug confused the daily
-    stale-scan and any UI that displayed indexing recency. Pin the fix.
+class TestGetArchiveStatus:
+    """``get_archive_status()`` bridges to ``archive_worker.get_status()``
+    and reports a backwards-compatible ``running`` flag for the
+    NM dispatcher (``helpers/refresh_cloud_token.py``).
+
+    The dispatcher polls ``/api/recent_archive/status`` after
+    ``/api/recent_archive/trigger`` and waits for ``running == False``
+    before kicking cloud sync. In the queue-driven architecture the
+    worker thread is always alive once started, so ``running`` must
+    track "is there work in flight right now" — the union of an
+    active file being copied AND any pending queue depth.
     """
 
-    def test_indexed_at_is_preserved_across_archive(self, tmp_path):
-        import sqlite3
+    def test_running_true_when_active_file(self):
+        # Worker is mid-file — dispatcher must wait.
+        with patch(
+            'services.archive_worker.get_status',
+            return_value={
+                'worker_running': True,
+                'active_file': '/foo/bar.mp4',
+                'queue_depth': 0,
+                'last_outcome': 'copied',
+            },
+        ):
+            status = vas.get_archive_status()
+            assert status['running'] is True
+            assert status['current_file'] == '/foo/bar.mp4'
 
-        db_path = str(tmp_path / "geo.db")
-        conn = sqlite3.connect(db_path)
-        conn.executescript(
-            """
-            CREATE TABLE indexed_files (
-                file_path TEXT PRIMARY KEY,
-                file_size INTEGER,
-                file_mtime REAL,
-                indexed_at TEXT,
-                waypoint_count INTEGER DEFAULT 0,
-                event_count INTEGER DEFAULT 0
-            );
-            CREATE TABLE waypoints (
-                id INTEGER PRIMARY KEY,
-                trip_id INTEGER, timestamp TEXT, lat REAL, lon REAL,
-                video_path TEXT, frame_offset INTEGER
-            );
-            CREATE TABLE detected_events (
-                id INTEGER PRIMARY KEY,
-                trip_id INTEGER, timestamp TEXT, lat REAL, lon REAL,
-                event_type TEXT, severity REAL, description TEXT,
-                video_path TEXT, frame_offset INTEGER, metadata TEXT
-            );
-            """
-        )
-        old_abs = "/mnt/gadget/part1-ro/TeslaCam/RecentClips/2026-05-10_12-00-00-front.mp4"
-        new_abs = "/home/pi/ArchivedClips/2026-05-10_12-00-00-front.mp4"
-        original_indexed_at = "2026-05-10T12:01:30.123456+00:00"
-        conn.execute(
-            "INSERT INTO indexed_files VALUES (?, ?, ?, ?, ?, ?)",
-            (old_abs, 12345, 1747000000.0, original_indexed_at, 5, 1),
-        )
-        conn.commit()
-        conn.close()
+    def test_running_true_when_queue_has_work(self):
+        # Worker is between files but more work is queued — still busy.
+        with patch(
+            'services.archive_worker.get_status',
+            return_value={
+                'worker_running': True,
+                'active_file': None,
+                'queue_depth': 12,
+                'last_outcome': 'copied',
+            },
+        ):
+            status = vas.get_archive_status()
+            assert status['running'] is True
+            assert status['queue_depth'] == 12
 
-        # Patch the module-level constant the function reads, then run.
-        with patch.object(vas, 'ARCHIVE_ENABLED', True), \
-             patch('config.MAPPING_DB_PATH', db_path):
-            vas._update_geodata_paths(
-                old_abs, new_abs,
-                "2026-05-10_12-00-00-front.mp4",
+    def test_running_false_when_idle(self):
+        # Worker is alive but the queue has drained and no active
+        # file. Dispatcher's wait loop exits and cloud sync proceeds.
+        with patch(
+            'services.archive_worker.get_status',
+            return_value={
+                'worker_running': True,
+                'active_file': None,
+                'queue_depth': 0,
+                'last_outcome': 'copied',
+            },
+        ):
+            status = vas.get_archive_status()
+            assert status['running'] is False
+
+    def test_running_false_when_worker_not_started(self):
+        # Worker thread never started (e.g. ARCHIVE_ENABLED was False
+        # at boot). Don't make the dispatcher wait forever.
+        with patch(
+            'services.archive_worker.get_status',
+            return_value={
+                'worker_running': False,
+                'active_file': None,
+                'queue_depth': 5,
+                'last_outcome': None,
+            },
+        ):
+            status = vas.get_archive_status()
+            assert status['running'] is False
+
+    def test_get_status_failure_returns_safe_default(self):
+        # If the worker module raises (e.g. import error in tests),
+        # return a safe default rather than 500-ing the API. The
+        # dispatcher will see running=False and move on.
+        with patch(
+            'services.archive_worker.get_status',
+            side_effect=RuntimeError("synthetic"),
+        ):
+            status = vas.get_archive_status()
+            assert status['running'] is False
+            assert 'error' in status
+
+    def test_dispatcher_compatible_keys_always_present(self):
+        # Pin the legacy field surface so the dispatcher's
+        # ``status.get("running")`` and any UI poll never KeyError.
+        with patch(
+            'services.archive_worker.get_status',
+            return_value={
+                'worker_running': True,
+                'active_file': None,
+                'queue_depth': 0,
+                'last_outcome': 'copied',
+            },
+        ):
+            status = vas.get_archive_status()
+            for key in (
+                'running', 'current_file', 'queue_depth',
+                'worker_running', 'last_outcome', 'error',
+            ):
+                assert key in status, f"missing legacy key {key!r}"
+
+
+class TestTriggerArchiveCleanup:
+    """Phase 3a (#98 / closes #91): ``trigger_archive_cleanup`` is now
+    a one-line wrapper for ``archive_watchdog.force_prune_now``.
+
+    The legacy implementation called ``smart_cleanup_archive``, which
+    in turn duplicated retention logic that already lives in
+    ``archive_watchdog._run_retention_prune``. Three overlapping
+    retention systems racing each other was the main bug source the
+    Phase 3a refactor closes. These tests pin the new contract:
+
+    * The shim MUST call into ``archive_watchdog.force_prune_now`` —
+      not into the deleted ``smart_cleanup_archive`` (which would
+      AttributeError now).
+    * The watchdog's return shape — including the
+      ``status='already_running'`` short-circuit — passes through
+      unchanged so the ``POST /api/archive_cleanup`` endpoint
+      response stays informative.
+    * Watchdog exceptions are swallowed and converted to a
+      structured error dict so the request thread never 500s.
+    """
+
+    def test_delegates_to_force_prune_now(self):
+        with patch(
+            'services.archive_watchdog.force_prune_now',
+        ) as mock_prune:
+            mock_prune.return_value = {
+                'deleted_count': 3,
+                'freed_bytes': 9_000_000,
+                'scanned': 42,
+                'kept_unsynced_count': 1,
+                'cutoff_iso': '2026-04-12T00:00:00+00:00',
+                'duration_seconds': 0.234,
+            }
+            result = vas.trigger_archive_cleanup()
+            mock_prune.assert_called_once_with()
+            assert result['deleted_count'] == 3
+            assert result['freed_bytes'] == 9_000_000
+            assert result['scanned'] == 42
+            assert result['kept_unsynced_count'] == 1
+            assert 'cutoff_iso' in result
+
+    def test_already_running_status_passthrough(self):
+        # When the watchdog short-circuits via the _retention_running
+        # guard (issue #91 fix), the wrapper must propagate the
+        # status verbatim — the cloud_archive blueprint surfaces it
+        # to the front end so the user sees "Cleanup already in
+        # progress" instead of a confusing zero-result response.
+        with patch(
+            'services.archive_watchdog.force_prune_now',
+            return_value={
+                'deleted_count': 0,
+                'freed_bytes': 0,
+                'scanned': 0,
+                'status': 'already_running',
+                'duration_seconds': 0.001,
+            },
+        ):
+            result = vas.trigger_archive_cleanup()
+            assert result.get('status') == 'already_running'
+            assert result['deleted_count'] == 0
+
+    def test_watchdog_exception_returns_error_dict(self):
+        # The watchdog raising must NOT 500 the endpoint — return a
+        # safe-default summary with an ``error`` key so the UI can
+        # render a clear message.
+        with patch(
+            'services.archive_watchdog.force_prune_now',
+            side_effect=RuntimeError("synthetic"),
+        ):
+            result = vas.trigger_archive_cleanup()
+            assert result['deleted_count'] == 0
+            assert result['freed_bytes'] == 0
+            assert result['scanned'] == 0
+            assert 'error' in result
+            assert 'synthetic' in result['error']
+
+    def test_watchdog_not_started_returns_error_dict(self):
+        # When the watchdog reports it isn't started, force_prune_now
+        # returns ``{'error': 'watchdog not started', ...}`` rather
+        # than raising. Pass the structure through unchanged.
+        with patch(
+            'services.archive_watchdog.force_prune_now',
+            return_value={
+                'deleted_count': 0,
+                'freed_bytes': 0,
+                'scanned': 0,
+                'error': 'watchdog not started',
+            },
+        ):
+            result = vas.trigger_archive_cleanup()
+            assert result['error'] == 'watchdog not started'
+
+    def test_no_legacy_smart_cleanup_attribute(self):
+        # Defensive regression: the old ``smart_cleanup_archive``,
+        # ``_proactive_retention``, ``_enforce_retention``,
+        # ``_prune_non_driving_archives``, and
+        # ``_purge_corrupt_archives`` symbols must NOT exist on the
+        # module. If a future refactor accidentally re-imports them
+        # from a backup, this test catches it before it ships.
+        for symbol in (
+            'smart_cleanup_archive',
+            '_proactive_retention',
+            '_enforce_retention',
+            '_purge_corrupt_archives',
+            '_prune_non_driving_archives',
+            '_update_geodata_paths',
+            '_delete_files_older_than',
+            '_trim_archive_to_size',
+            '_trim_archive_for_free_space',
+            '_get_archived_files_sorted',
+            '_buffered_copy',
+            '_is_complete_mp4',
+            '_check_memory',
+            '_check_disk_space',
+            '_get_archive_size',
+            '_update_archive_size',
+            '_get_teslacam_ro_path',
+            '_get_driving_time_ranges',
+            '_timestamp_from_filename',
+            '_is_during_driving',
+        ):
+            assert not hasattr(vas, symbol), (
+                f"video_archive_service.{symbol} was deleted in Phase 3a "
+                "(#98); reintroducing it would re-enable the racing "
+                "retention systems the refactor removed. Move any new "
+                "logic to archive_worker or archive_watchdog instead."
             )
-
-        conn = sqlite3.connect(db_path)
-        # Old row deleted, new row inserted under the ArchivedClips path.
-        old_row = conn.execute(
-            "SELECT * FROM indexed_files WHERE file_path = ?", (old_abs,)
-        ).fetchone()
-        assert old_row is None
-        new_row = conn.execute(
-            "SELECT file_size, file_mtime, indexed_at, waypoint_count, "
-            "event_count FROM indexed_files WHERE file_path = ?",
-            (new_abs,),
-        ).fetchone()
-        assert new_row is not None
-        # Critical: indexed_at must be carried over, not NULL.
-        assert new_row[2] == original_indexed_at, (
-            "indexed_at was dropped during archive — "
-            "INSERT regressed without the column"
-        )
-        # Other columns also preserved.
-        assert new_row[0] == 12345
-        assert new_row[1] == 1747000000.0
-        assert new_row[3] == 5
-        assert new_row[4] == 1
-        conn.close()
-


### PR DESCRIPTION
## Summary

Phase 3a.1 of the Video Pipeline Hardening epic (#97) — collapses the three overlapping retention systems into one. `archive_watchdog` is now the only retention system. Closes #91 (`_retention_running` guard, which was already shipped in `archive_watchdog` and is exercised by the existing `TestRetentionRunningGuard` suite plus new wrapper-passthrough tests).

## Files

* `scripts/web/services/video_archive_service.py`: **921 → 178 LOC (-743 LOC)**. Kept the public API the rest of the codebase depends on (`start_archive_timer`, `stop_archive_timer`, `trigger_archive_now`, `get_archive_status`, `trigger_archive_cleanup`); deleted the entire retention/copy/path-fixup helper ladder. `trigger_archive_cleanup` is now a one-line wrapper for `archive_watchdog.force_prune_now`. `get_archive_status` bridges to `archive_worker.get_status` so the dispatcher's `running`/`current_file` poll keeps working in the queue-driven architecture.
* `scripts/web/services/cleanup_service.py`: docstring clarifies USB-partition-only scope; explicitly notes `ArchivedClips/` retention is owned by `archive_watchdog`.
* `scripts/web/blueprints/cloud_archive.py`: `POST /api/archive_cleanup` docstring updated; behavior is the same delegated wrapper.
* `tests/test_video_archive_trigger.py`: 200 → 348 LOC. Replaced the now-dead `TestUpdateGeodataPaths` with `TestGetArchiveStatus` (6 tests) and `TestTriggerArchiveCleanup` (5 tests), plus a defensive `hasattr` regression guard listing every deleted symbol so a future re-import attempt fails loudly.

## Symbols deleted

\\\
smart_cleanup_archive          _proactive_retention
_enforce_retention             _purge_corrupt_archives
_prune_non_driving_archives    _update_geodata_paths
_delete_files_older_than       _trim_archive_to_size
_trim_archive_for_free_space   _get_archived_files_sorted
_buffered_copy                 _is_complete_mp4
_check_memory                  _check_disk_space
_get_archive_size              _update_archive_size
_get_teslacam_ro_path          _get_driving_time_ranges
_timestamp_from_filename       _is_during_driving
get_archive_dir                +6 module-level constants
\\\

All call sites (in production + tests) were verified before removal — only `trigger_archive_cleanup` and the dead test were external consumers.

## Why now

The three racing retention systems each read different config values, used different deletion criteria, and could write to the same database simultaneously. The May 7 trip-loss regression (cascade-deleting trips/waypoints when a clip rotated out) was rooted in this duplication — three places needed the same fix and only one got it. `archive_watchdog` is the canonical implementation: single `task_coordinator` slot, `_retention_running` guard, `_resolve_delete_unsynced` cloud-protection contract, and the "trips are sacred" invariant (deletes only `indexed_files` rows; NULLs `waypoints.video_path` / `detected_events.video_path` rather than cascade-deleting).

## Tests

* **964 passed, 3 skipped** (was 953; +12 net new, -1 obsolete).
* No changes to `archive_watchdog.py` itself — its existing comprehensive coverage (TestArchiveWatchdogLifecycle / TestArchiveWatchdogSeverity / TestArchiveWatchdogDiskSpace / TestArchiveWatchdogReporting / TestArchiveRetention / TestNoUSBGadgetCalls / TestRetentionRespectsCloudSync / TestResolveDeleteUnsynced / TestRetentionRunningGuard, ~50 tests) is the regression net for the canonical retention path.

## Out of scope

* **3a.2** (single config + Settings UI for Storage & Retention) — separate PR.
* **3a.3** (24h verification gate) — explicit ""trips sacred"" invariant verification on cybertruckusb.local before declaring Phase 3a complete.

## Verification

Smoke test plan after deploy:
1. `GET /api/recent_archive/status` returns `running`, `current_file`, `queue_depth` keys.
2. `POST /api/archive_cleanup` returns the watchdog summary (`deleted_count`, `freed_bytes`, `scanned`, `cutoff_iso`, etc.).
3. Two concurrent `POST /api/archive_cleanup` calls — second returns `status='already_running'`.
4. `trips` / `waypoints` / `detected_events` row counts unchanged across a prune.

Closes: part of #98 (item 3a.1)
Closes #91
