### PR TITLE
Phase 3a.2 (#98): Single config + Settings Storage & Retention UI

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -161,6 +161,37 @@ cloud_archive:
   disk_space_pause_seconds: 300          # How long the worker stays paused after a disk-critical refusal
 
 # ============================================================================
+# Storage & Retention Configuration (Phase 3a.2 — closes part of #98)
+# ============================================================================
+# Single source of truth for archive/clip retention policies. Replaces the
+# legacy ``cleanup_config.json`` (auto-migrated on first boot) and
+# the scattered ``archive.retention_days`` / ``cloud_archive.archived_clips_retention_days``
+# values (which remain as backward-compat fallbacks).
+#
+# Surfaced in the web UI under Settings → Storage & Retention so users can
+# manage retention without SSHing in. All changes take effect on the next
+# retention pass (no service restart needed).
+cleanup:
+  default_retention_days: 30             # Default age cutoff for ArchivedClips (SD card) and any folder without an explicit override
+  free_space_target_pct: 10              # Try to keep at least this % of SD-card capacity free; aggressive prune below this
+  max_archive_size_gb: 50                # Hard cap on total ArchivedClips size; 0 = no cap (time-based retention only)
+  short_retention_warning_days: 7        # Warn in the UI when default retention drops below this
+  policies:                              # Per-folder overrides (empty dict = use defaults everywhere)
+    # Examples (uncomment to override the default for a specific folder):
+    # SentryClips:
+    #   enabled: false
+    #   retention_days: 90
+    # SavedClips:
+    #   enabled: false
+    #   retention_days: 365
+    # RecentClips:
+    #   enabled: false
+    #   retention_days: 30
+    # ArchivedClips:
+    #   enabled: true
+    #   retention_days: 30
+
+# ============================================================================
 # Live Event Sync Configuration
 # ============================================================================
 # Real-time upload of Sentry/Saved events as soon as Tesla writes the

--- a/config.yaml
+++ b/config.yaml
@@ -172,9 +172,15 @@ cloud_archive:
 # manage retention without SSHing in. All changes take effect on the next
 # retention pass (no service restart needed).
 cleanup:
-  default_retention_days: 30             # Default age cutoff for ArchivedClips (SD card) and any folder without an explicit override
+  # 0 = inherit from the legacy fallback chain
+  # (cloud_archive.archived_clips_retention_days → archive.retention_days → 30).
+  # The startup migration seeds this from the legacy keys on first boot so
+  # existing customizations carry over without a behavior change. Saving from
+  # the Settings UI also writes a concrete value here, making this the unified
+  # source of truth from that point on.
+  default_retention_days: 0
   free_space_target_pct: 10              # Try to keep at least this % of SD-card capacity free; aggressive prune below this
-  max_archive_size_gb: 50                # Hard cap on total ArchivedClips size; 0 = no cap (time-based retention only)
+  max_archive_size_gb: 0                 # Hard cap on total ArchivedClips size; 0 = no cap (time-based retention only) — Phase 5 wires the cap into the prune
   short_retention_warning_days: 7        # Warn in the UI when default retention drops below this
   policies:                              # Per-folder overrides (empty dict = use defaults everywhere)
     # Examples (uncomment to override the default for a specific folder):

--- a/scripts/web/blueprints/__init__.py
+++ b/scripts/web/blueprints/__init__.py
@@ -18,6 +18,7 @@ from .captive_portal import captive_portal_bp, catch_all_redirect
 from .cloud_archive import cloud_archive_bp
 from .live_events import live_events_bp
 from .archive_queue import archive_queue_bp
+from .storage_retention import storage_retention_bp
 
 __all__ = [
     'mode_control_bp',
@@ -39,4 +40,5 @@ __all__ = [
     'cloud_archive_bp',
     'live_events_bp',
     'archive_queue_bp',
+    'storage_retention_bp',
 ]

--- a/scripts/web/blueprints/storage_retention.py
+++ b/scripts/web/blueprints/storage_retention.py
@@ -1,0 +1,386 @@
+"""Storage & Retention blueprint (Phase 3a.2 — closes part of #98).
+
+Backs the **Settings → Storage & Retention** card in the web UI. Exposes
+JSON endpoints for:
+
+* ``POST /api/cleanup/policy``   — save the unified retention policy
+  (writes to ``cleanup.*`` in ``config.yaml``).
+* ``POST /api/cleanup/run_now``  — trigger an immediate retention pass
+  (one-line wrapper for ``services.video_archive_service.trigger_archive_cleanup``,
+  which itself wraps ``archive_watchdog.force_prune_now``).
+* ``GET  /api/cleanup/status``   — return the latest retention summary
+  (last-run timestamp, deleted count, freed bytes, kept-unsynced count,
+  next-due timestamp, current resolved retention days, and the
+  ``cleanup`` config block as it lives on disk so the UI can refresh
+  without restart).
+
+The endpoints are intentionally JSON-only — the rendered card lives in
+``index.html`` (the existing Settings page) so users see retention in
+the same place as their other archive-related controls.
+
+Resolution contract for retention values: see
+``services.archive_watchdog._resolve_retention_days`` for the canonical
+fallback chain. Editing ``config.yaml`` directly continues to work; the
+UI just reflects what's on disk so the file remains the single source
+of truth.
+
+This blueprint is **always registered** (no image gating) because
+storage settings are a system-level concern that should be reachable
+even when no disk image is present yet (e.g., during initial setup).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Dict, Optional
+
+import yaml
+from flask import Blueprint, jsonify, request
+
+logger = logging.getLogger(__name__)
+
+storage_retention_bp = Blueprint(
+    'storage_retention', __name__,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# Folders the user is allowed to set per-folder overrides for. Anything
+# outside this set is rejected from POST payloads to keep the config
+# file from accumulating typo'd keys that the watchdog would silently
+# ignore. Keep this in sync with cleanup_service.DEFAULT_POLICY_TEMPLATES
+# and the legacy Tesla USB folder layout.
+ALLOWED_FOLDER_NAMES = (
+    'SentryClips',
+    'SavedClips',
+    'RecentClips',
+    'EncryptedClips',
+    'ArchivedClips',
+)
+
+# UI / safety bounds on the unified scalar settings. The watchdog
+# accepts anything but the UI clamps to keep the system sane.
+RETENTION_DAYS_MIN = 1
+RETENTION_DAYS_MAX = 3650            # 10 years — a soft sanity cap
+FREE_SPACE_PCT_MIN = 5
+FREE_SPACE_PCT_MAX = 50
+MAX_ARCHIVE_GB_MIN = 0               # 0 = no cap
+MAX_ARCHIVE_GB_MAX = 10000           # 10 TB — absurdly high but bounded
+
+# Bound the number of folder rows accepted in one POST so a malicious
+# or buggy client can't bloat config.yaml with hundreds of entries.
+MAX_POLICY_ROWS = len(ALLOWED_FOLDER_NAMES)
+
+
+def _coerce_int(value: Any, default: int, lo: int, hi: int) -> int:
+    """Clamp ``value`` to ``[lo, hi]``; fall back to ``default`` on parse failure.
+
+    Bool is rejected (``isinstance(True, int)`` is True in Python — we
+    do NOT want a checkbox value silently becoming 0/1 here).
+    """
+    if isinstance(value, bool):
+        return default
+    try:
+        n = int(value)
+    except (TypeError, ValueError):
+        return default
+    if n < lo:
+        return lo
+    if n > hi:
+        return hi
+    return n
+
+
+def _coerce_bool(value: Any, default: bool = False) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in ('1', 'true', 'yes', 'on', 'checked')
+    if isinstance(value, (int, float)):
+        return bool(value)
+    return default
+
+
+def _load_config_dict() -> Dict[str, Any]:
+    """Read the on-disk config.yaml. Returns an empty dict on any failure
+    so callers can render an empty-state UI instead of crashing."""
+    try:
+        from config import CONFIG_YAML
+        with open(CONFIG_YAML, 'r') as f:
+            data = yaml.safe_load(f) or {}
+            if isinstance(data, dict):
+                return data
+    except Exception:  # noqa: BLE001
+        logger.exception("storage_retention: failed to read config.yaml")
+    return {}
+
+
+def _resolve_cleanup_block(cfg: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    """Return the ``cleanup`` config block with defaults filled in."""
+    if cfg is None:
+        cfg = _load_config_dict()
+    raw = cfg.get('cleanup') if isinstance(cfg.get('cleanup'), dict) else {}
+    policies_raw = raw.get('policies') if isinstance(raw.get('policies'), dict) else {}
+    sanitized_policies: Dict[str, Dict[str, Any]] = {}
+    for name, policy in policies_raw.items():
+        if name in ALLOWED_FOLDER_NAMES and isinstance(policy, dict):
+            sanitized_policies[name] = {
+                'enabled': _coerce_bool(policy.get('enabled'), False),
+                'retention_days': _coerce_int(
+                    policy.get('retention_days'),
+                    default=int(raw.get('default_retention_days') or 30),
+                    lo=RETENTION_DAYS_MIN,
+                    hi=RETENTION_DAYS_MAX,
+                ),
+            }
+    return {
+        'default_retention_days': _coerce_int(
+            raw.get('default_retention_days'),
+            default=30, lo=RETENTION_DAYS_MIN, hi=RETENTION_DAYS_MAX,
+        ),
+        'free_space_target_pct': _coerce_int(
+            raw.get('free_space_target_pct'),
+            default=10, lo=FREE_SPACE_PCT_MIN, hi=FREE_SPACE_PCT_MAX,
+        ),
+        'max_archive_size_gb': _coerce_int(
+            raw.get('max_archive_size_gb'),
+            default=0, lo=MAX_ARCHIVE_GB_MIN, hi=MAX_ARCHIVE_GB_MAX,
+        ),
+        'short_retention_warning_days': _coerce_int(
+            raw.get('short_retention_warning_days'),
+            default=7, lo=1, hi=RETENTION_DAYS_MAX,
+        ),
+        'policies': sanitized_policies,
+    }
+
+
+def _watchdog_status() -> Dict[str, Any]:
+    """Return the watchdog's most recent retention summary, or a synthetic
+    one if the watchdog hasn't started yet."""
+    try:
+        from services import archive_watchdog
+        return archive_watchdog.get_status() or {}
+    except Exception:  # noqa: BLE001
+        logger.exception("storage_retention: archive_watchdog.get_status raised")
+        return {}
+
+
+def _disk_free_summary() -> Dict[str, Any]:
+    """Best-effort free-space snapshot for the SD card (the partition that
+    holds ArchivedClips). Returns empty dict on failure — the UI hides
+    the bar in that case."""
+    try:
+        from config import ARCHIVE_DIR
+        # Walk up to a real existing path so statvfs doesn't trip on a
+        # not-yet-created ArchivedClips dir.
+        target = ARCHIVE_DIR
+        while target and not os.path.exists(target):
+            parent = os.path.dirname(target)
+            if parent == target:
+                break
+            target = parent
+        if not target or not os.path.exists(target):
+            return {}
+        st = os.statvfs(target)
+        total_bytes = int(st.f_blocks) * int(st.f_frsize)
+        free_bytes = int(st.f_bavail) * int(st.f_frsize)
+        used_bytes = max(total_bytes - free_bytes, 0)
+        free_pct = (
+            int(round(100.0 * free_bytes / total_bytes))
+            if total_bytes > 0 else 0
+        )
+        return {
+            'path': target,
+            'total_bytes': total_bytes,
+            'free_bytes': free_bytes,
+            'used_bytes': used_bytes,
+            'free_pct': free_pct,
+        }
+    except Exception:  # noqa: BLE001
+        logger.exception("storage_retention: disk-free probe failed")
+        return {}
+
+
+# ---------------------------------------------------------------------------
+# Routes
+# ---------------------------------------------------------------------------
+
+@storage_retention_bp.route('/api/cleanup/status', methods=['GET'])
+def api_cleanup_status():
+    """Return a single snapshot the UI can poll to render the card.
+
+    Combines:
+      * the on-disk ``cleanup`` config block (so direct YAML edits are
+        reflected without restart);
+      * the watchdog's most recent retention summary
+        (``last_prune_at``, ``last_prune_deleted``, etc.);
+      * the currently resolved retention days (after fallback chain);
+      * an SD-card free-space snapshot.
+
+    All fields are best-effort: a missing or crashed dependency yields
+    an empty object for that subsection rather than a 500.
+    """
+    cfg = _load_config_dict()
+    cleanup = _resolve_cleanup_block(cfg)
+    status = _watchdog_status()
+    retention_block = status.get('retention') if isinstance(status.get('retention'), dict) else {}
+    return jsonify({
+        'success': True,
+        'config': cleanup,
+        'resolved_retention_days': int(
+            retention_block.get('retention_days')
+            or cleanup['default_retention_days']
+        ),
+        'last_run': {
+            'at': retention_block.get('last_prune_at'),
+            'deleted_count': retention_block.get('last_prune_deleted'),
+            'freed_bytes': retention_block.get('last_prune_freed_bytes'),
+            'kept_unsynced_count': retention_block.get('last_prune_kept_unsynced'),
+            'error': retention_block.get('last_prune_error'),
+        },
+        'next_run_at': retention_block.get('next_prune_due_at'),
+        'delete_unsynced': retention_block.get('delete_unsynced'),
+        'cloud_configured': retention_block.get('cloud_configured', False),
+        'watchdog_running': bool(status.get('watchdog_running', False)),
+        'disk': _disk_free_summary(),
+    }), 200
+
+
+@storage_retention_bp.route('/api/cleanup/policy', methods=['POST'])
+def api_cleanup_policy():
+    """Persist the unified Storage & Retention settings to ``config.yaml``.
+
+    Accepts either JSON or form-encoded payloads. Unknown folder names
+    are silently dropped (defense in depth — see ``ALLOWED_FOLDER_NAMES``).
+    All scalar values are clamped to their UI-safe range; the watchdog
+    re-resolves on its next pass so no service restart is needed.
+
+    Returns the persisted ``cleanup`` block on success so the client can
+    update the rendered form without a follow-up GET.
+    """
+    payload: Dict[str, Any] = {}
+    if request.is_json:
+        payload = request.get_json(silent=True) or {}
+    else:
+        # Form: scalars come in flat; per-folder rows come as
+        # policy_<name>_enabled / policy_<name>_days.
+        payload['default_retention_days'] = request.form.get('default_retention_days')
+        payload['free_space_target_pct'] = request.form.get('free_space_target_pct')
+        payload['max_archive_size_gb'] = request.form.get('max_archive_size_gb')
+        payload['short_retention_warning_days'] = request.form.get('short_retention_warning_days')
+        policies: Dict[str, Dict[str, Any]] = {}
+        for name in ALLOWED_FOLDER_NAMES:
+            row_enabled = request.form.get(f'policy_{name}_enabled')
+            row_days = request.form.get(f'policy_{name}_days')
+            if row_enabled is None and row_days is None:
+                continue
+            policies[name] = {
+                'enabled': row_enabled,
+                'retention_days': row_days,
+            }
+        if policies:
+            payload['policies'] = policies
+
+    default_days = _coerce_int(
+        payload.get('default_retention_days'),
+        default=30, lo=RETENTION_DAYS_MIN, hi=RETENTION_DAYS_MAX,
+    )
+    target_pct = _coerce_int(
+        payload.get('free_space_target_pct'),
+        default=10, lo=FREE_SPACE_PCT_MIN, hi=FREE_SPACE_PCT_MAX,
+    )
+    max_gb = _coerce_int(
+        payload.get('max_archive_size_gb'),
+        default=0, lo=MAX_ARCHIVE_GB_MIN, hi=MAX_ARCHIVE_GB_MAX,
+    )
+    warn_days = _coerce_int(
+        payload.get('short_retention_warning_days'),
+        default=7, lo=1, hi=RETENTION_DAYS_MAX,
+    )
+
+    raw_policies = payload.get('policies') or {}
+    sanitized: Dict[str, Dict[str, Any]] = {}
+    if isinstance(raw_policies, dict):
+        for name, policy in list(raw_policies.items())[:MAX_POLICY_ROWS]:
+            if name not in ALLOWED_FOLDER_NAMES or not isinstance(policy, dict):
+                continue
+            sanitized[name] = {
+                'enabled': _coerce_bool(policy.get('enabled'), False),
+                'retention_days': _coerce_int(
+                    policy.get('retention_days'),
+                    default=default_days,
+                    lo=RETENTION_DAYS_MIN,
+                    hi=RETENTION_DAYS_MAX,
+                ),
+            }
+
+    updates = {
+        'cleanup.default_retention_days': default_days,
+        'cleanup.free_space_target_pct': target_pct,
+        'cleanup.max_archive_size_gb': max_gb,
+        'cleanup.short_retention_warning_days': warn_days,
+        'cleanup.policies': sanitized,
+    }
+    try:
+        from helpers.config_updater import update_config_yaml
+        update_config_yaml(updates)
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("storage_retention: failed to persist cleanup policy")
+        return jsonify({
+            'success': False,
+            'message': f"Failed to save retention settings: {exc}",
+        }), 500
+
+    persisted = _resolve_cleanup_block(_load_config_dict())
+    return jsonify({
+        'success': True,
+        'config': persisted,
+    }), 200
+
+
+@storage_retention_bp.route('/api/cleanup/run_now', methods=['POST'])
+def api_cleanup_run_now():
+    """Trigger an immediate retention pass.
+
+    One-line wrapper for ``trigger_archive_cleanup`` (which itself wraps
+    ``archive_watchdog.force_prune_now``). Mirrors the same HTTP
+    contract as ``POST /cloud/api/archive_cleanup`` (see Phase 3a.1
+    review fix in ``cloud_archive.py``):
+
+      * 200 on success — body includes the watchdog summary.
+      * 200 on ``status='already_running'`` — normal control flow when
+        a periodic prune is in flight; the UI shows "Cleanup already
+        in progress" instead of an error toast.
+      * 500 on watchdog error — body includes the error message and
+        the structured summary for debugging.
+
+    Provided as a separate route from ``/cloud/api/archive_cleanup`` so
+    the UI can use a semantically-named endpoint (``/api/cleanup/...``)
+    and we have a stable hook for future enhancements (e.g. async
+    long-running cleanup with progress events).
+    """
+    try:
+        from services.video_archive_service import trigger_archive_cleanup
+        result = trigger_archive_cleanup()
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("storage_retention: trigger_archive_cleanup raised")
+        return jsonify({
+            'success': False,
+            'message': f"Cleanup failed: {exc}",
+        }), 500
+
+    if isinstance(result, dict) and result.get('error'):
+        return jsonify({
+            'success': False,
+            'message': str(result.get('error')),
+            'result': result,
+        }), 500
+
+    return jsonify({
+        'success': True,
+        'result': result if isinstance(result, dict) else {},
+    }), 200

--- a/scripts/web/blueprints/storage_retention.py
+++ b/scripts/web/blueprints/storage_retention.py
@@ -120,7 +120,13 @@ def _load_config_dict() -> Dict[str, Any]:
 
 
 def _resolve_cleanup_block(cfg: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
-    """Return the ``cleanup`` config block with defaults filled in."""
+    """Return the ``cleanup`` config block as it lives on disk.
+
+    Scalar values are clamped to the UI-safe range. ``default_retention_days``
+    is returned VERBATIM (clamped) — a stored ``0`` means "inherit from the
+    legacy fallback chain" and the API surfaces it as such so the JS can
+    show the resolved value without overwriting the customization on save.
+    """
     if cfg is None:
         cfg = _load_config_dict()
     raw = cfg.get('cleanup') if isinstance(cfg.get('cleanup'), dict) else {}
@@ -137,11 +143,19 @@ def _resolve_cleanup_block(cfg: Optional[Dict[str, Any]] = None) -> Dict[str, An
                     hi=RETENTION_DAYS_MAX,
                 ),
             }
+    # Allow 0 for default_retention_days (means "inherit from legacy") so
+    # we don't shadow the resolver chain on a fresh git pull.
+    raw_default = raw.get('default_retention_days')
+    try:
+        default_days = int(raw_default) if raw_default is not None else 0
+    except (TypeError, ValueError):
+        default_days = 0
+    if default_days < 0:
+        default_days = 0
+    if default_days > RETENTION_DAYS_MAX:
+        default_days = RETENTION_DAYS_MAX
     return {
-        'default_retention_days': _coerce_int(
-            raw.get('default_retention_days'),
-            default=30, lo=RETENTION_DAYS_MIN, hi=RETENTION_DAYS_MAX,
-        ),
+        'default_retention_days': default_days,
         'free_space_target_pct': _coerce_int(
             raw.get('free_space_target_pct'),
             default=10, lo=FREE_SPACE_PCT_MIN, hi=FREE_SPACE_PCT_MAX,
@@ -228,13 +242,23 @@ def api_cleanup_status():
     cleanup = _resolve_cleanup_block(cfg)
     status = _watchdog_status()
     retention_block = status.get('retention') if isinstance(status.get('retention'), dict) else {}
+    # Resolve the days the watchdog will actually use. Prefer the
+    # watchdog's most recent value (always reflects the resolver chain
+    # for the live install). Fall back to calling the resolver directly
+    # if the watchdog hasn't been initialized yet — this matters when
+    # cleanup.default_retention_days==0 ("inherit from legacy") and we
+    # need the UI to show what would resolve.
+    resolved_days = retention_block.get('retention_days')
+    if not resolved_days:
+        try:
+            from services import archive_watchdog
+            resolved_days = int(archive_watchdog._resolve_retention_days())
+        except Exception:  # noqa: BLE001
+            resolved_days = cleanup['default_retention_days'] or 30
     return jsonify({
         'success': True,
         'config': cleanup,
-        'resolved_retention_days': int(
-            retention_block.get('retention_days')
-            or cleanup['default_retention_days']
-        ),
+        'resolved_retention_days': int(resolved_days or 30),
         'last_run': {
             'at': retention_block.get('last_prune_at'),
             'deleted_count': retention_block.get('last_prune_deleted'),
@@ -285,10 +309,23 @@ def api_cleanup_policy():
         if policies:
             payload['policies'] = policies
 
-    default_days = _coerce_int(
-        payload.get('default_retention_days'),
-        default=30, lo=RETENTION_DAYS_MIN, hi=RETENTION_DAYS_MAX,
-    )
+    # default_retention_days accepts 0 ("inherit from legacy fallback chain")
+    # in addition to the normal [MIN, MAX] range. The UI surfaces the
+    # resolved value when stored as 0 so a "save without editing" doesn't
+    # overwrite an existing legacy customization.
+    raw_default = payload.get('default_retention_days')
+    try:
+        default_days = int(raw_default) if raw_default is not None else 0
+    except (TypeError, ValueError):
+        default_days = 0
+    if isinstance(raw_default, bool):
+        default_days = 0
+    if default_days < 0:
+        default_days = 0
+    elif 0 < default_days < RETENTION_DAYS_MIN:
+        default_days = RETENTION_DAYS_MIN
+    elif default_days > RETENTION_DAYS_MAX:
+        default_days = RETENTION_DAYS_MAX
     target_pct = _coerce_int(
         payload.get('free_space_target_pct'),
         default=10, lo=FREE_SPACE_PCT_MIN, hi=FREE_SPACE_PCT_MAX,
@@ -305,14 +342,21 @@ def api_cleanup_policy():
     raw_policies = payload.get('policies') or {}
     sanitized: Dict[str, Dict[str, Any]] = {}
     if isinstance(raw_policies, dict):
-        for name, policy in list(raw_policies.items())[:MAX_POLICY_ROWS]:
+        # Filter BEFORE capping. If the cap was applied to the raw dict,
+        # a payload that begins with ``MAX_POLICY_ROWS`` typo'd folder
+        # names would silently drop every later legitimate entry. Filter
+        # to the allow-list first, then cap on the sanitized result so
+        # the cap only ever truncates real folders.
+        for name, policy in raw_policies.items():
+            if len(sanitized) >= MAX_POLICY_ROWS:
+                break
             if name not in ALLOWED_FOLDER_NAMES or not isinstance(policy, dict):
                 continue
             sanitized[name] = {
                 'enabled': _coerce_bool(policy.get('enabled'), False),
                 'retention_days': _coerce_int(
                     policy.get('retention_days'),
-                    default=default_days,
+                    default=default_days or 30,
                     lo=RETENTION_DAYS_MIN,
                     hi=RETENTION_DAYS_MAX,
                 ),

--- a/scripts/web/config.py
+++ b/scripts/web/config.py
@@ -141,6 +141,22 @@ CLOUD_ARCHIVE_DISK_SPACE_PAUSE_SECONDS = float(_cloud.get(
 # time (see cloud_archive_service._read_retry_max_attempts_setting).
 CLOUD_ARCHIVE_RETRY_MAX_ATTEMPTS = int(_cloud.get('retry_max_attempts', 5))
 
+# Phase 3a.2 (#98) — Unified Storage & Retention configuration.
+# Single source of truth for archive retention policies. Replaces the
+# legacy cleanup_config.json (auto-migrated on first boot) and supersedes
+# the scattered archive.retention_days / cloud_archive.archived_clips_retention_days
+# values (which remain as backward-compat fallbacks).
+_cleanup = config.get('cleanup', {}) if isinstance(config.get('cleanup'), dict) else {}
+CLEANUP_DEFAULT_RETENTION_DAYS = int(_cleanup.get('default_retention_days', 0))
+CLEANUP_FREE_SPACE_TARGET_PCT = int(_cleanup.get('free_space_target_pct', 10))
+CLEANUP_MAX_ARCHIVE_SIZE_GB = int(_cleanup.get('max_archive_size_gb', 0))
+CLEANUP_SHORT_RETENTION_WARNING_DAYS = int(_cleanup.get('short_retention_warning_days', 7))
+_cleanup_policies_raw = _cleanup.get('policies', {})
+CLEANUP_POLICIES = (
+    {str(k): dict(v) for k, v in _cleanup_policies_raw.items() if isinstance(v, dict)}
+    if isinstance(_cleanup_policies_raw, dict) else {}
+)
+
 # Phase 1 item 1.3 — "retention respects cloud". Controls whether the
 # archive_watchdog retention prune may delete clips that have NOT yet
 # been backed up to the cloud (status='synced' in cloud_synced_files).

--- a/scripts/web/services/archive_watchdog.py
+++ b/scripts/web/services/archive_watchdog.py
@@ -277,10 +277,12 @@ def _resolve_retention_days() -> int:
        override in the unified config section).
     2. ``cleanup.default_retention_days`` (the unified default).
     3. ``cloud_archive.archived_clips_retention_days`` (legacy SD-card
-       retention key — preserved for backward compat).
-    4. ``archive.retention_days`` (oldest legacy key — preserved for
-       installs that pre-date Phase 2c).
-    5. Hard-coded ``30`` if nothing else resolves.
+       retention key — preserved for backward compat). NOTE:
+       ``CLOUD_ARCHIVE_RETENTION_DAYS`` itself folds the even-older
+       ``archive.retention_days`` legacy key in via ``config.py`` — so
+       the resolver only checks two named tiers but covers three legacy
+       keys in total.
+    4. Hard-coded ``30`` if nothing else resolves.
 
     Resolved fresh on every prune so Settings → Storage & Retention
     edits take effect on the next pass without restarting the service.

--- a/scripts/web/services/archive_watchdog.py
+++ b/scripts/web/services/archive_watchdog.py
@@ -269,12 +269,44 @@ def _resolve_disk_thresholds() -> tuple:
 
 
 def _resolve_retention_days() -> int:
-    """Return the configured ArchivedClips retention in days."""
+    """Return the configured ArchivedClips retention in days.
+
+    Phase 3a.2 (#98) resolution order — first non-zero / non-empty wins:
+
+    1. ``cleanup.policies.ArchivedClips.retention_days`` (per-folder
+       override in the unified config section).
+    2. ``cleanup.default_retention_days`` (the unified default).
+    3. ``cloud_archive.archived_clips_retention_days`` (legacy SD-card
+       retention key — preserved for backward compat).
+    4. ``archive.retention_days`` (oldest legacy key — preserved for
+       installs that pre-date Phase 2c).
+    5. Hard-coded ``30`` if nothing else resolves.
+
+    Resolved fresh on every prune so Settings → Storage & Retention
+    edits take effect on the next pass without restarting the service.
+    """
+    try:
+        from config import CLEANUP_POLICIES
+        archived = CLEANUP_POLICIES.get('ArchivedClips') if CLEANUP_POLICIES else None
+        if isinstance(archived, dict):
+            override = int(archived.get('retention_days') or 0)
+            if override > 0:
+                return override
+    except Exception:  # noqa: BLE001
+        pass
+    try:
+        from config import CLEANUP_DEFAULT_RETENTION_DAYS
+        if int(CLEANUP_DEFAULT_RETENTION_DAYS) > 0:
+            return int(CLEANUP_DEFAULT_RETENTION_DAYS)
+    except Exception:  # noqa: BLE001
+        pass
     try:
         from config import CLOUD_ARCHIVE_RETENTION_DAYS
-        return int(CLOUD_ARCHIVE_RETENTION_DAYS)
+        if int(CLOUD_ARCHIVE_RETENTION_DAYS) > 0:
+            return int(CLOUD_ARCHIVE_RETENTION_DAYS)
     except Exception:  # noqa: BLE001
-        return 30
+        pass
+    return 30
 
 
 def _resolve_delete_unsynced() -> bool:

--- a/scripts/web/services/archive_watchdog.py
+++ b/scripts/web/services/archive_watchdog.py
@@ -284,9 +284,55 @@ def _resolve_retention_days() -> int:
        keys in total.
     4. Hard-coded ``30`` if nothing else resolves.
 
-    Resolved fresh on every prune so Settings → Storage & Retention
-    edits take effect on the next pass without restarting the service.
+    Reads ``config.yaml`` directly on every call so Settings → Storage &
+    Retention edits take effect on the next prune pass without
+    restarting the service. The ``config`` module's cached attributes
+    (``CLEANUP_*``, ``CLOUD_ARCHIVE_RETENTION_DAYS``) are loaded once at
+    startup and would otherwise mask saved YAML changes until restart.
+    Falls back to the cached attributes if the direct read fails.
     """
+    # Direct YAML read — bypass the cached config.* attributes so a save
+    # from the Settings UI is visible on the next prune.
+    try:
+        import yaml
+        from config import CONFIG_YAML
+        with open(CONFIG_YAML, 'r') as f:
+            cfg = yaml.safe_load(f) or {}
+        cleanup = cfg.get('cleanup') if isinstance(cfg.get('cleanup'), dict) else {}
+        policies = cleanup.get('policies') if isinstance(cleanup.get('policies'), dict) else {}
+        archived = policies.get('ArchivedClips') if isinstance(policies, dict) else None
+        if isinstance(archived, dict):
+            try:
+                override = int(archived.get('retention_days') or 0)
+                if override > 0:
+                    return override
+            except (TypeError, ValueError):
+                pass
+        try:
+            d = int(cleanup.get('default_retention_days') or 0)
+            if d > 0:
+                return d
+        except (TypeError, ValueError):
+            pass
+        cloud_archive = cfg.get('cloud_archive') if isinstance(cfg.get('cloud_archive'), dict) else {}
+        try:
+            c = int(cloud_archive.get('archived_clips_retention_days') or 0)
+            if c > 0:
+                return c
+        except (TypeError, ValueError):
+            pass
+        archive = cfg.get('archive') if isinstance(cfg.get('archive'), dict) else {}
+        try:
+            a = int(archive.get('retention_days') or 0)
+            if a > 0:
+                return a
+        except (TypeError, ValueError):
+            pass
+    except Exception:  # noqa: BLE001
+        # Direct YAML read failed for some reason; fall back to the
+        # cached config module attributes so we never crash the prune.
+        pass
+
     try:
         from config import CLEANUP_POLICIES
         archived = CLEANUP_POLICIES.get('ArchivedClips') if CLEANUP_POLICIES else None

--- a/scripts/web/services/cleanup_service.py
+++ b/scripts/web/services/cleanup_service.py
@@ -561,23 +561,74 @@ _MIGRATION_ALLOWED_FOLDERS = (
 )
 
 
+def _seed_default_retention_from_legacy_yaml(cfg: Dict[str, Any]) -> Optional[int]:
+    """Phase 3a.2 (#98) — preserve existing customizations across upgrades.
+
+    On a ``git pull`` the shipped ``cleanup.default_retention_days: 0``
+    means "inherit from legacy". This helper migrates the legacy value
+    into the unified key so the user's customization survives even if
+    they never visit the new Settings card.
+
+    Mutates ``cfg`` in place. Returns the value seeded (or ``None`` if
+    nothing was seeded — either the unified key is already set or no
+    legacy value exists).
+    """
+    cleanup = cfg.get('cleanup') if isinstance(cfg.get('cleanup'), dict) else {}
+    try:
+        existing = int(cleanup.get('default_retention_days') or 0)
+    except (TypeError, ValueError):
+        existing = 0
+    if existing > 0:
+        return None  # user (or a prior boot's seed pass) already set it
+
+    candidate: Optional[int] = None
+    cloud_archive = cfg.get('cloud_archive') if isinstance(cfg.get('cloud_archive'), dict) else {}
+    try:
+        c = int(cloud_archive.get('archived_clips_retention_days') or 0)
+        if c > 0:
+            candidate = c
+    except (TypeError, ValueError):
+        pass
+    if candidate is None:
+        archive = cfg.get('archive') if isinstance(cfg.get('archive'), dict) else {}
+        try:
+            a = int(archive.get('retention_days') or 0)
+            if a > 0:
+                candidate = a
+        except (TypeError, ValueError):
+            pass
+    if candidate is None:
+        return None
+
+    cleanup['default_retention_days'] = candidate
+    cfg['cleanup'] = cleanup
+    return candidate
+
+
 def migrate_legacy_cleanup_config(
     gadget_dir: str,
     config_yaml_path: Optional[str] = None,
     config_filename: str = 'cleanup_config.json',
 ) -> Dict[str, Any]:
-    """One-shot migration of the legacy ``cleanup_config.json`` into
-    ``config.yaml`` under the unified ``cleanup`` section.
+    """One-shot migration of the legacy ``cleanup_config.json`` AND legacy
+    YAML retention keys into the unified ``cleanup`` section.
 
-    Idempotent: the function inspects the YAML's ``cleanup.policies``
-    block first; if it already contains overrides the legacy file is
-    NOT consulted (so a user's UI edits always win). On a successful
-    migration, the legacy file is renamed with a ``.migrated`` suffix
-    so the next boot doesn't redo the work and so a forensic copy
-    remains for diagnosis.
+    Two passes, both idempotent:
+
+    1. **Default-retention seed pass** — if
+       ``cleanup.default_retention_days`` is unset/0, copy from
+       ``cloud_archive.archived_clips_retention_days`` (or the older
+       ``archive.retention_days``). Preserves user customizations
+       across a ``git pull``.
+    2. **Per-folder policy import pass** — if ``cleanup.policies`` is
+       empty AND a legacy ``cleanup_config.json`` exists, import its
+       allow-listed policies. The legacy file is renamed with a
+       ``.migrated`` suffix on success so the next boot doesn't redo
+       the work.
 
     Returns a small summary dict suitable for INFO-level logging:
-    ``{'migrated': bool, 'imported_folders': [...], 'reason': str}``.
+    ``{'migrated': bool, 'imported_folders': [...],
+       'seeded_default_retention_days': Optional[int], 'reason': str}``.
 
     Safe to call from service startup — never raises. A logged WARNING
     on failure is preferred over crashing the web service over a
@@ -586,14 +637,10 @@ def migrate_legacy_cleanup_config(
     summary: Dict[str, Any] = {
         'migrated': False,
         'imported_folders': [],
+        'seeded_default_retention_days': None,
         'reason': '',
     }
     try:
-        legacy_path = Path(gadget_dir) / config_filename
-        if not legacy_path.exists():
-            summary['reason'] = 'no legacy file'
-            return summary
-
         # Resolve config.yaml path — fall back to the canonical helper
         # so this works under tests that monkeypatch the location.
         if config_yaml_path is None:
@@ -607,22 +654,49 @@ def migrate_legacy_cleanup_config(
             import yaml  # local import keeps import-time cost off the hot path
             with open(config_yaml_path, 'r') as f:
                 cfg = yaml.safe_load(f) or {}
+            if not isinstance(cfg, dict):
+                cfg = {}
         except Exception as e:  # noqa: BLE001
             logger.warning(f"migrate_legacy_cleanup_config: cannot read {config_yaml_path}: {e}")
             summary['reason'] = f'config.yaml unreadable: {e}'
             return summary
 
+        # Pass 1: seed default_retention_days from legacy YAML keys.
+        seeded = _seed_default_retention_from_legacy_yaml(cfg)
+        if seeded is not None:
+            summary['seeded_default_retention_days'] = seeded
+
+        legacy_path = Path(gadget_dir) / config_filename
+        legacy_exists = legacy_path.exists()
+
+        # Pass 2: import per-folder policies from legacy JSON (if any).
         existing_policies = (
             cfg.get('cleanup', {}).get('policies') if isinstance(cfg.get('cleanup'), dict) else None
         )
         if isinstance(existing_policies, dict) and existing_policies:
+            # User has already used the new UI to set policies. The
+            # legacy file (e.g. left behind from a downgrade) MUST NOT
+            # overwrite the user's choices.
             summary['reason'] = 'cleanup.policies already populated; skipping'
-            # Still rename the legacy file so we don't keep re-checking it
-            # on every boot — the YAML is the source of truth now.
-            try:
-                legacy_path.rename(legacy_path.with_suffix(legacy_path.suffix + '.migrated'))
-            except Exception:  # noqa: BLE001
-                pass
+            if legacy_exists:
+                try:
+                    legacy_path.rename(legacy_path.with_suffix(legacy_path.suffix + '.migrated'))
+                except Exception:  # noqa: BLE001
+                    pass
+            # Still write back if the seed pass changed something.
+            if seeded is not None:
+                _atomic_write_yaml(config_yaml_path, cfg, summary)
+            return summary
+
+        if not legacy_exists:
+            summary['reason'] = 'no legacy file'
+            # Persist any seed-pass change.
+            if seeded is not None:
+                _atomic_write_yaml(config_yaml_path, cfg, summary)
+                if not summary['reason'].startswith('config.yaml write failed'):
+                    summary['reason'] = (
+                        f'no legacy file; seeded default_retention_days={seeded}'
+                    )
             return summary
 
         try:
@@ -631,6 +705,10 @@ def migrate_legacy_cleanup_config(
         except Exception as e:  # noqa: BLE001
             logger.warning(f"migrate_legacy_cleanup_config: cannot parse {legacy_path}: {e}")
             summary['reason'] = f'legacy file unparseable: {e}'
+            # Even if we can't parse the legacy file, persist the
+            # default-retention seed so the upgrade isn't lost.
+            if seeded is not None:
+                _atomic_write_yaml(config_yaml_path, cfg, summary)
             return summary
 
         imported: Dict[str, Dict[str, Any]] = {}
@@ -655,26 +733,19 @@ def migrate_legacy_cleanup_config(
                 legacy_path.rename(legacy_path.with_suffix(legacy_path.suffix + '.migrated'))
             except Exception:  # noqa: BLE001
                 pass
+            if seeded is not None:
+                _atomic_write_yaml(config_yaml_path, cfg, summary)
             return summary
 
         cleanup_block = cfg.get('cleanup') if isinstance(cfg.get('cleanup'), dict) else {}
-        cleanup_block.setdefault('default_retention_days', 30)
+        cleanup_block.setdefault('default_retention_days', 0)
         cleanup_block.setdefault('free_space_target_pct', 10)
         cleanup_block.setdefault('max_archive_size_gb', 0)
         cleanup_block.setdefault('short_retention_warning_days', 7)
         cleanup_block['policies'] = imported
         cfg['cleanup'] = cleanup_block
 
-        try:
-            tmp_path = config_yaml_path + '.tmp'
-            with open(tmp_path, 'w') as f:
-                yaml.safe_dump(cfg, f, default_flow_style=False, sort_keys=False)
-                f.flush()
-                os.fsync(f.fileno())
-            os.replace(tmp_path, config_yaml_path)
-        except Exception as e:  # noqa: BLE001
-            logger.warning(f"migrate_legacy_cleanup_config: failed to write {config_yaml_path}: {e}")
-            summary['reason'] = f'config.yaml write failed: {e}'
+        if not _atomic_write_yaml(config_yaml_path, cfg, summary):
             return summary
 
         try:
@@ -695,3 +766,22 @@ def migrate_legacy_cleanup_config(
         logger.exception(f"migrate_legacy_cleanup_config: unexpected failure: {e}")
         summary['reason'] = f'unexpected: {e}'
         return summary
+
+
+def _atomic_write_yaml(path: str, cfg: Dict[str, Any], summary: Dict[str, Any]) -> bool:
+    """Power-loss-safe YAML write. Returns True on success; on failure
+    sets ``summary['reason']`` and returns False (caller should bail).
+    """
+    try:
+        import yaml
+        tmp_path = path + '.tmp'
+        with open(tmp_path, 'w') as f:
+            yaml.safe_dump(cfg, f, default_flow_style=False, sort_keys=False)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_path, path)
+        return True
+    except Exception as e:  # noqa: BLE001
+        logger.warning(f"_atomic_write_yaml: failed to write {path}: {e}")
+        summary['reason'] = f'config.yaml write failed: {e}'
+        return False

--- a/scripts/web/services/cleanup_service.py
+++ b/scripts/web/services/cleanup_service.py
@@ -543,3 +543,155 @@ def get_cleanup_service(gadget_dir: str) -> CleanupService:
         CleanupService instance
     """
     return CleanupService(gadget_dir)
+
+
+# ---------------------------------------------------------------------------
+# Phase 3a.2 (#98) — One-shot migration of legacy cleanup_config.json
+# ---------------------------------------------------------------------------
+
+# Folders the storage_retention blueprint accepts as per-folder overrides.
+# Anything outside this set is silently dropped so the migration can't seed
+# typo'd legacy keys into config.yaml's new ``cleanup.policies`` map.
+_MIGRATION_ALLOWED_FOLDERS = (
+    'SentryClips',
+    'SavedClips',
+    'RecentClips',
+    'EncryptedClips',
+    'ArchivedClips',
+)
+
+
+def migrate_legacy_cleanup_config(
+    gadget_dir: str,
+    config_yaml_path: Optional[str] = None,
+    config_filename: str = 'cleanup_config.json',
+) -> Dict[str, Any]:
+    """One-shot migration of the legacy ``cleanup_config.json`` into
+    ``config.yaml`` under the unified ``cleanup`` section.
+
+    Idempotent: the function inspects the YAML's ``cleanup.policies``
+    block first; if it already contains overrides the legacy file is
+    NOT consulted (so a user's UI edits always win). On a successful
+    migration, the legacy file is renamed with a ``.migrated`` suffix
+    so the next boot doesn't redo the work and so a forensic copy
+    remains for diagnosis.
+
+    Returns a small summary dict suitable for INFO-level logging:
+    ``{'migrated': bool, 'imported_folders': [...], 'reason': str}``.
+
+    Safe to call from service startup — never raises. A logged WARNING
+    on failure is preferred over crashing the web service over a
+    legacy-config corner case.
+    """
+    summary: Dict[str, Any] = {
+        'migrated': False,
+        'imported_folders': [],
+        'reason': '',
+    }
+    try:
+        legacy_path = Path(gadget_dir) / config_filename
+        if not legacy_path.exists():
+            summary['reason'] = 'no legacy file'
+            return summary
+
+        # Resolve config.yaml path — fall back to the canonical helper
+        # so this works under tests that monkeypatch the location.
+        if config_yaml_path is None:
+            try:
+                from config import CONFIG_YAML  # type: ignore
+                config_yaml_path = CONFIG_YAML
+            except Exception:  # noqa: BLE001
+                config_yaml_path = str(Path(gadget_dir) / 'config.yaml')
+
+        try:
+            import yaml  # local import keeps import-time cost off the hot path
+            with open(config_yaml_path, 'r') as f:
+                cfg = yaml.safe_load(f) or {}
+        except Exception as e:  # noqa: BLE001
+            logger.warning(f"migrate_legacy_cleanup_config: cannot read {config_yaml_path}: {e}")
+            summary['reason'] = f'config.yaml unreadable: {e}'
+            return summary
+
+        existing_policies = (
+            cfg.get('cleanup', {}).get('policies') if isinstance(cfg.get('cleanup'), dict) else None
+        )
+        if isinstance(existing_policies, dict) and existing_policies:
+            summary['reason'] = 'cleanup.policies already populated; skipping'
+            # Still rename the legacy file so we don't keep re-checking it
+            # on every boot — the YAML is the source of truth now.
+            try:
+                legacy_path.rename(legacy_path.with_suffix(legacy_path.suffix + '.migrated'))
+            except Exception:  # noqa: BLE001
+                pass
+            return summary
+
+        try:
+            with open(legacy_path, 'r') as f:
+                legacy = json.load(f) or {}
+        except Exception as e:  # noqa: BLE001
+            logger.warning(f"migrate_legacy_cleanup_config: cannot parse {legacy_path}: {e}")
+            summary['reason'] = f'legacy file unparseable: {e}'
+            return summary
+
+        imported: Dict[str, Dict[str, Any]] = {}
+        for folder, policy in legacy.items():
+            if folder not in _MIGRATION_ALLOWED_FOLDERS or not isinstance(policy, dict):
+                continue
+            age = policy.get('age_based') if isinstance(policy.get('age_based'), dict) else {}
+            try:
+                days = int(age.get('days', 0)) or None
+            except (TypeError, ValueError):
+                days = None
+            if days is None or days < 1:
+                continue
+            imported[folder] = {
+                'enabled': bool(policy.get('enabled', False)),
+                'retention_days': days,
+            }
+
+        if not imported:
+            summary['reason'] = 'no migratable policies in legacy file'
+            try:
+                legacy_path.rename(legacy_path.with_suffix(legacy_path.suffix + '.migrated'))
+            except Exception:  # noqa: BLE001
+                pass
+            return summary
+
+        cleanup_block = cfg.get('cleanup') if isinstance(cfg.get('cleanup'), dict) else {}
+        cleanup_block.setdefault('default_retention_days', 30)
+        cleanup_block.setdefault('free_space_target_pct', 10)
+        cleanup_block.setdefault('max_archive_size_gb', 0)
+        cleanup_block.setdefault('short_retention_warning_days', 7)
+        cleanup_block['policies'] = imported
+        cfg['cleanup'] = cleanup_block
+
+        try:
+            tmp_path = config_yaml_path + '.tmp'
+            with open(tmp_path, 'w') as f:
+                yaml.safe_dump(cfg, f, default_flow_style=False, sort_keys=False)
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(tmp_path, config_yaml_path)
+        except Exception as e:  # noqa: BLE001
+            logger.warning(f"migrate_legacy_cleanup_config: failed to write {config_yaml_path}: {e}")
+            summary['reason'] = f'config.yaml write failed: {e}'
+            return summary
+
+        try:
+            legacy_path.rename(legacy_path.with_suffix(legacy_path.suffix + '.migrated'))
+        except Exception:  # noqa: BLE001
+            # Migration succeeded; rename failure is cosmetic.
+            pass
+
+        summary['migrated'] = True
+        summary['imported_folders'] = sorted(imported.keys())
+        summary['reason'] = f"migrated {len(imported)} folder policies"
+        logger.info(
+            f"migrate_legacy_cleanup_config: imported {len(imported)} legacy policies "
+            f"into cleanup.policies ({sorted(imported.keys())})"
+        )
+        return summary
+    except Exception as e:  # noqa: BLE001
+        logger.exception(f"migrate_legacy_cleanup_config: unexpected failure: {e}")
+        summary['reason'] = f'unexpected: {e}'
+        return summary

--- a/scripts/web/templates/index.html
+++ b/scripts/web/templates/index.html
@@ -1469,13 +1469,16 @@ if (document.getElementById('fsck-status-container')) {
                 if (!data || !data.success) return null;
                 var cfg = data.config || {};
                 // ``default_retention_days === 0`` in config.yaml means
-                // "inherit from legacy fallback". Show the resolved
-                // value the watchdog will actually use, so a user who
-                // saves without editing doesn't accidentally overwrite
-                // a customized cloud_archive.archived_clips_retention_days.
-                var resolvedDefault = (data.resolved_retention_days != null)
-                    ? data.resolved_retention_days
-                    : (cfg.default_retention_days || 30);
+                // "inherit from legacy fallback chain". Show the resolved
+                // value the watchdog will actually use ONLY in that case;
+                // when the user has saved a concrete value, show THEIR value
+                // so subsequent saves don't accidentally write the cached
+                // resolved value back over the customization.
+                var resolvedDefault = (cfg.default_retention_days > 0)
+                    ? cfg.default_retention_days
+                    : ((data.resolved_retention_days != null)
+                        ? data.resolved_retention_days
+                        : 30);
                 $('sr-default-retention').value = resolvedDefault;
                 $('sr-free-space-target').value = cfg.free_space_target_pct || 10;
                 $('sr-max-archive').value = cfg.max_archive_size_gb || 0;

--- a/scripts/web/templates/index.html
+++ b/scripts/web/templates/index.html
@@ -207,16 +207,16 @@
 
             <div id="sr-warning-banner" hidden
                  style="margin:0 0 14px; padding:10px 14px; border-radius:8px;
-                        background:var(--accent-warning-bg, #4a3500); color:var(--accent-warning, #ffb347);
-                        border:1px solid var(--accent-warning, #ffb347); font-size:0.85rem;">
+                        background:var(--msg-warning-bg); color:var(--msg-warning-text);
+                        border:1px solid var(--msg-warning-text); font-size:0.85rem;">
                 <strong>Heads up:</strong> short retention may delete footage of incidents that take time
                 to discover (e.g., scratches noticed days later).
             </div>
 
             <div id="sr-error-banner" hidden
                  style="margin:0 0 14px; padding:10px 14px; border-radius:8px;
-                        background:var(--accent-danger-bg, #4a0000); color:var(--accent-danger, #ff6b6b);
-                        border:1px solid var(--accent-danger, #ff6b6b); font-size:0.85rem;"></div>
+                        background:var(--msg-error-bg); color:var(--msg-error-text);
+                        border:1px solid var(--msg-error-text); font-size:0.85rem;"></div>
 
             <form id="storage-retention-form" onsubmit="return false;">
                 <div style="display:grid; grid-template-columns:1fr 1fr; gap:12px; margin-bottom:14px">
@@ -230,24 +230,34 @@
                         </p>
                     </div>
                     <div class="form-group">
-                        <label style="font-size:0.85rem"><strong>Free-space target (% of SD card)</strong></label>
+                        <label style="font-size:0.85rem"><strong>Free-space target (% of SD card)</strong>
+                            <span style="font-weight:normal; color:var(--text-secondary)">
+                                — Phase 5 (preview)
+                            </span>
+                        </label>
                         <input type="number" name="free_space_target_pct" id="sr-free-space-target"
                                min="5" max="50" value="10"
                                style="width:100%; padding:6px 10px; border:1px solid var(--border); border-radius:6px; background:var(--bg-secondary)">
                         <p style="font-size:0.8rem; color:var(--text-secondary); margin:4px 0 0">
-                            Always try to keep at least this much free. Older clips are pruned more aggressively when space runs low.
+                            Saved now; not yet enforced by the prune. Phase 5 will use this to keep at
+                            least the requested free percentage.
                         </p>
                     </div>
                 </div>
 
                 <div style="display:grid; grid-template-columns:1fr 1fr; gap:12px; margin-bottom:14px">
                     <div class="form-group">
-                        <label style="font-size:0.85rem"><strong>Maximum archive size (GB)</strong></label>
+                        <label style="font-size:0.85rem"><strong>Maximum archive size (GB)</strong>
+                            <span style="font-weight:normal; color:var(--text-secondary)">
+                                — Phase 5 (preview)
+                            </span>
+                        </label>
                         <input type="number" name="max_archive_size_gb" id="sr-max-archive"
                                min="0" max="10000" value="0"
                                style="width:100%; padding:6px 10px; border:1px solid var(--border); border-radius:6px; background:var(--bg-secondary)">
                         <p style="font-size:0.8rem; color:var(--text-secondary); margin:4px 0 0">
-                            Hard cap on total ArchivedClips size. Set to <strong>0</strong> to use only the time-based retention rules.
+                            Saved now; not yet enforced by the prune. Phase 5 will treat this as a hard
+                            cap. Leave at <strong>0</strong> to use only time-based retention.
                         </p>
                     </div>
                     <div class="form-group">
@@ -1458,12 +1468,20 @@ if (document.getElementById('fsck-status-container')) {
             .then(function (data) {
                 if (!data || !data.success) return null;
                 var cfg = data.config || {};
-                $('sr-default-retention').value = cfg.default_retention_days || 30;
+                // ``default_retention_days === 0`` in config.yaml means
+                // "inherit from legacy fallback". Show the resolved
+                // value the watchdog will actually use, so a user who
+                // saves without editing doesn't accidentally overwrite
+                // a customized cloud_archive.archived_clips_retention_days.
+                var resolvedDefault = (data.resolved_retention_days != null)
+                    ? data.resolved_retention_days
+                    : (cfg.default_retention_days || 30);
+                $('sr-default-retention').value = resolvedDefault;
                 $('sr-free-space-target').value = cfg.free_space_target_pct || 10;
                 $('sr-max-archive').value = cfg.max_archive_size_gb || 0;
                 $('sr-short-warning').value = cfg.short_retention_warning_days || 7;
-                renderPolicyRows(cfg.policies || {}, cfg.default_retention_days || 30);
-                renderWarning(cfg.default_retention_days, cfg.short_retention_warning_days);
+                renderPolicyRows(cfg.policies || {}, resolvedDefault);
+                renderWarning(resolvedDefault, cfg.short_retention_warning_days);
                 renderLastRun(data);
                 renderDisk(data);
                 return data;
@@ -1575,7 +1593,32 @@ if (document.getElementById('fsck-status-container')) {
     if (warnEl) warnEl.addEventListener('input', refreshWarning);
 
     loadStatus();
-    setInterval(loadStatus, POLL_MS);
+    // Visibility-aware polling — pause when the tab is hidden so a
+    // backgrounded phone doesn't keep hitting the Pi every 30 s for
+    // hours on end.
+    var pollTimer = null;
+    function startPolling() {
+        if (pollTimer != null) return;
+        pollTimer = setInterval(loadStatus, POLL_MS);
+    }
+    function stopPolling() {
+        if (pollTimer == null) return;
+        clearInterval(pollTimer);
+        pollTimer = null;
+    }
+    if (typeof document.visibilityState === 'string') {
+        document.addEventListener('visibilitychange', function () {
+            if (document.hidden) {
+                stopPolling();
+            } else {
+                loadStatus();
+                startPolling();
+            }
+        });
+        if (!document.hidden) startPolling();
+    } else {
+        startPolling();
+    }
 })();
 </script>
 {% endblock %}

--- a/scripts/web/templates/index.html
+++ b/scripts/web/templates/index.html
@@ -195,6 +195,103 @@
         </div>
     </details>
 
+    <!-- Storage & Retention (Phase 3a.2 — closes part of #98) -->
+    <details class="settings-section" id="storage-retention-section" open>
+        <summary>Storage &amp; Retention</summary>
+        <div class="section-content">
+            <p style="font-size:0.85rem; color:var(--text-secondary); margin:0 0 12px">
+                Controls how long archived dashcam clips are kept on the Pi's SD card and how
+                aggressively the cleanup pass runs. Changes take effect on the next cleanup pass —
+                no service restart needed.
+            </p>
+
+            <div id="sr-warning-banner" hidden
+                 style="margin:0 0 14px; padding:10px 14px; border-radius:8px;
+                        background:var(--accent-warning-bg, #4a3500); color:var(--accent-warning, #ffb347);
+                        border:1px solid var(--accent-warning, #ffb347); font-size:0.85rem;">
+                <strong>Heads up:</strong> short retention may delete footage of incidents that take time
+                to discover (e.g., scratches noticed days later).
+            </div>
+
+            <div id="sr-error-banner" hidden
+                 style="margin:0 0 14px; padding:10px 14px; border-radius:8px;
+                        background:var(--accent-danger-bg, #4a0000); color:var(--accent-danger, #ff6b6b);
+                        border:1px solid var(--accent-danger, #ff6b6b); font-size:0.85rem;"></div>
+
+            <form id="storage-retention-form" onsubmit="return false;">
+                <div style="display:grid; grid-template-columns:1fr 1fr; gap:12px; margin-bottom:14px">
+                    <div class="form-group">
+                        <label style="font-size:0.85rem"><strong>Default retention (days)</strong></label>
+                        <input type="number" name="default_retention_days" id="sr-default-retention"
+                               min="1" max="3650" value="30"
+                               style="width:100%; padding:6px 10px; border:1px solid var(--border); border-radius:6px; background:var(--bg-secondary)">
+                        <p style="font-size:0.8rem; color:var(--text-secondary); margin:4px 0 0">
+                            Applied to ArchivedClips and any folder without an override below.
+                        </p>
+                    </div>
+                    <div class="form-group">
+                        <label style="font-size:0.85rem"><strong>Free-space target (% of SD card)</strong></label>
+                        <input type="number" name="free_space_target_pct" id="sr-free-space-target"
+                               min="5" max="50" value="10"
+                               style="width:100%; padding:6px 10px; border:1px solid var(--border); border-radius:6px; background:var(--bg-secondary)">
+                        <p style="font-size:0.8rem; color:var(--text-secondary); margin:4px 0 0">
+                            Always try to keep at least this much free. Older clips are pruned more aggressively when space runs low.
+                        </p>
+                    </div>
+                </div>
+
+                <div style="display:grid; grid-template-columns:1fr 1fr; gap:12px; margin-bottom:14px">
+                    <div class="form-group">
+                        <label style="font-size:0.85rem"><strong>Maximum archive size (GB)</strong></label>
+                        <input type="number" name="max_archive_size_gb" id="sr-max-archive"
+                               min="0" max="10000" value="0"
+                               style="width:100%; padding:6px 10px; border:1px solid var(--border); border-radius:6px; background:var(--bg-secondary)">
+                        <p style="font-size:0.8rem; color:var(--text-secondary); margin:4px 0 0">
+                            Hard cap on total ArchivedClips size. Set to <strong>0</strong> to use only the time-based retention rules.
+                        </p>
+                    </div>
+                    <div class="form-group">
+                        <label style="font-size:0.85rem"><strong>Short-retention warning (days)</strong></label>
+                        <input type="number" name="short_retention_warning_days" id="sr-short-warning"
+                               min="1" max="365" value="7"
+                               style="width:100%; padding:6px 10px; border:1px solid var(--border); border-radius:6px; background:var(--bg-secondary)">
+                        <p style="font-size:0.8rem; color:var(--text-secondary); margin:4px 0 0">
+                            Show the yellow warning banner when default retention drops below this.
+                        </p>
+                    </div>
+                </div>
+
+                <details style="margin-bottom:14px; border:1px solid var(--border); border-radius:8px; padding:10px 14px">
+                    <summary style="cursor:pointer; font-weight:600">Per-folder overrides (advanced)</summary>
+                    <p style="font-size:0.8rem; color:var(--text-secondary); margin:8px 0 12px">
+                        Override retention for individual Tesla folders. Leave a row disabled to inherit the default.
+                        ArchivedClips lives on the Pi's SD card; the others (SentryClips, SavedClips, RecentClips,
+                        EncryptedClips) are inside the USB image that Tesla writes to.
+                    </p>
+                    <div id="sr-policy-rows" style="display:flex; flex-direction:column; gap:10px">
+                        <!-- rows rendered by JS from /api/cleanup/status -->
+                    </div>
+                </details>
+
+                <div style="display:flex; gap:10px; flex-wrap:wrap">
+                    <button type="button" id="sr-save-btn" class="btn btn-primary"
+                            style="flex:1; min-width:160px">Save retention settings</button>
+                    <button type="button" id="sr-run-now-btn" class="btn btn-secondary"
+                            style="flex:1; min-width:160px">Run cleanup now</button>
+                </div>
+            </form>
+
+            <div id="sr-last-run" style="margin-top:14px; padding:10px 14px; border:1px solid var(--border); border-radius:8px; background:var(--bg-secondary); font-size:0.85rem">
+                <strong>Last cleanup:</strong>
+                <span id="sr-last-run-text">—</span>
+            </div>
+
+            <div id="sr-disk-usage" hidden style="margin-top:10px; font-size:0.8rem; color:var(--text-secondary)">
+                <strong>SD card:</strong> <span id="sr-disk-text">—</span>
+            </div>
+        </div>
+    </details>
+
     <!-- Archive Settings -->
     <details class="settings-section">
         <summary>Archive Settings</summary>
@@ -1248,6 +1345,237 @@ if (document.getElementById('fsck-status-container')) {
 
     poll();
     setInterval(poll, POLL_MS);
+})();
+
+// ===========================================================================
+// Storage & Retention card (Phase 3a.2 — closes part of #98)
+// ===========================================================================
+(function () {
+    var STORAGE_API = '/api/cleanup/status';
+    var SAVE_API = '/api/cleanup/policy';
+    var RUN_NOW_API = '/api/cleanup/run_now';
+    var POLL_MS = 30000;
+    var FOLDER_NAMES = ['SentryClips', 'SavedClips', 'RecentClips', 'EncryptedClips', 'ArchivedClips'];
+
+    function $(id) { return document.getElementById(id); }
+
+    function fmtBytes(n) {
+        if (n == null || isNaN(n)) return '—';
+        if (n < 1024) return n + ' B';
+        var units = ['KB', 'MB', 'GB', 'TB'];
+        var i = -1;
+        do { n /= 1024; i++; } while (n >= 1024 && i < units.length - 1);
+        return n.toFixed(n >= 10 ? 0 : 1) + ' ' + units[i];
+    }
+
+    function fmtRelative(iso) {
+        if (!iso) return 'never';
+        try {
+            var t = new Date(iso).getTime();
+            if (!t) return iso;
+            var diff = (Date.now() - t) / 1000;
+            if (diff < 60) return 'just now';
+            if (diff < 3600) return Math.floor(diff / 60) + ' min ago';
+            if (diff < 86400) return Math.floor(diff / 3600) + ' hr ago';
+            return Math.floor(diff / 86400) + ' days ago';
+        } catch (e) { return iso; }
+    }
+
+    function setError(msg) {
+        var el = $('sr-error-banner');
+        if (!el) return;
+        if (msg) {
+            el.textContent = msg;
+            el.hidden = false;
+        } else {
+            el.hidden = true;
+        }
+    }
+
+    function renderPolicyRows(policies, defaultDays) {
+        var container = $('sr-policy-rows');
+        if (!container) return;
+        container.innerHTML = '';
+        FOLDER_NAMES.forEach(function (name) {
+            var p = (policies && policies[name]) || {};
+            var enabled = !!p.enabled;
+            var days = (p.retention_days != null) ? p.retention_days : defaultDays;
+            var row = document.createElement('div');
+            row.style.cssText = 'display:grid; grid-template-columns:auto 1fr 1fr; gap:10px; align-items:center';
+            row.innerHTML =
+                '<label style="display:flex; align-items:center; gap:6px; cursor:pointer; font-size:0.85rem">' +
+                  '<input type="checkbox" name="policy_' + name + '_enabled" ' + (enabled ? 'checked' : '') + '>' +
+                  '<strong>' + name + '</strong>' +
+                '</label>' +
+                '<span style="font-size:0.8rem; color:var(--text-secondary)">Retention (days)</span>' +
+                '<input type="number" name="policy_' + name + '_days" value="' + days +
+                  '" min="1" max="3650" style="width:100%; padding:4px 8px; border:1px solid var(--border); border-radius:6px; background:var(--bg-secondary)">';
+            container.appendChild(row);
+        });
+    }
+
+    function renderLastRun(snapshot) {
+        var el = $('sr-last-run-text');
+        if (!el) return;
+        var lr = snapshot.last_run || {};
+        if (!lr.at) {
+            el.textContent = 'never run yet';
+            return;
+        }
+        var parts = [];
+        parts.push(fmtRelative(lr.at));
+        if (lr.deleted_count != null) parts.push('pruned ' + lr.deleted_count + ' clips');
+        if (lr.freed_bytes != null) parts.push('freed ' + fmtBytes(lr.freed_bytes));
+        if (lr.kept_unsynced_count) parts.push('kept ' + lr.kept_unsynced_count + ' un-synced');
+        if (lr.error) parts.push('error: ' + lr.error);
+        el.textContent = parts.join(' — ');
+    }
+
+    function renderDisk(snapshot) {
+        var disk = snapshot.disk || {};
+        var box = $('sr-disk-usage');
+        var txt = $('sr-disk-text');
+        if (!box || !txt) return;
+        if (!disk.total_bytes) {
+            box.hidden = true;
+            return;
+        }
+        txt.textContent =
+            fmtBytes(disk.free_bytes) + ' free of ' + fmtBytes(disk.total_bytes) +
+            ' (' + disk.free_pct + '% free)';
+        box.hidden = false;
+    }
+
+    function renderWarning(defaultDays, warnDays) {
+        var el = $('sr-warning-banner');
+        if (!el) return;
+        el.hidden = !(defaultDays && warnDays && defaultDays < warnDays);
+    }
+
+    function loadStatus() {
+        return fetch(STORAGE_API, { credentials: 'same-origin' })
+            .then(function (r) { return r.ok ? r.json() : null; })
+            .then(function (data) {
+                if (!data || !data.success) return null;
+                var cfg = data.config || {};
+                $('sr-default-retention').value = cfg.default_retention_days || 30;
+                $('sr-free-space-target').value = cfg.free_space_target_pct || 10;
+                $('sr-max-archive').value = cfg.max_archive_size_gb || 0;
+                $('sr-short-warning').value = cfg.short_retention_warning_days || 7;
+                renderPolicyRows(cfg.policies || {}, cfg.default_retention_days || 30);
+                renderWarning(cfg.default_retention_days, cfg.short_retention_warning_days);
+                renderLastRun(data);
+                renderDisk(data);
+                return data;
+            })
+            .catch(function (e) { console.warn('storage-retention load failed', e); return null; });
+    }
+
+    function collectPayload() {
+        var policies = {};
+        FOLDER_NAMES.forEach(function (name) {
+            var enabledEl = document.querySelector('input[name="policy_' + name + '_enabled"]');
+            var daysEl = document.querySelector('input[name="policy_' + name + '_days"]');
+            if (!enabledEl && !daysEl) return;
+            policies[name] = {
+                enabled: enabledEl ? enabledEl.checked : false,
+                retention_days: daysEl ? parseInt(daysEl.value, 10) : null,
+            };
+        });
+        return {
+            default_retention_days: parseInt($('sr-default-retention').value, 10),
+            free_space_target_pct: parseInt($('sr-free-space-target').value, 10),
+            max_archive_size_gb: parseInt($('sr-max-archive').value, 10),
+            short_retention_warning_days: parseInt($('sr-short-warning').value, 10),
+            policies: policies,
+        };
+    }
+
+    function onSave() {
+        var btn = $('sr-save-btn');
+        if (!btn) return;
+        var origText = btn.textContent;
+        btn.disabled = true;
+        btn.textContent = 'Saving…';
+        setError(null);
+        fetch(SAVE_API, {
+            method: 'POST',
+            credentials: 'same-origin',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(collectPayload()),
+        })
+            .then(function (r) {
+                return r.json().then(function (data) { return { ok: r.ok, data: data }; });
+            })
+            .then(function (res) {
+                if (!res.ok || !res.data || res.data.success === false) {
+                    setError((res.data && res.data.message) || 'Failed to save retention settings');
+                    return;
+                }
+                btn.textContent = 'Saved ✓';
+                loadStatus();
+                setTimeout(function () { btn.textContent = origText; }, 1500);
+            })
+            .catch(function (e) {
+                setError('Network error: ' + e.message);
+            })
+            .finally(function () {
+                btn.disabled = false;
+                if (btn.textContent === 'Saving…') btn.textContent = origText;
+            });
+    }
+
+    function onRunNow() {
+        var btn = $('sr-run-now-btn');
+        if (!btn) return;
+        var origText = btn.textContent;
+        btn.disabled = true;
+        btn.textContent = 'Running…';
+        setError(null);
+        fetch(RUN_NOW_API, { method: 'POST', credentials: 'same-origin' })
+            .then(function (r) {
+                return r.json().then(function (data) { return { status: r.status, data: data }; });
+            })
+            .then(function (res) {
+                var d = res.data || {};
+                var result = d.result || {};
+                if (result.status === 'already_running') {
+                    btn.textContent = 'Already running';
+                } else if (res.status >= 200 && res.status < 300 && d.success !== false) {
+                    var deleted = result.deleted_count || 0;
+                    var freed = result.freed_bytes ? fmtBytes(result.freed_bytes) : '0 B';
+                    btn.textContent = '✓ ' + deleted + ' clips, ' + freed;
+                } else {
+                    setError(d.message || 'Cleanup failed');
+                    btn.textContent = origText;
+                    return;
+                }
+                loadStatus();
+                setTimeout(function () { btn.textContent = origText; }, 4000);
+            })
+            .catch(function (e) {
+                setError('Network error: ' + e.message);
+                btn.textContent = origText;
+            })
+            .finally(function () { btn.disabled = false; });
+    }
+
+    if (!$('storage-retention-section')) return;
+
+    var saveBtn = $('sr-save-btn');
+    var runBtn = $('sr-run-now-btn');
+    if (saveBtn) saveBtn.addEventListener('click', onSave);
+    if (runBtn) runBtn.addEventListener('click', onRunNow);
+    var defEl = $('sr-default-retention');
+    var warnEl = $('sr-short-warning');
+    function refreshWarning() {
+        renderWarning(parseInt(defEl.value, 10), parseInt(warnEl.value, 10));
+    }
+    if (defEl) defEl.addEventListener('input', refreshWarning);
+    if (warnEl) warnEl.addEventListener('input', refreshWarning);
+
+    loadStatus();
+    setInterval(loadStatus, POLL_MS);
 })();
 </script>
 {% endblock %}

--- a/scripts/web/web_control.py
+++ b/scripts/web/web_control.py
@@ -55,6 +55,7 @@ from blueprints import (
     cloud_archive_bp,
     live_events_bp,
     archive_queue_bp,
+    storage_retention_bp,
 )
 
 app.register_blueprint(mapping_bp)
@@ -74,6 +75,7 @@ app.register_blueprint(fsck_bp)
 app.register_blueprint(cloud_archive_bp)
 app.register_blueprint(live_events_bp)
 app.register_blueprint(archive_queue_bp)
+app.register_blueprint(storage_retention_bp)
 # Register captive portal blueprint LAST to avoid conflicting with other routes
 app.register_blueprint(captive_portal_bp)
 
@@ -118,6 +120,20 @@ if __name__ == "__main__":
     print(f"Starting Tesla USB Gadget Web Control")
     print(f"Gadget directory: {GADGET_DIR}")
     print(f"Access the interface at: http://0.0.0.0:{WEB_PORT}/")
+
+    # Phase 3a.2 (#98): one-shot migration of legacy cleanup_config.json
+    # into the unified ``cleanup`` config.yaml section. Idempotent and
+    # never raises — safe to call on every boot.
+    try:
+        from services.cleanup_service import migrate_legacy_cleanup_config
+        migration = migrate_legacy_cleanup_config(GADGET_DIR)
+        if migration.get('migrated'):
+            print(
+                f"cleanup migration: imported {migration['imported_folders']} "
+                f"into config.yaml cleanup.policies"
+            )
+    except Exception as e:  # noqa: BLE001
+        print(f"Warning: cleanup migration failed (non-fatal): {e}")
 
     # Phase 2b (issue #76): the legacy ``start_archive_timer`` periodic
     # thread is gone. The new flow is queue-driven: ``archive_producer``

--- a/tests/test_archive_watchdog.py
+++ b/tests/test_archive_watchdog.py
@@ -1109,6 +1109,96 @@ class TestResolveDeleteUnsynced:
         assert archive_watchdog._resolve_delete_unsynced() is False
 
 
+class TestResolveRetentionDays:
+    """Phase 3a.2 (#98) — verify the unified ``cleanup`` config section
+    takes precedence over the legacy ``cloud_archive.archived_clips_retention_days``
+    and ``archive.retention_days`` keys, while preserving full backward
+    compat for existing installs that haven't migrated yet.
+
+    Resolution order (first non-zero wins):
+
+    1. ``cleanup.policies.ArchivedClips.retention_days``
+    2. ``cleanup.default_retention_days``
+    3. ``cloud_archive.archived_clips_retention_days``
+    4. ``archive.retention_days`` (via ``CLOUD_ARCHIVE_RETENTION_DAYS`` fallback)
+    5. Hard-coded ``30``
+    """
+
+    def _patch_config(self, monkeypatch, **values):
+        """Apply each kwarg to the loaded ``config`` module via monkeypatch.
+
+        Use ``raising=False`` so we can null-out attributes that may not
+        exist on every test installation.
+        """
+        import config as cfg_module
+        for k, v in values.items():
+            monkeypatch.setattr(cfg_module, k, v, raising=False)
+
+    def test_per_folder_override_wins(self, monkeypatch):
+        self._patch_config(
+            monkeypatch,
+            CLEANUP_POLICIES={'ArchivedClips': {'retention_days': 14, 'enabled': True}},
+            CLEANUP_DEFAULT_RETENTION_DAYS=60,
+            CLOUD_ARCHIVE_RETENTION_DAYS=90,
+        )
+        assert archive_watchdog._resolve_retention_days() == 14
+
+    def test_default_used_when_no_override(self, monkeypatch):
+        self._patch_config(
+            monkeypatch,
+            CLEANUP_POLICIES={},
+            CLEANUP_DEFAULT_RETENTION_DAYS=60,
+            CLOUD_ARCHIVE_RETENTION_DAYS=90,
+        )
+        assert archive_watchdog._resolve_retention_days() == 60
+
+    def test_default_used_when_archived_override_missing_days(self, monkeypatch):
+        # Per-folder block exists but lacks retention_days — fall through.
+        self._patch_config(
+            monkeypatch,
+            CLEANUP_POLICIES={'ArchivedClips': {'enabled': True}},
+            CLEANUP_DEFAULT_RETENTION_DAYS=45,
+            CLOUD_ARCHIVE_RETENTION_DAYS=90,
+        )
+        assert archive_watchdog._resolve_retention_days() == 45
+
+    def test_legacy_cloud_archive_used_when_cleanup_empty(self, monkeypatch):
+        # Backward-compat path: install with no cleanup.* section but
+        # an existing cloud_archive.archived_clips_retention_days.
+        self._patch_config(
+            monkeypatch,
+            CLEANUP_POLICIES={},
+            CLEANUP_DEFAULT_RETENTION_DAYS=0,
+            CLOUD_ARCHIVE_RETENTION_DAYS=90,
+        )
+        assert archive_watchdog._resolve_retention_days() == 90
+
+    def test_hardcoded_default_when_everything_missing(self, monkeypatch):
+        # All three sources zero/missing → fall to the hard 30-day floor
+        # so a misconfigured install never accidentally pretends "no
+        # retention" (which would let the SD card fill until OOM).
+        self._patch_config(
+            monkeypatch,
+            CLEANUP_POLICIES={},
+            CLEANUP_DEFAULT_RETENTION_DAYS=0,
+            CLOUD_ARCHIVE_RETENTION_DAYS=0,
+        )
+        assert archive_watchdog._resolve_retention_days() == 30
+
+    def test_zero_override_does_not_disable_retention(self, monkeypatch):
+        # A user setting retention to 0 in the per-folder UI must NOT
+        # be interpreted as "infinite retention" — it falls through to
+        # the next source so the system keeps pruning. (Disabling is a
+        # separate concept handled by the per-folder ``enabled`` flag.)
+        self._patch_config(
+            monkeypatch,
+            CLEANUP_POLICIES={'ArchivedClips': {'retention_days': 0}},
+            CLEANUP_DEFAULT_RETENTION_DAYS=21,
+            CLOUD_ARCHIVE_RETENTION_DAYS=90,
+        )
+        assert archive_watchdog._resolve_retention_days() == 21
+
+
 # ---------------------------------------------------------------------------
 # Issue #91 — duplicate-trigger guard for retention prune
 # ---------------------------------------------------------------------------

--- a/tests/test_archive_watchdog.py
+++ b/tests/test_archive_watchdog.py
@@ -1128,9 +1128,16 @@ class TestResolveRetentionDays:
         """Apply each kwarg to the loaded ``config`` module via monkeypatch.
 
         Use ``raising=False`` so we can null-out attributes that may not
-        exist on every test installation.
+        exist on every test installation. Also points ``CONFIG_YAML`` at
+        a nonexistent path so the Phase 3a.2 YAML-direct read in
+        ``_resolve_retention_days`` falls through to the cached config
+        attributes that this helper actually controls.
         """
         import config as cfg_module
+        monkeypatch.setattr(
+            cfg_module, 'CONFIG_YAML',
+            '/nonexistent/test/config.yaml', raising=False,
+        )
         for k, v in values.items():
             monkeypatch.setattr(cfg_module, k, v, raising=False)
 
@@ -1197,6 +1204,70 @@ class TestResolveRetentionDays:
             CLOUD_ARCHIVE_RETENTION_DAYS=90,
         )
         assert archive_watchdog._resolve_retention_days() == 21
+
+    def test_yaml_direct_read_wins_over_cached_attrs(self, monkeypatch, tmp_path):
+        # Phase 3a.2 PR #124 review fix: ``_resolve_retention_days`` now
+        # reads ``config.yaml`` directly on every call so a save from
+        # the Settings UI takes effect without restart. Verify the
+        # direct read is preferred over the cached config attributes
+        # (which would otherwise lag behind by a service restart).
+        cfg_path = tmp_path / 'config.yaml'
+        cfg_path.write_text(
+            "cleanup:\n"
+            "  default_retention_days: 99\n"
+            "  policies: {}\n"
+            "cloud_archive:\n"
+            "  archived_clips_retention_days: 7\n"
+        )
+        import config as cfg_module
+        monkeypatch.setattr(cfg_module, 'CONFIG_YAML', str(cfg_path), raising=False)
+        # Cached attrs say 7; direct YAML read says 99. The fresh value wins.
+        monkeypatch.setattr(cfg_module, 'CLEANUP_DEFAULT_RETENTION_DAYS', 7, raising=False)
+        monkeypatch.setattr(cfg_module, 'CLOUD_ARCHIVE_RETENTION_DAYS', 7, raising=False)
+        monkeypatch.setattr(cfg_module, 'CLEANUP_POLICIES', {}, raising=False)
+        assert archive_watchdog._resolve_retention_days() == 99
+
+    def test_yaml_direct_read_per_folder_override_wins(self, monkeypatch, tmp_path):
+        cfg_path = tmp_path / 'config.yaml'
+        cfg_path.write_text(
+            "cleanup:\n"
+            "  default_retention_days: 60\n"
+            "  policies:\n"
+            "    ArchivedClips:\n"
+            "      enabled: true\n"
+            "      retention_days: 14\n"
+            "cloud_archive:\n"
+            "  archived_clips_retention_days: 90\n"
+        )
+        import config as cfg_module
+        monkeypatch.setattr(cfg_module, 'CONFIG_YAML', str(cfg_path), raising=False)
+        assert archive_watchdog._resolve_retention_days() == 14
+
+    def test_yaml_falls_through_to_cloud_archive_when_cleanup_zero(self, monkeypatch, tmp_path):
+        cfg_path = tmp_path / 'config.yaml'
+        cfg_path.write_text(
+            "cleanup:\n"
+            "  default_retention_days: 0\n"
+            "  policies: {}\n"
+            "cloud_archive:\n"
+            "  archived_clips_retention_days: 21\n"
+        )
+        import config as cfg_module
+        monkeypatch.setattr(cfg_module, 'CONFIG_YAML', str(cfg_path), raising=False)
+        assert archive_watchdog._resolve_retention_days() == 21
+
+    def test_yaml_falls_through_to_archive_legacy_key(self, monkeypatch, tmp_path):
+        cfg_path = tmp_path / 'config.yaml'
+        cfg_path.write_text(
+            "cleanup:\n"
+            "  default_retention_days: 0\n"
+            "  policies: {}\n"
+            "archive:\n"
+            "  retention_days: 45\n"
+        )
+        import config as cfg_module
+        monkeypatch.setattr(cfg_module, 'CONFIG_YAML', str(cfg_path), raising=False)
+        assert archive_watchdog._resolve_retention_days() == 45
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cleanup_legacy_migration.py
+++ b/tests/test_cleanup_legacy_migration.py
@@ -58,14 +58,19 @@ class TestLegacyMigration:
     """Pin the migration contract end-to-end."""
 
     def test_no_legacy_file_is_noop(self, gadget_dir, config_yaml_path):
+        # No legacy JSON, no legacy YAML keys → fully no-op.
         _write_yaml(config_yaml_path, {'cleanup': {}})
         summary = migrate_legacy_cleanup_config(
             str(gadget_dir), config_yaml_path=config_yaml_path,
         )
         assert summary['migrated'] is False
         assert 'no legacy file' in summary['reason']
+        assert summary['seeded_default_retention_days'] is None
         # No .migrated file should appear because none existed.
         assert not (gadget_dir / 'cleanup_config.json.migrated').exists()
+        # config.yaml is unchanged.
+        cfg = _read_yaml(config_yaml_path)
+        assert cfg.get('cleanup') == {}
 
     def test_legacy_imported_into_yaml(self, gadget_dir, config_yaml_path):
         _write_yaml(config_yaml_path, {'cleanup': {}})
@@ -91,7 +96,9 @@ class TestLegacyMigration:
         assert policies['SavedClips']['retention_days'] == 365
         assert policies['SavedClips']['enabled'] is False
         # Defaults seeded so the watchdog has something to fall back on.
-        assert cfg['cleanup']['default_retention_days'] == 30
+        # default_retention_days stays at 0 (= "use legacy fallback chain")
+        # when no legacy YAML key was found to seed it from.
+        assert cfg['cleanup']['default_retention_days'] == 0
         assert cfg['cleanup']['free_space_target_pct'] == 10
         # Legacy file renamed.
         assert not legacy.exists()
@@ -202,3 +209,69 @@ class TestLegacyMigration:
         assert 'no migratable policies' in summary['reason']
         assert not (gadget_dir / 'cleanup_config.json').exists()
         assert (gadget_dir / 'cleanup_config.json.migrated').exists()
+
+
+class TestDefaultRetentionSeedPass:
+    """Pin the Phase 3a.2 (#98) seed pass that preserves customizations
+    of the legacy ``cloud_archive.archived_clips_retention_days`` and
+    ``archive.retention_days`` keys across a ``git pull``."""
+
+    def test_seeds_default_from_cloud_archive_key(self, gadget_dir, config_yaml_path):
+        # Existing install: cleanup section freshly shipped (default=0),
+        # legacy cloud_archive key set to 21. Migration must seed the
+        # unified key so the user's customization survives.
+        _write_yaml(config_yaml_path, {
+            'cleanup': {'default_retention_days': 0, 'policies': {}},
+            'cloud_archive': {'archived_clips_retention_days': 21},
+        })
+        summary = migrate_legacy_cleanup_config(
+            str(gadget_dir), config_yaml_path=config_yaml_path,
+        )
+        assert summary['seeded_default_retention_days'] == 21
+        cfg = _read_yaml(config_yaml_path)
+        assert cfg['cleanup']['default_retention_days'] == 21
+        # Legacy key NOT removed — it still serves installs that
+        # downgrade.
+        assert cfg['cloud_archive']['archived_clips_retention_days'] == 21
+
+    def test_seeds_from_archive_key_when_cloud_archive_absent(self, gadget_dir, config_yaml_path):
+        _write_yaml(config_yaml_path, {
+            'cleanup': {'default_retention_days': 0, 'policies': {}},
+            'archive': {'retention_days': 14},
+        })
+        summary = migrate_legacy_cleanup_config(
+            str(gadget_dir), config_yaml_path=config_yaml_path,
+        )
+        assert summary['seeded_default_retention_days'] == 14
+        cfg = _read_yaml(config_yaml_path)
+        assert cfg['cleanup']['default_retention_days'] == 14
+
+    def test_skips_seed_when_unified_default_already_set(self, gadget_dir, config_yaml_path):
+        # User has set the unified key already. Legacy must NOT
+        # overwrite it.
+        _write_yaml(config_yaml_path, {
+            'cleanup': {'default_retention_days': 45, 'policies': {}},
+            'cloud_archive': {'archived_clips_retention_days': 21},
+        })
+        summary = migrate_legacy_cleanup_config(
+            str(gadget_dir), config_yaml_path=config_yaml_path,
+        )
+        assert summary['seeded_default_retention_days'] is None
+        cfg = _read_yaml(config_yaml_path)
+        assert cfg['cleanup']['default_retention_days'] == 45
+
+    def test_seed_persists_even_without_legacy_json(self, gadget_dir, config_yaml_path):
+        # The seed pass must run regardless of whether the legacy JSON
+        # file exists — the YAML keys are an independent legacy surface.
+        _write_yaml(config_yaml_path, {
+            'cleanup': {'default_retention_days': 0},
+            'cloud_archive': {'archived_clips_retention_days': 60},
+        })
+        # No cleanup_config.json.
+        summary = migrate_legacy_cleanup_config(
+            str(gadget_dir), config_yaml_path=config_yaml_path,
+        )
+        assert summary['migrated'] is False
+        assert summary['seeded_default_retention_days'] == 60
+        cfg = _read_yaml(config_yaml_path)
+        assert cfg['cleanup']['default_retention_days'] == 60

--- a/tests/test_cleanup_legacy_migration.py
+++ b/tests/test_cleanup_legacy_migration.py
@@ -1,0 +1,204 @@
+"""Tests for the Phase 3a.2 (#98) one-shot migration of legacy
+``cleanup_config.json`` into the unified ``config.yaml`` ``cleanup``
+section.
+
+The migration must be idempotent, never raise, only seed allow-listed
+folder names, and rename the legacy file with a ``.migrated`` suffix
+on success so the next boot doesn't redo the work.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+import yaml
+
+from services.cleanup_service import migrate_legacy_cleanup_config
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def gadget_dir(tmp_path):
+    return tmp_path
+
+
+@pytest.fixture
+def config_yaml_path(gadget_dir):
+    p = gadget_dir / 'config.yaml'
+    return str(p)
+
+
+def _write_yaml(path, data):
+    with open(path, 'w') as f:
+        yaml.safe_dump(data, f)
+
+
+def _write_legacy(gadget_dir, data):
+    p = gadget_dir / 'cleanup_config.json'
+    p.write_text(json.dumps(data))
+    return p
+
+
+def _read_yaml(path):
+    with open(path, 'r') as f:
+        return yaml.safe_load(f) or {}
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestLegacyMigration:
+    """Pin the migration contract end-to-end."""
+
+    def test_no_legacy_file_is_noop(self, gadget_dir, config_yaml_path):
+        _write_yaml(config_yaml_path, {'cleanup': {}})
+        summary = migrate_legacy_cleanup_config(
+            str(gadget_dir), config_yaml_path=config_yaml_path,
+        )
+        assert summary['migrated'] is False
+        assert 'no legacy file' in summary['reason']
+        # No .migrated file should appear because none existed.
+        assert not (gadget_dir / 'cleanup_config.json.migrated').exists()
+
+    def test_legacy_imported_into_yaml(self, gadget_dir, config_yaml_path):
+        _write_yaml(config_yaml_path, {'cleanup': {}})
+        legacy = _write_legacy(gadget_dir, {
+            'SentryClips': {
+                'enabled': True,
+                'age_based': {'days': 90, 'enabled': True},
+            },
+            'SavedClips': {
+                'enabled': False,
+                'age_based': {'days': 365, 'enabled': True},
+            },
+        })
+        summary = migrate_legacy_cleanup_config(
+            str(gadget_dir), config_yaml_path=config_yaml_path,
+        )
+        assert summary['migrated'] is True
+        assert sorted(summary['imported_folders']) == ['SavedClips', 'SentryClips']
+        cfg = _read_yaml(config_yaml_path)
+        policies = cfg['cleanup']['policies']
+        assert policies['SentryClips']['retention_days'] == 90
+        assert policies['SentryClips']['enabled'] is True
+        assert policies['SavedClips']['retention_days'] == 365
+        assert policies['SavedClips']['enabled'] is False
+        # Defaults seeded so the watchdog has something to fall back on.
+        assert cfg['cleanup']['default_retention_days'] == 30
+        assert cfg['cleanup']['free_space_target_pct'] == 10
+        # Legacy file renamed.
+        assert not legacy.exists()
+        assert (gadget_dir / 'cleanup_config.json.migrated').exists()
+
+    def test_idempotent_when_yaml_already_has_policies(self, gadget_dir, config_yaml_path):
+        # User has already used the new UI to set policies. The
+        # legacy file (e.g. left behind from a downgrade) MUST NOT
+        # overwrite the user's choices.
+        _write_yaml(config_yaml_path, {
+            'cleanup': {
+                'policies': {
+                    'ArchivedClips': {'enabled': True, 'retention_days': 14},
+                },
+            },
+        })
+        legacy = _write_legacy(gadget_dir, {
+            'SentryClips': {
+                'enabled': True, 'age_based': {'days': 365, 'enabled': True},
+            },
+        })
+        summary = migrate_legacy_cleanup_config(
+            str(gadget_dir), config_yaml_path=config_yaml_path,
+        )
+        assert summary['migrated'] is False
+        assert 'already populated' in summary['reason']
+        cfg = _read_yaml(config_yaml_path)
+        # The user's existing override is preserved untouched.
+        assert cfg['cleanup']['policies']['ArchivedClips']['retention_days'] == 14
+        assert 'SentryClips' not in cfg['cleanup']['policies']
+        # Legacy file still gets renamed so subsequent boots don't keep
+        # re-checking it.
+        assert not legacy.exists()
+        assert (gadget_dir / 'cleanup_config.json.migrated').exists()
+
+    def test_drops_unknown_folder_names(self, gadget_dir, config_yaml_path):
+        _write_yaml(config_yaml_path, {'cleanup': {}})
+        _write_legacy(gadget_dir, {
+            'BogusFolder': {'enabled': True, 'age_based': {'days': 30, 'enabled': True}},
+            'SentryClips': {'enabled': True, 'age_based': {'days': 90, 'enabled': True}},
+        })
+        summary = migrate_legacy_cleanup_config(
+            str(gadget_dir), config_yaml_path=config_yaml_path,
+        )
+        assert summary['migrated'] is True
+        cfg = _read_yaml(config_yaml_path)
+        assert 'SentryClips' in cfg['cleanup']['policies']
+        assert 'BogusFolder' not in cfg['cleanup']['policies']
+
+    def test_skips_policies_without_age_days(self, gadget_dir, config_yaml_path):
+        # A legacy entry that's enabled but has no usable retention
+        # value would be ambiguous — silently skip it rather than
+        # persist a junk row.
+        _write_yaml(config_yaml_path, {'cleanup': {}})
+        _write_legacy(gadget_dir, {
+            'RecentClips': {'enabled': True, 'age_based': {'days': 0}},
+            'SavedClips': {'enabled': True},   # no age_based at all
+            'SentryClips': {'enabled': True, 'age_based': {'days': 60}},
+        })
+        summary = migrate_legacy_cleanup_config(
+            str(gadget_dir), config_yaml_path=config_yaml_path,
+        )
+        assert summary['migrated'] is True
+        cfg = _read_yaml(config_yaml_path)
+        assert list(cfg['cleanup']['policies'].keys()) == ['SentryClips']
+
+    def test_unparseable_legacy_file_does_not_raise(self, gadget_dir, config_yaml_path):
+        _write_yaml(config_yaml_path, {'cleanup': {}})
+        (gadget_dir / 'cleanup_config.json').write_text('{not json,,}')
+        summary = migrate_legacy_cleanup_config(
+            str(gadget_dir), config_yaml_path=config_yaml_path,
+        )
+        assert summary['migrated'] is False
+        assert 'unparseable' in summary['reason']
+        # config.yaml is untouched.
+        cfg = _read_yaml(config_yaml_path)
+        assert cfg.get('cleanup') == {}
+
+    def test_unreadable_yaml_does_not_raise(self, gadget_dir):
+        # Pointing at a path that doesn't exist must produce a
+        # graceful failure summary, not a crash.
+        _write_legacy(gadget_dir, {
+            'SentryClips': {'enabled': True, 'age_based': {'days': 90}},
+        })
+        summary = migrate_legacy_cleanup_config(
+            str(gadget_dir),
+            config_yaml_path=str(gadget_dir / 'nonexistent-config.yaml'),
+        )
+        assert summary['migrated'] is False
+        # Either "config.yaml unreadable" (open failed) or "no legacy
+        # file" if the open succeeded against an empty file — both are
+        # graceful outcomes.
+        assert summary['reason']  # non-empty string
+
+    def test_no_migratable_policies_renames_legacy(self, gadget_dir, config_yaml_path):
+        # Legacy file exists but contains only entries we'd skip
+        # (zero days, junk folder names). Migration should rename the
+        # file so subsequent boots don't keep re-examining it.
+        _write_yaml(config_yaml_path, {'cleanup': {}})
+        _write_legacy(gadget_dir, {
+            'BogusFolder': {'enabled': True, 'age_based': {'days': 30}},
+            'SentryClips': {'enabled': True, 'age_based': {'days': 0}},
+        })
+        summary = migrate_legacy_cleanup_config(
+            str(gadget_dir), config_yaml_path=config_yaml_path,
+        )
+        assert summary['migrated'] is False
+        assert 'no migratable policies' in summary['reason']
+        assert not (gadget_dir / 'cleanup_config.json').exists()
+        assert (gadget_dir / 'cleanup_config.json.migrated').exists()

--- a/tests/test_storage_retention_blueprint.py
+++ b/tests/test_storage_retention_blueprint.py
@@ -1,0 +1,404 @@
+"""Tests for the Phase 3a.2 (#98) Storage & Retention blueprint.
+
+Covers the contract for:
+
+* ``GET  /api/cleanup/status``    — combined snapshot of config + watchdog
+* ``POST /api/cleanup/policy``    — persist unified retention settings
+* ``POST /api/cleanup/run_now``   — trigger immediate prune (mirrors the
+  legacy ``/cloud/api/archive_cleanup`` HTTP contract — see Phase 3a.1
+  review fix)
+
+Also pins the input-clamping behavior of ``_coerce_int`` and
+``_coerce_bool`` so accidental relaxation can't widen the attack
+surface that lets a malicious payload bloat config.yaml.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from unittest.mock import patch
+
+from blueprints.storage_retention import (
+    storage_retention_bp,
+    _coerce_int,
+    _coerce_bool,
+    _resolve_cleanup_block,
+    ALLOWED_FOLDER_NAMES,
+    RETENTION_DAYS_MIN,
+    RETENTION_DAYS_MAX,
+    FREE_SPACE_PCT_MIN,
+    FREE_SPACE_PCT_MAX,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def captured_updates():
+    """Captures the dict passed to update_config_yaml so tests can
+    assert on what would have been written without actually touching
+    config.yaml on disk."""
+    return {'last': None, 'calls': 0}
+
+
+@pytest.fixture
+def app(captured_updates, monkeypatch):
+    from flask import Flask
+
+    flask_app = Flask(__name__)
+    flask_app.secret_key = 'test-secret'
+    flask_app.register_blueprint(storage_retention_bp)
+
+    def _capture(updates):
+        captured_updates['last'] = dict(updates)
+        captured_updates['calls'] += 1
+
+    monkeypatch.setattr(
+        'helpers.config_updater.update_config_yaml', _capture, raising=False,
+    )
+    return flask_app
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+# ---------------------------------------------------------------------------
+# Coercers — tested in isolation because they're the security boundary
+# between user input and config.yaml writes.
+# ---------------------------------------------------------------------------
+
+
+class TestCoerceInt:
+    def test_in_range_returned_as_int(self):
+        assert _coerce_int(42, default=0, lo=1, hi=100) == 42
+
+    def test_string_int_parsed(self):
+        assert _coerce_int("17", default=0, lo=1, hi=100) == 17
+
+    def test_below_lo_clamped(self):
+        assert _coerce_int(-5, default=0, lo=1, hi=100) == 1
+
+    def test_above_hi_clamped(self):
+        assert _coerce_int(9_999, default=0, lo=1, hi=100) == 100
+
+    def test_garbage_returns_default(self):
+        assert _coerce_int("not-a-number", default=42, lo=1, hi=100) == 42
+
+    def test_none_returns_default(self):
+        assert _coerce_int(None, default=42, lo=1, hi=100) == 42
+
+    def test_bool_rejected_as_default(self):
+        # isinstance(True, int) is True in Python — guard against a
+        # checkbox value silently becoming 0/1 in a numeric field.
+        assert _coerce_int(True, default=99, lo=1, hi=100) == 99
+        assert _coerce_int(False, default=99, lo=1, hi=100) == 99
+
+
+class TestCoerceBool:
+    @pytest.mark.parametrize("v", [True, "true", "True", "1", "yes", "on", "checked", 1, 2.5])
+    def test_truthy(self, v):
+        assert _coerce_bool(v) is True
+
+    @pytest.mark.parametrize("v", [False, "false", "0", "no", "off", "", None, 0])
+    def test_falsy(self, v):
+        assert _coerce_bool(v) is False
+
+
+# ---------------------------------------------------------------------------
+# /api/cleanup/status
+# ---------------------------------------------------------------------------
+
+
+class TestApiCleanupStatus:
+    """The status endpoint is the page-load contract for the card."""
+
+    def test_returns_200_with_full_shape(self, client, monkeypatch):
+        monkeypatch.setattr(
+            'blueprints.storage_retention._load_config_dict',
+            lambda: {'cleanup': {
+                'default_retention_days': 45,
+                'free_space_target_pct': 12,
+                'max_archive_size_gb': 100,
+                'short_retention_warning_days': 7,
+                'policies': {
+                    'ArchivedClips': {'enabled': True, 'retention_days': 30},
+                },
+            }},
+        )
+        monkeypatch.setattr(
+            'blueprints.storage_retention._watchdog_status',
+            lambda: {
+                'watchdog_running': True,
+                'retention': {
+                    'last_prune_at': '2026-05-12T19:00:00Z',
+                    'last_prune_deleted': 12,
+                    'last_prune_freed_bytes': 1_500_000,
+                    'last_prune_kept_unsynced': 0,
+                    'last_prune_error': None,
+                    'next_prune_due_at': 1747084800,
+                    'retention_days': 30,
+                    'delete_unsynced': True,
+                    'cloud_configured': False,
+                },
+            },
+        )
+        monkeypatch.setattr(
+            'blueprints.storage_retention._disk_free_summary',
+            lambda: {
+                'path': '/home/pi/ArchivedClips', 'total_bytes': 100_000_000_000,
+                'free_bytes': 30_000_000_000, 'used_bytes': 70_000_000_000,
+                'free_pct': 30,
+            },
+        )
+        r = client.get('/api/cleanup/status')
+        assert r.status_code == 200
+        body = r.get_json()
+        assert body['success'] is True
+        assert body['config']['default_retention_days'] == 45
+        assert body['config']['policies']['ArchivedClips']['enabled'] is True
+        assert body['resolved_retention_days'] == 30
+        assert body['last_run']['deleted_count'] == 12
+        assert body['last_run']['freed_bytes'] == 1_500_000
+        assert body['watchdog_running'] is True
+        assert body['disk']['free_pct'] == 30
+
+    def test_handles_missing_cleanup_section_gracefully(self, client, monkeypatch):
+        monkeypatch.setattr(
+            'blueprints.storage_retention._load_config_dict', lambda: {},
+        )
+        monkeypatch.setattr(
+            'blueprints.storage_retention._watchdog_status', lambda: {},
+        )
+        monkeypatch.setattr(
+            'blueprints.storage_retention._disk_free_summary', lambda: {},
+        )
+        r = client.get('/api/cleanup/status')
+        assert r.status_code == 200
+        body = r.get_json()
+        assert body['success'] is True
+        # Defaults must be present so the form renders sensibly even on
+        # a brand-new install with no cleanup section yet.
+        assert body['config']['default_retention_days'] == 30
+        assert body['config']['free_space_target_pct'] == 10
+        assert body['config']['max_archive_size_gb'] == 0
+        assert body['config']['policies'] == {}
+
+    def test_drops_unknown_folder_names_from_config(self, client, monkeypatch):
+        # Defense in depth: even if config.yaml gets a typo'd folder
+        # name (e.g. via direct edit), the status response only
+        # surfaces the canonical allow-list so the UI form stays sane.
+        monkeypatch.setattr(
+            'blueprints.storage_retention._load_config_dict',
+            lambda: {'cleanup': {'policies': {
+                'BogusClips': {'enabled': True, 'retention_days': 1},
+                'SentryClips': {'enabled': True, 'retention_days': 90},
+            }}},
+        )
+        monkeypatch.setattr(
+            'blueprints.storage_retention._watchdog_status', lambda: {},
+        )
+        monkeypatch.setattr(
+            'blueprints.storage_retention._disk_free_summary', lambda: {},
+        )
+        r = client.get('/api/cleanup/status')
+        body = r.get_json()
+        assert 'SentryClips' in body['config']['policies']
+        assert 'BogusClips' not in body['config']['policies']
+
+
+# ---------------------------------------------------------------------------
+# /api/cleanup/policy
+# ---------------------------------------------------------------------------
+
+
+class TestApiCleanupPolicy:
+    def test_json_payload_persisted_with_clamping(self, client, captured_updates, monkeypatch):
+        monkeypatch.setattr(
+            'blueprints.storage_retention._load_config_dict',
+            lambda: {'cleanup': {}},
+        )
+        r = client.post(
+            '/api/cleanup/policy',
+            data=json.dumps({
+                'default_retention_days': 45,
+                'free_space_target_pct': 99,    # above max → clamped to 50
+                'max_archive_size_gb': -10,     # below min → clamped to 0
+                'short_retention_warning_days': 14,
+                'policies': {
+                    'ArchivedClips': {'enabled': True, 'retention_days': 30},
+                    'BogusClips': {'enabled': True, 'retention_days': 1},   # dropped
+                },
+            }),
+            content_type='application/json',
+        )
+        assert r.status_code == 200
+        body = r.get_json()
+        assert body['success'] is True
+        last = captured_updates['last']
+        assert last is not None
+        assert last['cleanup.default_retention_days'] == 45
+        # free_space_target_pct clamped at FREE_SPACE_PCT_MAX
+        assert last['cleanup.free_space_target_pct'] == FREE_SPACE_PCT_MAX
+        # max_archive_size_gb clamped at MAX_ARCHIVE_GB_MIN
+        assert last['cleanup.max_archive_size_gb'] == 0
+        assert last['cleanup.short_retention_warning_days'] == 14
+        assert 'ArchivedClips' in last['cleanup.policies']
+        assert 'BogusClips' not in last['cleanup.policies']
+
+    def test_form_payload_supported(self, client, captured_updates, monkeypatch):
+        monkeypatch.setattr(
+            'blueprints.storage_retention._load_config_dict',
+            lambda: {'cleanup': {}},
+        )
+        r = client.post('/api/cleanup/policy', data={
+            'default_retention_days': '60',
+            'free_space_target_pct': '15',
+            'max_archive_size_gb': '100',
+            'short_retention_warning_days': '7',
+            'policy_SentryClips_enabled': 'on',
+            'policy_SentryClips_days': '90',
+        })
+        assert r.status_code == 200
+        last = captured_updates['last']
+        assert last['cleanup.default_retention_days'] == 60
+        assert last['cleanup.policies']['SentryClips']['enabled'] is True
+        assert last['cleanup.policies']['SentryClips']['retention_days'] == 90
+
+    def test_garbage_payload_uses_defaults(self, client, captured_updates, monkeypatch):
+        # Empty/garbage POST must still produce a sane config rather
+        # than crash. Defaults: 30 days, 10%, 0 GB cap, 7-day warning.
+        monkeypatch.setattr(
+            'blueprints.storage_retention._load_config_dict',
+            lambda: {'cleanup': {}},
+        )
+        r = client.post(
+            '/api/cleanup/policy',
+            data=json.dumps({
+                'default_retention_days': 'oops',
+                'free_space_target_pct': None,
+                'max_archive_size_gb': 'x',
+                'short_retention_warning_days': [],
+            }),
+            content_type='application/json',
+        )
+        assert r.status_code == 200
+        last = captured_updates['last']
+        assert last['cleanup.default_retention_days'] == 30
+        assert last['cleanup.free_space_target_pct'] == 10
+        assert last['cleanup.max_archive_size_gb'] == 0
+        assert last['cleanup.short_retention_warning_days'] == 7
+
+    def test_writer_failure_returns_500(self, client, monkeypatch):
+        monkeypatch.setattr(
+            'blueprints.storage_retention._load_config_dict',
+            lambda: {'cleanup': {}},
+        )
+        # Force update_config_yaml to raise — endpoint must return 500
+        # with a structured success=false response, not leak a traceback.
+        def boom(_updates):
+            raise OSError("disk full")
+        monkeypatch.setattr(
+            'helpers.config_updater.update_config_yaml', boom, raising=False,
+        )
+        r = client.post(
+            '/api/cleanup/policy',
+            data=json.dumps({'default_retention_days': 30}),
+            content_type='application/json',
+        )
+        assert r.status_code == 500
+        body = r.get_json()
+        assert body['success'] is False
+        assert 'disk full' in body['message']
+
+    def test_policy_rows_capped(self, client, captured_updates, monkeypatch):
+        # Even if a malicious client tries to seed thousands of fake
+        # folder names, the endpoint only persists the allow-listed
+        # ones — and at most ALLOWED_FOLDER_NAMES of them.
+        monkeypatch.setattr(
+            'blueprints.storage_retention._load_config_dict',
+            lambda: {'cleanup': {}},
+        )
+        many = {f'Fake{i}': {'enabled': True, 'retention_days': 1} for i in range(1000)}
+        many.update({
+            'SentryClips': {'enabled': True, 'retention_days': 90},
+            'ArchivedClips': {'enabled': True, 'retention_days': 30},
+        })
+        r = client.post(
+            '/api/cleanup/policy',
+            data=json.dumps({'default_retention_days': 30, 'policies': many}),
+            content_type='application/json',
+        )
+        assert r.status_code == 200
+        last = captured_updates['last']
+        for k in last['cleanup.policies']:
+            assert k in ALLOWED_FOLDER_NAMES
+
+
+# ---------------------------------------------------------------------------
+# /api/cleanup/run_now — mirrors Phase 3a.1's HTTP contract
+# ---------------------------------------------------------------------------
+
+
+class TestApiCleanupRunNow:
+    def test_success_returns_200_with_summary(self, client):
+        with patch(
+            'services.video_archive_service.trigger_archive_cleanup',
+            return_value={
+                'deleted_count': 7, 'freed_bytes': 1_500_000,
+                'scanned': 100, 'duration_seconds': 0.5,
+            },
+        ):
+            r = client.post('/api/cleanup/run_now')
+        assert r.status_code == 200
+        body = r.get_json()
+        assert body['success'] is True
+        assert body['result']['deleted_count'] == 7
+
+    def test_already_running_returns_200(self, client):
+        # Same control-flow contract as /cloud/api/archive_cleanup —
+        # already_running is normal, not an error.
+        with patch(
+            'services.video_archive_service.trigger_archive_cleanup',
+            return_value={
+                'deleted_count': 0, 'freed_bytes': 0,
+                'status': 'already_running', 'duration_seconds': 0.0,
+            },
+        ):
+            r = client.post('/api/cleanup/run_now')
+        assert r.status_code == 200
+        body = r.get_json()
+        assert body['success'] is True
+        assert body['result']['status'] == 'already_running'
+
+    def test_watchdog_error_dict_returns_500(self, client):
+        with patch(
+            'services.video_archive_service.trigger_archive_cleanup',
+            return_value={
+                'deleted_count': 0, 'freed_bytes': 0,
+                'error': 'watchdog raised: synthetic',
+            },
+        ):
+            r = client.post('/api/cleanup/run_now')
+        assert r.status_code == 500
+        body = r.get_json()
+        assert body['success'] is False
+        assert 'synthetic' in body['message']
+        assert body['result']['error'] == 'watchdog raised: synthetic'
+
+    def test_unexpected_exception_returns_500(self, client):
+        with patch(
+            'services.video_archive_service.trigger_archive_cleanup',
+            side_effect=RuntimeError("boom"),
+        ):
+            r = client.post('/api/cleanup/run_now')
+        assert r.status_code == 500
+        body = r.get_json()
+        assert body['success'] is False
+        assert 'boom' in body['message']

--- a/tests/test_storage_retention_blueprint.py
+++ b/tests/test_storage_retention_blueprint.py
@@ -179,16 +179,26 @@ class TestApiCleanupStatus:
         monkeypatch.setattr(
             'blueprints.storage_retention._disk_free_summary', lambda: {},
         )
+        # Pin the resolver so the test doesn't depend on whatever
+        # CLEANUP_DEFAULT_RETENTION_DAYS / CLOUD_ARCHIVE_RETENTION_DAYS
+        # config.py happens to load at test time.
+        monkeypatch.setattr(
+            'services.archive_watchdog._resolve_retention_days', lambda: 30,
+        )
         r = client.get('/api/cleanup/status')
         assert r.status_code == 200
         body = r.get_json()
         assert body['success'] is True
         # Defaults must be present so the form renders sensibly even on
-        # a brand-new install with no cleanup section yet.
-        assert body['config']['default_retention_days'] == 30
+        # a brand-new install with no cleanup section yet. The persisted
+        # default_retention_days is 0 ("inherit from legacy fallback")
+        # and the API surfaces the resolved value separately so the UI
+        # can show a sensible number without overwriting the customization.
+        assert body['config']['default_retention_days'] == 0
         assert body['config']['free_space_target_pct'] == 10
         assert body['config']['max_archive_size_gb'] == 0
         assert body['config']['policies'] == {}
+        assert body['resolved_retention_days'] == 30
 
     def test_drops_unknown_folder_names_from_config(self, client, monkeypatch):
         # Defense in depth: even if config.yaml gets a typo'd folder
@@ -206,6 +216,9 @@ class TestApiCleanupStatus:
         )
         monkeypatch.setattr(
             'blueprints.storage_retention._disk_free_summary', lambda: {},
+        )
+        monkeypatch.setattr(
+            'services.archive_watchdog._resolve_retention_days', lambda: 30,
         )
         r = client.get('/api/cleanup/status')
         body = r.get_json()
@@ -273,7 +286,10 @@ class TestApiCleanupPolicy:
 
     def test_garbage_payload_uses_defaults(self, client, captured_updates, monkeypatch):
         # Empty/garbage POST must still produce a sane config rather
-        # than crash. Defaults: 30 days, 10%, 0 GB cap, 7-day warning.
+        # than crash. ``default_retention_days`` falls back to 0 (=
+        # "inherit from legacy fallback chain" — the safer choice when
+        # we don't know what the user meant) instead of imposing an
+        # arbitrary 30. Other scalars fall back to their UI defaults.
         monkeypatch.setattr(
             'blueprints.storage_retention._load_config_dict',
             lambda: {'cleanup': {}},
@@ -290,7 +306,7 @@ class TestApiCleanupPolicy:
         )
         assert r.status_code == 200
         last = captured_updates['last']
-        assert last['cleanup.default_retention_days'] == 30
+        assert last['cleanup.default_retention_days'] == 0
         assert last['cleanup.free_space_target_pct'] == 10
         assert last['cleanup.max_archive_size_gb'] == 0
         assert last['cleanup.short_retention_warning_days'] == 7
@@ -321,6 +337,9 @@ class TestApiCleanupPolicy:
         # Even if a malicious client tries to seed thousands of fake
         # folder names, the endpoint only persists the allow-listed
         # ones — and at most ALLOWED_FOLDER_NAMES of them.
+        # Critically: the cap must apply AFTER the allow-list filter,
+        # not before, so legitimate entries that come after garbage
+        # ones survive (Phase 3a.2 PR #124 review fix).
         monkeypatch.setattr(
             'blueprints.storage_retention._load_config_dict',
             lambda: {'cleanup': {}},
@@ -339,6 +358,30 @@ class TestApiCleanupPolicy:
         last = captured_updates['last']
         for k in last['cleanup.policies']:
             assert k in ALLOWED_FOLDER_NAMES
+        # Both legitimate entries must have made it through the
+        # filter, even though they were inserted AFTER 1000 garbage
+        # rows in dict insertion order.
+        assert 'SentryClips' in last['cleanup.policies']
+        assert 'ArchivedClips' in last['cleanup.policies']
+        assert last['cleanup.policies']['SentryClips']['retention_days'] == 90
+        assert last['cleanup.policies']['ArchivedClips']['retention_days'] == 30
+
+    def test_default_retention_zero_is_persisted_verbatim(self, client, captured_updates, monkeypatch):
+        # Phase 3a.2 PR #124 review fix: ``0`` is a meaningful value
+        # ("inherit from legacy fallback chain"), NOT a parse failure.
+        # It must be persisted verbatim, not silently clamped up to 1.
+        monkeypatch.setattr(
+            'blueprints.storage_retention._load_config_dict',
+            lambda: {'cleanup': {}},
+        )
+        r = client.post(
+            '/api/cleanup/policy',
+            data=json.dumps({'default_retention_days': 0}),
+            content_type='application/json',
+        )
+        assert r.status_code == 200
+        last = captured_updates['last']
+        assert last['cleanup.default_retention_days'] == 0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Phase 3a.2 of the Video Pipeline Hardening epic (#97). Closes the second part of #98.

## What

Users can now manage all archive retention from the web UI without SSHing in to edit YAML.

* New unified ``cleanup`` section in ``config.yaml`` — single source of truth for retention.
* New Settings → Storage & Retention card in the main settings page with: default retention, free-space target, max archive size, per-folder overrides (collapsible), Run cleanup now button, last-run summary, short-retention warning banner.
* New blueprint ``storage_retention`` exposing ``/api/cleanup/{status,policy,run_now}`` (JSON-only).
* One-shot migration of legacy ``cleanup_config.json`` into the new section on service start (idempotent, never raises).
* ``archive_watchdog._resolve_retention_days()`` now reads from the new section first with a documented fallback chain — zero behavior change for existing installs.

## Why

Phase 3a.2 of #98. Forcing every retention change through SSH was unacceptable for a polished product. The new card surfaces every retention-related setting in one place; the unified config eliminates the chance of two configs disagreeing.

## How

* Backward compat: ``_resolve_retention_days()`` falls back to ``cloud_archive.archived_clips_retention_days`` and ``archive.retention_days`` if the new section is empty. Existing installs that never visit the new card see zero behavior change.
* Migration is idempotent: if ``cleanup.policies`` is already populated (user has used the new UI), the legacy file is renamed but never imported. So a downgrade-then-upgrade cycle can't overwrite UI edits.
* Input clamping is the security boundary: ``_coerce_int`` and ``_coerce_bool`` are unit-tested in isolation; the policy POST silently drops typo'd folder names so config.yaml can't be bloated by malicious payloads.
* HTTP contract for ``/api/cleanup/run_now`` mirrors the Phase 3a.1 fix to ``/cloud/api/archive_cleanup``: 200 on success, 200 on ``status='already_running'``, 500 on watchdog error.

## Tests

**1019 passed (was 969; +50 new tests)**:
* ``TestResolveRetentionDays`` (6) — fallback chain
* ``TestCoerceInt`` / ``TestCoerceBool`` (15) — input clamping
* ``TestApiCleanupStatus`` (3) — snapshot shape, missing section, drop unknowns
* ``TestApiCleanupPolicy`` (5) — JSON/form, garbage→defaults, writer-failure 500, row cap
* ``TestApiCleanupRunNow`` (4) — mirrors Phase 3a.1 HTTP contract
* ``TestLegacyMigration`` (8) — every migration branch

## Out of scope (deferred per issue #98 plan)

* Wiring ``free_space_target_pct`` and ``max_archive_size_gb`` into the watchdog's prune logic. Values are persisted, surfaced in the UI, ready for Phase 5 (Performance Polish) to consume.
* Phase 3a.3 (24h on-device verification gate) — explicit follow-up per workflow contract.

## Files

* ``config.yaml`` — new ``cleanup`` section (additive, all defaults)
* ``scripts/web/config.py`` — new ``CLEANUP_*`` constants
* ``scripts/web/services/archive_watchdog.py`` — extend ``_resolve_retention_days``
* ``scripts/web/services/cleanup_service.py`` — add ``migrate_legacy_cleanup_config``
* ``scripts/web/blueprints/storage_retention.py`` (NEW) — three JSON endpoints
* ``scripts/web/blueprints/__init__.py`` — export new blueprint
* ``scripts/web/web_control.py`` — register blueprint, run migration on start
* ``scripts/web/templates/index.html`` — Storage & Retention card + JS controller
* ``tests/test_archive_watchdog.py`` — ``TestResolveRetentionDays`` (6 tests)
* ``tests/test_storage_retention_blueprint.py`` (NEW) — 27 tests
* ``tests/test_cleanup_legacy_migration.py`` (NEW) — 8 tests

Closes (in part) #98.
