### PR TITLE
Phase 4.3: Files-lost counter banner (#101)

### DIFF
--- a/scripts/web/blueprints/system_health.py
+++ b/scripts/web/blueprints/system_health.py
@@ -181,12 +181,19 @@ def _archive_block() -> Dict[str, Any]:
             'enabled': False,
             'paused': False,
             'queue_depth': 0,
+            'lost_24h': 0,
         }
     try:
         from services import archive_queue, archive_watchdog, archive_worker
         watchdog = archive_watchdog.get_status() or {}
         worker = archive_worker.get_status() or {}
         counts = archive_queue.get_queue_status() or {}
+        # Phase 4.3: count files Tesla rotated out before we copied them
+        # in the last 24 h. Cheap indexed COUNT(*); safe on every poll.
+        try:
+            lost_24h = int(archive_queue.count_source_gone_recent(24) or 0)
+        except Exception:  # noqa: BLE001 — never let a counter kill the page
+            lost_24h = 0
     except Exception as e:  # noqa: BLE001
         return {
             'severity': SEV_UNKNOWN,
@@ -194,6 +201,7 @@ def _archive_block() -> Dict[str, Any]:
             'enabled': True,
             'paused': False,
             'queue_depth': 0,
+            'lost_24h': 0,
             '_error': str(e)[:120],
         }
 
@@ -215,6 +223,13 @@ def _archive_block() -> Dict[str, Any]:
     elif wd_sev == SEV_ERROR:
         sev = SEV_ERROR
         msg = (watchdog.get('message') or 'Watchdog error')[:80]
+    elif lost_24h > 0:
+        # Lost-files dominates dead-letters because lost footage is
+        # unrecoverable, whereas a dead-letter row still has the source
+        # data on the SD card and can be retried.
+        sev = SEV_WARN
+        msg = (f'{lost_24h} clip{"s" if lost_24h != 1 else ""} '
+               'lost in last 24h')
     elif dead > 0:
         sev = SEV_WARN
         msg = f'{dead} dead-letter row{"s" if dead != 1 else ""}'
@@ -240,6 +255,7 @@ def _archive_block() -> Dict[str, Any]:
         'paused': paused,
         'queue_depth': pending,
         'dead_letter_count': dead,
+        'lost_24h': lost_24h,
     }
 
 

--- a/scripts/web/services/archive_queue.py
+++ b/scripts/web/services/archive_queue.py
@@ -399,10 +399,22 @@ def count_source_gone_recent(hours: int = 24,
     set on the row (the worker always claims a row before stat'ing the
     source), and the source-gone determination happens within seconds
     of the claim. So ``claimed_at`` is the closest proxy for "when did
-    Tesla lose this clip from our perspective".
+    Tesla lose this clip from our perspective". The :func:`mark_source_gone`
+    precondition (``WHERE status='claimed'``) guarantees ``claimed_at``
+    is never NULL on a ``source_gone`` row, so the counter cannot
+    silently undercount because of an out-of-flow caller.
 
-    Cheap COUNT(*) — uses the existing index on ``status``. Safe to
-    call on every health-card poll (~30 ms typical).
+    Cheap COUNT(*) — uses the v11 partial index
+    ``archive_queue_source_gone_claimed`` (``ON archive_queue(claimed_at)
+    WHERE status = 'source_gone'``), which keeps the lookup O(log n)
+    even though the ``archive_queue`` table grows monotonically (no
+    retention today). On a v10 DB that hasn't been re-initialized yet
+    this falls back to a full table scan, which is still acceptable
+    because the table is bounded by row count rather than by free
+    disk space (a few thousand ``source_gone`` rows COUNT in well
+    under 100 ms even on the SD card). The ``hours <= 0`` guard plus
+    the silent-on-error contract make this safe to call on every
+    health-card poll.
 
     Returns 0 if the DB is missing, the table doesn't exist yet, or any
     SQLite error fires — never raises.
@@ -830,6 +842,18 @@ def mark_source_gone(row_id: int, *,
     rotated out by Tesla before we got to copy it. No retry, no
     dead-letter sidecar — this is normal behavior on RecentClips after
     ~60 minutes of no clean shutdown.
+
+    Precondition: the row MUST already be ``claimed`` (i.e., a worker
+    has called :func:`claim_next_for_worker` and the row has a
+    populated ``claimed_at``). The Phase 4.3 files-lost banner relies
+    on ``claimed_at`` as the timestamp filter for the 24-hour window;
+    a hypothetical out-of-flow caller that marks a fresh ``pending``
+    row as ``source_gone`` would silently undercount because that row
+    has ``claimed_at IS NULL``. Enforcing the precondition in the
+    UPDATE's ``WHERE`` clause guarantees we never produce an
+    unattributable row. Returns ``False`` (rowcount == 0) if the row
+    is not in ``claimed`` state, which is also what the worker
+    expects when another worker has already terminated the row.
     """
     if not row_id:
         return False
@@ -843,6 +867,7 @@ def mark_source_gone(row_id: int, *,
                SET status = 'source_gone',
                    last_error = NULL
              WHERE id = ?
+               AND status = 'claimed'
             """,
             (int(row_id),),
         )

--- a/scripts/web/services/archive_queue.py
+++ b/scripts/web/services/archive_queue.py
@@ -384,6 +384,64 @@ def enqueue_many_for_archive(source_paths: Iterable[str], *,
         return 0
 
 
+def count_source_gone_recent(hours: int = 24,
+                             *, db_path: Optional[str] = None) -> int:
+    """Return the number of ``source_gone`` rows in the last N hours.
+
+    Phase 4.3 (issue #101) — surface "files Tesla rotated out before we
+    could copy them" as a Settings banner. The truth signal is the
+    archive_queue rows that the worker terminated as ``source_gone``
+    (file vanished between enqueue and copy attempt — Tesla's
+    RecentClips circular buffer rolled them off).
+
+    Uses ``claimed_at`` as the timestamp filter. Rationale: by the time
+    the worker calls :func:`mark_source_gone`, ``claimed_at`` has been
+    set on the row (the worker always claims a row before stat'ing the
+    source), and the source-gone determination happens within seconds
+    of the claim. So ``claimed_at`` is the closest proxy for "when did
+    Tesla lose this clip from our perspective".
+
+    Cheap COUNT(*) — uses the existing index on ``status``. Safe to
+    call on every health-card poll (~30 ms typical).
+
+    Returns 0 if the DB is missing, the table doesn't exist yet, or any
+    SQLite error fires — never raises.
+    """
+    if hours <= 0:
+        return 0
+    db_path = _resolve_db_path(db_path)
+    conn = None
+    try:
+        conn = _open_archive_conn(db_path)
+        # ``CAST(strftime('%s', x) AS INTEGER)`` works for both ISO-8601
+        # text (the format ``_iso_now`` writes — includes ``T`` and
+        # ``+00:00``) and SQLite's own ``datetime('now')`` format.
+        # Using integer-second arithmetic instead of julianday floats
+        # avoids the precision foot-gun documented in the project-wide
+        # gotchas (see ``copilot-instructions.md``).
+        row = conn.execute(
+            """
+            SELECT COUNT(*) AS n
+              FROM archive_queue
+             WHERE status = 'source_gone'
+               AND claimed_at IS NOT NULL
+               AND CAST(strftime('%s', claimed_at) AS INTEGER) >=
+                   CAST(strftime('%s', 'now') AS INTEGER) - ?
+            """,
+            (int(hours) * 3600,),
+        ).fetchone()
+        return int(row['n'] or 0) if row else 0
+    except sqlite3.Error as e:
+        logger.warning("count_source_gone_recent failed: %s", e)
+        return 0
+    finally:
+        if conn is not None:
+            try:
+                conn.close()
+            except sqlite3.Error:
+                pass
+
+
 def get_queue_status(db_path: Optional[str] = None) -> Dict[str, int]:
     """Return per-status counts for the queue.
 

--- a/scripts/web/services/mapping_migrations.py
+++ b/scripts/web/services/mapping_migrations.py
@@ -46,7 +46,7 @@ logger = logging.getLogger(__name__)
 # Database Schema & Management
 # ---------------------------------------------------------------------------
 
-_SCHEMA_VERSION = 10
+_SCHEMA_VERSION = 11
 _BACKUP_RETENTION = 3  # Keep this many migration backups before pruning oldest
 
 _SCHEMA_SQL = """
@@ -211,6 +211,18 @@ CREATE TABLE IF NOT EXISTS archive_queue (
 CREATE INDEX IF NOT EXISTS archive_queue_ready
     ON archive_queue(status, priority, expected_mtime)
     WHERE status = 'pending';
+-- Files-lost banner index (Phase 4.3 / v11): the Settings card polls
+-- ``count_source_gone_recent`` every 15 s, which scans rows with
+-- ``status='source_gone'`` filtered by ``claimed_at`` recency. The
+-- ``archive_queue`` table grows monotonically (no retention today),
+-- so without a partial index this becomes a full table scan once
+-- ``source_gone_count`` reaches the thousands (which it already has
+-- on production devices — 2 387 rows seen in the wild). The partial
+-- index keeps the lookup O(log n) and is tiny because only the
+-- ``source_gone`` rows are present.
+CREATE INDEX IF NOT EXISTS archive_queue_source_gone_claimed
+    ON archive_queue(claimed_at)
+    WHERE status = 'source_gone';
 """
 
 
@@ -389,6 +401,15 @@ def _init_db(db_path: str) -> sqlite3.Connection:
         # will be the consumer. Created by the executescript above
         # (CREATE TABLE IF NOT EXISTS / CREATE INDEX IF NOT EXISTS
         # are idempotent); no data migration required.
+        # v11: ``archive_queue_source_gone_claimed`` partial index for
+        # the Phase 4.3 (#101) files-lost banner. The Settings card
+        # polls ``count_source_gone_recent`` every 15 s, which would
+        # otherwise scan the entire growing-without-bound
+        # ``archive_queue`` table once the ``source_gone`` count
+        # reaches the thousands. The partial index keeps the query
+        # O(log n) and is tiny because only ``source_gone`` rows are
+        # included. Created by the executescript above; no data
+        # migration required.
         conn.execute("DELETE FROM schema_version")
         conn.execute(
             "INSERT INTO schema_version (version) VALUES (?)",

--- a/scripts/web/templates/index.html
+++ b/scripts/web/templates/index.html
@@ -57,6 +57,48 @@
     </div>
     {% endif %}
 
+    <!-- Files-Lost banner (Phase 4.3 — issue #101).
+         Hidden by default; shown by JS poller when archive.lost_24h > 0.
+         This is the user-facing version of the worker's source_gone
+         counter — clips Tesla rotated out of RecentClips before we
+         could archive them. Lost dashcam footage is unrecoverable, so
+         this banner is intentionally loud (red) and links to the
+         Failed Jobs page for the full archive history. -->
+    <div id="files-lost-banner" hidden
+         style="margin:12px 0; padding:12px 14px;
+                border-radius:8px;
+                background:var(--msg-error-bg, #4a1f1f);
+                color:var(--msg-error-text, #ffd7d7);
+                border:1px solid var(--accent-error, #f44336);
+                display:flex; align-items:center; gap:10px;">
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none"
+             stroke="currentColor" stroke-width="2"
+             stroke-linecap="round" stroke-linejoin="round"
+             aria-hidden="true" style="flex-shrink:0;">
+            <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/>
+            <line x1="12" y1="9" x2="12" y2="13"/>
+            <line x1="12" y1="17" x2="12.01" y2="17"/>
+        </svg>
+        <div style="flex:1;">
+            <strong id="files-lost-title">
+                Footage may have been lost
+            </strong>
+            <div id="files-lost-detail"
+                 style="font-size:0.9rem; margin-top:2px;
+                        opacity:0.92;">
+                Tesla rotated clips out of RecentClips before
+                we could copy them. Check Failed Jobs for details.
+            </div>
+        </div>
+        <a id="files-lost-link" href="#"
+           style="color:inherit; text-decoration:underline;
+                  font-size:0.9rem; min-height:44px; min-width:44px;
+                  display:inline-flex; align-items:center;
+                  padding:0 10px;">
+            Details
+        </a>
+    </div>
+
     <!-- System Health (Phase 4.2 — issue #101) -->
     <details class="settings-section" id="system-health-section" open>
         <summary>System Health</summary>
@@ -1777,11 +1819,45 @@ if (document.getElementById('fsck-status-container')) {
                 errorEl.hidden = true;
                 renderRows(payload);
                 renderOverall(payload);
+                renderFilesLostBanner(payload);
             })
             .catch(function(e) {
                 console.warn('system_health load failed:', e);
                 errorEl.hidden = false;
             });
+    }
+
+    // Phase 4.3 (issue #101) — files-lost banner. Surfaces the
+    // archive worker's source_gone counter (clips Tesla rotated out
+    // before we could copy them) when the 24 h count is non-zero.
+    // Lost dashcam footage is unrecoverable, so the banner is
+    // intentionally loud and persistent until the count drops back
+    // to zero (which happens automatically as old source_gone rows
+    // age past the 24 h window, or sooner if the user purges them).
+    var lostBanner   = document.getElementById('files-lost-banner');
+    var lostDetail   = document.getElementById('files-lost-detail');
+    var lostLink     = document.getElementById('files-lost-link');
+    if (lostLink && jobsUrl) lostLink.href = jobsUrl;
+
+    function renderFilesLostBanner(payload) {
+        if (!lostBanner) return;
+        var arc = payload.archive || {};
+        var n = parseInt(arc.lost_24h, 10) || 0;
+        if (n <= 0) {
+            lostBanner.hidden = true;
+            return;
+        }
+        if (lostDetail) {
+            lostDetail.textContent =
+                n === 1
+                ? '1 clip lost in the last 24 hours — Tesla ' +
+                  'rotated it out of RecentClips before it could ' +
+                  'be archived. Device may be overloaded.'
+                : n + ' clips lost in the last 24 hours — Tesla ' +
+                  'rotated them out of RecentClips before they ' +
+                  'could be archived. Device may be overloaded.';
+        }
+        lostBanner.hidden = false;
     }
 
     function startPoll() {

--- a/tests/test_archive_queue.py
+++ b/tests/test_archive_queue.py
@@ -906,6 +906,92 @@ class TestMarkSourceGone:
         assert mark_source_gone(999999, db_path=db) is False
 
 
+class TestCountSourceGoneRecent:
+    """Phase 4.3 (#101) — files-lost banner data source."""
+
+    def test_zero_when_no_source_gone_rows(self, db, sample_file):
+        # Just claim+copy a row, no source_gone events.
+        enqueue_for_archive(sample_file, db_path=db)
+        row = claim_next_for_worker('w1', db_path=db)
+        archive_queue.mark_copied(row['id'], '/tmp/dest.mp4', db_path=db)
+        assert archive_queue.count_source_gone_recent(24, db_path=db) == 0
+
+    def test_counts_recent_source_gone(self, db, tmp_path):
+        # Three source_gone rows, all recent.
+        for i in range(3):
+            f = tmp_path / f"clip_{i}.mp4"
+            f.write_text("x")
+            enqueue_for_archive(str(f), db_path=db)
+            row = claim_next_for_worker(f'w{i}', db_path=db)
+            mark_source_gone(row['id'], db_path=db)
+        assert archive_queue.count_source_gone_recent(24, db_path=db) == 3
+
+    def test_excludes_non_source_gone(self, db, tmp_path):
+        f1 = tmp_path / "a.mp4"
+        f1.write_text("x")
+        enqueue_for_archive(str(f1), db_path=db)
+        r1 = claim_next_for_worker('w1', db_path=db)
+        mark_source_gone(r1['id'], db_path=db)
+
+        f2 = tmp_path / "b.mp4"
+        f2.write_text("x")
+        enqueue_for_archive(str(f2), db_path=db)
+        r2 = claim_next_for_worker('w2', db_path=db)
+        archive_queue.mark_copied(r2['id'], '/tmp/b.mp4', db_path=db)
+
+        # Only the source_gone row counts.
+        assert archive_queue.count_source_gone_recent(24, db_path=db) == 1
+
+    def test_excludes_old_source_gone(self, db, sample_file):
+        # Insert a source_gone row but backdate claimed_at to 48 h ago.
+        enqueue_for_archive(sample_file, db_path=db)
+        row = claim_next_for_worker('w1', db_path=db)
+        mark_source_gone(row['id'], db_path=db)
+        with sqlite3.connect(db) as conn:
+            conn.execute(
+                "UPDATE archive_queue SET claimed_at = "
+                "datetime('now', '-48 hours') WHERE id = ?",
+                (row['id'],),
+            )
+            conn.commit()
+        assert archive_queue.count_source_gone_recent(24, db_path=db) == 0
+        # Wider window picks it back up.
+        assert archive_queue.count_source_gone_recent(72, db_path=db) == 1
+
+    def test_zero_hours_returns_zero(self, db, sample_file):
+        # Defensive: a 0-hour window must short-circuit, not return all.
+        enqueue_for_archive(sample_file, db_path=db)
+        row = claim_next_for_worker('w1', db_path=db)
+        mark_source_gone(row['id'], db_path=db)
+        assert archive_queue.count_source_gone_recent(0, db_path=db) == 0
+
+    def test_handles_iso_with_t_separator(self, db, sample_file):
+        """``_iso_now`` writes ``YYYY-MM-DDTHH:MM:SS+00:00`` — the
+        ``T`` separator and tz suffix must not break the SQLite
+        ``strftime('%s', ...)`` filter.
+        """
+        enqueue_for_archive(sample_file, db_path=db)
+        row = claim_next_for_worker('w1', db_path=db)
+        mark_source_gone(row['id'], db_path=db)
+        # Confirm the stored claimed_at is the ISO-T format.
+        with sqlite3.connect(db) as conn:
+            ts = conn.execute(
+                "SELECT claimed_at FROM archive_queue WHERE id = ?",
+                (row['id'],),
+            ).fetchone()[0]
+        assert 'T' in ts
+        assert '+' in ts or 'Z' in ts
+        assert archive_queue.count_source_gone_recent(24, db_path=db) == 1
+
+    def test_returns_zero_on_db_failure(self, db, monkeypatch):
+        def boom(*a, **kw):
+            raise sqlite3.OperationalError("disk I/O error")
+        monkeypatch.setattr(archive_queue, '_open_archive_conn', boom)
+        # Must never raise — health card poll on a broken DB should
+        # show 0 lost rather than 500 the dashboard.
+        assert archive_queue.count_source_gone_recent(24, db_path=db) == 0
+
+
 class TestReleaseClaim:
     def test_returns_to_pending_without_metadata(self, db, sample_file):
         enqueue_for_archive(sample_file, db_path=db)

--- a/tests/test_archive_queue.py
+++ b/tests/test_archive_queue.py
@@ -905,6 +905,57 @@ class TestMarkSourceGone:
     def test_returns_false_for_unknown_id(self, db):
         assert mark_source_gone(999999, db_path=db) is False
 
+    def test_refuses_to_mark_pending_row(self, db, sample_file):
+        """PR #134 review-fix: precondition tightening.
+
+        ``mark_source_gone`` MUST require ``status='claimed'`` so the
+        ``count_source_gone_recent`` 24-hour-window query (which filters
+        on ``claimed_at``) cannot silently undercount a hypothetical
+        out-of-flow caller's row that has ``claimed_at IS NULL``.
+        """
+        assert enqueue_for_archive(sample_file, db_path=db) is True
+        rows = list_queue(db_path=db)
+        assert rows[0]['status'] == 'pending'
+        row_id = rows[0]['id']
+        # Row is `pending`, claimed_at IS NULL — must refuse.
+        assert mark_source_gone(row_id, db_path=db) is False
+        rows = list_queue(db_path=db)
+        # Row stays pending; status was NOT mutated.
+        assert rows[0]['status'] == 'pending'
+        assert rows[0]['claimed_at'] is None
+
+    def test_refuses_to_mark_already_copied_row(self, db, sample_file, tmp_path):
+        """Once a row is `copied`, mark_source_gone must not regress it."""
+        dest = tmp_path / 'dest.mp4'
+        dest.write_bytes(b'x')
+        enqueue_for_archive(sample_file, db_path=db)
+        row = claim_next_for_worker('w1', db_path=db)
+        assert mark_copied(row['id'], str(dest), db_path=db) is True
+        # Row is now `copied` — mark_source_gone must refuse.
+        assert mark_source_gone(row['id'], db_path=db) is False
+        rows = list_queue(db_path=db)
+        assert rows[0]['status'] == 'copied'
+
+    def test_refuses_to_mark_dead_letter_row(self, db, sample_file):
+        """A failed (dead-letter) row must not be re-classifiable."""
+        enqueue_for_archive(sample_file, db_path=db)
+        row = claim_next_for_worker('w1', db_path=db)
+        # mark_failed transitions to dead_letter once attempts hit cap.
+        # Force the cap quickly by pre-bumping attempts via direct DB.
+        with sqlite3.connect(db) as c:
+            c.execute(
+                "UPDATE archive_queue SET attempts = 99 WHERE id = ?",
+                (row['id'],),
+            )
+        mark_failed(row['id'], 'simulated', db_path=db)
+        rows = list_queue(db_path=db)
+        # Confirm the row is now dead_letter (precondition for the test).
+        assert rows[0]['status'] == 'dead_letter'
+        # Now mark_source_gone must refuse.
+        assert mark_source_gone(row['id'], db_path=db) is False
+        rows = list_queue(db_path=db)
+        assert rows[0]['status'] == 'dead_letter'
+
 
 class TestCountSourceGoneRecent:
     """Phase 4.3 (#101) — files-lost banner data source."""

--- a/tests/test_system_health_blueprint.py
+++ b/tests/test_system_health_blueprint.py
@@ -478,6 +478,118 @@ def test_archive_block_watchdog_error(monkeypatch):
     assert 'Disk almost full' in block['message']
 
 
+def test_archive_block_files_lost_24h_warns(monkeypatch):
+    """Phase 4.3 — non-zero lost_24h must surface as warn with a
+    user-facing message that includes the count."""
+    import blueprints.system_health as sh
+    from services import archive_queue, archive_watchdog, archive_worker
+    monkeypatch.setattr(sh, 'ARCHIVE_QUEUE_ENABLED', True, raising=False)
+
+    monkeypatch.setattr(archive_queue, 'get_queue_status',
+                        lambda: {'pending': 0, 'dead_letter': 0})
+    monkeypatch.setattr(archive_queue, 'count_source_gone_recent',
+                        lambda hours=24: 12)
+    monkeypatch.setattr(archive_watchdog, 'get_status',
+                        lambda: {'severity': 'ok', 'message': ''})
+    monkeypatch.setattr(archive_worker, 'get_status',
+                        lambda: {'worker_running': True, 'paused': False})
+
+    block = sh._archive_block()
+    assert block['severity'] == 'warn'
+    assert block['lost_24h'] == 12
+    assert '12' in block['message']
+    assert 'lost' in block['message'].lower()
+
+
+def test_archive_block_files_lost_pluralization(monkeypatch):
+    """Singular vs plural messages for 1 vs N clips lost."""
+    import blueprints.system_health as sh
+    from services import archive_queue, archive_watchdog, archive_worker
+    monkeypatch.setattr(sh, 'ARCHIVE_QUEUE_ENABLED', True, raising=False)
+    monkeypatch.setattr(archive_queue, 'get_queue_status',
+                        lambda: {'pending': 0, 'dead_letter': 0})
+    monkeypatch.setattr(archive_queue, 'count_source_gone_recent',
+                        lambda hours=24: 1)
+    monkeypatch.setattr(archive_watchdog, 'get_status',
+                        lambda: {'severity': 'ok'})
+    monkeypatch.setattr(archive_worker, 'get_status',
+                        lambda: {'worker_running': True, 'paused': False})
+
+    block = sh._archive_block()
+    assert '1 clip lost' in block['message']
+    assert '1 clips' not in block['message']
+
+
+def test_archive_block_files_lost_takes_precedence_over_dead_letters(
+        monkeypatch):
+    """Lost files dominate dead-letter rows because lost footage is
+    unrecoverable, while DL rows still have the source on disk."""
+    import blueprints.system_health as sh
+    from services import archive_queue, archive_watchdog, archive_worker
+    monkeypatch.setattr(sh, 'ARCHIVE_QUEUE_ENABLED', True, raising=False)
+    monkeypatch.setattr(archive_queue, 'get_queue_status',
+                        lambda: {'pending': 0, 'dead_letter': 5})
+    monkeypatch.setattr(archive_queue, 'count_source_gone_recent',
+                        lambda hours=24: 3)
+    monkeypatch.setattr(archive_watchdog, 'get_status',
+                        lambda: {'severity': 'ok'})
+    monkeypatch.setattr(archive_worker, 'get_status',
+                        lambda: {'worker_running': True, 'paused': False})
+
+    block = sh._archive_block()
+    assert 'lost' in block['message'].lower()
+    assert 'dead-letter' not in block['message'].lower()
+
+
+def test_archive_block_lost_24h_zero_means_ok(monkeypatch):
+    """Zero lost files must not bump severity."""
+    import blueprints.system_health as sh
+    from services import archive_queue, archive_watchdog, archive_worker
+    monkeypatch.setattr(sh, 'ARCHIVE_QUEUE_ENABLED', True, raising=False)
+    monkeypatch.setattr(archive_queue, 'get_queue_status',
+                        lambda: {'pending': 0, 'dead_letter': 0})
+    monkeypatch.setattr(archive_queue, 'count_source_gone_recent',
+                        lambda hours=24: 0)
+    monkeypatch.setattr(archive_watchdog, 'get_status',
+                        lambda: {'severity': 'ok'})
+    monkeypatch.setattr(archive_worker, 'get_status',
+                        lambda: {'worker_running': True, 'paused': False})
+
+    block = sh._archive_block()
+    assert block['severity'] == 'ok'
+    assert block['lost_24h'] == 0
+
+
+def test_archive_block_count_source_gone_failure_safe(monkeypatch):
+    """If count_source_gone_recent throws, _archive_block must
+    degrade to lost_24h=0, not 500 the dashboard."""
+    import blueprints.system_health as sh
+    from services import archive_queue, archive_watchdog, archive_worker
+    monkeypatch.setattr(sh, 'ARCHIVE_QUEUE_ENABLED', True, raising=False)
+    monkeypatch.setattr(archive_queue, 'get_queue_status',
+                        lambda: {'pending': 0, 'dead_letter': 0})
+    def boom(hours=24):
+        raise RuntimeError("DB locked")
+    monkeypatch.setattr(archive_queue, 'count_source_gone_recent', boom)
+    monkeypatch.setattr(archive_watchdog, 'get_status',
+                        lambda: {'severity': 'ok'})
+    monkeypatch.setattr(archive_worker, 'get_status',
+                        lambda: {'worker_running': True, 'paused': False})
+
+    block = sh._archive_block()
+    assert block['lost_24h'] == 0
+    assert block['severity'] == 'ok'
+
+
+def test_archive_block_disabled_includes_lost_24h_field(monkeypatch):
+    """The disabled block must still include lost_24h: 0 so JS
+    consumers don't have to special-case missing keys."""
+    import blueprints.system_health as sh
+    monkeypatch.setattr(sh, 'ARCHIVE_QUEUE_ENABLED', False, raising=False)
+    block = sh._archive_block()
+    assert block['lost_24h'] == 0
+
+
 # ---------------------------------------------------------------------------
 # Cloud block
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Surfaces the archive worker's `source_gone` counter (clips Tesla rotated out
of RecentClips before we could copy them) as a Settings banner so the user
knows when they're silently losing dashcam footage.

## Why

This counter is the truest "are we keeping up?" signal. If it grows steadily,
the device is falling behind and footage is being lost forever. Today the
counter exists internally but is never shown — users only find out months
later when they go looking for a specific clip and it's gone.

## Backend

- New `archive_queue.count_source_gone_recent(hours, db_path)` — cheap
  COUNT(*) over rows with `status='source_gone'` and `claimed_at` within
  the last N hours. Uses `CAST(strftime('%s', ...) AS INTEGER)` integer
  arithmetic per the project gotchas (julianday float math is forbidden
  for second-gap windows; that exact bug caused trip-merge fragmentation
  in PR #78). Returns 0 on any SQLite error so the health-card poll
  cannot 500.

- `system_health._archive_block` now calls the helper, surfaces `lost_24h`
  in the JSON payload, and bumps severity to `warn` with a user-facing
  message when `lost_24h > 0`. The lost-files branch sits **above**
  dead-letters in the severity ladder because lost footage is
  unrecoverable, while a dead-letter row still has the source on the
  SD card and can be retried.

## Settings UI

- New banner above the System Health card. Hidden by default; rendered
  by the existing JS poller when `archive.lost_24h > 0`. Loud red
  styling (alert-triangle icon, `--accent-error` border) with a
  "Details" link to the Failed Jobs page. Banner copy is pluralized
  correctly: "1 clip lost" vs "N clips lost".

- Touch-target compliant: link is 44×44 px minimum per the design
  system.

## Tests

- 7 new `count_source_gone_recent` tests: zero state, multiple rows,
  exclusion of non-source_gone, exclusion of old rows (with the wider
  window picking them up), zero-hours short-circuit, ISO-T timestamp
  format compatibility, DB-failure safety.

- 6 new `_archive_block` tests: warn surfacing with lost_24h,
  pluralization, lost-takes-precedence-over-dead-letters, zero means
  ok, count failure-safe path, disabled-block field shape.

- **1128 pass + 3 skipped** (was 1115 + 3; +13 regression tests).

## Files

- `scripts/web/services/archive_queue.py` (+62 LOC) — new helper
- `scripts/web/blueprints/system_health.py` (+15 LOC) — surface
  `lost_24h`, bump severity
- `scripts/web/templates/index.html` (+92 LOC) — banner + JS poller
  extension
- `tests/test_archive_queue.py` (+92 LOC) — `TestCountSourceGoneRecent`
- `tests/test_system_health_blueprint.py` (+105 LOC) — 6 new tests

Closes part of #101.
