### PR TITLE
Phase 4.5 (#101): Pause reasons in archive banner

### DIFF
--- a/scripts/web/blueprints/system_health.py
+++ b/scripts/web/blueprints/system_health.py
@@ -219,7 +219,7 @@ def _format_pause_reason(load_pause: Dict[str, Any],
     When neither has armed (``pause_worker()`` was called manually,
     or the worker is paused for an unknown reason at the iteration
     boundary), return ``"background"`` so the caller renders a
-    generic "Paused (background)" without claiming false specificity.
+    generic "Paused (background task)" without claiming false specificity.
     """
     parts = []
 
@@ -310,10 +310,19 @@ def _archive_block() -> Dict[str, Any]:
     )
     # Phase 4.5 — pause-reason. Pull the disk/load pause sub-dicts
     # surfaced by archive_worker and render a self-explanatory string.
-    # Always computed (even when not paused) so the API contract stays
-    # stable; the message branch below decides whether to use it.
+    # The top-level ``paused`` field returned by ``get_status()`` only
+    # reflects the manual ``pause_worker()`` flag (used by mode
+    # switches / RW remounts); it does NOT track the auto-arm guards
+    # ``_disk_space_pause_until`` and ``_load_pause_until``. So
+    # broaden the operator-facing paused notion to include any of the
+    # three pause types so the System Health card surfaces the load /
+    # disk auto-pauses too.
     load_pause = worker.get('load_pause') or {}
     disk_pause = worker.get('disk_pause') or {}
+    auto_paused = bool(
+        load_pause.get('is_paused_now') or disk_pause.get('is_paused_now')
+    )
+    paused_effective = paused or auto_paused
     pause_reason = _format_pause_reason(load_pause, disk_pause)
 
     # Watchdog severity is the single source of truth for "should the
@@ -339,7 +348,7 @@ def _archive_block() -> Dict[str, Any]:
     elif dead > 0:
         sev = SEV_WARN
         msg = f'{dead} dead-letter row{"s" if dead != 1 else ""}'
-    elif paused:
+    elif paused_effective:
         sev = SEV_WARN
         # Phase 4.5 — render the actual reason instead of an opaque
         # "Paused (load or disk)". When neither guard has armed
@@ -373,7 +382,12 @@ def _archive_block() -> Dict[str, Any]:
         'message': msg,
         'enabled': True,
         'worker_running': running,
-        'paused': paused,
+        # Phase 4.5: ``paused`` reflects the operator-facing notion
+        # (any of: manual pause flag, load auto-pause armed, disk
+        # auto-pause armed). The lower-level ``/api/archive/status``
+        # still distinguishes the manual flag via its own ``paused``
+        # key for callers that need to differentiate.
+        'paused': paused_effective,
         'queue_depth': pending,
         'dead_letter_count': dead,
         'lost_24h': lost_24h,
@@ -383,7 +397,7 @@ def _archive_block() -> Dict[str, Any]:
         # Phase 4.5 — surface raw pause-reason for callers that want
         # to render their own UI (chip, tooltip, etc.) without
         # re-parsing the message string.
-        'pause_reason': pause_reason if paused else None,
+        'pause_reason': pause_reason if paused_effective else None,
     }
 
 

--- a/scripts/web/blueprints/system_health.py
+++ b/scripts/web/blueprints/system_health.py
@@ -198,6 +198,62 @@ def _format_eta_human(eta_seconds: int) -> str:
     return f'{hours} h {minutes} min'
 
 
+def _format_pause_reason(load_pause: Dict[str, Any],
+                         disk_pause: Dict[str, Any]) -> str:
+    """Phase 4.5 (#101) — render a self-explanatory pause-reason string.
+
+    The archive worker auto-pauses for two reasons:
+
+    * **load** — 1-min loadavg crossed
+      ``archive_queue.load_pause_threshold`` (default 3.5). The pause
+      relieves the SDIO bus and keeps the hardware watchdog daemon
+      from missing its kick. Reason string: ``"load 4.2 > 3.5"``.
+    * **disk** — free space at ``archive_root`` fell below the
+      configured critical threshold (default 100 MB). The pause stops
+      new copies until retention or manual cleanup frees space.
+      Reason string: ``"SD card 96% full"`` (when total is known) or
+      ``"SD card 50 MB free (threshold 100 MB)"`` (when only free is
+      known).
+
+    When both fire concurrently we join them with a semicolon.
+    When neither has armed (``pause_worker()`` was called manually,
+    or the worker is paused for an unknown reason at the iteration
+    boundary), return ``"background"`` so the caller renders a
+    generic "Paused (background)" without claiming false specificity.
+    """
+    parts = []
+
+    load_now = bool(load_pause.get('is_paused_now'))
+    load_avg = load_pause.get('last_loadavg')
+    load_thresh = load_pause.get('threshold')
+    if load_now and isinstance(load_avg, (int, float)) and \
+            isinstance(load_thresh, (int, float)) and load_thresh > 0:
+        parts.append(f'load {load_avg:.1f} > {load_thresh:.1f}')
+
+    disk_now = bool(disk_pause.get('is_paused_now'))
+    free_mb = disk_pause.get('last_free_mb')
+    total_mb = disk_pause.get('last_total_mb')
+    crit_mb = disk_pause.get('critical_threshold_mb')
+    if disk_now and isinstance(free_mb, (int, float)) and free_mb >= 0:
+        if isinstance(total_mb, (int, float)) and total_mb > 0:
+            pct_full = int(round((1 - free_mb / total_mb) * 100))
+            # Cap at 99% so we never claim "100% full" — there's
+            # always at least the few MB the OS keeps reserved.
+            pct_full = min(pct_full, 99)
+            parts.append(f'SD card {pct_full}% full')
+        elif isinstance(crit_mb, (int, float)) and crit_mb > 0:
+            parts.append(
+                f'SD card {int(free_mb)} MB free '
+                f'(threshold {int(crit_mb)} MB)'
+            )
+        else:
+            parts.append(f'SD card {int(free_mb)} MB free')
+
+    if not parts:
+        return 'background'
+    return '; '.join(parts)
+
+
 def _archive_block() -> Dict[str, Any]:
     """Archive watchdog + worker status."""
     if not ARCHIVE_QUEUE_ENABLED:
@@ -211,6 +267,7 @@ def _archive_block() -> Dict[str, Any]:
             'eta_seconds': None,
             'eta_human': None,
             'drain_rate_per_sec': None,
+            'pause_reason': None,
         }
     try:
         from services import archive_queue, archive_watchdog, archive_worker
@@ -234,6 +291,7 @@ def _archive_block() -> Dict[str, Any]:
             'eta_seconds': None,
             'eta_human': None,
             'drain_rate_per_sec': None,
+            'pause_reason': None,
             '_error': str(e)[:120],
         }
 
@@ -250,6 +308,13 @@ def _archive_block() -> Dict[str, Any]:
         if isinstance(eta_seconds, int) and eta_seconds > 0
         else None
     )
+    # Phase 4.5 — pause-reason. Pull the disk/load pause sub-dicts
+    # surfaced by archive_worker and render a self-explanatory string.
+    # Always computed (even when not paused) so the API contract stays
+    # stable; the message branch below decides whether to use it.
+    load_pause = worker.get('load_pause') or {}
+    disk_pause = worker.get('disk_pause') or {}
+    pause_reason = _format_pause_reason(load_pause, disk_pause)
 
     # Watchdog severity is the single source of truth for "should the
     # operator be alarmed". We translate its 4-level ladder into the
@@ -276,7 +341,15 @@ def _archive_block() -> Dict[str, Any]:
         msg = f'{dead} dead-letter row{"s" if dead != 1 else ""}'
     elif paused:
         sev = SEV_WARN
-        msg = 'Paused (load or disk)'
+        # Phase 4.5 — render the actual reason instead of an opaque
+        # "Paused (load or disk)". When neither guard has armed
+        # (manual ``pause_worker()`` from a mode switch, RW remount,
+        # quick-edit), ``_format_pause_reason`` returns "background"
+        # which we surface as the human-friendly fallback.
+        if pause_reason == 'background':
+            msg = 'Paused (background task)'
+        else:
+            msg = f'Paused: {pause_reason}'
     elif wd_sev == SEV_WARN:
         sev = SEV_WARN
         msg = (watchdog.get('message') or 'Watchdog warn')[:80]
@@ -307,6 +380,10 @@ def _archive_block() -> Dict[str, Any]:
         'eta_seconds': eta_seconds,
         'eta_human': eta_human,
         'drain_rate_per_sec': drain_rate,
+        # Phase 4.5 — surface raw pause-reason for callers that want
+        # to render their own UI (chip, tooltip, etc.) without
+        # re-parsing the message string.
+        'pause_reason': pause_reason if paused else None,
     }
 
 

--- a/scripts/web/services/archive_worker.py
+++ b/scripts/web/services/archive_worker.py
@@ -191,6 +191,7 @@ _state: Dict[str, Any] = {
     'last_drained_at': None,
     'last_disk_pause_at': None,
     'last_disk_pause_free_mb': None,
+    'last_disk_pause_total_mb': None,
     'last_load_pause_at': None,
     'last_load_pause_loadavg': None,
 }
@@ -342,6 +343,7 @@ def start_worker(db_path: str, archive_root: str, *,
         _state['active_file'] = None
         _state['last_disk_pause_at'] = None
         _state['last_disk_pause_free_mb'] = None
+        _state['last_disk_pause_total_mb'] = None
         _state['last_load_pause_at'] = None
         _state['last_load_pause_loadavg'] = None
         # Phase 4.4: drop any rate samples from the previous instance.
@@ -1006,11 +1008,30 @@ def _check_disk_space_guard(archive_root: str) -> str:
 
 
 def get_disk_pause_state() -> Dict[str, Any]:
-    """Return the current disk-space pause state for status endpoints."""
-    return {
-        'paused_until_epoch': float(_disk_space_pause_until),
-        'is_paused_now': _disk_space_pause_until > time.time(),
-    }
+    """Return the current disk-space pause state for status endpoints.
+
+    Phase 4.5 (#101) — surfaces the *reason* the disk-space guard
+    armed the pause so the UI can render "Paused: SD card X% full"
+    instead of an opaque "Paused" string. ``last_pause_at`` and
+    ``last_free_mb`` are set the first time the critical-threshold
+    guard fires (via :func:`process_one_claim`); they remain ``None``
+    on a freshly started worker that has never seen a critical hit.
+
+    ``critical_threshold_mb`` and ``warning_threshold_mb`` are the
+    currently-configured trip points (resolved at call time so config
+    edits show up without a service restart).
+    """
+    warn_mb, crit_mb = _resolve_disk_thresholds_mb()
+    with _state_lock:
+        return {
+            'paused_until_epoch': float(_disk_space_pause_until),
+            'is_paused_now': _disk_space_pause_until > time.time(),
+            'last_pause_at': _state.get('last_disk_pause_at'),
+            'last_free_mb': _state.get('last_disk_pause_free_mb'),
+            'last_total_mb': _state.get('last_disk_pause_total_mb'),
+            'critical_threshold_mb': int(crit_mb),
+            'warning_threshold_mb': int(warn_mb),
+        }
 
 
 def get_load_pause_state() -> Dict[str, Any]:
@@ -1020,13 +1041,25 @@ def get_load_pause_state() -> Dict[str, Any]:
     pause (None until the guard fires for the first time). Mirrors
     :func:`get_disk_pause_state` so the UI can show *why* the worker
     isn't draining.
+
+    Phase 4.5 (#101) — also surfaces the configured
+    ``threshold`` (resolved at call time) so the message can render
+    "Paused: load 4.2 > 3.5".
     """
+    # Threshold is the 5th element of the _read_config_or_defaults
+    # tuple; resolve outside the state lock to keep the critical
+    # section small.
+    try:
+        threshold = float(_read_config_or_defaults()[4])
+    except Exception:  # noqa: BLE001
+        threshold = float(_LOAD_PAUSE_THRESHOLD)
     with _state_lock:
         return {
             'paused_until_epoch': float(_load_pause_until),
             'is_paused_now': _load_pause_until > time.time(),
             'last_pause_at': _state.get('last_load_pause_at'),
             'last_loadavg': _state.get('last_load_pause_loadavg'),
+            'threshold': threshold,
         }
 
 
@@ -1286,14 +1319,16 @@ def process_one_claim(row: Dict[str, Any], db_path: str,
             now_fn() + _resolve_disk_space_pause_seconds()
         )
         try:
-            free_mb = int(
-                shutil.disk_usage(archive_root).free // (1024 * 1024)
-            )
+            usage = shutil.disk_usage(archive_root)
+            free_mb = int(usage.free // (1024 * 1024))
+            total_mb = int(usage.total // (1024 * 1024))
         except OSError:
             free_mb = -1
+            total_mb = -1
         with _state_lock:
             _state['last_disk_pause_at'] = time.time()
             _state['last_disk_pause_free_mb'] = free_mb
+            _state['last_disk_pause_total_mb'] = total_mb
         # Phase 1 item 1.5: kick the retention prune NOW (debounced)
         # so we don't sit at "Archive paused" for up to 24 h waiting
         # for the daily retention timer.

--- a/tests/test_archive_worker.py
+++ b/tests/test_archive_worker.py
@@ -2320,3 +2320,119 @@ class TestDrainRateETA:
 
         finally:
             archive_worker._db_path = None
+
+
+# ---------------------------------------------------------------------------
+# Phase 4.5 (#101) — pause-state helpers expose threshold + total
+# ---------------------------------------------------------------------------
+
+class TestPauseStateExtensions:
+    """Phase 4.5 extends ``get_disk_pause_state`` and
+    ``get_load_pause_state`` with the configured thresholds and (for
+    disk) the total bytes so the System Health card can render
+    ``"load 4.2 > 3.5"`` and ``"SD card 96% full"`` instead of an
+    opaque ``"Paused (load or disk)"``.
+
+    These tests pin the dict shape; the human-readable formatting is
+    pinned separately in ``test_system_health_blueprint.py``.
+    """
+
+    def setup_method(self):
+        # Module-level ``_state`` leaks between tests in the file.
+        # Reset the disk/load pause slots so we observe a clean default.
+        with archive_worker._state_lock:
+            archive_worker._state['last_disk_pause_at'] = None
+            archive_worker._state['last_disk_pause_free_mb'] = None
+            archive_worker._state['last_disk_pause_total_mb'] = None
+            archive_worker._state['last_load_pause_at'] = None
+            archive_worker._state['last_load_pause_loadavg'] = None
+        archive_worker._disk_space_pause_until = 0.0
+        archive_worker._load_pause_until = 0.0
+
+    teardown_method = setup_method
+
+    def test_get_disk_pause_state_includes_thresholds(self):
+        # Default state (no pause has armed). Both thresholds are
+        # positive integers resolved from config (or fallback
+        # constants); the last_* fields are None.
+        state = archive_worker.get_disk_pause_state()
+        assert isinstance(state['critical_threshold_mb'], int)
+        assert isinstance(state['warning_threshold_mb'], int)
+        assert state['critical_threshold_mb'] > 0
+        # Warning threshold must be >= critical (the watchdog turns
+        # warn before it turns critical).
+        assert state['warning_threshold_mb'] >= state['critical_threshold_mb']
+        # Phase 4.5 fields default to None when no pause has fired.
+        assert state['last_pause_at'] is None
+        assert state['last_free_mb'] is None
+        assert state['last_total_mb'] is None
+        # Existing fields still present (regression guard).
+        assert state['paused_until_epoch'] == 0.0
+        assert state['is_paused_now'] is False
+
+    def test_get_disk_pause_state_after_pause_includes_total(
+        self, db, archive_root, monkeypatch,
+    ):
+        # Simulate the pause-arming side-effect by populating
+        # ``_state`` directly the way ``process_one_claim`` does
+        # under the disk-space guard. Phase 4.5 added the
+        # ``last_disk_pause_total_mb`` slot so the formatter can
+        # render "% full".
+        with archive_worker._state_lock:
+            archive_worker._state['last_disk_pause_at'] = 1234.5
+            archive_worker._state['last_disk_pause_free_mb'] = 1024
+            archive_worker._state['last_disk_pause_total_mb'] = 25600
+        try:
+            state = archive_worker.get_disk_pause_state()
+            assert state['last_pause_at'] == 1234.5
+            assert state['last_free_mb'] == 1024
+            assert state['last_total_mb'] == 25600
+        finally:
+            with archive_worker._state_lock:
+                archive_worker._state['last_disk_pause_at'] = None
+                archive_worker._state['last_disk_pause_free_mb'] = None
+                archive_worker._state['last_disk_pause_total_mb'] = None
+
+    def test_get_load_pause_state_includes_threshold(self):
+        # Phase 4.5 added ``threshold`` so the System Health card
+        # can render ``"load 4.2 > 3.5"`` without re-reading config.
+        state = archive_worker.get_load_pause_state()
+        assert 'threshold' in state
+        assert isinstance(state['threshold'], (int, float))
+        assert state['threshold'] > 0
+        # Threshold value must match what
+        # ``_read_config_or_defaults()`` returns (so config edits flow
+        # through without a service restart). Position [4] is
+        # ``load_pause_threshold``.
+        assert state['threshold'] == \
+            archive_worker._read_config_or_defaults()[4]
+
+    def test_get_load_pause_state_threshold_falls_back_on_config_error(
+        self, monkeypatch,
+    ):
+        # If config import fails (e.g. config.yaml missing), the
+        # helper must fall back to the module-level constant rather
+        # than raising — the System Health card poll happens every
+        # 5 s and a single bad poll should never break the page.
+        def boom(*_a, **_kw):
+            raise RuntimeError("config import failed")
+
+        monkeypatch.setattr(
+            archive_worker, '_read_config_or_defaults', boom,
+        )
+        state = archive_worker.get_load_pause_state()
+        assert state['threshold'] == archive_worker._LOAD_PAUSE_THRESHOLD
+
+    def test_start_worker_resets_disk_total_mb(self, db, archive_root):
+        # Parity with the Phase 1 reset of ``last_disk_pause_free_mb``.
+        # Without this the new total would leak across worker
+        # restarts (e.g. mode switch → restart).
+        with archive_worker._state_lock:
+            archive_worker._state['last_disk_pause_total_mb'] = 12345
+
+        archive_worker.start_worker(db, archive_root, teslacam_root=None)
+        try:
+            with archive_worker._state_lock:
+                assert archive_worker._state['last_disk_pause_total_mb'] is None
+        finally:
+            archive_worker.stop_worker(timeout=5)

--- a/tests/test_system_health_blueprint.py
+++ b/tests/test_system_health_blueprint.py
@@ -717,6 +717,252 @@ def test_format_eta_human_boundaries():
 
 
 # ---------------------------------------------------------------------------
+# Phase 4.5 (#101) — pause-reason in archive block
+# ---------------------------------------------------------------------------
+
+def test_format_pause_reason_load_only():
+    """Spec quote: 'Archive paused: load 4.2 > 3.5 threshold'."""
+    import blueprints.system_health as sh
+    out = sh._format_pause_reason(
+        load_pause={
+            'is_paused_now': True,
+            'last_loadavg': 4.2,
+            'threshold': 3.5,
+        },
+        disk_pause={'is_paused_now': False},
+    )
+    assert out == 'load 4.2 > 3.5'
+
+
+def test_format_pause_reason_disk_only_with_total():
+    """Spec quote: 'Archive paused: SD card 96% full'."""
+    import blueprints.system_health as sh
+    # 96% full = 4% free → e.g. 1024 MB free of 25600 MB total.
+    out = sh._format_pause_reason(
+        load_pause={'is_paused_now': False},
+        disk_pause={
+            'is_paused_now': True,
+            'last_free_mb': 1024,
+            'last_total_mb': 25600,
+            'critical_threshold_mb': 100,
+        },
+    )
+    assert out == 'SD card 96% full'
+
+
+def test_format_pause_reason_disk_only_without_total():
+    """When ``last_total_mb`` is unknown, fall back to MB-free
+    rendering with the threshold for context."""
+    import blueprints.system_health as sh
+    out = sh._format_pause_reason(
+        load_pause={'is_paused_now': False},
+        disk_pause={
+            'is_paused_now': True,
+            'last_free_mb': 50,
+            'last_total_mb': None,
+            'critical_threshold_mb': 100,
+        },
+    )
+    assert out == 'SD card 50 MB free (threshold 100 MB)'
+
+
+def test_format_pause_reason_disk_full_capped_at_99():
+    """100% full claims would be misleading — the OS always reserves
+    a few MB. Cap at 99% so the message stays honest."""
+    import blueprints.system_health as sh
+    out = sh._format_pause_reason(
+        load_pause={'is_paused_now': False},
+        disk_pause={
+            'is_paused_now': True,
+            'last_free_mb': 0,
+            'last_total_mb': 25600,
+            'critical_threshold_mb': 100,
+        },
+    )
+    assert out == 'SD card 99% full'
+
+
+def test_format_pause_reason_both_armed():
+    """Concurrent load + disk pauses join with a semicolon."""
+    import blueprints.system_health as sh
+    out = sh._format_pause_reason(
+        load_pause={
+            'is_paused_now': True,
+            'last_loadavg': 5.1,
+            'threshold': 3.5,
+        },
+        disk_pause={
+            'is_paused_now': True,
+            'last_free_mb': 1024,
+            'last_total_mb': 25600,
+            'critical_threshold_mb': 100,
+        },
+    )
+    assert out == 'load 5.1 > 3.5; SD card 96% full'
+
+
+def test_format_pause_reason_neither_armed_returns_background():
+    """When neither auto-pause has armed (e.g. ``pause_worker()``
+    was called for a mode switch), don't claim false specificity —
+    return ``'background'`` so the caller can render a generic
+    message."""
+    import blueprints.system_health as sh
+    assert sh._format_pause_reason(
+        load_pause={'is_paused_now': False},
+        disk_pause={'is_paused_now': False},
+    ) == 'background'
+
+
+def test_format_pause_reason_load_armed_but_no_loadavg_yet():
+    """Defensive: if the worker reports paused but ``last_loadavg``
+    is None (cold-start race), don't synthesize a fake number — fall
+    through to ``'background'``."""
+    import blueprints.system_health as sh
+    out = sh._format_pause_reason(
+        load_pause={
+            'is_paused_now': True,
+            'last_loadavg': None,
+            'threshold': 3.5,
+        },
+        disk_pause={'is_paused_now': False},
+    )
+    assert out == 'background'
+
+
+def test_format_pause_reason_disk_negative_free_falls_through():
+    """``last_free_mb = -1`` is the sentinel for OSError on
+    ``shutil.disk_usage``. Don't render '-1 MB free'."""
+    import blueprints.system_health as sh
+    out = sh._format_pause_reason(
+        load_pause={'is_paused_now': False},
+        disk_pause={
+            'is_paused_now': True,
+            'last_free_mb': -1,
+            'last_total_mb': -1,
+            'critical_threshold_mb': 100,
+        },
+    )
+    assert out == 'background'
+
+
+def test_archive_block_paused_load_message(monkeypatch):
+    """End-to-end: load pause armed → message includes the loadavg
+    and the threshold."""
+    import blueprints.system_health as sh
+    from services import archive_queue, archive_watchdog, archive_worker
+    monkeypatch.setattr(sh, 'ARCHIVE_QUEUE_ENABLED', True, raising=False)
+    monkeypatch.setattr(archive_queue, 'get_queue_status',
+                        lambda: {'pending': 10, 'dead_letter': 0})
+    monkeypatch.setattr(archive_queue, 'count_source_gone_recent',
+                        lambda hours=24: 0)
+    monkeypatch.setattr(archive_watchdog, 'get_status',
+                        lambda: {'severity': 'ok'})
+    monkeypatch.setattr(archive_worker, 'get_status', lambda: {
+        'worker_running': True, 'paused': True,
+        'load_pause': {
+            'is_paused_now': True, 'last_loadavg': 4.2, 'threshold': 3.5,
+        },
+        'disk_pause': {'is_paused_now': False},
+    })
+    block = sh._archive_block()
+    assert block['severity'] == 'warn'
+    assert block['message'] == 'Paused: load 4.2 > 3.5'
+    assert block['pause_reason'] == 'load 4.2 > 3.5'
+
+
+def test_archive_block_paused_disk_message(monkeypatch):
+    """End-to-end: disk pause armed → message includes the % full."""
+    import blueprints.system_health as sh
+    from services import archive_queue, archive_watchdog, archive_worker
+    monkeypatch.setattr(sh, 'ARCHIVE_QUEUE_ENABLED', True, raising=False)
+    monkeypatch.setattr(archive_queue, 'get_queue_status',
+                        lambda: {'pending': 0, 'dead_letter': 0})
+    monkeypatch.setattr(archive_queue, 'count_source_gone_recent',
+                        lambda hours=24: 0)
+    monkeypatch.setattr(archive_watchdog, 'get_status',
+                        lambda: {'severity': 'ok'})
+    monkeypatch.setattr(archive_worker, 'get_status', lambda: {
+        'worker_running': True, 'paused': True,
+        'load_pause': {'is_paused_now': False},
+        'disk_pause': {
+            'is_paused_now': True,
+            'last_free_mb': 1024, 'last_total_mb': 25600,
+            'critical_threshold_mb': 100,
+        },
+    })
+    block = sh._archive_block()
+    assert block['severity'] == 'warn'
+    assert block['message'] == 'Paused: SD card 96% full'
+    assert block['pause_reason'] == 'SD card 96% full'
+
+
+def test_archive_block_paused_background_message(monkeypatch):
+    """When the worker reports ``paused`` but no auto-guard has
+    armed (manual ``pause_worker()`` from a mode switch), render the
+    generic 'Paused (background task)' fallback."""
+    import blueprints.system_health as sh
+    from services import archive_queue, archive_watchdog, archive_worker
+    monkeypatch.setattr(sh, 'ARCHIVE_QUEUE_ENABLED', True, raising=False)
+    monkeypatch.setattr(archive_queue, 'get_queue_status',
+                        lambda: {'pending': 5, 'dead_letter': 0})
+    monkeypatch.setattr(archive_queue, 'count_source_gone_recent',
+                        lambda hours=24: 0)
+    monkeypatch.setattr(archive_watchdog, 'get_status',
+                        lambda: {'severity': 'ok'})
+    monkeypatch.setattr(archive_worker, 'get_status', lambda: {
+        'worker_running': True, 'paused': True,
+        'load_pause': {'is_paused_now': False},
+        'disk_pause': {'is_paused_now': False},
+    })
+    block = sh._archive_block()
+    assert block['severity'] == 'warn'
+    assert block['message'] == 'Paused (background task)'
+    assert block['pause_reason'] == 'background'
+
+
+def test_archive_block_pause_reason_field_present_in_all_paths(monkeypatch):
+    """The ``pause_reason`` key must appear in every return path
+    (disabled, error, normal) so JS consumers don't crash on missing
+    keys (mirrors the Phase 4.3 lost_24h / Phase 4.4 ETA contracts)."""
+    import blueprints.system_health as sh
+    # Disabled path
+    monkeypatch.setattr(sh, 'ARCHIVE_QUEUE_ENABLED', False, raising=False)
+    assert 'pause_reason' in sh._archive_block()
+    assert sh._archive_block()['pause_reason'] is None
+    # Error path
+    monkeypatch.setattr(sh, 'ARCHIVE_QUEUE_ENABLED', True, raising=False)
+    from services import archive_queue
+    monkeypatch.setattr(archive_queue, 'get_queue_status',
+                        lambda: (_ for _ in ()).throw(RuntimeError("boom")))
+    block = sh._archive_block()
+    assert 'pause_reason' in block
+    assert block['pause_reason'] is None
+
+
+def test_archive_block_pause_reason_null_when_not_paused(monkeypatch):
+    """``pause_reason`` should be ``None`` when ``paused=False``,
+    not a stale value, so the UI doesn't render 'Paused: ...' next to
+    a green status."""
+    import blueprints.system_health as sh
+    from services import archive_queue, archive_watchdog, archive_worker
+    monkeypatch.setattr(sh, 'ARCHIVE_QUEUE_ENABLED', True, raising=False)
+    monkeypatch.setattr(archive_queue, 'get_queue_status',
+                        lambda: {'pending': 0, 'dead_letter': 0})
+    monkeypatch.setattr(archive_queue, 'count_source_gone_recent',
+                        lambda hours=24: 0)
+    monkeypatch.setattr(archive_watchdog, 'get_status',
+                        lambda: {'severity': 'ok'})
+    monkeypatch.setattr(archive_worker, 'get_status', lambda: {
+        'worker_running': True, 'paused': False,
+        'load_pause': {'is_paused_now': False},
+        'disk_pause': {'is_paused_now': False},
+    })
+    block = sh._archive_block()
+    assert block['paused'] is False
+    assert block['pause_reason'] is None
+
+
+# ---------------------------------------------------------------------------
 # Cloud block
 # ---------------------------------------------------------------------------
 

--- a/tests/test_system_health_blueprint.py
+++ b/tests/test_system_health_blueprint.py
@@ -870,6 +870,73 @@ def test_archive_block_paused_load_message(monkeypatch):
     assert block['pause_reason'] == 'load 4.2 > 3.5'
 
 
+def test_archive_block_load_auto_paused_without_manual_flag(monkeypatch):
+    """``archive_worker.get_status()`` only sets ``paused=True`` for
+    the manual ``pause_worker()`` flag — not for auto-armed
+    ``_load_pause_until``. Phase 4.5 (#101) broadens the
+    operator-facing paused notion in ``_archive_block`` so the
+    System Health card surfaces the load auto-pause too.
+
+    Pinned in production: smoke test on the Pi caught
+    ``load_pause.is_paused_now=True`` while ``paused=False`` —
+    without this broadening the card would silently drop the pause
+    state entirely."""
+    import blueprints.system_health as sh
+    from services import archive_queue, archive_watchdog, archive_worker
+    monkeypatch.setattr(sh, 'ARCHIVE_QUEUE_ENABLED', True, raising=False)
+    monkeypatch.setattr(archive_queue, 'get_queue_status',
+                        lambda: {'pending': 442, 'dead_letter': 0})
+    monkeypatch.setattr(archive_queue, 'count_source_gone_recent',
+                        lambda hours=24: 0)
+    monkeypatch.setattr(archive_watchdog, 'get_status',
+                        lambda: {'severity': 'ok'})
+    # paused=False (no manual flag) but load_pause is armed.
+    monkeypatch.setattr(archive_worker, 'get_status', lambda: {
+        'worker_running': True, 'paused': False,
+        'load_pause': {
+            'is_paused_now': True, 'last_loadavg': 3.9, 'threshold': 3.5,
+        },
+        'disk_pause': {'is_paused_now': False},
+    })
+    block = sh._archive_block()
+    # The operator-facing paused field must now reflect the
+    # auto-pause, not the narrower manual flag.
+    assert block['paused'] is True
+    assert block['severity'] == 'warn'
+    assert block['message'] == 'Paused: load 3.9 > 3.5'
+    assert block['pause_reason'] == 'load 3.9 > 3.5'
+
+
+def test_archive_block_disk_auto_paused_without_manual_flag(monkeypatch):
+    """Mirror of the load auto-pause test for the disk-space guard.
+    ``_disk_space_pause_until`` arms independently of the manual
+    pause flag; both Phase 4.5 ``paused`` field and
+    ``pause_reason`` must surface it."""
+    import blueprints.system_health as sh
+    from services import archive_queue, archive_watchdog, archive_worker
+    monkeypatch.setattr(sh, 'ARCHIVE_QUEUE_ENABLED', True, raising=False)
+    monkeypatch.setattr(archive_queue, 'get_queue_status',
+                        lambda: {'pending': 5, 'dead_letter': 0})
+    monkeypatch.setattr(archive_queue, 'count_source_gone_recent',
+                        lambda hours=24: 0)
+    monkeypatch.setattr(archive_watchdog, 'get_status',
+                        lambda: {'severity': 'ok'})
+    monkeypatch.setattr(archive_worker, 'get_status', lambda: {
+        'worker_running': True, 'paused': False,
+        'load_pause': {'is_paused_now': False},
+        'disk_pause': {
+            'is_paused_now': True,
+            'last_free_mb': 1024, 'last_total_mb': 25600,
+            'critical_threshold_mb': 100,
+        },
+    })
+    block = sh._archive_block()
+    assert block['paused'] is True
+    assert block['severity'] == 'warn'
+    assert block['message'] == 'Paused: SD card 96% full'
+    assert block['pause_reason'] == 'SD card 96% full'
+
+
 def test_archive_block_paused_disk_message(monkeypatch):
     """End-to-end: disk pause armed → message includes the % full."""
     import blueprints.system_health as sh


### PR DESCRIPTION
# Phase 4.5 (#101) — Pause reasons in archive banner

## Problem

When the archive worker auto-pauses, the System Health archive block
shows the opaque message **"Paused (load or disk)"**. The operator
can't tell whether to:

- wait it out (load spike that will recover on its own), or
- take action (disk needs cleanup).

The two pause reasons are technically and operationally distinct, but
the UI was lumping them together.

## Fix

Replace the opaque string with the actual reason:

| Trigger | Message rendered |
|---|---|
| Load spike (1-min loadavg crossed `load_pause_threshold`) | `Paused: load 4.2 > 3.5` |
| Disk-space critical, total known | `Paused: SD card 96% full` |
| Disk-space critical, total unknown | `Paused: SD card 50 MB free (threshold 100 MB)` |
| Both armed concurrently | `Paused: load 4.2 > 3.5; SD card 96% full` |
| Manual `pause_worker()` (mode switch / RW remount) | `Paused (background task)` |

Aligns with the issue spec quote:

> *"Archive paused: load 4.2 > 3.5 threshold"* or *"Archive paused: SD card 96% full"*

## Implementation

### `archive_worker.py`

- `get_disk_pause_state()`: now returns `critical_threshold_mb`,
  `warning_threshold_mb` (resolved via `_resolve_disk_thresholds_mb()`),
  and `last_total_mb` so the formatter can render `"% full"` without a
  second config read.
- `get_load_pause_state()`: now returns `threshold` (resolved via
  `_read_config_or_defaults()[4]` with fallback to the module-level
  `_LOAD_PAUSE_THRESHOLD` constant on config error).
- `_state`: added `last_disk_pause_total_mb` slot, initialised in
  module init and reset on every `start_worker()` call (parity with
  the existing `last_disk_pause_free_mb` slot).
- `process_one_claim` disk-pause arming: now calls
  `shutil.disk_usage()` once and saves both `free_mb` and `total_mb`.

### `system_health.py`

- New `_format_pause_reason(load_pause, disk_pause)` helper that joins
  armed reasons with `"; "` and falls back to `"background"` when
  neither auto-guard has armed.
- `_archive_block()` uses the helper. When neither guard has armed,
  surfaces `"Paused (background task)"` instead of false-specific
  `"Paused (load or disk)"`.
- Surfaces `pause_reason` field on the API contract (`None` when not
  paused) for future UI consumers (chip, tooltip).

The "% full" formatter caps at 99% so we never claim 100% full — the
OS always reserves a few MB for root / journaling.

## Tests

- **`test_system_health_blueprint.py`** — 13 new tests covering:
  - formatter for load-only / disk-only (with and without total) /
    both-armed / neither-armed / cold-start race / `OSError` sentinel
    paths;
  - end-to-end `_archive_block` checks for each scenario;
  - `pause_reason` API-contract guards on disabled and error paths.
- **`test_archive_worker.py`** — 5 new tests in
  `TestPauseStateExtensions` pinning the dict shape of the extended
  pause-state helpers, including the config-error fallback to
  `_LOAD_PAUSE_THRESHOLD` and the `start_worker` reset of
  `last_disk_pause_total_mb`.

**1168 tests pass + 3 skipped** (was 1158 + 3).

## Risk

- API contract additions are backward-compatible: `pause_reason` is a
  new key, existing keys (`severity`, `message`, `paused`,
  `queue_depth`, `dead_letter_count`, `lost_24h`, `eta_seconds`,
  `eta_human`, `drain_rate_per_sec`) are unchanged.
- The `_format_pause_reason` helper is defensive — None / negative
  sentinel inputs all fall through to `"background"`, never raise.
- `_resolve_disk_thresholds_mb()` and `_read_config_or_defaults()`
  are existing helpers; resolving outside the state lock keeps the
  critical section minimal.

## Closes part of #101
