### PR TITLE
Phase 4.9 (#101): one-time iOS fullscreen toast on map overlay

### DIFF
--- a/scripts/web/templates/mapping.html
+++ b/scripts/web/templates/mapping.html
@@ -2719,15 +2719,92 @@ function overlayFullscreen() {
     // fullscreen — acceptable platform limitation. Use Maximize (the
     // adjacent button) on iOS to get an HUD-visible fill of the
     // browser viewport instead.
+    //
+    // Phase 4.9 (#101): show a one-time toast on first iOS fullscreen
+    // tap so users know the HUD loss is a Safari limitation and that
+    // "Maximize" is the HUD-preserving alternative. Persisted via
+    // localStorage so the user is nagged at most once per browser.
     const stage = document.querySelector('.video-overlay-stage');
     const v = document.getElementById('overlayVideo');
     if (!v) return;
+
+    if (isIosSafari() && !hasShownIosFullscreenToast()) {
+        // Phase 4.9 (#101) — first-tap behaviour on iOS Safari:
+        // SHOW THE TOAST AND SKIP FULLSCREEN. If we entered fullscreen
+        // immediately the toast would be hidden behind the OS player
+        // and the user would never see the explanation. Skipping the
+        // fullscreen on the very first tap is acceptable because the
+        // user's stated intent is "give me a bigger view" and the
+        // toast explicitly recommends Maximize, which delivers that
+        // intent without losing the HUD.
+        //
+        // Subsequent taps (after the localStorage flag is set) proceed
+        // to webkitEnterFullscreen normally for users who deliberately
+        // want OS fullscreen and accept the HUD loss.
+        showIosFullscreenToast();
+        markIosFullscreenToastShown();
+        return;
+    }
+
     if (stage && stage.requestFullscreen) {
         stage.requestFullscreen().catch(() => {});
     } else if (stage && stage.webkitRequestFullscreen) {
         stage.webkitRequestFullscreen();
     } else if (v.webkitEnterFullscreen) {
         v.webkitEnterFullscreen();
+    }
+}
+
+// Phase 4.9 (#101) — iOS Safari detection.
+// iPad on iOS 13+ identifies its UA as "Macintosh" but exposes the
+// touch-event API, so we combine the two signals. Returns true on
+// iPhone, iPad, and iPod across all modern iOS versions.
+function isIosSafari() {
+    if (typeof navigator === 'undefined') return false;
+    const ua = navigator.userAgent || '';
+    if (/iPhone|iPad|iPod/i.test(ua)) return true;
+    // iPadOS desktop-mode masquerade: Mac UA + touch support.
+    const isMac = /Macintosh/i.test(ua);
+    const hasTouch = (typeof navigator.maxTouchPoints === 'number' &&
+                      navigator.maxTouchPoints > 1);
+    return isMac && hasTouch;
+}
+
+const IOS_FULLSCREEN_TOAST_KEY = 'iosFullscreenToastShown';
+
+function hasShownIosFullscreenToast() {
+    try {
+        return localStorage.getItem(IOS_FULLSCREEN_TOAST_KEY) === '1';
+    } catch (e) {
+        // Private browsing / disabled storage → re-show every time
+        // rather than crashing. Toast is still polite and one-tap.
+        return false;
+    }
+}
+
+function markIosFullscreenToastShown() {
+    try {
+        localStorage.setItem(IOS_FULLSCREEN_TOAST_KEY, '1');
+    } catch (e) { /* storage disabled — ignore */ }
+}
+
+// Polite, single-line toast pointing iOS users at the Maximize
+// button. Uses the existing showToast() infra (info severity) so
+// dark/light mode + dismiss timing are inherited. Falls back to a
+// console.log if showToast isn't available — never blocks the
+// fullscreen action.
+function showIosFullscreenToast() {
+    const msg = ('iOS Safari hides the HUD in fullscreen. ' +
+                 'Tap Maximize for an HUD-visible view, ' +
+                 'or tap Fullscreen again to continue without HUD.');
+    if (typeof showToast === 'function') {
+        showToast(msg, 'info');
+    } else {
+        // Defensive — base.html owns showToast. If a future refactor
+        // moves it, surface a developer-visible warning rather than
+        // crashing the fullscreen path.
+        try { console.log('TeslaUSB iOS fullscreen toast:', msg); }
+        catch (e) {}
     }
 }
 

--- a/scripts/web/templates/mapping.html
+++ b/scripts/web/templates/mapping.html
@@ -2728,7 +2728,7 @@ function overlayFullscreen() {
     const v = document.getElementById('overlayVideo');
     if (!v) return;
 
-    if (isIosSafari() && !hasShownIosFullscreenToast()) {
+    if (isIos() && !hasShownIosFullscreenToast()) {
         // Phase 4.9 (#101) — first-tap behaviour on iOS Safari:
         // SHOW THE TOAST AND SKIP FULLSCREEN. If we entered fullscreen
         // immediately the toast would be hidden behind the OS player
@@ -2759,7 +2759,12 @@ function overlayFullscreen() {
 // iPad on iOS 13+ identifies its UA as "Macintosh" but exposes the
 // touch-event API, so we combine the two signals. Returns true on
 // iPhone, iPad, and iPod across all modern iOS versions.
-function isIosSafari() {
+// iOS detection: returns true for any iOS browser (iPhone, iPad,
+// iPod, iPad-on-iOS-13+ in desktop-mode masquerade). Apple policy
+// requires every iOS browser to use WebKit, so the toast applies
+// equally to Safari, Chrome, Firefox, etc. on iOS — the function
+// is intentionally named for iOS, not Safari specifically.
+function isIos() {
     if (typeof navigator === 'undefined') return false;
     const ua = navigator.userAgent || '';
     if (/iPhone|iPad|iPod/i.test(ua)) return true;
@@ -2769,23 +2774,40 @@ function isIosSafari() {
                       navigator.maxTouchPoints > 1);
     return isMac && hasTouch;
 }
+// Backwards-compatible alias for any external caller (and a more
+// discoverable name from the IDE). Both names point at the same
+// function — never diverge.
+const isIosSafari = isIos;
 
 const IOS_FULLSCREEN_TOAST_KEY = 'iosFullscreenToastShown';
 
+// In-memory fallback flag for browsers where localStorage throws on
+// EVERY access (Safari Private Mode quota=0). Without this the early
+// return in overlayFullscreen() would fire on every tap and the user
+// could never reach webkitEnterFullscreen — softlocking the button
+// despite the toast text saying "tap Fullscreen again to continue."
+// Module-scoped so it survives across taps within the same page load
+// (the only durability we need — Private Mode doesn't persist
+// preferences across reloads anyway).
+let _iosFullscreenToastShownInMemory = false;
+
 function hasShownIosFullscreenToast() {
+    if (_iosFullscreenToastShownInMemory) return true;
     try {
         return localStorage.getItem(IOS_FULLSCREEN_TOAST_KEY) === '1';
     } catch (e) {
-        // Private browsing / disabled storage → re-show every time
-        // rather than crashing. Toast is still polite and one-tap.
+        // Private browsing / disabled storage → fall back to the
+        // in-memory flag (which mark…() also sets), so the second
+        // tap proceeds to fullscreen normally.
         return false;
     }
 }
 
 function markIosFullscreenToastShown() {
+    _iosFullscreenToastShownInMemory = true;
     try {
         localStorage.setItem(IOS_FULLSCREEN_TOAST_KEY, '1');
-    } catch (e) { /* storage disabled — ignore */ }
+    } catch (e) { /* storage disabled — in-memory flag is enough */ }
 }
 
 // Polite, single-line toast pointing iOS users at the Maximize

--- a/tests/test_ios_fullscreen_toast.py
+++ b/tests/test_ios_fullscreen_toast.py
@@ -51,7 +51,10 @@ def mapping_html_text():
 class TestIosDetection:
 
     def test_isios_safari_function_present(self, mapping_html_text):
-        assert 'function isIosSafari()' in mapping_html_text
+        # Backwards-compatible alias preserved AND the canonical
+        # `isIos` name introduced (review fix on PR #140).
+        assert 'function isIos()' in mapping_html_text
+        assert 'const isIosSafari = isIos' in mapping_html_text
 
     def test_detects_iphone_ipad_ipod(self, mapping_html_text):
         """The classic UA tokens (iPhone, iPad, iPod) must trigger
@@ -63,7 +66,7 @@ class TestIosDetection:
         combine the Mac UA with maxTouchPoints to disambiguate iPad
         from a real Mac (which has zero touch points)."""
         block = mapping_html_text[
-            mapping_html_text.index('function isIosSafari()'):
+            mapping_html_text.index('function isIos()'):
         ][:1500]
         assert '/Macintosh/i' in block
         assert 'maxTouchPoints' in block
@@ -72,7 +75,7 @@ class TestIosDetection:
         """Must guard against `navigator` being undefined in headless
         / SSR contexts to avoid a ReferenceError in older renderers."""
         block = mapping_html_text[
-            mapping_html_text.index('function isIosSafari()'):
+            mapping_html_text.index('function isIos()'):
         ][:1500]
         assert "typeof navigator === 'undefined'" in block
 
@@ -113,6 +116,48 @@ class TestOneTimeToast:
                 f"{fn_name} must try-catch localStorage access"
             )
             assert 'catch' in block
+
+    def test_in_memory_fallback_for_private_mode(self, mapping_html_text):
+        """Safari Private Mode has localStorage quota=0 — setItem
+        throws but getItem returns null. Without an in-memory flag the
+        early return in overlayFullscreen() would fire on EVERY tap
+        and the user could never reach webkitEnterFullscreen
+        (softlocking the button despite the toast saying 'tap again').
+        Pin the in-memory flag contract added in the PR #140 review
+        fix.
+        """
+        # Module-scoped flag declaration present.
+        assert '_iosFullscreenToastShownInMemory = false' in mapping_html_text
+
+        # hasShown checks the in-memory flag FIRST so it short-circuits
+        # before touching localStorage.
+        has_block_start = mapping_html_text.index(
+            'function hasShownIosFullscreenToast'
+        )
+        has_block = mapping_html_text[has_block_start:has_block_start + 800]
+        in_memory_idx = has_block.index('_iosFullscreenToastShownInMemory')
+        try_idx = has_block.index('try {')
+        assert in_memory_idx < try_idx, (
+            'hasShownIosFullscreenToast must check the in-memory flag '
+            'BEFORE the try/localStorage block, otherwise Safari '
+            'Private Mode will softlock the Fullscreen button.'
+        )
+
+        # mark…() sets the in-memory flag UNCONDITIONALLY (before the
+        # try/catch around localStorage).
+        mark_block_start = mapping_html_text.index(
+            'function markIosFullscreenToastShown'
+        )
+        mark_block = mapping_html_text[mark_block_start:mark_block_start + 800]
+        mark_set_idx = mark_block.index(
+            '_iosFullscreenToastShownInMemory = true'
+        )
+        mark_try_idx = mark_block.index('try {')
+        assert mark_set_idx < mark_try_idx, (
+            'markIosFullscreenToastShown must set the in-memory flag '
+            'BEFORE attempting localStorage.setItem, so Private Mode '
+            'tap #2 succeeds even if setItem throws.'
+        )
 
     def test_show_helper_falls_back_when_showtoast_missing(self,
                                                            mapping_html_text):
@@ -163,13 +208,13 @@ class TestFirstTapSkipsFullscreen:
 
         # The iOS branch must contain BOTH showIosFullscreenToast and
         # an early return.
-        assert 'isIosSafari()' in body
+        assert 'isIos()' in body
         assert '!hasShownIosFullscreenToast()' in body
         assert 'showIosFullscreenToast()' in body
         assert 'markIosFullscreenToastShown()' in body
         # The early return MUST appear inside the iOS branch — i.e.
         # before the requestFullscreen / webkitEnterFullscreen calls.
-        ios_branch_idx = body.index('isIosSafari()')
+        ios_branch_idx = body.index('isIos()')
         return_idx = body.index('return;', ios_branch_idx)
         fs_call_idx = body.index('requestFullscreen()')
         assert return_idx < fs_call_idx, (

--- a/tests/test_ios_fullscreen_toast.py
+++ b/tests/test_ios_fullscreen_toast.py
@@ -1,0 +1,189 @@
+"""Phase 4.9 (#101) — iOS fullscreen toast in mapping.html.
+
+The toast is a one-time, polite warning shown the FIRST time an iOS
+Safari user taps the Fullscreen button on the video overlay. Because
+iOS hands fullscreen off to its native player (which cannot have
+HTML overlaid), the heads-up display (HUD) with map/speed/time
+disappears in OS fullscreen — a Safari limitation we cannot
+work around.
+
+The fix:
+
+1. Detect iOS Safari (incl. iPad on iOS 13+ desktop-mode masquerade).
+2. On the FIRST fullscreen tap from an iOS browser, show the toast
+   AND skip the fullscreen call. If we entered fullscreen the toast
+   would be hidden behind the OS player — the user would never see
+   the explanation.
+3. Persist the "shown" flag in localStorage so we don't nag the user.
+4. Subsequent taps proceed to ``webkitEnterFullscreen`` normally for
+   users who deliberately want OS fullscreen and accept the HUD loss.
+
+Because this is pure client-side JS that depends on browser APIs, we
+verify the contract by reading mapping.html as text and pinning the
+markers, branches, and sentinel keys.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+
+import pytest
+
+
+_MAPPING_HTML = os.path.join(
+    os.path.dirname(__file__),
+    '..', 'scripts', 'web', 'templates', 'mapping.html',
+)
+
+
+@pytest.fixture(scope='module')
+def mapping_html_text():
+    with open(_MAPPING_HTML, 'r', encoding='utf-8') as f:
+        return f.read()
+
+
+# ---------------------------------------------------------------------------
+# iOS detection contract
+# ---------------------------------------------------------------------------
+
+
+class TestIosDetection:
+
+    def test_isios_safari_function_present(self, mapping_html_text):
+        assert 'function isIosSafari()' in mapping_html_text
+
+    def test_detects_iphone_ipad_ipod(self, mapping_html_text):
+        """The classic UA tokens (iPhone, iPad, iPod) must trigger
+        detection on every iOS version."""
+        assert '/iPhone|iPad|iPod/i' in mapping_html_text
+
+    def test_detects_ipados_desktop_masquerade(self, mapping_html_text):
+        """iPadOS 13+ identifies as Macintosh; the function must
+        combine the Mac UA with maxTouchPoints to disambiguate iPad
+        from a real Mac (which has zero touch points)."""
+        block = mapping_html_text[
+            mapping_html_text.index('function isIosSafari()'):
+        ][:1500]
+        assert '/Macintosh/i' in block
+        assert 'maxTouchPoints' in block
+
+    def test_detection_is_defensive(self, mapping_html_text):
+        """Must guard against `navigator` being undefined in headless
+        / SSR contexts to avoid a ReferenceError in older renderers."""
+        block = mapping_html_text[
+            mapping_html_text.index('function isIosSafari()'):
+        ][:1500]
+        assert "typeof navigator === 'undefined'" in block
+
+
+# ---------------------------------------------------------------------------
+# One-time toast contract
+# ---------------------------------------------------------------------------
+
+
+class TestOneTimeToast:
+
+    def test_localstorage_key_is_stable(self, mapping_html_text):
+        """The localStorage key must not change without a migration —
+        otherwise users who saw the toast in one release will see it
+        again after upgrade."""
+        assert "IOS_FULLSCREEN_TOAST_KEY = 'iosFullscreenToastShown'" in (
+            mapping_html_text
+        )
+
+    def test_has_shown_helper_present(self, mapping_html_text):
+        assert 'function hasShownIosFullscreenToast()' in mapping_html_text
+
+    def test_mark_helper_present(self, mapping_html_text):
+        assert 'function markIosFullscreenToastShown()' in mapping_html_text
+
+    def test_show_helper_present(self, mapping_html_text):
+        assert 'function showIosFullscreenToast()' in mapping_html_text
+
+    def test_localstorage_access_is_try_wrapped(self, mapping_html_text):
+        """Private browsing or storage-disabled mode must not crash
+        the fullscreen path. Both helpers must wrap localStorage in
+        try/catch."""
+        for fn_name in ('hasShownIosFullscreenToast',
+                        'markIosFullscreenToastShown'):
+            block_start = mapping_html_text.index('function ' + fn_name)
+            block = mapping_html_text[block_start:block_start + 600]
+            assert 'try {' in block, (
+                f"{fn_name} must try-catch localStorage access"
+            )
+            assert 'catch' in block
+
+    def test_show_helper_falls_back_when_showtoast_missing(self,
+                                                           mapping_html_text):
+        """Defensive fallback: if a refactor moves showToast, the
+        function must log to console rather than crashing."""
+        block_start = mapping_html_text.index('function showIosFullscreenToast')
+        block = mapping_html_text[block_start:block_start + 1200]
+        assert "typeof showToast === 'function'" in block
+        assert 'console.log' in block
+
+    def test_toast_text_mentions_maximize(self, mapping_html_text):
+        """The whole point of the toast is to redirect the user to
+        the Maximize button. Pin the keyword."""
+        block_start = mapping_html_text.index('function showIosFullscreenToast')
+        block = mapping_html_text[block_start:block_start + 1200]
+        assert 'Maximize' in block
+
+    def test_toast_uses_info_severity(self, mapping_html_text):
+        """Polite, informational — not a warning or error. 'info' is
+        the existing showToast severity for non-actionable hints."""
+        block_start = mapping_html_text.index('function showIosFullscreenToast')
+        block = mapping_html_text[block_start:block_start + 1200]
+        assert "showToast(msg, 'info')" in block
+
+
+# ---------------------------------------------------------------------------
+# Skip-fullscreen-on-first-tap contract
+# ---------------------------------------------------------------------------
+
+
+class TestFirstTapSkipsFullscreen:
+
+    def test_first_tap_branch_returns_before_fullscreen(self,
+                                                       mapping_html_text):
+        """The whole point of the design is: on the first iOS tap we
+        SHOW the toast and SKIP fullscreen, because entering OS
+        fullscreen would hide the toast. Pin the early-return."""
+        # Slice from overlayFullscreen() to its closing brace.
+        start = mapping_html_text.index('function overlayFullscreen()')
+        # End at the next "function " definition.
+        rest = mapping_html_text[start:]
+        # Function span is bounded; take ~3500 chars to be safe and
+        # then trim at the next top-level "function ".
+        end_offset = rest.find('\nfunction ', 50)
+        if end_offset == -1:
+            end_offset = 3500
+        body = rest[:end_offset]
+
+        # The iOS branch must contain BOTH showIosFullscreenToast and
+        # an early return.
+        assert 'isIosSafari()' in body
+        assert '!hasShownIosFullscreenToast()' in body
+        assert 'showIosFullscreenToast()' in body
+        assert 'markIosFullscreenToastShown()' in body
+        # The early return MUST appear inside the iOS branch — i.e.
+        # before the requestFullscreen / webkitEnterFullscreen calls.
+        ios_branch_idx = body.index('isIosSafari()')
+        return_idx = body.index('return;', ios_branch_idx)
+        fs_call_idx = body.index('requestFullscreen()')
+        assert return_idx < fs_call_idx, (
+            "The first-iOS-tap branch must `return;` before the "
+            "fullscreen calls. Otherwise the toast is hidden behind "
+            "the OS player."
+        )
+
+    def test_subsequent_taps_proceed_to_fullscreen(self, mapping_html_text):
+        """Once the localStorage flag is set, the function must fall
+        through to the original fullscreen call ladder. Pin all three
+        branches stay intact."""
+        start = mapping_html_text.index('function overlayFullscreen()')
+        body = mapping_html_text[start:start + 4000]
+        assert 'stage.requestFullscreen' in body
+        assert 'stage.webkitRequestFullscreen' in body
+        assert 'v.webkitEnterFullscreen' in body


### PR DESCRIPTION
## Phase 4.9 (#101) — One-time iOS fullscreen toast

### Problem

iOS Safari hands fullscreen off to its native player which cannot have HTML overlaid, so the heads-up display (HUD) with map / speed / time disappears in OS fullscreen. This is a Safari OS limitation we cannot work around — but until now there was no in-product hint that the user should reach for the **Maximize** button (which fills the viewport while preserving the HUD) instead.

### Fix

Add a one-time, polite toast that fires on the **first** Fullscreen tap from an iOS Safari browser. Subsequent taps proceed to OS fullscreen normally for users who deliberately want it and accept the HUD loss.

### Design decisions

1. **First iOS tap shows the toast and SKIPS the fullscreen call.** If we entered OS fullscreen the toast (which lives in the page DOM) would be hidden behind the OS player and the user would never see the explanation. Skipping the fullscreen on the first tap is acceptable — the toast explicitly recommends Maximize, which delivers the user's actual intent ("give me a bigger view") without losing the HUD.

2. **Subsequent taps fall through** to `webkitEnterFullscreen` normally. The localStorage key `iosFullscreenToastShown` tracks the one-time-shown state.

3. **iOS detection** combines:
   - the classic UA token regex `/iPhone|iPad|iPod/i`, AND
   - the iPad-on-iOS-13+ desktop-mode masquerade (Mac UA + `maxTouchPoints > 1`).

   Both signals are required because iPad in desktop mode reports as Macintosh.

4. **localStorage access wrapped in try / catch** — private browsing throws on access. On failure `hasShownIosFullscreenToast()` returns false, so the toast re-shows; acceptable degradation.

5. **`showToast` call has a defensive `console.log` fallback** if a future refactor moves it. Never blocks the fullscreen path.

### Toast text

> iOS Safari hides the HUD in fullscreen. Tap Maximize for an HUD-visible view, or tap Fullscreen again to continue without HUD.

### Tests

`tests/test_ios_fullscreen_toast.py` — 14 new tests, text-based assertions on the template that pin every contract above:
- detection function present + UA tokens + iPad masquerade + defensive `typeof navigator`
- localStorage key string is stable (`iosFullscreenToastShown`)
- all 4 helpers present (`isIosSafari`, `hasShown…`, `mark…`, `show…`)
- localStorage access try/catch wrapped in both helpers
- toast text mentions "Maximize", uses `'info'` severity
- early `return;` happens in the iOS branch BEFORE the fullscreen calls
- subsequent-tap fall-through to all three fullscreen branches preserved

### Suite

```
1210 passed, 3 skipped in 63.79s
```

(was 1196 + 3, +14 new)

### Scope

Single template file modified: `scripts/web/templates/mapping.html`. No backend changes. No CSS changes. No new dependencies.

### Closes

Phase 4.9 sub-item of #101.

---

🤖 Generated with [Copilot](https://github.com/features/copilot)

Co-Authored-By: Copilot <copilot@github.com>
