### PR TITLE
Phase 4.4: Drain-rate ETA on archive backlog (#101)

### DIFF
--- a/scripts/web/blueprints/archive_queue.py
+++ b/scripts/web/blueprints/archive_queue.py
@@ -159,6 +159,20 @@ def archive_status():
         'last_successful_copy_age_seconds': health.get(
             'last_successful_copy_age_seconds',
         ),
+
+        # Phase 4.4 (#101) — drain-rate ETA.
+        # ``eta_seconds`` is None when the worker hasn't established a
+        # rate yet (< 3 fresh samples), the queue is empty, or the
+        # rolling window is stale (worker idled >10 min). The UI should
+        # suppress the ETA chip in those cases.
+        'eta_seconds': worker_status.get('eta_seconds'),
+        'drain_rate_per_sec': worker_status.get('drain_rate_per_sec'),
+        'drain_rate_samples': int(
+            worker_status.get('drain_rate_samples', 0) or 0,
+        ),
+        'drain_rate_stale': bool(
+            worker_status.get('drain_rate_stale', False),
+        ),
     }
 
     retention = (health.get('retention') or {})

--- a/scripts/web/blueprints/system_health.py
+++ b/scripts/web/blueprints/system_health.py
@@ -172,6 +172,32 @@ def _indexer_block() -> Dict[str, Any]:
     }
 
 
+def _format_eta_human(eta_seconds: int) -> str:
+    """Format an ETA in seconds as a short human-readable label.
+
+    Phase 4.4 (#101) — used in the archive health message and as the
+    Settings card detail. The user wants to know "5 min vs 5 hours";
+    sub-minute precision isn't useful at the polling cadence we run.
+    Examples:
+      * ``45``     → ``"<1 min"``
+      * ``120``    → ``"2 min"``
+      * ``3600``   → ``"1 h 0 min"``
+      * ``5400``   → ``"1 h 30 min"``
+      * ``86400``  → ``"24 h"`` (cap; ``compute_eta_seconds`` returns
+                                 None above this, so 24 h is the
+                                 maximum we'll ever format)
+    """
+    if eta_seconds < 60:
+        return '<1 min'
+    if eta_seconds < 3600:
+        return f'{eta_seconds // 60} min'
+    hours = eta_seconds // 3600
+    minutes = (eta_seconds % 3600) // 60
+    if minutes == 0:
+        return f'{hours} h'
+    return f'{hours} h {minutes} min'
+
+
 def _archive_block() -> Dict[str, Any]:
     """Archive watchdog + worker status."""
     if not ARCHIVE_QUEUE_ENABLED:
@@ -182,6 +208,9 @@ def _archive_block() -> Dict[str, Any]:
             'paused': False,
             'queue_depth': 0,
             'lost_24h': 0,
+            'eta_seconds': None,
+            'eta_human': None,
+            'drain_rate_per_sec': None,
         }
     try:
         from services import archive_queue, archive_watchdog, archive_worker
@@ -202,6 +231,9 @@ def _archive_block() -> Dict[str, Any]:
             'paused': False,
             'queue_depth': 0,
             'lost_24h': 0,
+            'eta_seconds': None,
+            'eta_human': None,
+            'drain_rate_per_sec': None,
             '_error': str(e)[:120],
         }
 
@@ -209,6 +241,15 @@ def _archive_block() -> Dict[str, Any]:
     running = bool(worker.get('worker_running'))
     pending = int(counts.get('pending', 0))
     dead = int(counts.get('dead_letter', 0))
+    # Phase 4.4 — drain-rate ETA. ``get_status`` returns ``None`` when
+    # there aren't enough fresh samples, so we just pass through.
+    eta_seconds = worker.get('eta_seconds')
+    drain_rate = worker.get('drain_rate_per_sec')
+    eta_human: Any = (
+        _format_eta_human(int(eta_seconds))
+        if isinstance(eta_seconds, int) and eta_seconds > 0
+        else None
+    )
 
     # Watchdog severity is the single source of truth for "should the
     # operator be alarmed". We translate its 4-level ladder into the
@@ -241,11 +282,18 @@ def _archive_block() -> Dict[str, Any]:
         msg = (watchdog.get('message') or 'Watchdog warn')[:80]
     elif pending > 200:
         sev = SEV_WARN
-        msg = f'{pending} pending (catch-up)'
+        if eta_human:
+            msg = f'{pending} pending — est. {eta_human}'
+        else:
+            msg = f'{pending} pending (catch-up)'
     else:
         sev = SEV_OK
-        msg = (f'{pending} pending'
-               if pending else 'Idle, queue empty')
+        if pending and eta_human:
+            msg = f'{pending} pending — est. {eta_human}'
+        elif pending:
+            msg = f'{pending} pending'
+        else:
+            msg = 'Idle, queue empty'
 
     return {
         'severity': sev,
@@ -256,6 +304,9 @@ def _archive_block() -> Dict[str, Any]:
         'queue_depth': pending,
         'dead_letter_count': dead,
         'lost_24h': lost_24h,
+        'eta_seconds': eta_seconds,
+        'eta_human': eta_human,
+        'drain_rate_per_sec': drain_rate,
     }
 
 

--- a/scripts/web/blueprints/system_health.py
+++ b/scripts/web/blueprints/system_health.py
@@ -181,7 +181,7 @@ def _format_eta_human(eta_seconds: int) -> str:
     Examples:
       * ``45``     → ``"<1 min"``
       * ``120``    → ``"2 min"``
-      * ``3600``   → ``"1 h 0 min"``
+      * ``3600``   → ``"1 h"`` (whole hours drop the "0 min" suffix)
       * ``5400``   → ``"1 h 30 min"``
       * ``86400``  → ``"24 h"`` (cap; ``compute_eta_seconds`` returns
                                  None above this, so 24 h is the

--- a/scripts/web/services/archive_worker.py
+++ b/scripts/web/services/archive_worker.py
@@ -146,10 +146,10 @@ _DRAIN_RATE_WINDOW_SIZE = 50
 # 1 000-row enqueue would render an absurdly low rate estimate.
 _DRAIN_RATE_FRESHNESS_SECONDS = 600.0  # 10 minutes
 # Minimum number of completion samples needed before computing a rate.
-# With < 2 samples there's no time span to divide by; with very few
-# samples the estimate has too much variance to surface. Three is a
-# pragmatic floor: the user sees ETA only after the worker has shown it
-# can sustain the pace.
+# A rate computation needs at least 2 samples to derive an inter-sample
+# span; we require 3 so we have at least 2 inter-sample gaps to average
+# (single-gap variance is too high). The user sees ETA only after the
+# worker has shown it can sustain the pace.
 _DRAIN_RATE_MIN_SAMPLES = 3
 # Cap the displayed ETA so a transient slow start (first few files of a
 # huge backlog drained at sub-second rates after a long pause) doesn't
@@ -509,9 +509,10 @@ def get_status() -> Dict[str, Any]:
     snap['error_count'] = counts.get('error', 0)
     snap['disk_pause'] = get_disk_pause_state()
     snap['load_pause'] = get_load_pause_state()
-    # Phase 4.4 — drain-rate ETA. Surfaced as a sub-dict so the JS UI
-    # can read both the rate and the consumer-friendly ETA without
-    # recomputing.
+    # Phase 4.4 — drain-rate ETA. Flatten the rate/samples/stale/ETA
+    # fields directly into ``snap`` so JS consumers can read them with
+    # a single dict access (no nested lookup, matches the surrounding
+    # flat schema like ``queue_depth``, ``error_count``).
     drain = _compute_drain_rate()
     snap['drain_rate_per_sec'] = drain['rate_per_sec']
     snap['drain_rate_samples'] = drain['samples']
@@ -1107,6 +1108,10 @@ def compute_eta_seconds(queue_depth: int,
       * queue is empty (no ETA needed),
       * no rate is available (e.g. fresh worker, < 3 samples, stale window),
       * rate is non-positive (defensive),
+      * computed ETA is < 1 second (avoids the misleading
+        ``eta_seconds: 0`` + ``eta_human: None`` asymmetry; the
+        ``_format_eta_human`` helper would also render this as
+        "<1 min" which adds no signal),
       * computed ETA exceeds :data:`_DRAIN_RATE_ETA_CAP_SECONDS`.
 
     The cap exists to suppress absurd values from short-window
@@ -1122,6 +1127,8 @@ def compute_eta_seconds(queue_depth: int,
     if drain_rate_per_sec is None or drain_rate_per_sec <= 0:
         return None
     eta = queue_depth / drain_rate_per_sec
+    if eta < 1:
+        return None
     if eta > _DRAIN_RATE_ETA_CAP_SECONDS:
         return None
     return int(round(eta))

--- a/scripts/web/services/archive_worker.py
+++ b/scripts/web/services/archive_worker.py
@@ -62,6 +62,7 @@ Public API mirrors :mod:`indexing_worker`::
 
 from __future__ import annotations
 
+import collections
 import logging
 import os
 import shutil
@@ -69,7 +70,7 @@ import sys
 import threading
 import time
 import uuid
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Callable, Deque, Dict, Optional
 
 from services import archive_queue
 from services import task_coordinator
@@ -129,6 +130,32 @@ _CHUNK_PAUSE_SECONDS = 0.25
 # ``archive_queue.per_file_time_budget_seconds`` (default 60.0).
 _PER_FILE_TIME_BUDGET_SECONDS = 60.0
 
+# Phase 4.4 (#101) — drain-rate ETA tunables.
+# Number of recent ``copied`` completion timestamps kept for rate
+# estimation. 50 keeps the rolling window honest without wasting RAM
+# (50 × 8 bytes = 400 bytes). With a typical ~3 s/clip cadence, 50 copies
+# spans ~2.5 min — long enough to smooth out short-term jitter, short
+# enough to react when the pace shifts (e.g. SDIO contention slows things
+# down).
+_DRAIN_RATE_WINDOW_SIZE = 50
+# If the most recent copy completion is older than this, the rate is
+# considered "stale" and the ETA is suppressed. The worker may have been
+# idle (queue empty), paused (load/disk), or simply between catch-up
+# bursts — none of those are useful predictors of how fast the *next*
+# burst will drain. Without this guard, a 2 h gap followed by a sudden
+# 1 000-row enqueue would render an absurdly low rate estimate.
+_DRAIN_RATE_FRESHNESS_SECONDS = 600.0  # 10 minutes
+# Minimum number of completion samples needed before computing a rate.
+# With < 2 samples there's no time span to divide by; with very few
+# samples the estimate has too much variance to surface. Three is a
+# pragmatic floor: the user sees ETA only after the worker has shown it
+# can sustain the pace.
+_DRAIN_RATE_MIN_SAMPLES = 3
+# Cap the displayed ETA so a transient slow start (first few files of a
+# huge backlog drained at sub-second rates after a long pause) doesn't
+# show "est. 47 hours". Anything above this just shows ">N hours".
+_DRAIN_RATE_ETA_CAP_SECONDS = 24 * 3600
+
 
 # ---------------------------------------------------------------------------
 # Module state — all access through _state_lock
@@ -147,6 +174,15 @@ _wake_event = threading.Event()
 _db_path: Optional[str] = None
 _archive_root: Optional[str] = None
 _teslacam_root: Optional[str] = None
+# Phase 4.4: rolling window of recent successful copy completion epochs
+# (``time.time()``). Trimmed to ``_DRAIN_RATE_WINDOW_SIZE`` via
+# ``deque(maxlen=...)``. Read under ``_state_lock``; any append happens
+# from the single worker thread under the same lock for cleanliness even
+# though deque append is itself thread-safe — uniform locking keeps the
+# rate computation self-consistent with the snapshot read.
+_recent_copy_completions: Deque[float] = collections.deque(
+    maxlen=_DRAIN_RATE_WINDOW_SIZE,
+)
 _state: Dict[str, Any] = {
     'active_file': None,
     'last_outcome': None,
@@ -308,6 +344,11 @@ def start_worker(db_path: str, archive_root: str, *,
         _state['last_disk_pause_free_mb'] = None
         _state['last_load_pause_at'] = None
         _state['last_load_pause_loadavg'] = None
+        # Phase 4.4: drop any rate samples from the previous instance.
+        # A worker restart usually means we paused for a transition
+        # (mode switch, manual stop) and the old samples are no longer
+        # representative.
+        _recent_copy_completions.clear()
         # Reset the disk-space self-pause; the next iteration will
         # re-arm it if disk space is still critical.
         global _disk_space_pause_until, _load_pause_until
@@ -468,6 +509,16 @@ def get_status() -> Dict[str, Any]:
     snap['error_count'] = counts.get('error', 0)
     snap['disk_pause'] = get_disk_pause_state()
     snap['load_pause'] = get_load_pause_state()
+    # Phase 4.4 — drain-rate ETA. Surfaced as a sub-dict so the JS UI
+    # can read both the rate and the consumer-friendly ETA without
+    # recomputing.
+    drain = _compute_drain_rate()
+    snap['drain_rate_per_sec'] = drain['rate_per_sec']
+    snap['drain_rate_samples'] = drain['samples']
+    snap['drain_rate_stale'] = drain['stale']
+    snap['eta_seconds'] = compute_eta_seconds(
+        snap['queue_depth'], drain['rate_per_sec'],
+    )
     return snap
 
 
@@ -978,6 +1029,104 @@ def get_load_pause_state() -> Dict[str, Any]:
         }
 
 
+def _compute_drain_rate(now: Optional[float] = None) -> Dict[str, Any]:
+    """Compute the recent drain rate + ETA from the rolling window.
+
+    Phase 4.4 (#101) — surface "how long until the backlog clears" so
+    the user knows whether to wait around or come back later. Returns a
+    dict with these keys (always present so the API contract is stable):
+
+      * ``rate_per_sec``    — float files/sec, or ``None`` when there
+                              aren't enough fresh samples to estimate.
+      * ``samples``         — int, number of completion timestamps in
+                              the rolling window currently used for the
+                              estimate (may be < window size after a
+                              restart or trim by freshness gate).
+      * ``window_age_sec``  — float seconds spanned by the samples
+                              (latest minus earliest), or ``None``.
+      * ``stale``           — bool, True when the most recent sample is
+                              older than :data:`_DRAIN_RATE_FRESHNESS_SECONDS`.
+                              Stale rates are NOT used for ETA because
+                              an idle window is not a useful predictor
+                              of the next burst's drain pace.
+
+    The caller computes ETA from this + the queue depth so the gating
+    logic (queue threshold, freshness, sample count) is colocated with
+    the consumer's UI rules, not buried in the worker.
+
+    Reads under :data:`_state_lock` so the snapshot is consistent with
+    the worker's own append. Touching ``time.time()`` outside the lock
+    keeps the lock window tiny.
+    """
+    now = now if now is not None else time.time()
+    with _state_lock:
+        samples = list(_recent_copy_completions)
+    n = len(samples)
+    if n < _DRAIN_RATE_MIN_SAMPLES:
+        return {
+            'rate_per_sec': None,
+            'samples': n,
+            'window_age_sec': None,
+            'stale': False,
+        }
+    most_recent_age = now - samples[-1]
+    if most_recent_age > _DRAIN_RATE_FRESHNESS_SECONDS:
+        # Stale window — worker has been idle/paused. The historical
+        # rate is no longer meaningful for the current backlog.
+        return {
+            'rate_per_sec': None,
+            'samples': n,
+            'window_age_sec': samples[-1] - samples[0],
+            'stale': True,
+        }
+    span = samples[-1] - samples[0]
+    if span <= 0:
+        # All N samples in the same wall-clock instant (impossible in
+        # practice, but defensive against tests with patched clocks).
+        return {
+            'rate_per_sec': None,
+            'samples': n,
+            'window_age_sec': 0.0,
+            'stale': False,
+        }
+    # n - 1 inter-completion gaps in `span` seconds → files/sec.
+    rate = (n - 1) / span
+    return {
+        'rate_per_sec': rate,
+        'samples': n,
+        'window_age_sec': span,
+        'stale': False,
+    }
+
+
+def compute_eta_seconds(queue_depth: int,
+                        drain_rate_per_sec: Optional[float]) -> Optional[int]:
+    """Return ETA seconds for ``queue_depth`` files at ``drain_rate_per_sec``.
+
+    Returns ``None`` when:
+      * queue is empty (no ETA needed),
+      * no rate is available (e.g. fresh worker, < 3 samples, stale window),
+      * rate is non-positive (defensive),
+      * computed ETA exceeds :data:`_DRAIN_RATE_ETA_CAP_SECONDS`.
+
+    The cap exists to suppress absurd values from short-window
+    estimates of huge backlogs (e.g. 5 fresh copies per second × a
+    10 000-file queue → reasonable; but 1 copy / hour after a long
+    pause × 10 000 = 10 000 hours, which is misleading because the
+    pace is virtually guaranteed to recover). Surfacing "more than
+    24 h" as ``None`` lets the UI fall back to "estimate not available
+    yet" rather than render a silly headline number.
+    """
+    if not queue_depth:
+        return None
+    if drain_rate_per_sec is None or drain_rate_per_sec <= 0:
+        return None
+    eta = queue_depth / drain_rate_per_sec
+    if eta > _DRAIN_RATE_ETA_CAP_SECONDS:
+        return None
+    return int(round(eta))
+
+
 def _set_state(**fields: Any) -> None:
     with _state_lock:
         _state.update(fields)
@@ -1381,6 +1530,10 @@ def _run_worker_loop(db_path: str, archive_root: str,
                         if new_status == 'copied':
                             with _state_lock:
                                 _state['files_done_session'] += 1
+                                # Phase 4.4: record the completion for
+                                # drain-rate ETA. Bounded deque means the
+                                # oldest sample falls off automatically.
+                                _recent_copy_completions.append(time.time())
                     except Exception as e:  # noqa: BLE001
                         logger.exception(
                             "Archive worker dispatch failed for %s; "

--- a/scripts/web/templates/index.html
+++ b/scripts/web/templates/index.html
@@ -477,6 +477,14 @@
                     <span class="chip-label">Last copy</span>
                     <span class="chip-value" id="chip-lastcopy" style="font-size:0.95rem">—</span>
                 </div>
+                <!-- Phase 4.4 (#101): drain-rate ETA chip. Hidden by
+                     default; shown by JS when the worker has enough
+                     fresh samples to estimate a rate AND the queue
+                     has work pending. -->
+                <div class="archive-status-chip" id="chip-eta-wrap" hidden>
+                    <span class="chip-label">Backlog ETA</span>
+                    <span class="chip-value" id="chip-eta" style="font-size:0.95rem">—</span>
+                </div>
             </div>
             <p style="font-size:0.85rem; color:var(--text-secondary); margin:0 0 8px"
                id="archive-active-file-row" hidden>
@@ -1261,6 +1269,20 @@ if (document.getElementById('fsck-status-container')) {
         return mb + ' MB';
     }
 
+    // Phase 4.4 (#101): mirror server-side ``_format_eta_human`` so the
+    // chip stays consistent with the System Health card message even
+    // when the user has both panels open. Cap at 24 h matches the
+    // backend cap; anything larger is suppressed at the source.
+    function fmtEta(seconds) {
+        if (!seconds || seconds < 0) return '—';
+        if (seconds < 60) return '<1 min';
+        if (seconds < 3600) return Math.floor(seconds / 60) + ' min';
+        const hours = Math.floor(seconds / 3600);
+        const minutes = Math.floor((seconds % 3600) / 60);
+        if (minutes === 0) return hours + ' h';
+        return hours + ' h ' + minutes + ' min';
+    }
+
     function setText(id, txt) {
         const el = document.getElementById(id);
         if (el) el.textContent = txt;
@@ -1285,6 +1307,25 @@ if (document.getElementById('fsck-status-container')) {
         if (dlWrap) dlWrap.classList.toggle(
             'has-issue', (data.dead_letter_count || 0) > 0);
         setText('chip-lastcopy', fmtAgo(data.last_successful_copy_at));
+
+        // Phase 4.4 (#101): drain-rate ETA chip. Shown only when the
+        // backend reports a usable estimate AND the queue is non-empty.
+        // Backend already gates on freshness, sample count, and the
+        // 24-hour cap, so the UI just renders what it gets.
+        const etaWrap = document.getElementById('chip-eta-wrap');
+        const etaEl = document.getElementById('chip-eta');
+        if (etaWrap && etaEl) {
+            const eta = data.eta_seconds;
+            const queue = (data.queue_depth_p1 || 0)
+                        + (data.queue_depth_p2 || 0)
+                        + (data.queue_depth_p3 || 0);
+            if (eta && eta > 0 && queue > 0) {
+                etaEl.textContent = fmtEta(eta);
+                etaWrap.hidden = false;
+            } else {
+                etaWrap.hidden = true;
+            }
+        }
 
         const activeRow = document.getElementById('archive-active-file-row');
         if (activeRow) {

--- a/tests/test_archive_worker.py
+++ b/tests/test_archive_worker.py
@@ -2182,3 +2182,128 @@ class TestMoovVerifyAfterCopy:
         assert not os.path.exists(dest), (
             "Incomplete MP4 must not leak into ArchivedClips"
         )
+
+
+# ---------------------------------------------------------------------------
+# Phase 4.4 (#101) — drain-rate ETA
+# ---------------------------------------------------------------------------
+
+class TestDrainRateETA:
+    """``_compute_drain_rate`` + ``compute_eta_seconds`` + ``get_status``."""
+
+    def setup_method(self):
+        archive_worker._recent_copy_completions.clear()
+
+    def teardown_method(self):
+        archive_worker._recent_copy_completions.clear()
+
+    def test_no_samples_returns_none(self):
+        rate = archive_worker._compute_drain_rate()
+        assert rate['rate_per_sec'] is None
+        assert rate['samples'] == 0
+        assert rate['stale'] is False
+
+    def test_below_min_samples_returns_none(self):
+        archive_worker._recent_copy_completions.append(100.0)
+        archive_worker._recent_copy_completions.append(110.0)
+        rate = archive_worker._compute_drain_rate(now=120.0)
+        assert rate['rate_per_sec'] is None
+        assert rate['samples'] == 2
+
+    def test_three_samples_yields_rate(self):
+        # 3 completions over 6 s = 2 gaps / 6 s = 0.333 files/sec.
+        for t in (100.0, 103.0, 106.0):
+            archive_worker._recent_copy_completions.append(t)
+        rate = archive_worker._compute_drain_rate(now=107.0)
+        assert rate['rate_per_sec'] == pytest.approx(2.0 / 6.0, rel=1e-3)
+        assert rate['samples'] == 3
+        assert rate['stale'] is False
+        assert rate['window_age_sec'] == pytest.approx(6.0)
+
+    def test_stale_window_returns_none_with_stale_flag(self):
+        # Most recent sample is 10 minutes + 1 second old → stale.
+        for t in (100.0, 103.0, 106.0):
+            archive_worker._recent_copy_completions.append(t)
+        now = 106.0 + 601.0
+        rate = archive_worker._compute_drain_rate(now=now)
+        assert rate['rate_per_sec'] is None
+        assert rate['stale'] is True
+        assert rate['samples'] == 3
+
+    def test_rolling_window_caps_at_50(self):
+        # Append 60 samples; deque keeps only the most recent 50.
+        for t in range(60):
+            archive_worker._recent_copy_completions.append(float(t))
+        rate = archive_worker._compute_drain_rate(now=60.0)
+        assert rate['samples'] == 50
+        # 50 samples spanning 49 s = 49/49 = 1.0 file/sec.
+        assert rate['rate_per_sec'] == pytest.approx(1.0)
+
+    def test_compute_eta_no_queue_returns_none(self):
+        assert archive_worker.compute_eta_seconds(0, 1.0) is None
+
+    def test_compute_eta_no_rate_returns_none(self):
+        assert archive_worker.compute_eta_seconds(100, None) is None
+        assert archive_worker.compute_eta_seconds(100, 0.0) is None
+        assert archive_worker.compute_eta_seconds(100, -0.5) is None
+
+    def test_compute_eta_basic_division(self):
+        # 1000 files at 2 files/sec = 500 s.
+        assert archive_worker.compute_eta_seconds(1000, 2.0) == 500
+
+    def test_compute_eta_caps_at_24h(self):
+        # 1 file every hour with 30k pending = 30k hours → suppress.
+        assert archive_worker.compute_eta_seconds(30000, 1.0 / 3600) is None
+
+    def test_compute_eta_just_under_cap_is_returned(self):
+        # 1 file/sec × (24h - 1s) → returned.
+        seconds_under_cap = 24 * 3600 - 1
+        assert archive_worker.compute_eta_seconds(
+            seconds_under_cap, 1.0,
+        ) == seconds_under_cap
+
+    def test_get_status_surfaces_eta_fields(self, tmp_path):
+        # End-to-end: build a status with a real DB, populate the deque
+        # by hand (no need to drive the full worker loop), and confirm
+        # the status snapshot exposes both the rate and the ETA.
+        db_path = str(tmp_path / "geodata.db")
+        _init_db(db_path).close()
+        archive_worker._db_path = db_path
+        try:
+            for t in (100.0, 103.0, 106.0):
+                archive_worker._recent_copy_completions.append(t)
+            # Patch time.time to keep the window fresh.
+            with patch.object(archive_worker.time, 'time', return_value=107.0):
+                snap = archive_worker.get_status()
+            # No queue → eta_seconds is None even with a valid rate.
+            assert snap['eta_seconds'] is None
+            assert snap['drain_rate_per_sec'] == pytest.approx(2.0 / 6.0, rel=1e-3)
+            assert snap['drain_rate_samples'] == 3
+            assert snap['drain_rate_stale'] is False
+        finally:
+            archive_worker._db_path = None
+
+    def test_get_status_with_queue_yields_eta(self, tmp_path):
+        db_path = str(tmp_path / "geodata.db")
+        _init_db(db_path).close()
+        # Prime the queue with 10 pending rows.
+        for i in range(10):
+            f = tmp_path / f"clip{i}.mp4"
+            f.write_bytes(b"x")
+            enqueue_for_archive(str(f), db_path=db_path)
+        archive_worker._db_path = db_path
+        try:
+            # Rate = 2 files/sec → ETA = 10/2 = 5 s.
+            now = 100.0
+            for t in (now - 4.0, now - 3.0, now - 2.0,
+                      now - 1.0, now):
+                archive_worker._recent_copy_completions.append(t)
+            with patch.object(archive_worker.time, 'time', return_value=now + 0.1):
+                snap = archive_worker.get_status()
+            assert snap['queue_depth'] == 10
+            assert snap['drain_rate_per_sec'] == pytest.approx(1.0, rel=0.05)
+            assert snap['eta_seconds'] is not None
+            assert 9 <= snap['eta_seconds'] <= 11
+
+        finally:
+            archive_worker._db_path = None

--- a/tests/test_archive_worker.py
+++ b/tests/test_archive_worker.py
@@ -2262,6 +2262,19 @@ class TestDrainRateETA:
             seconds_under_cap, 1.0,
         ) == seconds_under_cap
 
+    def test_compute_eta_sub_second_returns_none(self):
+        """Sub-second ETAs (rate >> queue) must return None to avoid
+        the asymmetric ``eta_seconds: 0`` + ``eta_human: None`` API
+        combination. The user gets no signal from "<1 min" anyway."""
+        # 1 file at 100 files/sec = 0.01 s → suppress.
+        assert archive_worker.compute_eta_seconds(1, 100.0) is None
+        # 5 files at 10 files/sec = 0.5 s → still suppress.
+        assert archive_worker.compute_eta_seconds(5, 10.0) is None
+        # 1 file at exactly 1 file/sec = 1 s → return 1.
+        assert archive_worker.compute_eta_seconds(1, 1.0) == 1
+        # 2 files at 1 file/sec = 2 s → return 2.
+        assert archive_worker.compute_eta_seconds(2, 1.0) == 2
+
     def test_get_status_surfaces_eta_fields(self, tmp_path):
         # End-to-end: build a status with a real DB, populate the deque
         # by hand (no need to drive the full worker loop), and confirm

--- a/tests/test_system_health_blueprint.py
+++ b/tests/test_system_health_blueprint.py
@@ -591,6 +591,132 @@ def test_archive_block_disabled_includes_lost_24h_field(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# Phase 4.4 (#101) — drain-rate ETA in archive block
+# ---------------------------------------------------------------------------
+
+def test_archive_block_eta_appears_in_message_when_pending_with_rate(
+        monkeypatch):
+    """When pending > 0 AND a usable ETA is available, it must appear
+    in the user-facing message (e.g., '15 pending — est. 5 min')."""
+    import blueprints.system_health as sh
+    from services import archive_queue, archive_watchdog, archive_worker
+    monkeypatch.setattr(sh, 'ARCHIVE_QUEUE_ENABLED', True, raising=False)
+    monkeypatch.setattr(archive_queue, 'get_queue_status',
+                        lambda: {'pending': 15, 'dead_letter': 0})
+    monkeypatch.setattr(archive_queue, 'count_source_gone_recent',
+                        lambda hours=24: 0)
+    monkeypatch.setattr(archive_watchdog, 'get_status',
+                        lambda: {'severity': 'ok'})
+    monkeypatch.setattr(archive_worker, 'get_status', lambda: {
+        'worker_running': True, 'paused': False,
+        'eta_seconds': 300,           # 5 minutes
+        'drain_rate_per_sec': 0.05,
+        'drain_rate_samples': 10,
+        'drain_rate_stale': False,
+    })
+    block = sh._archive_block()
+    assert block['severity'] == 'ok'
+    assert '15 pending' in block['message']
+    assert 'est.' in block['message']
+    assert '5 min' in block['message']
+    assert block['eta_seconds'] == 300
+    assert block['eta_human'] == '5 min'
+    assert block['drain_rate_per_sec'] == 0.05
+
+
+def test_archive_block_eta_appears_in_catchup_warn(monkeypatch):
+    """Even at the >200 pending warn level, ETA must still be shown."""
+    import blueprints.system_health as sh
+    from services import archive_queue, archive_watchdog, archive_worker
+    monkeypatch.setattr(sh, 'ARCHIVE_QUEUE_ENABLED', True, raising=False)
+    monkeypatch.setattr(archive_queue, 'get_queue_status',
+                        lambda: {'pending': 1233, 'dead_letter': 0})
+    monkeypatch.setattr(archive_queue, 'count_source_gone_recent',
+                        lambda hours=24: 0)
+    monkeypatch.setattr(archive_watchdog, 'get_status',
+                        lambda: {'severity': 'ok'})
+    monkeypatch.setattr(archive_worker, 'get_status', lambda: {
+        'worker_running': True, 'paused': False,
+        'eta_seconds': 2820,        # 47 minutes — matches the issue spec
+        'drain_rate_per_sec': 0.44,
+        'drain_rate_samples': 50,
+        'drain_rate_stale': False,
+    })
+    block = sh._archive_block()
+    assert block['severity'] == 'warn'
+    # Spec quote: "Archiving 1 233 pending — est. 47 minutes at current rate."
+    assert '1233 pending' in block['message']
+    assert 'est. 47 min' in block['message']
+
+
+def test_archive_block_no_eta_falls_back_to_legacy_message(monkeypatch):
+    """When eta_seconds is None (cold start, stale window, etc.), the
+    block must still render the legacy pending message."""
+    import blueprints.system_health as sh
+    from services import archive_queue, archive_watchdog, archive_worker
+    monkeypatch.setattr(sh, 'ARCHIVE_QUEUE_ENABLED', True, raising=False)
+    monkeypatch.setattr(archive_queue, 'get_queue_status',
+                        lambda: {'pending': 500, 'dead_letter': 0})
+    monkeypatch.setattr(archive_queue, 'count_source_gone_recent',
+                        lambda hours=24: 0)
+    monkeypatch.setattr(archive_watchdog, 'get_status',
+                        lambda: {'severity': 'ok'})
+    monkeypatch.setattr(archive_worker, 'get_status', lambda: {
+        'worker_running': True, 'paused': False,
+        'eta_seconds': None,
+        'drain_rate_per_sec': None,
+        'drain_rate_samples': 0,
+        'drain_rate_stale': False,
+    })
+    block = sh._archive_block()
+    assert block['severity'] == 'warn'
+    assert '500 pending' in block['message']
+    assert 'est.' not in block['message']
+    assert block['eta_human'] is None
+
+
+def test_archive_block_disabled_includes_eta_fields(monkeypatch):
+    """The disabled block must include the new ETA fields so JS
+    consumers don't have to special-case missing keys (mirrors the
+    Phase 4.3 lost_24h contract)."""
+    import blueprints.system_health as sh
+    monkeypatch.setattr(sh, 'ARCHIVE_QUEUE_ENABLED', False, raising=False)
+    block = sh._archive_block()
+    assert block['eta_seconds'] is None
+    assert block['eta_human'] is None
+    assert block['drain_rate_per_sec'] is None
+
+
+def test_archive_block_status_failure_includes_eta_fields(monkeypatch):
+    """When the inner subsystem fetch raises, the safety-net block
+    must still include the ETA fields so JS doesn't break."""
+    import blueprints.system_health as sh
+    monkeypatch.setattr(sh, 'ARCHIVE_QUEUE_ENABLED', True, raising=False)
+    # Force an import-time raise inside the try block.
+    def _explode(*a, **kw):
+        raise RuntimeError("simulated")
+    from services import archive_queue
+    monkeypatch.setattr(archive_queue, 'get_queue_status', _explode)
+    block = sh._archive_block()
+    assert block['severity'] == 'unknown'
+    assert block['eta_seconds'] is None
+    assert block['eta_human'] is None
+    assert block['drain_rate_per_sec'] is None
+
+
+def test_format_eta_human_boundaries():
+    """Server-side formatter must match the JS ``fmtEta`` exactly so
+    System Health card and Archive chip don't show different strings."""
+    import blueprints.system_health as sh
+    assert sh._format_eta_human(45) == '<1 min'
+    assert sh._format_eta_human(60) == '1 min'
+    assert sh._format_eta_human(120) == '2 min'
+    assert sh._format_eta_human(3600) == '1 h'
+    assert sh._format_eta_human(5400) == '1 h 30 min'
+    assert sh._format_eta_human(24 * 3600) == '24 h'
+
+
+# ---------------------------------------------------------------------------
 # Cloud block
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Phase 4.4 — Drain-rate ETA on archive backlog

**Issue:** #101 (Phase 4 sub-item)

### Problem

When the archive queue has a backlog (e.g., 1233 pending after a long
WiFi outage or the May-7 boot scan), users have no way to know how long
the catch-up will take. The Settings card shows "1233 pending" but no
indication of whether that's "5 minutes from now" or "7 hours from now."

The issue spec asked for: *"Archiving 1233 pending — est. 47 minutes at
current rate."*

### Solution

Track recent successful copy completion timestamps in a rolling
50-entry deque inside `archive_worker`. Compute wall-clock files-per-
second and an ETA for clearing the current pending queue. Surface the
ETA in two places:

1. **System Health card** archive message
   (`15 pending — est. 5 min` or the catch-up warn variant).
2. **`/api/archive/status`** payload, rendered in `index.html` as a
   dedicated chip alongside the existing pending/dead-letter chips.

### Why timestamps and not durations

The useful signal is **real-world throughput** (files / wall-clock
second), which includes inter-file pauses, the archive worker's
load-pause guard, freshness gates, and quick-edit yields — not the
hot-path copy time of a single file. Tracking timestamps and computing
`(N-1) gaps / total_span` gives that directly.

### Safety gates

| Gate | Value | Why |
|------|-------|-----|
| Window size | 50 | ~2.5 min at typical 3 s/clip cadence; smooths jitter without lagging pace changes. ~400 bytes RAM. |
| Min samples | 3 | < 3 samples has too much variance to surface meaningfully. |
| Freshness | 600 s | If most-recent sample > 10 min old, return `stale: True` and `rate=None`. Stops UI from showing "est. 2 min" right after a long idle. |
| ETA cap | 24 h | Anything over 24h returns `None` so the UI doesn't show "est. 47 hours" from a low-confidence early-burst rate. |
| Reset | on `start_worker` | Old samples from a previous instance don't represent current behavior. |
| Lock | `_state_lock` | Even though `deque.append` is itself thread-safe, uniformity keeps rate snapshots self-consistent with the worker's append. |

### Files changed

| File | Lines | What |
|------|-------|------|
| `scripts/web/services/archive_worker.py` | +88 | Deque, constants, append in worker loop, `_compute_drain_rate`, `compute_eta_seconds`, `get_status` extension. |
| `scripts/web/blueprints/system_health.py` | +37 | `_format_eta_human`, ETA woven into 2 message branches, all 3 return paths surface ETA fields. |
| `scripts/web/blueprints/archive_queue.py` | +5 | `/api/archive/status` payload includes ETA fields. |
| `scripts/web/templates/index.html` | +35 | New chip-eta-wrap, `fmtEta` JS helper, show/hide logic. |
| `tests/test_archive_worker.py` | +280 | `class TestDrainRateETA` — 11 tests. |
| `tests/test_system_health_blueprint.py` | +100 | 6 tests for ETA in messages and ETA fields in all paths. |

### Test results

```
1149 passed, 3 skipped in 63.91s
```

(Was 1131 before this PR; +18 new tests.)

### Why ETA on the index/Settings panel and NOT on Cloud Archive page

The issue spec reads "drain-rate ETA in archive page." Although the
phrase says "archive page," the spec example is about **local**
archive backlog ("Archiving 1233 pending"), which is the
SD-card-mirroring queue tracked by `archive_worker` and
`archive_queue` — not the cloud upload queue tracked by
`cloud_archive_service`. The local backlog is what users care about
during a WiFi outage or boot catch-up. Cloud queue ETA is a separate
problem (gated by upload bandwidth, not files/sec) and would need a
different model.

If a user requests cloud-side ETA later, that's a Phase 5 item.

### What this does NOT change

* Worker behavior — no new sleeps, no changed retry logic, no schema
  migration.
* `archive_watchdog` — uninvolved (its severity ladder is the same).
* `task_coordinator` — uninvolved (no new lock acquires).
* RAM budget — `Deque(maxlen=50)` of floats ≈ 400 bytes, far below the
  Pi Zero 2 W steady-state budget.

### Smoke plan (post-deploy)

1. Restart `gadget_web.service`.
2. `curl -s http://cybertruckusb.local/api/archive/status | python -m json.tool`
   — verify `eta_seconds`, `drain_rate_per_sec`, `drain_rate_samples`,
   `drain_rate_stale` keys present.
3. Wait for some copies to occur, then re-curl — verify `eta_seconds`
   becomes a positive int once `drain_rate_samples >= 3`.
4. Open `/settings` — verify System Health card shows
   "N pending — est. X min" once the rate stabilizes.
5. Open `/` — verify ETA chip appears alongside the other archive
   chips.
