### PR TITLE
Phase 4.6 (#101): LES daily data-cap banner

### DIFF
--- a/scripts/web/services/live_event_sync_service.py
+++ b/scripts/web/services/live_event_sync_service.py
@@ -1348,7 +1348,12 @@ def get_status() -> Dict:
     with _status_lock:
         snapshot.update(_status)
 
-    # Add queue counts (cheap aggregate query).
+    # Add queue counts (cheap aggregate query). Phase 4.6 (#101)
+    # reuses the same connection to compute the fresh data-cap
+    # state so the cloud_archive page banner is accurate even when
+    # the worker is idle (LES idles between events; the cached
+    # ``data_cap_reached`` would otherwise lag until the next
+    # upload cycle).
     try:
         conn = _open_db()
         try:
@@ -1362,10 +1367,34 @@ def get_status() -> Dict:
                 ).fetchone()
                 counts[st] = int(row['n']) if row else 0
             snapshot['queue_counts'] = counts
+
+            # Phase 4.6 — fresh today-uploaded count + cap state so
+            # the cloud_archive banner is correct on every poll.
+            today_bytes = _today_uploaded_bytes(conn)
+            snapshot['data_uploaded_today_bytes'] = today_bytes
+            cap_mb = int(LIVE_EVENT_DAILY_DATA_CAP_MB)
+            snapshot['daily_data_cap_mb'] = cap_mb
+            if cap_mb > 0:
+                cap_bytes = cap_mb * 1024 * 1024
+                snapshot['data_cap_reached'] = today_bytes >= cap_bytes
+                snapshot['data_cap_pct'] = min(
+                    100, int(round((today_bytes / cap_bytes) * 100))
+                )
+            else:
+                # Unlimited — banner stays hidden, percent is null.
+                snapshot['data_cap_reached'] = False
+                snapshot['data_cap_pct'] = None
         finally:
             conn.close()
     except Exception as e:
         snapshot['queue_counts'] = {'error': str(e)[:200]}
+        # Defensive: keep the cap fields present even on DB error so
+        # the JS consumer doesn't crash on missing keys (mirrors the
+        # Phase 4.4 ETA / Phase 4.5 pause_reason contract).
+        snapshot.setdefault('data_uploaded_today_bytes', 0)
+        snapshot.setdefault('daily_data_cap_mb', int(LIVE_EVENT_DAILY_DATA_CAP_MB))
+        snapshot.setdefault('data_cap_reached', False)
+        snapshot.setdefault('data_cap_pct', None)
 
     # Surface the cross-subsystem coordination signal so the
     # WiFi-connect dispatcher's drain wait can yield correctly when

--- a/scripts/web/templates/cloud_archive.html
+++ b/scripts/web/templates/cloud_archive.html
@@ -578,6 +578,20 @@
             <div id="lesActiveLine" style="display: none; margin-bottom: var(--space-4); padding: 8px 12px; border-radius: var(--radius-md); background: var(--msg-info-bg); color: var(--msg-info-text); font-size: var(--text-sm);">
                 <strong>Uploading:</strong> <span id="lesActiveFile"></span>
             </div>
+            {# Phase 4.6 (#101) — Daily data-cap banner. Hidden until LES
+               reports data_cap_reached=true. The cap is configurable via
+               live_event_sync.daily_data_cap_mb (0 = unlimited). When the
+               cap is hit, the worker idles until the local clock crosses
+               midnight UTC, so the user knows uploads will resume on
+               their own — no action required. #}
+            <div id="lesDataCapBanner" style="display: none; margin-bottom: var(--space-4); padding: 10px 12px; border-radius: var(--radius-md); background: var(--msg-warning-bg); color: var(--msg-warning-text); font-size: var(--text-sm);">
+                <strong>Daily data cap reached.</strong>
+                <span id="lesDataCapDetail" style="margin-left: 4px;"></span>
+                <span style="display: block; margin-top: 4px; opacity: 0.85; font-size: var(--text-xs);">
+                    Uploads will resume automatically at midnight UTC.
+                    Adjust the cap below or set it to 0 (unlimited) to keep uploading today.
+                </span>
+            </div>
             <div id="lesLastError" style="display: none; margin-bottom: var(--space-4); padding: 8px 12px; border-radius: var(--radius-md); background: var(--msg-error-bg); color: var(--msg-error-text); font-size: var(--text-sm);">
                 <strong>Last error:</strong> <span id="lesLastErrorText"></span>
             </div>
@@ -1879,6 +1893,28 @@
                 errBox.style.display = 'block';
             } else if (errBox) {
                 errBox.style.display = 'none';
+            }
+
+            /* Phase 4.6 (#101) — daily data-cap banner. Show with the
+               percentage and MB-uploaded vs MB-cap so the user knows
+               (a) the cap was hit, (b) by how much, (c) that uploads
+               will resume at midnight UTC. */
+            var capBanner = document.getElementById('lesDataCapBanner');
+            var capDetail = document.getElementById('lesDataCapDetail');
+            if (capBanner && capDetail) {
+                if (data.data_cap_reached === true && data.daily_data_cap_mb > 0) {
+                    var todayMb = Math.round(
+                        (data.data_uploaded_today_bytes || 0) / (1024 * 1024)
+                    );
+                    var pct = (data.data_cap_pct === null || data.data_cap_pct === undefined)
+                        ? '' : ' (' + data.data_cap_pct + '%)';
+                    capDetail.textContent =
+                        todayMb + ' MB uploaded today, cap ' +
+                        data.daily_data_cap_mb + ' MB' + pct + '.';
+                    capBanner.style.display = 'block';
+                } else {
+                    capBanner.style.display = 'none';
+                }
             }
         } catch (e) { /* ignore network blips */ }
     }

--- a/tests/test_live_event_sync_data_cap.py
+++ b/tests/test_live_event_sync_data_cap.py
@@ -1,0 +1,186 @@
+"""Phase 4.6 (#101) — Tests for the LES daily data-cap surfacing in
+``get_status()`` so the cloud_archive page banner can render the
+"Daily data cap reached" message correctly.
+
+The banner UI itself is template-driven (cloud_archive.html); these
+tests pin only the API contract additions:
+
+* ``data_uploaded_today_bytes`` — total bytes uploaded today (UTC),
+  recomputed fresh on every ``get_status()`` call (not cached on
+  ``_status``) so the banner is accurate even when the worker is
+  idle (LES idles between events; the cached value would otherwise
+  lag until the next upload cycle).
+* ``daily_data_cap_mb`` — the configured cap in MB (0 = unlimited).
+* ``data_cap_reached`` — boolean: today_bytes >= cap_bytes.
+* ``data_cap_pct`` — integer 0..100 (None when cap is 0/unlimited).
+
+All four keys MUST appear on every successful and failed code path
+(matches Phase 4.4 ETA / Phase 4.5 pause_reason contract).
+"""
+import os
+import sqlite3
+from datetime import datetime, timezone
+
+import pytest
+
+import sys
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(HERE, '..', 'scripts', 'web'))
+
+from services import live_event_sync_service as les  # noqa: E402
+
+
+@pytest.fixture
+def fresh_les_db(tmp_path, monkeypatch):
+    """Point LES at a tmp cloud_sync.db with the LES schema applied."""
+    db_path = str(tmp_path / "cloud_sync.db")
+    monkeypatch.setattr(les, 'CLOUD_ARCHIVE_DB_PATH', db_path, raising=False)
+    # Initialise schema by opening once.
+    conn = les._open_db()
+    try:
+        les._ensure_schema(conn)
+    finally:
+        conn.close()
+    return db_path
+
+
+def _insert_uploaded_row(db_path, bytes_uploaded, uploaded_at_iso=None):
+    """Insert a fully-uploaded row with the given byte count."""
+    if uploaded_at_iso is None:
+        uploaded_at_iso = datetime.now(timezone.utc).isoformat()
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            "INSERT INTO live_event_queue "
+            "(event_dir, event_json_path, status, "
+            " enqueued_at, uploaded_at, bytes_uploaded) "
+            "VALUES (?, ?, 'uploaded', ?, ?, ?)",
+            ('/dev/null', '/dev/null', uploaded_at_iso,
+             uploaded_at_iso, int(bytes_uploaded)),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Phase 4.6 contract: keys present on EVERY return path
+# ---------------------------------------------------------------------------
+
+class TestDataCapStatusContract:
+
+    def test_unlimited_cap_returns_none_pct(self, fresh_les_db, monkeypatch):
+        # Cap=0 means unlimited — banner stays hidden, pct is None.
+        monkeypatch.setattr(les, 'LIVE_EVENT_DAILY_DATA_CAP_MB', 0,
+                            raising=False)
+        snap = les.get_status()
+        assert snap['data_cap_reached'] is False
+        assert snap['data_cap_pct'] is None
+        assert snap['daily_data_cap_mb'] == 0
+        assert snap['data_uploaded_today_bytes'] == 0
+
+    def test_cap_set_no_uploads_yet_zero_pct(self, fresh_les_db, monkeypatch):
+        monkeypatch.setattr(les, 'LIVE_EVENT_DAILY_DATA_CAP_MB', 100,
+                            raising=False)
+        snap = les.get_status()
+        assert snap['data_cap_reached'] is False
+        assert snap['data_cap_pct'] == 0
+        assert snap['daily_data_cap_mb'] == 100
+        assert snap['data_uploaded_today_bytes'] == 0
+
+    def test_cap_set_partial_usage(self, fresh_les_db, monkeypatch):
+        # 50 MB uploaded today against a 100 MB cap → 50 % full.
+        _insert_uploaded_row(fresh_les_db, 50 * 1024 * 1024)
+        monkeypatch.setattr(les, 'LIVE_EVENT_DAILY_DATA_CAP_MB', 100,
+                            raising=False)
+        snap = les.get_status()
+        assert snap['data_cap_reached'] is False
+        assert snap['data_cap_pct'] == 50
+        assert snap['data_uploaded_today_bytes'] == 50 * 1024 * 1024
+
+    def test_cap_reached_exactly_at_threshold(self, fresh_les_db, monkeypatch):
+        # 100 MB uploaded against 100 MB cap → reached (>=).
+        _insert_uploaded_row(fresh_les_db, 100 * 1024 * 1024)
+        monkeypatch.setattr(les, 'LIVE_EVENT_DAILY_DATA_CAP_MB', 100,
+                            raising=False)
+        snap = les.get_status()
+        assert snap['data_cap_reached'] is True
+        assert snap['data_cap_pct'] == 100
+
+    def test_cap_overshoot_capped_at_100_pct(self, fresh_les_db, monkeypatch):
+        # 250 MB uploaded against 100 MB cap → cap_pct must clamp at 100.
+        # (e.g., a single event upload that exceeded the cap because the
+        # check is post-upload.)
+        _insert_uploaded_row(fresh_les_db, 250 * 1024 * 1024)
+        monkeypatch.setattr(les, 'LIVE_EVENT_DAILY_DATA_CAP_MB', 100,
+                            raising=False)
+        snap = les.get_status()
+        assert snap['data_cap_reached'] is True
+        assert snap['data_cap_pct'] == 100, (
+            "cap_pct must clamp at 100 — never claim 250% so the banner "
+            "stays trustworthy."
+        )
+
+    def test_db_error_falls_back_with_keys_present(
+        self, fresh_les_db, monkeypatch,
+    ):
+        # If the DB read raises, the keys MUST still be present so JS
+        # consumers don't crash on missing keys.
+        monkeypatch.setattr(les, 'LIVE_EVENT_DAILY_DATA_CAP_MB', 200,
+                            raising=False)
+
+        def boom(*_a, **_kw):
+            raise RuntimeError("DB error")
+
+        monkeypatch.setattr(les, '_open_db', boom)
+        snap = les.get_status()
+        # Queue counts surface the error as documented.
+        assert 'error' in snap['queue_counts']
+        # Phase 4.6 keys must be present even on error path.
+        assert snap['data_uploaded_today_bytes'] == 0
+        assert snap['daily_data_cap_mb'] == 200
+        assert snap['data_cap_reached'] is False
+        assert snap['data_cap_pct'] is None
+
+    def test_yesterdays_uploads_dont_count(self, fresh_les_db, monkeypatch):
+        # ``_today_uploaded_bytes`` filters by ``uploaded_at >= today_iso``.
+        # An upload from yesterday must not be billed against today's cap.
+        from datetime import timedelta
+        yesterday = (datetime.now(timezone.utc) - timedelta(days=1)
+                     ).isoformat()
+        _insert_uploaded_row(
+            fresh_les_db, 200 * 1024 * 1024,
+            uploaded_at_iso=yesterday,
+        )
+        monkeypatch.setattr(les, 'LIVE_EVENT_DAILY_DATA_CAP_MB', 100,
+                            raising=False)
+        snap = les.get_status()
+        # Yesterday's upload doesn't count → today_bytes == 0.
+        assert snap['data_uploaded_today_bytes'] == 0
+        assert snap['data_cap_reached'] is False
+        assert snap['data_cap_pct'] == 0
+
+
+# ---------------------------------------------------------------------------
+# Phase 4.6: queue counts contract still intact (regression guard)
+# ---------------------------------------------------------------------------
+
+class TestExistingContractStillIntact:
+    """The Phase 4.6 changes added cap fields but must not regress the
+    pre-existing queue_counts / has_ready_work contract."""
+
+    def test_queue_counts_still_present(self, fresh_les_db, monkeypatch):
+        monkeypatch.setattr(les, 'LIVE_EVENT_DAILY_DATA_CAP_MB', 0,
+                            raising=False)
+        snap = les.get_status()
+        assert 'queue_counts' in snap
+        assert set(snap['queue_counts'].keys()) >= {
+            'pending', 'uploading', 'uploaded', 'failed',
+        }
+
+    def test_has_ready_work_still_present(self, fresh_les_db, monkeypatch):
+        monkeypatch.setattr(les, 'LIVE_EVENT_DAILY_DATA_CAP_MB', 0,
+                            raising=False)
+        snap = les.get_status()
+        assert 'has_ready_work' in snap
+        assert isinstance(snap['has_ready_work'], bool)


### PR DESCRIPTION
# Phase 4.6 (#101) — LES daily data-cap banner

## Problem

The Live Event Sync (LES) worker has a configurable
`live_event_sync.daily_data_cap_mb` setting (0 = unlimited). When
enabled and exceeded, the worker idles until the local clock crosses
midnight UTC. **There was no UI surface for this state** — the user
sees the queue stop draining and has no way to know whether:

- WiFi dropped,
- the worker crashed,
- a row is stuck in backoff, or
- the daily data cap simply kicked in (the most benign of the four —
  uploads will resume on their own).

## Fix

Add a clear "Daily data cap reached" banner to the LES section of
`cloud_archive.html`, populated by a new `lesRefreshStatus` JS branch
backed by 4 new fields on `/api/live_events/status`:

| Field | Type | Meaning |
|---|---|---|
| `data_uploaded_today_bytes` | int | Sum of `bytes_uploaded` for today (UTC), recomputed fresh on every poll. |
| `daily_data_cap_mb` | int | Configured cap (0 = unlimited). |
| `data_cap_reached` | bool | `today_bytes >= cap_bytes`. |
| `data_cap_pct` | int 0..100 \| null | Clamped at 100 so an overshoot can't claim e.g. 250 %. `null` when unlimited. |

When `data_cap_reached` is true, the banner renders:

> **Daily data cap reached.** 487 MB uploaded today, cap 500 MB (97 %).
> *Uploads will resume automatically at midnight UTC. Adjust the cap below or set it to 0 (unlimited) to keep uploading today.*

## Implementation

### `live_event_sync_service.py`

`get_status()` now reuses the existing DB connection (no extra
`_open_db()` round-trip) to compute the fresh data-cap state. The
existing `_today_uploaded_bytes()` helper is reused — it filters
`uploaded_at >= today_iso` so yesterday's uploads don't count.

All 4 fields appear on every code path including DB error
(`setdefault` after the `except` branch) so JS consumers don't crash
on missing keys. Mirrors the Phase 4.4 ETA / Phase 4.5 `pause_reason`
contract.

### `templates/cloud_archive.html`

New `#lesDataCapBanner` div in the LES status section (between the
active-upload line and the last-error line). Hidden by default. JS
poll shows/hides it based on the new fields.

Banner uses the existing `--msg-warning-bg` / `--msg-warning-text`
tokens so it works in both dark and light mode without hardcoded hex
values, and the WCAG AA contrast is automatic.

## Tests

New `tests/test_live_event_sync_data_cap.py` (9 tests) pinning:

- unlimited cap → `pct=None`, `reached=False`
- cap set, no uploads → `pct=0`, `reached=False`
- 50% usage → `pct=50`, `reached=False`
- exactly at threshold → `reached=True` (`>=` semantics)
- overshoot → `pct` clamps at 100
- DB error path → all 4 keys still present (defensive)
- yesterday's uploads don't count → `today_bytes=0`
- regression guards for `queue_counts` and `has_ready_work` contracts

**1179 tests pass + 3 skipped** (was 1170 + 3).

## Risk

- API contract additions are backward-compatible: 4 new keys,
  existing keys (`active_file`, `last_uploaded_at`,
  `last_uploaded_event`, `last_error`, `queue_counts`,
  `has_ready_work`, etc.) unchanged.
- Reusing the existing DB connection means **zero additional DB
  round-trips per poll** — the `_today_uploaded_bytes` query is one
  cheap aggregate against the `uploaded_at` index.
- Banner uses CSS custom properties — no dark/light mode regression.

## Closes part of #101
