### PR TITLE
Phase 4.2: System Health card on Settings (#101)

### DIFF
--- a/scripts/web/blueprints/__init__.py
+++ b/scripts/web/blueprints/__init__.py
@@ -20,6 +20,7 @@ from .live_events import live_events_bp
 from .archive_queue import archive_queue_bp
 from .storage_retention import storage_retention_bp
 from .jobs import jobs_bp
+from .system_health import system_health_bp
 
 __all__ = [
     'mode_control_bp',
@@ -43,4 +44,5 @@ __all__ = [
     'archive_queue_bp',
     'storage_retention_bp',
     'jobs_bp',
+    'system_health_bp',
 ]

--- a/scripts/web/blueprints/system_health.py
+++ b/scripts/web/blueprints/system_health.py
@@ -38,11 +38,9 @@ from flask import Blueprint, jsonify
 
 from config import (
     ARCHIVE_QUEUE_ENABLED,
-    CLOUD_ARCHIVE_DB_PATH,
     CLOUD_ARCHIVE_ENABLED,
     GADGET_DIR,
     LIVE_EVENT_SYNC_ENABLED,
-    MAPPING_DB_PATH,
     MAPPING_ENABLED,
 )
 
@@ -65,7 +63,6 @@ SEV_UNKNOWN = 'unknown'
 # disabled — but it should outrank a healthy ``ok`` so the dot still
 # turns amber when something is silently broken.
 _SEV_RANK = {SEV_OK: 0, SEV_UNKNOWN: 1, SEV_WARN: 2, SEV_ERROR: 3}
-_SEV_BY_RANK = {v: k for k, v in _SEV_RANK.items()}
 
 
 # ---------------------------------------------------------------------------
@@ -75,6 +72,12 @@ _SEV_BY_RANK = {v: k for k, v in _SEV_RANK.items()}
 _SHELL_PROBE_TTL_SECONDS = 30.0
 _probe_cache: Dict[str, Tuple[float, Any]] = {}
 _probe_lock = threading.Lock()
+# Per-name in-flight locks: a concurrent cold-cache burst on the same
+# probe name (e.g. two visibility-change events landing simultaneously)
+# would otherwise double-spawn ``nmcli``/``sudo bash`` because we drop
+# the global lock around ``fn()``. The per-name lock serialises probes
+# of the same name without blocking unrelated probes.
+_probe_inflight: Dict[str, threading.Lock] = {}
 
 
 def _cached_probe(name: str, fn: Callable[[], Any]) -> Any:
@@ -83,20 +86,34 @@ def _cached_probe(name: str, fn: Callable[[], Any]) -> Any:
     Also recovers from probe failure: on exception we cache the error
     string for the same TTL so a misbehaving subprocess can't flood
     the page with retries.
+
+    Concurrency: per-probe-name in-flight lock guarantees only one
+    ``fn()`` invocation per name regardless of caller count, so a cold
+    cache burst cannot stack subprocesses.
     """
     now = time.time()
     with _probe_lock:
         cached = _probe_cache.get(name)
         if cached and now - cached[0] < _SHELL_PROBE_TTL_SECONDS:
             return cached[1]
-    try:
-        value = fn()
-    except Exception as e:  # noqa: BLE001
-        logger.warning("system_health probe %s failed: %s", name, e)
-        value = {'_error': str(e)[:120]}
-    with _probe_lock:
-        _probe_cache[name] = (now, value)
-    return value
+        inflight = _probe_inflight.setdefault(name, threading.Lock())
+
+    with inflight:
+        # Re-check cache after acquiring per-name lock — another caller
+        # may have just populated it while we waited.
+        now = time.time()
+        with _probe_lock:
+            cached = _probe_cache.get(name)
+            if cached and now - cached[0] < _SHELL_PROBE_TTL_SECONDS:
+                return cached[1]
+        try:
+            value = fn()
+        except Exception as e:  # noqa: BLE001
+            logger.warning("system_health probe %s failed: %s", name, e)
+            value = {'_error': str(e)[:120]}
+        with _probe_lock:
+            _probe_cache[name] = (time.time(), value)
+        return value
 
 
 # ---------------------------------------------------------------------------
@@ -380,7 +397,7 @@ def _wifi_block() -> Dict[str, Any]:
         }
 
     connected = bool(sta.get('connected'))
-    ssid = sta.get('current_ssid')
+    ssid = sta.get('current_ssid') or 'Unknown'
     signal_raw = sta.get('signal')
     try:
         signal_pct = int(signal_raw) if signal_raw not in (None, '', 'Unknown') else None

--- a/scripts/web/blueprints/system_health.py
+++ b/scripts/web/blueprints/system_health.py
@@ -1,0 +1,486 @@
+"""System Health endpoint — single-poll snapshot for the Settings card.
+
+Phase 4.2 (issue #101) collapses every background-subsystem status feed
+into one cheap JSON payload so the at-a-glance card on Settings (and the
+nav-bar status dot in Phase 4.8) can render with a single HTTP request.
+
+Design rules
+------------
+* **Cheap.** No subprocesses on the hot path. WiFi/AP probes spawn
+  ``nmcli``/``sudo bash`` and take ~50–200 ms each — they get a 30 s
+  TTL cache so the 5 s poll loop the dot will use cannot pin a CPU
+  core. Every other subsystem already has an in-memory snapshot
+  helper; we just call those.
+* **Fault-tolerant.** Any subsystem that raises is reported as
+  ``severity: "unknown"`` with a one-line error; the page always
+  renders. One bad SQLite DB cannot make the rest of the dashboard
+  500.
+* **Stable shape.** Every subsystem block has ``severity`` (``ok`` /
+  ``warn`` / ``error`` / ``unknown``) and ``message`` (≤ 80 chars,
+  user-friendly). The dot can colour itself purely from ``severity``;
+  the card can render the message verbatim.
+* **No identifier disclosure.** ``message`` strings are short
+  user-facing labels — they MUST NOT contain absolute paths, rclone
+  bucket names, or other identifiers an LAN/AP guest doesn't need.
+  This mirrors the redaction contract from the Failed Jobs page.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import threading
+import time
+from typing import Any, Callable, Dict, Tuple
+
+from flask import Blueprint, jsonify
+
+from config import (
+    ARCHIVE_QUEUE_ENABLED,
+    CLOUD_ARCHIVE_DB_PATH,
+    CLOUD_ARCHIVE_ENABLED,
+    GADGET_DIR,
+    LIVE_EVENT_SYNC_ENABLED,
+    MAPPING_DB_PATH,
+    MAPPING_ENABLED,
+)
+
+logger = logging.getLogger(__name__)
+
+system_health_bp = Blueprint('system_health', __name__)
+
+
+# ---------------------------------------------------------------------------
+# Severity vocabulary
+# ---------------------------------------------------------------------------
+
+SEV_OK = 'ok'
+SEV_WARN = 'warn'
+SEV_ERROR = 'error'
+SEV_UNKNOWN = 'unknown'
+
+# Ranking used for the rolled-up ``overall`` block. A subsystem in
+# ``unknown`` is not as bad as an ``error`` — the worker may simply be
+# disabled — but it should outrank a healthy ``ok`` so the dot still
+# turns amber when something is silently broken.
+_SEV_RANK = {SEV_OK: 0, SEV_UNKNOWN: 1, SEV_WARN: 2, SEV_ERROR: 3}
+_SEV_BY_RANK = {v: k for k, v in _SEV_RANK.items()}
+
+
+# ---------------------------------------------------------------------------
+# 30 s TTL cache for shell-out probes (WiFi / AP)
+# ---------------------------------------------------------------------------
+
+_SHELL_PROBE_TTL_SECONDS = 30.0
+_probe_cache: Dict[str, Tuple[float, Any]] = {}
+_probe_lock = threading.Lock()
+
+
+def _cached_probe(name: str, fn: Callable[[], Any]) -> Any:
+    """Return ``fn()`` cached for :data:`_SHELL_PROBE_TTL_SECONDS`.
+
+    Also recovers from probe failure: on exception we cache the error
+    string for the same TTL so a misbehaving subprocess can't flood
+    the page with retries.
+    """
+    now = time.time()
+    with _probe_lock:
+        cached = _probe_cache.get(name)
+        if cached and now - cached[0] < _SHELL_PROBE_TTL_SECONDS:
+            return cached[1]
+    try:
+        value = fn()
+    except Exception as e:  # noqa: BLE001
+        logger.warning("system_health probe %s failed: %s", name, e)
+        value = {'_error': str(e)[:120]}
+    with _probe_lock:
+        _probe_cache[name] = (now, value)
+    return value
+
+
+# ---------------------------------------------------------------------------
+# Per-subsystem snapshots
+# ---------------------------------------------------------------------------
+
+def _indexer_block() -> Dict[str, Any]:
+    """Indexer worker liveness + queue depth."""
+    if not MAPPING_ENABLED:
+        return {
+            'severity': SEV_UNKNOWN,
+            'message': 'Indexing disabled in config',
+            'enabled': False,
+            'queue_depth': 0,
+            'worker_running': False,
+        }
+    try:
+        from services import indexing_worker  # type: ignore
+        snap = indexing_worker.get_worker_status() or {}
+    except Exception as e:  # noqa: BLE001
+        return {
+            'severity': SEV_UNKNOWN,
+            'message': 'Status fetch failed',
+            'enabled': True,
+            'queue_depth': 0,
+            'worker_running': False,
+            '_error': str(e)[:120],
+        }
+
+    running = bool(snap.get('worker_running'))
+    queue_depth = int(snap.get('queue_depth') or 0)
+    dead = int(snap.get('dead_letter_count') or 0)
+
+    if not running:
+        sev = SEV_ERROR
+        msg = 'Worker not running'
+    elif dead > 0:
+        sev = SEV_WARN
+        msg = f'{dead} dead-letter row{"s" if dead != 1 else ""}'
+    elif queue_depth > 100:
+        sev = SEV_WARN
+        msg = f'{queue_depth} queued (catch-up)'
+    else:
+        sev = SEV_OK
+        msg = (f'{queue_depth} queued'
+               if queue_depth else 'Idle, queue empty')
+
+    return {
+        'severity': sev,
+        'message': msg,
+        'enabled': True,
+        'worker_running': running,
+        'queue_depth': queue_depth,
+        'dead_letter_count': dead,
+        'active': bool(snap.get('active_file')),
+    }
+
+
+def _archive_block() -> Dict[str, Any]:
+    """Archive watchdog + worker status."""
+    if not ARCHIVE_QUEUE_ENABLED:
+        return {
+            'severity': SEV_UNKNOWN,
+            'message': 'Archive queue disabled',
+            'enabled': False,
+            'paused': False,
+            'queue_depth': 0,
+        }
+    try:
+        from services import archive_queue, archive_watchdog, archive_worker
+        watchdog = archive_watchdog.get_status() or {}
+        worker = archive_worker.get_status() or {}
+        counts = archive_queue.get_queue_status() or {}
+    except Exception as e:  # noqa: BLE001
+        return {
+            'severity': SEV_UNKNOWN,
+            'message': 'Status fetch failed',
+            'enabled': True,
+            'paused': False,
+            'queue_depth': 0,
+            '_error': str(e)[:120],
+        }
+
+    paused = bool(worker.get('paused'))
+    running = bool(worker.get('worker_running'))
+    pending = int(counts.get('pending', 0))
+    dead = int(counts.get('dead_letter', 0))
+
+    # Watchdog severity is the single source of truth for "should the
+    # operator be alarmed". We translate its 4-level ladder into the
+    # health card's 4-level vocabulary 1:1.
+    wd_sev = (watchdog.get('severity') or 'ok').lower()
+    if wd_sev not in (SEV_OK, SEV_WARN, SEV_ERROR):
+        wd_sev = SEV_UNKNOWN
+
+    if not running:
+        sev = SEV_ERROR
+        msg = 'Worker not running'
+    elif wd_sev == SEV_ERROR:
+        sev = SEV_ERROR
+        msg = (watchdog.get('message') or 'Watchdog error')[:80]
+    elif dead > 0:
+        sev = SEV_WARN
+        msg = f'{dead} dead-letter row{"s" if dead != 1 else ""}'
+    elif paused:
+        sev = SEV_WARN
+        msg = 'Paused (load or disk)'
+    elif wd_sev == SEV_WARN:
+        sev = SEV_WARN
+        msg = (watchdog.get('message') or 'Watchdog warn')[:80]
+    elif pending > 200:
+        sev = SEV_WARN
+        msg = f'{pending} pending (catch-up)'
+    else:
+        sev = SEV_OK
+        msg = (f'{pending} pending'
+               if pending else 'Idle, queue empty')
+
+    return {
+        'severity': sev,
+        'message': msg,
+        'enabled': True,
+        'worker_running': running,
+        'paused': paused,
+        'queue_depth': pending,
+        'dead_letter_count': dead,
+    }
+
+
+def _cloud_block() -> Dict[str, Any]:
+    """Cloud archive worker status + queue counts."""
+    if not CLOUD_ARCHIVE_ENABLED:
+        return {
+            'severity': SEV_UNKNOWN,
+            'message': 'Cloud archive disabled',
+            'enabled': False,
+            'queue_depth': 0,
+        }
+    try:
+        from services.cloud_archive_service import (
+            count_dead_letters, get_sync_status,
+        )
+        sync = get_sync_status() or {}
+        dead = int(count_dead_letters() or 0)
+    except Exception as e:  # noqa: BLE001
+        return {
+            'severity': SEV_UNKNOWN,
+            'message': 'Status fetch failed',
+            'enabled': True,
+            'queue_depth': 0,
+            '_error': str(e)[:120],
+        }
+
+    running = bool(sync.get('running'))
+    pending = int(sync.get('files_total', 0)) - int(sync.get('files_done', 0))
+    if pending < 0:
+        pending = 0
+
+    if dead > 0:
+        sev = SEV_WARN
+        msg = f'{dead} dead-letter row{"s" if dead != 1 else ""}'
+    elif running:
+        sev = SEV_OK
+        msg = (f'Uploading ({pending} pending)'
+               if pending else 'Uploading')
+    elif pending > 0:
+        sev = SEV_OK
+        msg = f'{pending} queued for next WiFi'
+    else:
+        sev = SEV_OK
+        msg = 'Idle, queue empty'
+
+    return {
+        'severity': sev,
+        'message': msg,
+        'enabled': True,
+        'running': running,
+        'queue_depth': pending,
+        'dead_letter_count': dead,
+        'last_sync_at': sync.get('last_completed_at'),
+    }
+
+
+def _les_block() -> Dict[str, Any]:
+    """Live Event Sync status."""
+    if not LIVE_EVENT_SYNC_ENABLED:
+        return {
+            'severity': SEV_UNKNOWN,
+            'message': 'LES disabled in config',
+            'enabled': False,
+            'queue_depth': 0,
+        }
+    try:
+        from services.live_event_sync_service import (
+            count_failed, get_status,
+        )
+        snap = get_status() or {}
+        failed = int(count_failed() or 0)
+    except Exception as e:  # noqa: BLE001
+        return {
+            'severity': SEV_UNKNOWN,
+            'message': 'Status fetch failed',
+            'enabled': True,
+            'queue_depth': 0,
+            '_error': str(e)[:120],
+        }
+
+    counts = snap.get('queue_counts') or {}
+    pending = int(counts.get('pending', 0)) + int(counts.get('uploading', 0))
+    running = bool(snap.get('worker_running'))
+
+    if failed > 0:
+        sev = SEV_WARN
+        msg = f'{failed} failed event{"s" if failed != 1 else ""}'
+    elif not running:
+        sev = SEV_WARN
+        msg = 'Worker idle'
+    elif pending > 0:
+        sev = SEV_OK
+        msg = f'{pending} pending'
+    else:
+        sev = SEV_OK
+        msg = 'Idle, queue empty'
+
+    return {
+        'severity': sev,
+        'message': msg,
+        'enabled': True,
+        'worker_running': running,
+        'queue_depth': pending,
+        'failed_count': failed,
+        'last_uploaded_at': snap.get('last_uploaded_at'),
+    }
+
+
+def _disk_block() -> Dict[str, Any]:
+    """SD card free space (the home-directory filesystem)."""
+    target = GADGET_DIR or '/home/pi'
+    try:
+        usage = shutil.disk_usage(target)
+    except OSError as e:
+        return {
+            'severity': SEV_UNKNOWN,
+            'message': 'Disk usage probe failed',
+            '_error': str(e)[:120],
+        }
+
+    total_gb = usage.total / (1024 ** 3)
+    free_gb = usage.free / (1024 ** 3)
+    used_pct = (usage.used / usage.total) * 100 if usage.total else 0.0
+
+    if used_pct >= 95:
+        sev = SEV_ERROR
+        msg = f'Critical: {used_pct:.1f}% full'
+    elif used_pct >= 85:
+        sev = SEV_WARN
+        msg = f'{used_pct:.1f}% full'
+    else:
+        sev = SEV_OK
+        msg = f'{free_gb:.1f} GB free'
+
+    return {
+        'severity': sev,
+        'message': msg,
+        'used_pct': round(used_pct, 1),
+        'free_gb': round(free_gb, 2),
+        'total_gb': round(total_gb, 2),
+    }
+
+
+def _wifi_block() -> Dict[str, Any]:
+    """STA WiFi state + AP active flag (cached for 30 s)."""
+    sta = _cached_probe('wifi_sta', _probe_wifi_sta)
+    ap = _cached_probe('wifi_ap', _probe_wifi_ap)
+
+    if isinstance(sta, dict) and sta.get('_error'):
+        return {
+            'severity': SEV_UNKNOWN,
+            'message': 'WiFi probe failed',
+            '_error': sta['_error'],
+        }
+
+    connected = bool(sta.get('connected'))
+    ssid = sta.get('current_ssid')
+    signal_raw = sta.get('signal')
+    try:
+        signal_pct = int(signal_raw) if signal_raw not in (None, '', 'Unknown') else None
+    except (TypeError, ValueError):
+        signal_pct = None
+
+    ap_active = bool((ap or {}).get('ap_active'))
+
+    if connected:
+        if signal_pct is not None and signal_pct < 30:
+            sev = SEV_WARN
+            msg = f'{ssid} (weak: {signal_pct}%)'
+        else:
+            sev = SEV_OK
+            sig_text = f' {signal_pct}%' if signal_pct is not None else ''
+            msg = f'{ssid}{sig_text}'
+    elif ap_active:
+        sev = SEV_WARN
+        msg = 'STA offline — AP active'
+    else:
+        sev = SEV_ERROR
+        msg = 'No WiFi'
+
+    return {
+        'severity': sev,
+        'message': msg,
+        'connected': connected,
+        'ssid': ssid,
+        'signal': signal_pct,
+        'ap_active': ap_active,
+    }
+
+
+def _probe_wifi_sta() -> Dict[str, Any]:
+    from services.wifi_service import get_current_wifi_connection
+    return get_current_wifi_connection() or {}
+
+
+def _probe_wifi_ap() -> Dict[str, Any]:
+    from services.ap_service import ap_status
+    return ap_status() or {}
+
+
+# ---------------------------------------------------------------------------
+# Aggregator + route
+# ---------------------------------------------------------------------------
+
+_BLOCKS: Tuple[Tuple[str, Callable[[], Dict[str, Any]]], ...] = (
+    ('indexer', _indexer_block),
+    ('archive', _archive_block),
+    ('cloud', _cloud_block),
+    ('live_event_sync', _les_block),
+    ('disk', _disk_block),
+    ('wifi', _wifi_block),
+)
+
+
+def _build_health() -> Dict[str, Any]:
+    """Compose the full payload, isolating per-subsystem crashes."""
+    payload: Dict[str, Any] = {}
+    worst = SEV_OK
+    worst_msg = ''
+    worst_subsystem = None
+
+    for name, fn in _BLOCKS:
+        try:
+            block = fn()
+        except Exception as e:  # noqa: BLE001 — never let one block 500 the page
+            logger.exception("system_health: %s block crashed", name)
+            block = {
+                'severity': SEV_UNKNOWN,
+                'message': 'Block error',
+                '_error': str(e)[:120],
+            }
+        payload[name] = block
+
+        sev = block.get('severity', SEV_UNKNOWN)
+        if _SEV_RANK.get(sev, 0) > _SEV_RANK.get(worst, 0):
+            worst = sev
+            worst_msg = block.get('message', '')
+            worst_subsystem = name
+
+    payload['overall'] = {
+        'severity': worst,
+        'message': (
+            f'{worst_subsystem}: {worst_msg}'
+            if worst != SEV_OK and worst_subsystem else 'All systems normal'
+        ),
+        'subsystem': worst_subsystem,
+    }
+    payload['generated_at'] = int(time.time())
+    return payload
+
+
+@system_health_bp.route('/api/system/health', methods=['GET'])
+def api_system_health():
+    """Return one JSON snapshot of every background subsystem.
+
+    Used by the Settings system-health card and (Phase 4.8) the
+    nav-bar status dot. Both poll on a fixed interval, so this
+    endpoint MUST stay sub-100 ms in the cached path.
+    """
+    return jsonify(_build_health())

--- a/scripts/web/templates/index.html
+++ b/scripts/web/templates/index.html
@@ -57,6 +57,49 @@
     </div>
     {% endif %}
 
+    <!-- System Health (Phase 4.2 — issue #101) -->
+    <details class="settings-section" id="system-health-section" open>
+        <summary>System Health</summary>
+        <div class="section-content">
+            <div id="system-health-card"
+                 data-poll-url="{{ url_for('system_health.api_system_health') }}"
+                 data-jobs-url="{{ url_for('jobs.failed_jobs_page') }}"
+                 style="display:flex; flex-direction:column; gap:6px;">
+                <p id="system-health-overall"
+                   style="margin:0 0 6px; padding:8px 12px;
+                          border-radius:8px; font-size:0.95rem;
+                          display:flex; align-items:center; gap:8px;
+                          background:var(--bg-secondary);
+                          border:1px solid var(--border-color);">
+                    <span class="health-dot health-dot-unknown"
+                          aria-hidden="true"
+                          style="width:10px; height:10px; border-radius:50%;
+                                 display:inline-block; flex-shrink:0;
+                                 background:var(--text-secondary);"></span>
+                    <span id="system-health-overall-text">
+                        Loading…
+                    </span>
+                </p>
+                <div id="system-health-rows"
+                     style="display:grid;
+                            grid-template-columns:auto auto 1fr;
+                            gap:6px 12px; align-items:center;
+                            font-size:0.9rem;">
+                    <!-- Rows rendered by JS from /api/system/health -->
+                </div>
+                <p id="system-health-error" hidden
+                   style="font-size:0.85rem; color:var(--msg-error-text);
+                          margin:6px 0 0;">
+                    System Health probe failed —
+                    <button type="button" class="btn btn-ghost"
+                            id="system-health-retry-btn"
+                            style="padding:2px 6px; min-height:0;
+                                   font-size:0.85rem;">retry</button>
+                </p>
+            </div>
+        </div>
+    </details>
+
     <!-- WiFi Networks -->
     <details class="settings-section" open>
         <summary>WiFi Networks</summary>
@@ -1628,6 +1671,126 @@ if (document.getElementById('fsck-status-container')) {
     } else {
         startPolling();
     }
+})();
+
+// ---------------------------------------------------------------------------
+// System Health card (Phase 4.2 — issue #101)
+// ---------------------------------------------------------------------------
+(function() {
+    var card = document.getElementById('system-health-card');
+    if (!card) return;
+    var pollUrl = card.getAttribute('data-poll-url');
+    var jobsUrl = card.getAttribute('data-jobs-url');
+    var POLL_MS = 15000;  // 15 s — far below the cached probe TTL
+    var rowsBox = document.getElementById('system-health-rows');
+    var overallText = document.getElementById('system-health-overall-text');
+    var overallEl = document.getElementById('system-health-overall');
+    var errorEl = document.getElementById('system-health-error');
+    var retryBtn = document.getElementById('system-health-retry-btn');
+    var pollHandle = null;
+
+    var SUBSYSTEMS = [
+        { key: 'indexer',         label: 'Video Indexer' },
+        { key: 'archive',         label: 'Local Archive' },
+        { key: 'cloud',           label: 'Cloud Sync' },
+        { key: 'live_event_sync', label: 'Live Event Sync' },
+        { key: 'disk',            label: 'SD Card' },
+        { key: 'wifi',            label: 'WiFi' },
+    ];
+
+    var SEV_COLORS = {
+        ok:      'var(--accent-success, #4caf50)',
+        warn:    'var(--accent-warning, #ff9800)',
+        error:   'var(--accent-error,   #f44336)',
+        unknown: 'var(--text-secondary, #888)',
+    };
+
+    function escapeText(s) {
+        if (s == null) return '';
+        return String(s)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;');
+    }
+
+    function dotMarkup(severity) {
+        var color = SEV_COLORS[severity] || SEV_COLORS.unknown;
+        return '<span aria-label="' + escapeText(severity) + '" ' +
+               'style="width:10px; height:10px; border-radius:50%; ' +
+               'display:inline-block; flex-shrink:0; background:' + color +
+               ';"></span>';
+    }
+
+    function renderRows(payload) {
+        var html = '';
+        for (var i = 0; i < SUBSYSTEMS.length; i++) {
+            var sub = SUBSYSTEMS[i];
+            var block = payload[sub.key] || {};
+            var sev = block.severity || 'unknown';
+            var msg = escapeText(block.message || '\u2014');
+            html += '<div>' + dotMarkup(sev) + '</div>';
+            html += '<div style="color:var(--text-primary)">' +
+                    escapeText(sub.label) + '</div>';
+            html += '<div style="color:var(--text-secondary); ' +
+                    'overflow:hidden; text-overflow:ellipsis; ' +
+                    'white-space:nowrap;">' + msg + '</div>';
+        }
+        rowsBox.innerHTML = html;
+    }
+
+    function renderOverall(payload) {
+        var overall = payload.overall || { severity: 'unknown',
+                                            message: 'Unknown' };
+        var sev = overall.severity || 'unknown';
+        var color = SEV_COLORS[sev] || SEV_COLORS.unknown;
+        overallEl.querySelector('.health-dot').style.background = color;
+        overallText.textContent = overall.message || 'Unknown';
+        if (sev !== 'ok' && jobsUrl &&
+                !overallEl.classList.contains('linked')) {
+            overallEl.style.cursor = 'pointer';
+            overallEl.classList.add('linked');
+            overallEl.addEventListener('click', function() {
+                window.location.href = jobsUrl;
+            });
+        }
+    }
+
+    function loadHealth() {
+        fetch(pollUrl, { cache: 'no-store' })
+            .then(function(r) {
+                if (!r.ok) throw new Error('HTTP ' + r.status);
+                return r.json();
+            })
+            .then(function(payload) {
+                errorEl.hidden = true;
+                renderRows(payload);
+                renderOverall(payload);
+            })
+            .catch(function(e) {
+                console.warn('system_health load failed:', e);
+                errorEl.hidden = false;
+            });
+    }
+
+    function startPoll() {
+        if (pollHandle) return;
+        loadHealth();
+        pollHandle = setInterval(loadHealth, POLL_MS);
+    }
+
+    function stopPoll() {
+        if (pollHandle) clearInterval(pollHandle);
+        pollHandle = null;
+    }
+
+    if (retryBtn) retryBtn.addEventListener('click', loadHealth);
+
+    document.addEventListener('visibilitychange', function() {
+        if (document.hidden) stopPoll();
+        else startPoll();
+    });
+
+    if (!document.hidden) startPoll();
 })();
 </script>
 {% endblock %}

--- a/scripts/web/templates/index.html
+++ b/scripts/web/templates/index.html
@@ -93,8 +93,10 @@
                     System Health probe failed —
                     <button type="button" class="btn btn-ghost"
                             id="system-health-retry-btn"
-                            style="padding:2px 6px; min-height:0;
-                                   font-size:0.85rem;">retry</button>
+                            aria-label="Retry system health probe"
+                            style="min-height:44px; min-width:44px;
+                                   padding:0 14px; margin-left:6px;
+                                   font-size:0.9rem;">Retry</button>
                 </p>
             </div>
         </div>
@@ -1738,6 +1740,10 @@ if (document.getElementById('fsck-status-container')) {
         rowsBox.innerHTML = html;
     }
 
+    function jumpToJobs() {
+        if (jobsUrl) window.location.href = jobsUrl;
+    }
+
     function renderOverall(payload) {
         var overall = payload.overall || { severity: 'unknown',
                                             message: 'Unknown' };
@@ -1745,13 +1751,19 @@ if (document.getElementById('fsck-status-container')) {
         var color = SEV_COLORS[sev] || SEV_COLORS.unknown;
         overallEl.querySelector('.health-dot').style.background = color;
         overallText.textContent = overall.message || 'Unknown';
-        if (sev !== 'ok' && jobsUrl &&
-                !overallEl.classList.contains('linked')) {
+        // Toggle the click affordance to track the current severity —
+        // a system that recovers to 'ok' must shed both the listener
+        // and the pointer cursor, otherwise it still looks clickable.
+        var shouldLink = sev !== 'ok' && !!jobsUrl;
+        var isLinked = overallEl.classList.contains('linked');
+        if (shouldLink && !isLinked) {
             overallEl.style.cursor = 'pointer';
             overallEl.classList.add('linked');
-            overallEl.addEventListener('click', function() {
-                window.location.href = jobsUrl;
-            });
+            overallEl.addEventListener('click', jumpToJobs);
+        } else if (!shouldLink && isLinked) {
+            overallEl.style.cursor = '';
+            overallEl.classList.remove('linked');
+            overallEl.removeEventListener('click', jumpToJobs);
         }
     }
 

--- a/scripts/web/web_control.py
+++ b/scripts/web/web_control.py
@@ -57,6 +57,7 @@ from blueprints import (
     archive_queue_bp,
     storage_retention_bp,
     jobs_bp,
+    system_health_bp,
 )
 
 app.register_blueprint(mapping_bp)
@@ -78,6 +79,7 @@ app.register_blueprint(live_events_bp)
 app.register_blueprint(archive_queue_bp)
 app.register_blueprint(storage_retention_bp)
 app.register_blueprint(jobs_bp)
+app.register_blueprint(system_health_bp)
 # Register captive portal blueprint LAST to avoid conflicting with other routes
 app.register_blueprint(captive_portal_bp)
 

--- a/tests/test_system_health_blueprint.py
+++ b/tests/test_system_health_blueprint.py
@@ -1,0 +1,510 @@
+"""Tests for Phase 4.2 — System Health endpoint (#101).
+
+Verifies:
+
+* Per-subsystem snapshot helpers (``_indexer_block``, ``_archive_block``,
+  ``_cloud_block``, ``_les_block``, ``_disk_block``, ``_wifi_block``)
+  produce stable severity + message under healthy, warning, error,
+  disabled, and crashing conditions.
+* The aggregator (``_build_health``) isolates per-subsystem crashes —
+  one bad block must not 500 the page.
+* ``/api/system/health`` returns a well-formed payload with the
+  expected keys and a single ``overall`` rollup.
+* The 30 s probe cache returns the cached value on a second call
+  within the TTL and refetches after the TTL expires (verified by
+  patching ``time.time``).
+* ``overall.severity`` reflects the worst severity across blocks
+  using the documented ``ok < unknown < warn < error`` ranking.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import Any, Dict
+from unittest.mock import patch
+
+import pytest
+
+# Make sure ``scripts/web`` is on sys.path for the tests to import the
+# blueprint module (the suite already does this for other blueprints,
+# but we add it here defensively in case this test file is run alone).
+_WEB_DIR = os.path.join(
+    os.path.dirname(__file__), '..', 'scripts', 'web',
+)
+if _WEB_DIR not in sys.path:
+    sys.path.insert(0, _WEB_DIR)
+
+
+# ---------------------------------------------------------------------------
+# _build_health + crash isolation
+# ---------------------------------------------------------------------------
+
+def test_build_health_returns_all_subsystems():
+    from blueprints.system_health import _build_health
+    payload = _build_health()
+    for key in ('indexer', 'archive', 'cloud', 'live_event_sync',
+                'disk', 'wifi', 'overall', 'generated_at'):
+        assert key in payload, f"missing key: {key}"
+    # Each block must declare a severity.
+    for key in ('indexer', 'archive', 'cloud', 'live_event_sync',
+                'disk', 'wifi'):
+        assert payload[key].get('severity') in (
+            'ok', 'warn', 'error', 'unknown'
+        ), f"{key} has invalid severity: {payload[key].get('severity')}"
+
+
+def test_build_health_isolates_crashing_block(monkeypatch):
+    """One subsystem raising must not break the rest of the dashboard."""
+    import blueprints.system_health as sh
+
+    def boom():
+        raise RuntimeError("kaboom")
+
+    new_blocks = tuple(
+        (name, boom if name == 'indexer' else fn)
+        for name, fn in sh._BLOCKS
+    )
+    monkeypatch.setattr(sh, '_BLOCKS', new_blocks)
+
+    payload = sh._build_health()
+    assert payload['indexer']['severity'] == 'unknown'
+    assert payload['indexer'].get('_error', '').startswith('kaboom')
+    # Other blocks still reported.
+    for key in ('archive', 'cloud', 'live_event_sync', 'disk', 'wifi'):
+        assert key in payload
+
+
+def test_overall_severity_ranking(monkeypatch):
+    """overall == worst across blocks using ok < unknown < warn < error."""
+    import blueprints.system_health as sh
+
+    def block_ok():    return {'severity': 'ok',    'message': 'fine'}
+    def block_warn():  return {'severity': 'warn',  'message': 'meh'}
+    def block_err():   return {'severity': 'error', 'message': 'bad'}
+    def block_unk():   return {'severity': 'unknown', 'message': 'shrug'}
+
+    monkeypatch.setattr(sh, '_BLOCKS', (
+        ('a', block_ok), ('b', block_warn), ('c', block_unk),
+    ))
+    out = sh._build_health()
+    assert out['overall']['severity'] == 'warn'
+    assert out['overall']['subsystem'] == 'b'
+
+    monkeypatch.setattr(sh, '_BLOCKS', (
+        ('a', block_ok), ('b', block_warn), ('c', block_err),
+    ))
+    out = sh._build_health()
+    assert out['overall']['severity'] == 'error'
+    assert out['overall']['subsystem'] == 'c'
+
+    monkeypatch.setattr(sh, '_BLOCKS', (
+        ('a', block_ok), ('b', block_unk),
+    ))
+    out = sh._build_health()
+    assert out['overall']['severity'] == 'unknown'
+
+    monkeypatch.setattr(sh, '_BLOCKS', (
+        ('a', block_ok),
+    ))
+    out = sh._build_health()
+    assert out['overall']['severity'] == 'ok'
+    assert out['overall']['message'] == 'All systems normal'
+
+
+# ---------------------------------------------------------------------------
+# Probe cache
+# ---------------------------------------------------------------------------
+
+def test_probe_cache_returns_cached_value(monkeypatch):
+    import blueprints.system_health as sh
+
+    # Reset cache for this test.
+    sh._probe_cache.clear()
+
+    calls = {'n': 0}
+    def slow_probe():
+        calls['n'] += 1
+        return {'value': calls['n']}
+
+    fake_now = [1000.0]
+    monkeypatch.setattr(sh.time, 'time', lambda: fake_now[0])
+
+    a = sh._cached_probe('test', slow_probe)
+    assert a == {'value': 1}
+    assert calls['n'] == 1
+
+    # Second call within TTL should hit cache.
+    fake_now[0] = 1010.0
+    b = sh._cached_probe('test', slow_probe)
+    assert b == {'value': 1}
+    assert calls['n'] == 1
+
+    # After TTL expires, refetch.
+    fake_now[0] = 1031.0
+    c = sh._cached_probe('test', slow_probe)
+    assert c == {'value': 2}
+    assert calls['n'] == 2
+
+
+def test_probe_cache_caches_failure(monkeypatch):
+    """A failing probe must be cached too (don't retry every poll)."""
+    import blueprints.system_health as sh
+    sh._probe_cache.clear()
+
+    calls = {'n': 0}
+    def bad_probe():
+        calls['n'] += 1
+        raise RuntimeError("network down")
+
+    fake_now = [1000.0]
+    monkeypatch.setattr(sh.time, 'time', lambda: fake_now[0])
+
+    a = sh._cached_probe('failing', bad_probe)
+    assert a.get('_error', '').startswith('network down')
+
+    # Same TTL window — should not re-call.
+    fake_now[0] = 1015.0
+    b = sh._cached_probe('failing', bad_probe)
+    assert calls['n'] == 1
+    assert b == a
+
+
+# ---------------------------------------------------------------------------
+# Disk block
+# ---------------------------------------------------------------------------
+
+def test_disk_block_critical(monkeypatch):
+    import blueprints.system_health as sh
+    from collections import namedtuple
+    Usage = namedtuple('Usage', ['total', 'used', 'free'])
+    monkeypatch.setattr(
+        sh.shutil, 'disk_usage',
+        lambda path: Usage(total=100 * 1024**3,
+                           used=96 * 1024**3,
+                           free=4 * 1024**3),
+    )
+    block = sh._disk_block()
+    assert block['severity'] == 'error'
+    assert 'Critical' in block['message']
+    assert block['used_pct'] == 96.0
+
+
+def test_disk_block_warn(monkeypatch):
+    import blueprints.system_health as sh
+    from collections import namedtuple
+    Usage = namedtuple('Usage', ['total', 'used', 'free'])
+    monkeypatch.setattr(
+        sh.shutil, 'disk_usage',
+        lambda path: Usage(total=100 * 1024**3,
+                           used=88 * 1024**3,
+                           free=12 * 1024**3),
+    )
+    block = sh._disk_block()
+    assert block['severity'] == 'warn'
+    assert block['used_pct'] == 88.0
+
+
+def test_disk_block_ok(monkeypatch):
+    import blueprints.system_health as sh
+    from collections import namedtuple
+    Usage = namedtuple('Usage', ['total', 'used', 'free'])
+    monkeypatch.setattr(
+        sh.shutil, 'disk_usage',
+        lambda path: Usage(total=200 * 1024**3,
+                           used=80 * 1024**3,
+                           free=120 * 1024**3),
+    )
+    block = sh._disk_block()
+    assert block['severity'] == 'ok'
+    assert block['free_gb'] == 120.0
+    assert 'free' in block['message']
+
+
+def test_disk_block_oserror(monkeypatch):
+    import blueprints.system_health as sh
+    def fail(path):
+        raise OSError("disk gone")
+    monkeypatch.setattr(sh.shutil, 'disk_usage', fail)
+    block = sh._disk_block()
+    assert block['severity'] == 'unknown'
+    assert 'probe failed' in block['message'].lower()
+
+
+# ---------------------------------------------------------------------------
+# WiFi block
+# ---------------------------------------------------------------------------
+
+def test_wifi_block_connected_strong(monkeypatch):
+    import blueprints.system_health as sh
+    sh._probe_cache.clear()
+    monkeypatch.setattr(
+        sh, '_probe_wifi_sta',
+        lambda: {'connected': True, 'current_ssid': 'HomeNet', 'signal': '85'},
+    )
+    monkeypatch.setattr(sh, '_probe_wifi_ap', lambda: {'ap_active': False})
+    block = sh._wifi_block()
+    assert block['severity'] == 'ok'
+    assert 'HomeNet' in block['message']
+    assert block['signal'] == 85
+    assert block['ap_active'] is False
+
+
+def test_wifi_block_connected_weak(monkeypatch):
+    import blueprints.system_health as sh
+    sh._probe_cache.clear()
+    monkeypatch.setattr(
+        sh, '_probe_wifi_sta',
+        lambda: {'connected': True, 'current_ssid': 'WeakNet', 'signal': '20'},
+    )
+    monkeypatch.setattr(sh, '_probe_wifi_ap', lambda: {'ap_active': False})
+    block = sh._wifi_block()
+    assert block['severity'] == 'warn'
+    assert 'weak' in block['message'].lower()
+
+
+def test_wifi_block_offline_ap_active(monkeypatch):
+    import blueprints.system_health as sh
+    sh._probe_cache.clear()
+    monkeypatch.setattr(
+        sh, '_probe_wifi_sta',
+        lambda: {'connected': False, 'current_ssid': None, 'signal': None},
+    )
+    monkeypatch.setattr(sh, '_probe_wifi_ap', lambda: {'ap_active': True})
+    block = sh._wifi_block()
+    assert block['severity'] == 'warn'
+    assert 'AP active' in block['message']
+    assert block['ap_active'] is True
+
+
+def test_wifi_block_no_wifi(monkeypatch):
+    import blueprints.system_health as sh
+    sh._probe_cache.clear()
+    monkeypatch.setattr(
+        sh, '_probe_wifi_sta',
+        lambda: {'connected': False, 'current_ssid': None, 'signal': None},
+    )
+    monkeypatch.setattr(sh, '_probe_wifi_ap', lambda: {'ap_active': False})
+    block = sh._wifi_block()
+    assert block['severity'] == 'error'
+    assert 'No WiFi' in block['message']
+
+
+# ---------------------------------------------------------------------------
+# Indexer block
+# ---------------------------------------------------------------------------
+
+def test_indexer_block_disabled(monkeypatch):
+    import blueprints.system_health as sh
+    monkeypatch.setattr(sh, 'MAPPING_ENABLED', False, raising=False)
+    block = sh._indexer_block()
+    assert block['severity'] == 'unknown'
+    assert block['enabled'] is False
+
+
+def test_indexer_block_running_idle(monkeypatch):
+    import blueprints.system_health as sh
+    from services import indexing_worker
+    monkeypatch.setattr(sh, 'MAPPING_ENABLED', True, raising=False)
+    monkeypatch.setattr(indexing_worker, 'get_worker_status', lambda: {
+        'worker_running': True, 'queue_depth': 0,
+        'dead_letter_count': 0, 'active_file': None,
+    })
+    block = sh._indexer_block()
+    assert block['severity'] == 'ok'
+    assert 'Idle' in block['message']
+
+
+def test_indexer_block_dead_letter(monkeypatch):
+    import blueprints.system_health as sh
+    from services import indexing_worker
+    monkeypatch.setattr(sh, 'MAPPING_ENABLED', True, raising=False)
+    monkeypatch.setattr(indexing_worker, 'get_worker_status', lambda: {
+        'worker_running': True, 'queue_depth': 5,
+        'dead_letter_count': 3, 'active_file': None,
+    })
+    block = sh._indexer_block()
+    assert block['severity'] == 'warn'
+    assert '3 dead-letter' in block['message']
+
+
+def test_indexer_block_not_running(monkeypatch):
+    import blueprints.system_health as sh
+    from services import indexing_worker
+    monkeypatch.setattr(sh, 'MAPPING_ENABLED', True, raising=False)
+    monkeypatch.setattr(indexing_worker, 'get_worker_status', lambda: {
+        'worker_running': False, 'queue_depth': 0,
+        'dead_letter_count': 0, 'active_file': None,
+    })
+    block = sh._indexer_block()
+    assert block['severity'] == 'error'
+
+
+def test_indexer_block_catchup(monkeypatch):
+    import blueprints.system_health as sh
+    from services import indexing_worker
+    monkeypatch.setattr(sh, 'MAPPING_ENABLED', True, raising=False)
+    monkeypatch.setattr(indexing_worker, 'get_worker_status', lambda: {
+        'worker_running': True, 'queue_depth': 250,
+        'dead_letter_count': 0, 'active_file': '/some/file.mp4',
+    })
+    block = sh._indexer_block()
+    assert block['severity'] == 'warn'
+    assert 'catch-up' in block['message']
+
+
+# ---------------------------------------------------------------------------
+# Archive block
+# ---------------------------------------------------------------------------
+
+def test_archive_block_disabled(monkeypatch):
+    import blueprints.system_health as sh
+    monkeypatch.setattr(sh, 'ARCHIVE_QUEUE_ENABLED', False, raising=False)
+    block = sh._archive_block()
+    assert block['severity'] == 'unknown'
+
+
+def test_archive_block_paused(monkeypatch):
+    import blueprints.system_health as sh
+    from services import archive_queue, archive_watchdog, archive_worker
+    monkeypatch.setattr(sh, 'ARCHIVE_QUEUE_ENABLED', True, raising=False)
+
+    monkeypatch.setattr(archive_queue, 'get_queue_status',
+                        lambda: {'pending': 10, 'dead_letter': 0})
+    monkeypatch.setattr(archive_watchdog, 'get_status',
+                        lambda: {'severity': 'ok', 'message': ''})
+    monkeypatch.setattr(archive_worker, 'get_status',
+                        lambda: {'worker_running': True, 'paused': True})
+
+    block = sh._archive_block()
+    assert block['severity'] == 'warn'
+    assert 'Paused' in block['message']
+
+
+def test_archive_block_watchdog_error(monkeypatch):
+    import blueprints.system_health as sh
+    from services import archive_queue, archive_watchdog, archive_worker
+    monkeypatch.setattr(sh, 'ARCHIVE_QUEUE_ENABLED', True, raising=False)
+
+    monkeypatch.setattr(archive_queue, 'get_queue_status',
+                        lambda: {'pending': 0, 'dead_letter': 0})
+    monkeypatch.setattr(archive_watchdog, 'get_status',
+                        lambda: {'severity': 'error',
+                                 'message': 'Disk almost full'})
+    monkeypatch.setattr(archive_worker, 'get_status',
+                        lambda: {'worker_running': True, 'paused': False})
+
+    block = sh._archive_block()
+    assert block['severity'] == 'error'
+    assert 'Disk almost full' in block['message']
+
+
+# ---------------------------------------------------------------------------
+# Cloud block
+# ---------------------------------------------------------------------------
+
+def test_cloud_block_disabled(monkeypatch):
+    import blueprints.system_health as sh
+    monkeypatch.setattr(sh, 'CLOUD_ARCHIVE_ENABLED', False, raising=False)
+    block = sh._cloud_block()
+    assert block['severity'] == 'unknown'
+
+
+def test_cloud_block_dead_letters(monkeypatch):
+    import blueprints.system_health as sh
+    from services import cloud_archive_service as cas
+    monkeypatch.setattr(sh, 'CLOUD_ARCHIVE_ENABLED', True, raising=False)
+
+    monkeypatch.setattr(cas, 'count_dead_letters', lambda: 4)
+    monkeypatch.setattr(cas, 'get_sync_status', lambda: {
+        'running': False, 'files_total': 0, 'files_done': 0,
+    })
+    block = sh._cloud_block()
+    assert block['severity'] == 'warn'
+    assert 'dead-letter' in block['message']
+
+
+def test_cloud_block_uploading(monkeypatch):
+    import blueprints.system_health as sh
+    from services import cloud_archive_service as cas
+    monkeypatch.setattr(sh, 'CLOUD_ARCHIVE_ENABLED', True, raising=False)
+
+    monkeypatch.setattr(cas, 'count_dead_letters', lambda: 0)
+    monkeypatch.setattr(cas, 'get_sync_status', lambda: {
+        'running': True, 'files_total': 100, 'files_done': 30,
+    })
+    block = sh._cloud_block()
+    assert block['severity'] == 'ok'
+    assert '70 pending' in block['message']
+    assert block['queue_depth'] == 70
+
+
+# ---------------------------------------------------------------------------
+# LES block
+# ---------------------------------------------------------------------------
+
+def test_les_block_disabled(monkeypatch):
+    import blueprints.system_health as sh
+    monkeypatch.setattr(sh, 'LIVE_EVENT_SYNC_ENABLED', False, raising=False)
+    block = sh._les_block()
+    assert block['severity'] == 'unknown'
+
+
+def test_les_block_failed_rows(monkeypatch):
+    import blueprints.system_health as sh
+    from services import live_event_sync_service as les
+    monkeypatch.setattr(sh, 'LIVE_EVENT_SYNC_ENABLED', True, raising=False)
+
+    monkeypatch.setattr(les, 'count_failed', lambda: 2)
+    monkeypatch.setattr(les, 'get_status', lambda: {
+        'worker_running': True,
+        'queue_counts': {'pending': 0, 'uploading': 0},
+    })
+    block = sh._les_block()
+    assert block['severity'] == 'warn'
+    assert 'failed' in block['message']
+
+
+def test_les_block_worker_idle(monkeypatch):
+    import blueprints.system_health as sh
+    from services import live_event_sync_service as les
+    monkeypatch.setattr(sh, 'LIVE_EVENT_SYNC_ENABLED', True, raising=False)
+
+    monkeypatch.setattr(les, 'count_failed', lambda: 0)
+    monkeypatch.setattr(les, 'get_status', lambda: {
+        'worker_running': False,
+        'queue_counts': {'pending': 0, 'uploading': 0},
+    })
+    block = sh._les_block()
+    assert block['severity'] == 'warn'
+    assert 'idle' in block['message'].lower()
+
+
+# ---------------------------------------------------------------------------
+# Blueprint route
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def health_app():
+    from flask import Flask
+    from blueprints.system_health import system_health_bp
+
+    app = Flask(__name__)
+    app.register_blueprint(system_health_bp)
+    app.config['TESTING'] = True
+    return app
+
+
+def test_api_returns_json_payload(health_app, monkeypatch):
+    import blueprints.system_health as sh
+    monkeypatch.setattr(sh, '_BLOCKS', (
+        ('indexer', lambda: {'severity': 'ok', 'message': 'idle'}),
+    ))
+    client = health_app.test_client()
+    rv = client.get('/api/system/health')
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert 'overall' in body
+    assert 'generated_at' in body
+    assert body['overall']['severity'] == 'ok'
+    assert body['indexer']['severity'] == 'ok'

--- a/tests/test_system_health_blueprint.py
+++ b/tests/test_system_health_blueprint.py
@@ -290,6 +290,85 @@ def test_wifi_block_no_wifi(monkeypatch):
     assert 'No WiFi' in block['message']
 
 
+def test_wifi_block_connected_none_ssid_no_literal(monkeypatch):
+    """Regression: ssid=None must not render literal 'None' in the message.
+
+    NetworkManager occasionally returns a connected state with a missing
+    SSID field (transient race during reassociation). The card text
+    must fall back to 'Unknown' rather than show the Python repr of None.
+    """
+    import blueprints.system_health as sh
+    sh._probe_cache.clear()
+    monkeypatch.setattr(
+        sh, '_probe_wifi_sta',
+        lambda: {'connected': True, 'current_ssid': None, 'signal': '60'},
+    )
+    monkeypatch.setattr(sh, '_probe_wifi_ap', lambda: {'ap_active': False})
+    block = sh._wifi_block()
+    assert 'None' not in block['message']
+    assert 'Unknown' in block['message']
+
+
+def test_wifi_block_connected_empty_ssid_no_literal(monkeypatch):
+    """Empty-string SSID also falls back to 'Unknown'."""
+    import blueprints.system_health as sh
+    sh._probe_cache.clear()
+    monkeypatch.setattr(
+        sh, '_probe_wifi_sta',
+        lambda: {'connected': True, 'current_ssid': '', 'signal': '60'},
+    )
+    monkeypatch.setattr(sh, '_probe_wifi_ap', lambda: {'ap_active': False})
+    block = sh._wifi_block()
+    assert 'Unknown' in block['message']
+
+
+def test_probe_cache_concurrent_cold_cache_no_duplicate_spawn(monkeypatch):
+    """Regression: cold-cache burst must not double-spawn ``fn()``.
+
+    Without the per-name in-flight lock, two threads that both miss the
+    cache will each release the global lock and call ``fn()`` in
+    parallel — defeating the "never spawn duplicate nmcli/sudo bash"
+    guarantee. With the per-name lock, the second caller waits for the
+    first and returns the freshly cached value.
+    """
+    import threading
+    import blueprints.system_health as sh
+    sh._probe_cache.clear()
+    sh._probe_inflight.clear()
+
+    calls = {'n': 0}
+    started = threading.Event()
+    proceed = threading.Event()
+
+    def slow_probe():
+        calls['n'] += 1
+        started.set()
+        # Hold the probe long enough that all concurrent callers
+        # would observe a cache miss if there were no in-flight lock.
+        proceed.wait(timeout=2.0)
+        return {'value': calls['n']}
+
+    results: list = []
+
+    def worker():
+        results.append(sh._cached_probe('concurrent', slow_probe))
+
+    threads = [threading.Thread(target=worker) for _ in range(5)]
+    for t in threads:
+        t.start()
+    # Wait for the first thread to enter the probe.
+    assert started.wait(timeout=2.0), "no thread entered the probe"
+    # Let the probe complete; remaining threads must reuse the cache.
+    proceed.set()
+    for t in threads:
+        t.join(timeout=2.0)
+
+    assert calls['n'] == 1, f"probe spawned {calls['n']} times, expected 1"
+    assert len(results) == 5
+    for r in results:
+        assert r == {'value': 1}
+
+
 # ---------------------------------------------------------------------------
 # Indexer block
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Adds a System Health card at the top of the Settings page plus a single
`GET /api/system/health` endpoint that returns one JSON snapshot of
every background subsystem.

## What it shows

- **Indexer** — worker liveness, queue depth, dead-letter count
- **Local Archive** — watchdog severity, paused state, queue depth, DLs
- **Cloud Sync** — running state, pending count, DLs, last upload time
- **Live Event Sync** — worker liveness, pending, failed
- **SD Card** — used %, free GB (warn @ 85%, error @ 95%)
- **WiFi** — SSID + signal % when connected, AP-active flag, weak-signal warn
- **Overall** — clickable row that jumps to Failed Jobs when amber/red

Each block reports a 4-level `severity` (`ok` / `warn` / `error` /
`unknown`) and an `overall` rollup uses the documented
`ok < unknown < warn < error` ranking — so the upcoming Phase 4.8
nav-bar status dot can colour itself purely from `overall.severity`
without re-rendering text.

## Why it matters

Today, asking "is anything broken?" requires drilling into 5 different
sub-pages. Phase 4.1 gave us a single Failed Jobs page; this PR puts
the at-a-glance dashboard one click in front of it.

## Design notes

- **Cheap by construction.** `nmcli` and `sudo bash ap_control.sh
  status` are the only subprocess probes; both go through a 30 s TTL
  cache (incl. cached failures) so the 15 s page poll never pins the
  SDIO bus.
- **Per-subsystem crash isolation.** `_build_health` wraps each block
  call in try/except — one bad SQLite DB cannot 500 the dashboard.
- **No identifier disclosure.** Messages are short user-facing labels
  (e.g. `Idle, queue empty`, `250 queued (catch-up)`). No absolute
  paths, no rclone bucket/host names — same redaction contract as the
  Failed Jobs page (PR #131).
- **Visibility-aware polling.** The JS poller stops on hidden tabs and
  resumes on `visibilitychange`.

## Files

- **NEW** `scripts/web/blueprints/system_health.py` (~390 LOC)
- **NEW** `tests/test_system_health_blueprint.py` (28 tests)
- `scripts/web/blueprints/__init__.py` — register `system_health_bp`
- `scripts/web/web_control.py` — register blueprint
- `scripts/web/templates/index.html` — System Health card + JS poller

## Tests

- 28 new tests: full subsystem matrix (healthy / warn / error /
  disabled / crashing) for indexer / archive / cloud / LES / disk / WiFi,
  plus crash-isolation, severity-ranking, probe-cache TTL, and
  cached-failure behavior.
- Full suite: **1112 pass, 3 skipped** (was 1084).

## Verification (post-merge, on cybertruckusb.local)

- `GET /api/system/health` returns well-formed JSON < 100 ms
- Settings page shows the new card with live dots
- Probe cache: second call within 30 s does NOT spawn nmcli/sudo
- Block-isolation: forcing a subsystem error still renders the rest

Closes part of #101.