### PR TITLE
Phase 5.2 — score-priority connection batching (1+N → 1)

### DIFF
--- a/scripts/web/services/cloud_archive_service.py
+++ b/scripts/web/services/cloud_archive_service.py
@@ -637,28 +637,61 @@ def _init_cloud_tables(db_path: str) -> sqlite3.Connection:
 # ---------------------------------------------------------------------------
 
 def _load_geo_hits(db_path: Optional[str] = None) -> Optional[Set[str]]:
-    """Pre-fetch the set of event-directory basenames that have any waypoint
-    geolocation hit in geodata.db.
+    """Pre-fetch the set of "anchors" — strings that legacy
+    ``_score_event_priority`` would match via ``LIKE '%dir_name%'`` —
+    extracted from every non-NULL ``waypoints.video_path`` row.
 
     Phase 5.2 — replaces the per-event ``get_db_connection() → SELECT … LIKE``
     pattern in :func:`_score_event_priority`. For a queue with N candidate
     events the legacy code opened N fresh SQLite connections and ran one
     full-scan ``LIKE '%dir%'`` query each. This helper does ONE connection
-    and ONE ``SELECT DISTINCT video_path`` then derives the parent-dir
-    basename in Python (set-build) so the per-event check collapses to an
-    O(1) ``in`` lookup.
+    and ONE ``SELECT DISTINCT video_path`` then derives every possible
+    ``dir_name`` anchor in Python (set-build) so the per-event check
+    collapses to an O(1) ``in`` lookup.
 
-    Uses a raw ``sqlite3.connect`` rather than ``mapping_queries.
-    get_db_connection`` because the latter runs the full v6 schema
-    initialization on every call. This helper is read-only and called
-    once per discover pass — schema migration is a different lifecycle
-    and belongs in the indexing path, not the cloud picker. Skipping it
-    also means ``_load_geo_hits`` doesn't crash when geodata.db is
-    missing or partially initialized: it simply returns ``None`` so the
-    scorer falls back to the legacy per-event query path.
+    The legacy LIKE substring pattern actually accepts THREE anchor shapes
+    because :func:`_discover_events` calls the scorer with two different
+    ``event_dir`` shapes:
+
+      * **Nested event dirs** (``SentryClips/2026-05-12_10-00-00``) —
+        ``dir_name`` is a 19-char timestamp.
+      * **Flat ArchivedClips files** (``ArchivedClips/2026-05-12_10-00-00-front.mp4``) —
+        ``dir_name`` is the full filename (``os.path.basename`` of the
+        FILE, not a directory).
+
+    And ``waypoints.video_path`` in production is stored as
+    ``ArchivedClips/<basename>`` — never the original nested
+    ``SentryClips/<event-dir>/<file>`` form. So we MUST look at the
+    file's basename and the leading-19-char timestamp prefix, not
+    just the parent-dir basename. (PR #143 reviewer caught this: the
+    parent-dir-only build always produced ``"ArchivedClips"`` and
+    silently demoted geo-tier events to the no-geo tier, which under
+    ``sync_non_event_videos: false`` would drop them from the queue.)
+
+    For each ``video_path`` we add three anchors to the set:
+      1. ``os.path.basename(os.path.dirname(vp))`` — catches the
+         nested-event-dir naming pattern (``RecentClips`` /
+         ``ArchivedClips`` are always added but never collide with a
+         real event-dir name, so they're harmless noise).
+      2. ``os.path.basename(vp)`` — catches the flat-ArchivedClips
+         file-basename naming pattern.
+      3. The leading 19-char ``YYYY-MM-DD_HH-MM-SS`` timestamp prefix
+         of the file basename — catches the nested-event-dir case
+         even when the indexer has rewritten the path to flat form
+         (which is the production situation).
+
+    Uses raw ``sqlite3.connect`` rather than
+    ``mapping_queries.get_db_connection`` because the latter runs the
+    full v6 schema initialization on every call. This helper is
+    read-only and called once per discover pass — schema migration is
+    a different lifecycle and belongs in the indexing path, not the
+    cloud picker. Skipping it also means ``_load_geo_hits`` doesn't
+    crash when geodata.db is missing or partially initialized: it
+    returns ``None`` so the scorer falls back to the legacy per-event
+    query path.
 
     Returns:
-      * a ``set`` of dir-name strings (may be empty if waypoints table
+      * a ``set`` of anchor strings (may be empty if waypoints table
         has no rows) — caller should use ``in`` for the per-event check.
       * ``None`` if mapping is disabled, the DB doesn't exist, or the
         query raises (no waypoints table, locked, etc.) — caller MUST
@@ -699,6 +732,13 @@ def _load_geo_hits(db_path: Optional[str] = None) -> Optional[Set[str]]:
         except Exception:
             pass
 
+    # YYYY-MM-DD_HH-MM-SS Tesla event timestamp pattern (19 chars).
+    # Pre-compiled in the function body — we only get here once per
+    # discover pass, so the compile cost is negligible and keeps the
+    # helper self-contained.
+    import re
+    _TS_RE = re.compile(r"\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}")
+
     for row in rows:
         # Plain sqlite3 connection (no row_factory) → tuple access.
         try:
@@ -707,15 +747,33 @@ def _load_geo_hits(db_path: Optional[str] = None) -> Optional[Set[str]]:
             continue
         if not vp:
             continue
-        # Tesla layout: ARCHIVE_DIR/<event-dir>/<camera-file>.mp4
-        # waypoints.video_path may also be a flat ArchivedClips path:
-        #   ARCHIVE_DIR/<filename>.mp4
-        # In the flat-file case ``dirname`` is ARCHIVE_DIR (which is not
-        # an event dir), so its basename will not match any event entry —
-        # safe no-op.
+
+        # Anchor 1: parent-dir basename. Catches the nested
+        # ``SentryClips/<event-dir>/<file>`` naming convention. In
+        # current production this is almost always ``ArchivedClips`` /
+        # ``RecentClips`` (because the indexer rewrites paths to the
+        # flat form), which is harmless noise: those names never
+        # collide with a real Tesla event-dir basename.
         parent = os.path.basename(os.path.dirname(vp))
         if parent:
             hits.add(parent)
+
+        # Anchor 2: file basename. Catches flat ArchivedClips files
+        # where ``_discover_events`` calls the scorer with a full
+        # filename as the ``event_dir`` argument.
+        base = os.path.basename(vp)
+        if base:
+            hits.add(base)
+
+            # Anchor 3: leading 19-char Tesla-timestamp prefix of the
+            # file basename. Catches the nested-event-dir case (where
+            # ``dir_name`` is just the 19-char timestamp) even when
+            # the indexer has rewritten the path to the flat form
+            # (which is the production situation per PR #143 review).
+            m = _TS_RE.match(base)
+            if m:
+                hits.add(m.group(0))
+
     return hits
 
 

--- a/scripts/web/services/cloud_archive_service.py
+++ b/scripts/web/services/cloud_archive_service.py
@@ -18,7 +18,7 @@ import subprocess
 import threading
 import time
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -636,7 +636,93 @@ def _init_cloud_tables(db_path: str) -> sqlite3.Connection:
 # Priority Scoring
 # ---------------------------------------------------------------------------
 
-def _score_event_priority(event_dir: str) -> int:
+def _load_geo_hits(db_path: Optional[str] = None) -> Optional[Set[str]]:
+    """Pre-fetch the set of event-directory basenames that have any waypoint
+    geolocation hit in geodata.db.
+
+    Phase 5.2 — replaces the per-event ``get_db_connection() → SELECT … LIKE``
+    pattern in :func:`_score_event_priority`. For a queue with N candidate
+    events the legacy code opened N fresh SQLite connections and ran one
+    full-scan ``LIKE '%dir%'`` query each. This helper does ONE connection
+    and ONE ``SELECT DISTINCT video_path`` then derives the parent-dir
+    basename in Python (set-build) so the per-event check collapses to an
+    O(1) ``in`` lookup.
+
+    Uses a raw ``sqlite3.connect`` rather than ``mapping_queries.
+    get_db_connection`` because the latter runs the full v6 schema
+    initialization on every call. This helper is read-only and called
+    once per discover pass — schema migration is a different lifecycle
+    and belongs in the indexing path, not the cloud picker. Skipping it
+    also means ``_load_geo_hits`` doesn't crash when geodata.db is
+    missing or partially initialized: it simply returns ``None`` so the
+    scorer falls back to the legacy per-event query path.
+
+    Returns:
+      * a ``set`` of dir-name strings (may be empty if waypoints table
+        has no rows) — caller should use ``in`` for the per-event check.
+      * ``None`` if mapping is disabled, the DB doesn't exist, or the
+        query raises (no waypoints table, locked, etc.) — caller MUST
+        treat ``None`` as "fall back to per-event lookup" so behaviour
+        matches the legacy code path.
+    """
+    try:
+        from config import MAPPING_ENABLED, MAPPING_DB_PATH
+    except ImportError:
+        return None
+    if not MAPPING_ENABLED:
+        return None
+    path = db_path or MAPPING_DB_PATH
+
+    # Refuse to create the DB if it doesn't exist — that would mask
+    # real configuration problems and create an empty file the indexer
+    # would then try to migrate. ``None`` is the right "I have no info"
+    # response.
+    if not path or not os.path.isfile(path):
+        return None
+
+    try:
+        conn = sqlite3.connect(path, timeout=5.0)
+    except Exception:
+        return None
+
+    hits: Set[str] = set()
+    try:
+        rows = conn.execute(
+            "SELECT DISTINCT video_path FROM waypoints "
+            "WHERE video_path IS NOT NULL"
+        ).fetchall()
+    except Exception:
+        return None
+    finally:
+        try:
+            conn.close()
+        except Exception:
+            pass
+
+    for row in rows:
+        # Plain sqlite3 connection (no row_factory) → tuple access.
+        try:
+            vp = row[0]
+        except (IndexError, TypeError):
+            continue
+        if not vp:
+            continue
+        # Tesla layout: ARCHIVE_DIR/<event-dir>/<camera-file>.mp4
+        # waypoints.video_path may also be a flat ArchivedClips path:
+        #   ARCHIVE_DIR/<filename>.mp4
+        # In the flat-file case ``dirname`` is ARCHIVE_DIR (which is not
+        # an event dir), so its basename will not match any event entry —
+        # safe no-op.
+        parent = os.path.basename(os.path.dirname(vp))
+        if parent:
+            hits.add(parent)
+    return hits
+
+
+def _score_event_priority(
+    event_dir: str,
+    geo_hits: Optional[Set[str]] = None,
+) -> int:
     """Score an event directory for sync priority (lower = higher priority).
 
     Priority order:
@@ -666,22 +752,32 @@ def _score_event_priority(event_dir: str) -> int:
 
     # Check geodata.db for geolocation
     if score >= 200:
-        try:
-            from config import MAPPING_ENABLED, MAPPING_DB_PATH
-            if MAPPING_ENABLED:
-                from services.mapping_queries import get_db_connection
-                conn = get_db_connection(MAPPING_DB_PATH)
-                # Escape LIKE wildcards in dir_name to prevent unintended matches
-                safe_name = dir_name.replace('\\', '\\\\').replace('%', '\\%').replace('_', '\\_')
-                row = conn.execute(
-                    "SELECT COUNT(*) as cnt FROM waypoints WHERE video_path LIKE ? ESCAPE '\\'",
-                    (f'%{safe_name}%',)
-                ).fetchone()
-                conn.close()
-                if row and row['cnt'] > 0:
-                    score = 100  # Has geolocation — medium priority
-        except Exception:
-            pass
+        # Phase 5.2 — fast path: caller pre-fetched the geo-hit set in a
+        # single ``SELECT DISTINCT video_path`` query. Skip the per-event
+        # SQLite connection entirely. ``geo_hits is None`` means "no
+        # batched lookup available" (mapping disabled, import failed,
+        # query raised) → fall through to the legacy per-event query so
+        # behaviour matches direct callers (tests).
+        if geo_hits is not None:
+            if dir_name in geo_hits:
+                score = 100
+        else:
+            try:
+                from config import MAPPING_ENABLED, MAPPING_DB_PATH
+                if MAPPING_ENABLED:
+                    from services.mapping_queries import get_db_connection
+                    conn = get_db_connection(MAPPING_DB_PATH)
+                    # Escape LIKE wildcards in dir_name to prevent unintended matches
+                    safe_name = dir_name.replace('\\', '\\\\').replace('%', '\\%').replace('_', '\\_')
+                    row = conn.execute(
+                        "SELECT COUNT(*) as cnt FROM waypoints WHERE video_path LIKE ? ESCAPE '\\'",
+                        (f'%{safe_name}%',)
+                    ).fetchone()
+                    conn.close()
+                    if row and row['cnt'] > 0:
+                        score = 100  # Has geolocation — medium priority
+            except Exception:
+                pass
 
     # Add age-based sub-score (older = lower number = higher priority)
     try:
@@ -922,12 +1018,21 @@ def _discover_events(
     except ImportError:
         pass
 
+    # Phase 5.2 — pre-fetch the geo-hit set ONCE so the scorer doesn't
+    # open a fresh SQLite connection per event. For a queue of N candidate
+    # events the legacy per-event ``LIKE '%dir%'`` pattern was N
+    # connection-open + N full-scan queries; now it's ONE
+    # ``SELECT DISTINCT video_path`` + N O(1) set lookups. ``None``
+    # signals fallback to per-event lookup (mapping disabled / import
+    # failed / query raised) so behaviour matches direct callers.
+    geo_hits = _load_geo_hits()
+
     # Score every candidate once so we can both filter and sort without
     # invoking the (relatively expensive) scorer twice. Score >= 200 means
     # neither an event.json trigger nor any waypoint geolocation hit was
     # found — i.e. routine driving footage.
     scored: List[Tuple[Tuple[str, str, int], int]] = [
-        (t, _score_event_priority(t[0])) for t in events
+        (t, _score_event_priority(t[0], geo_hits=geo_hits)) for t in events
     ]
 
     # Phase 2.3 — When ``sync_non_event_videos`` is False the picker MUST

--- a/tests/test_score_priority_batching.py
+++ b/tests/test_score_priority_batching.py
@@ -266,6 +266,101 @@ class TestScorePriorityBatching:
         result = svc._load_geo_hits()
         assert result is None
 
+    def test_geo_hits_matches_flat_archived_clips_shape(
+            self, tmp_path, monkeypatch):
+        """REGRESSION GUARD (PR #143 review).
+
+        In production the indexer rewrites every waypoint's
+        ``video_path`` to the flat ``ArchivedClips/<basename>`` form —
+        NEVER the original nested ``SentryClips/<event-dir>/<file>``
+        form. The first iteration of this PR derived only the parent
+        dir basename, which always produced ``"ArchivedClips"`` /
+        ``"RecentClips"`` — never the event timestamp.
+
+        The result was that ``_score_event_priority`` for an event
+        like ``SentryClips/2026-05-12_10-00-00`` would NOT find its
+        waypoint anchor in ``geo_hits`` and would silently demote the
+        event from the geo tier (100) to the no-geo tier (200+).
+        Under ``sync_non_event_videos: false`` (the default) that
+        causes the clip to be DROPPED from the queue.
+
+        This test pins the production data shape end-to-end:
+        - waypoint stored as ``ArchivedClips/<timestamp>-front.mp4``
+        - event dir ``SentryClips/<timestamp>`` (timestamp dir_name)
+        - geo_hits MUST contain the timestamp string so the per-event
+          ``in`` check matches.
+        """
+        # Production-shaped geodata.db: waypoint stored as flat
+        # ``ArchivedClips/2026-05-12_10-00-00-front.mp4``.
+        db_path = _make_geodata_db(tmp_path, [
+            "ArchivedClips/2026-05-12_10-00-00-front.mp4",
+            "ArchivedClips/2026-05-12_11-00-00-back.mp4",
+        ])
+        monkeypatch.setattr(config, "MAPPING_ENABLED", True, raising=False)
+        monkeypatch.setattr(config, "MAPPING_DB_PATH", db_path, raising=False)
+
+        hits = svc._load_geo_hits()
+        assert hits is not None
+
+        # Anchor 3: the leading 19-char timestamp prefix MUST be in
+        # the set so a SentryClips event-dir basename can match.
+        assert "2026-05-12_10-00-00" in hits, (
+            "Missing timestamp anchor — SentryClips event dirs would "
+            "fail to match their flat-stored waypoints. Reproduces "
+            "PR #143 critical finding."
+        )
+        assert "2026-05-12_11-00-00" in hits
+
+        # Anchor 2: the full filename MUST also be in the set so a
+        # flat-ArchivedClips event call (where dir_name is the file
+        # basename) can match.
+        assert "2026-05-12_10-00-00-front.mp4" in hits
+        assert "2026-05-12_11-00-00-back.mp4" in hits
+
+        # Anchor 1: parent-dir basename — harmless noise but documents
+        # the contract.
+        assert "ArchivedClips" in hits
+
+    def test_score_via_geo_hits_matches_flat_path_production_shape(
+            self, tmp_path, monkeypatch):
+        """End-to-end: a SentryClips event-dir score with batched
+        geo_hits MUST equal the legacy per-event score when waypoints
+        are stored in the flat production form.
+
+        This is the test that would have caught the PR #143 critical
+        finding before deploy.
+        """
+        # Production-shaped geodata.db.
+        db_path = _make_geodata_db(tmp_path, [
+            "ArchivedClips/2026-05-12_10-00-00-front.mp4",
+        ])
+        monkeypatch.setattr(config, "MAPPING_ENABLED", True, raising=False)
+        monkeypatch.setattr(config, "MAPPING_DB_PATH", db_path, raising=False)
+
+        # SentryClips event dir with the matching timestamp.
+        teslacam = tmp_path / "TeslaCam"
+        sentry = teslacam / "SentryClips"
+        sentry.mkdir(parents=True)
+        event_dir = _make_event_dir(
+            str(sentry), "2026-05-12_10-00-00", with_event_json=False)
+
+        legacy_score = svc._score_event_priority(event_dir)
+        hits = svc._load_geo_hits()
+        batched_score = svc._score_event_priority(event_dir, geo_hits=hits)
+
+        assert legacy_score == batched_score, (
+            f"Score mismatch on production-shape data: "
+            f"legacy={legacy_score} batched={batched_score}. "
+            f"PR #143 critical finding regression."
+        )
+        # Both should be in the geo tier (100-199), not the no-geo
+        # tier (200+).
+        assert 100 <= batched_score < 200, (
+            f"Expected geo tier, got {batched_score}. The flat-path "
+            f"anchors (basename + 19-char prefix) were not added to "
+            f"geo_hits."
+        )
+
     def test_score_via_geo_hits_skips_db_connection_entirely(
             self, teslacam_with_geo, monkeypatch):
         """When ``geo_hits`` is provided, ``_score_event_priority`` MUST NOT

--- a/tests/test_score_priority_batching.py
+++ b/tests/test_score_priority_batching.py
@@ -1,0 +1,298 @@
+"""Tests for Phase 5.2 — score-priority connection batching.
+
+`_score_event_priority` previously opened a fresh sqlite3 connection per
+event and ran a full-scan ``LIKE '%dir%'`` query inside the per-event scoring
+comprehension in ``_discover_events``. For a queue with N candidate events
+that's N connection opens and N full-scan queries.
+
+The fix pre-fetches the set of event-directory basenames that have any
+waypoint geolocation hit ONCE via ``_load_geo_hits()`` (a single
+``SELECT DISTINCT video_path FROM waypoints WHERE video_path IS NOT NULL``)
+and passes it into each scorer call as ``geo_hits``. The per-event check
+collapses to an O(1) ``in`` lookup.
+
+The legacy per-event query path is preserved as a fallback when ``geo_hits
+is None`` (mapping disabled, import failed, query raised) so direct callers
+of ``_score_event_priority`` continue to work without arrange.
+
+These tests pin:
+  1. semantic equivalence — score with batched geo_hits == score without
+  2. fallback — geo_hits=None preserves legacy per-event lookup
+  3. single connection — _discover_events opens ONE geodata.db connection
+     regardless of candidate count
+  4. empty result — geo_hits=set() means no event dir matches, so geo
+     tier (100) is skipped correctly
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+from typing import List
+from unittest.mock import patch
+
+import pytest
+
+import config
+from services import cloud_archive_service as svc
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _make_event_dir(parent: str, name: str, with_event_json: bool = False,
+                    with_video: bool = True) -> str:
+    """Create a minimal Tesla event directory."""
+    event_dir = os.path.join(parent, name)
+    os.makedirs(event_dir, exist_ok=True)
+    if with_event_json:
+        with open(os.path.join(event_dir, "event.json"), "w") as f:
+            f.write('{"reason":"sentry_aware_object_detection"}')
+    if with_video:
+        with open(os.path.join(event_dir, "front.mp4"), "wb") as f:
+            f.write(b"\x00" * 1024)
+    return event_dir
+
+
+def _make_geodata_db(tmp_path, video_paths: List[str]) -> str:
+    """Build a geodata.db with the production schema and the given video
+    paths inserted into the ``waypoints`` table.
+
+    Uses ``mapping_migrations._init_db`` so the schema matches the v6
+    layout that the legacy ``_score_event_priority`` per-event path
+    expects (it goes through ``mapping_queries.get_db_connection`` which
+    runs the full migration on every connect).
+    """
+    db_path = str(tmp_path / "geodata.db")
+    # Provision the full v6 schema by calling _init_db once.
+    from services.mapping_migrations import _init_db
+    conn = _init_db(db_path)
+    try:
+        # waypoints requires a parent trip row (FK ON DELETE CASCADE).
+        conn.execute(
+            "INSERT INTO trips (start_time, end_time) "
+            "VALUES ('2026-05-12T11:00:00', '2026-05-12T11:05:00')"
+        )
+        trip_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+        for vp in video_paths:
+            conn.execute(
+                "INSERT INTO waypoints "
+                "(trip_id, timestamp, lat, lon, video_path) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (trip_id, "2026-05-12T11:01:00", 37.0, -122.0, vp),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+    return db_path
+
+
+@pytest.fixture
+def teslacam_with_geo(tmp_path, monkeypatch):
+    """Build a TeslaCam tree with mixed event/non-event dirs and a
+    geodata.db where SOME of the non-event dirs have waypoints.
+
+    Layout:
+      SentryClips/
+        2026-05-12_10-00-00/  (event.json → score 0)
+        2026-05-12_11-00-00/  (no event.json, HAS geodata waypoint → score 100)
+        2026-05-12_12-00-00/  (no event.json, NO geodata → score 200+)
+    """
+    teslacam = tmp_path / "TeslaCam"
+    sentry = teslacam / "SentryClips"
+    sentry.mkdir(parents=True)
+
+    _make_event_dir(str(sentry), "2026-05-12_10-00-00", with_event_json=True)
+    _make_event_dir(str(sentry), "2026-05-12_11-00-00", with_event_json=False)
+    _make_event_dir(str(sentry), "2026-05-12_12-00-00", with_event_json=False)
+
+    # geodata.db: only the 11-00-00 dir has waypoints. The flat ArchivedClips
+    # path is included to verify the dirname-derivation does not blow up
+    # when a waypoint references a flat file.
+    db_path = _make_geodata_db(tmp_path, [
+        f"{sentry}/2026-05-12_11-00-00/front-2026-05-12_11-01-00.mp4",
+        "/home/pi/ArchivedClips/somefile.mp4",  # flat — parent is ArchivedClips, irrelevant
+    ])
+
+    monkeypatch.setattr(config, "MAPPING_ENABLED", True, raising=False)
+    monkeypatch.setattr(config, "MAPPING_DB_PATH", db_path, raising=False)
+    # Make sure the non-event filter doesn't drop our score-200 dir.
+    monkeypatch.setattr(svc, "_read_sync_non_event_setting",
+                        lambda: True, raising=True)
+
+    return str(teslacam), db_path
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestScorePriorityBatching:
+    """Phase 5.2 — collapse N+1 to 1 SQL connection per discover pass."""
+
+    def test_geo_hits_lookup_matches_legacy_per_event_score(
+            self, teslacam_with_geo):
+        """Score with batched geo_hits == score with legacy per-event query."""
+        teslacam, _ = teslacam_with_geo
+        sentry = os.path.join(teslacam, "SentryClips")
+        event_dir_with_geo = os.path.join(sentry, "2026-05-12_11-00-00")
+        event_dir_no_geo = os.path.join(sentry, "2026-05-12_12-00-00")
+
+        # Legacy path — geo_hits=None falls through to per-event query.
+        legacy_with_geo = svc._score_event_priority(event_dir_with_geo)
+        legacy_no_geo = svc._score_event_priority(event_dir_no_geo)
+
+        # Batched path — pre-fetch once, pass set in.
+        geo_hits = svc._load_geo_hits()
+        assert geo_hits is not None, "Expected geo_hits to load successfully"
+
+        batched_with_geo = svc._score_event_priority(
+            event_dir_with_geo, geo_hits=geo_hits)
+        batched_no_geo = svc._score_event_priority(
+            event_dir_no_geo, geo_hits=geo_hits)
+
+        assert legacy_with_geo == batched_with_geo, (
+            f"Score mismatch for geo dir: legacy={legacy_with_geo} "
+            f"batched={batched_with_geo}"
+        )
+        assert legacy_no_geo == batched_no_geo, (
+            f"Score mismatch for non-geo dir: legacy={legacy_no_geo} "
+            f"batched={batched_no_geo}"
+        )
+        # Tier sanity: geo dir is in the 100-199 tier, no-geo dir is 200+.
+        assert 100 <= batched_with_geo < 200, batched_with_geo
+        assert batched_no_geo >= 200, batched_no_geo
+
+    def test_geo_hits_none_falls_back_to_per_event_query(
+            self, teslacam_with_geo):
+        """``geo_hits=None`` MUST trigger the legacy per-event SQLite path so
+        existing direct callers (tests, future code) keep working.
+        """
+        teslacam, _ = teslacam_with_geo
+        event_dir_with_geo = os.path.join(
+            teslacam, "SentryClips", "2026-05-12_11-00-00")
+
+        score = svc._score_event_priority(event_dir_with_geo, geo_hits=None)
+        assert 100 <= score < 200, (
+            f"Expected geo tier (100-199) via legacy path, got {score}"
+        )
+
+    def test_discover_events_opens_single_geodata_connection(
+            self, teslacam_with_geo, monkeypatch):
+        """For N candidate events, ``_discover_events`` opens ONE geodata.db
+        connection (in ``_load_geo_hits``) — not N (one per event).
+
+        This is the regression guard — if a future refactor moves the
+        per-event query back inside the comprehension, this test fails.
+        """
+        teslacam, db_path = teslacam_with_geo
+
+        # Spy on sqlite3.connect to count opens.
+        original_connect = sqlite3.connect
+        call_count = {"n": 0, "paths": []}
+
+        def counting_connect(target, *args, **kwargs):
+            # Only count opens to the geodata.db under test (other tests in
+            # the same process may use sqlite3 for their own fixtures).
+            if target == db_path:
+                call_count["n"] += 1
+                call_count["paths"].append(target)
+            return original_connect(target, *args, **kwargs)
+
+        monkeypatch.setattr(sqlite3, "connect", counting_connect,
+                            raising=True)
+
+        result = svc._discover_events(teslacam, conn=None)
+
+        # Sanity: discovered all 3 event dirs.
+        assert len(result) == 3, (
+            f"Expected 3 events, got {[r[1] for r in result]}"
+        )
+
+        # ONE connection — the _load_geo_hits batched fetch — regardless of
+        # candidate count. Legacy code would have opened 2 connections (for
+        # the two no-event-json dirs that fall through to the geo check).
+        assert call_count["n"] == 1, (
+            f"Expected 1 geodata connection (batched), got {call_count['n']} "
+            f"to paths: {call_count['paths']}"
+        )
+
+    def test_load_geo_hits_returns_dirname_set(self, teslacam_with_geo):
+        """``_load_geo_hits`` returns the parent-dir basename of every
+        non-NULL ``waypoints.video_path``.
+        """
+        _, _ = teslacam_with_geo
+        hits = svc._load_geo_hits()
+        assert hits is not None
+        # The 11-00-00 dir's waypoint contributes its parent basename:
+        assert "2026-05-12_11-00-00" in hits
+        # The flat ArchivedClips path contributes 'ArchivedClips' (irrelevant
+        # for matching but proves we don't blow up on flat paths).
+        assert "ArchivedClips" in hits
+
+    def test_load_geo_hits_returns_none_when_mapping_disabled(
+            self, tmp_path, monkeypatch):
+        """``MAPPING_ENABLED=False`` ⇒ ``_load_geo_hits`` returns None so
+        callers fall through to legacy per-event query.
+        """
+        monkeypatch.setattr(config, "MAPPING_ENABLED", False, raising=False)
+        assert svc._load_geo_hits() is None
+
+    def test_load_geo_hits_handles_missing_db_gracefully(
+            self, tmp_path, monkeypatch):
+        """A missing geodata.db returns None (not a crash, not an empty set).
+        Returning ``None`` is the documented signal for "fall back to
+        per-event lookup" — empty set would silently say "no geo hits"
+        and demote events that DO have geolocation in production.
+        """
+        monkeypatch.setattr(config, "MAPPING_ENABLED", True, raising=False)
+        monkeypatch.setattr(config, "MAPPING_DB_PATH",
+                            str(tmp_path / "does_not_exist.db"),
+                            raising=False)
+        result = svc._load_geo_hits()
+        assert result is None
+
+    def test_load_geo_hits_handles_missing_table_gracefully(
+            self, tmp_path, monkeypatch):
+        """An existing-but-empty SQLite file (no waypoints table) returns
+        None — same fallback semantics as the missing-DB case.
+        """
+        empty_db = str(tmp_path / "empty.db")
+        # Create empty DB (no schema).
+        sqlite3.connect(empty_db).close()
+        monkeypatch.setattr(config, "MAPPING_ENABLED", True, raising=False)
+        monkeypatch.setattr(config, "MAPPING_DB_PATH", empty_db, raising=False)
+        result = svc._load_geo_hits()
+        assert result is None
+
+    def test_score_via_geo_hits_skips_db_connection_entirely(
+            self, teslacam_with_geo, monkeypatch):
+        """When ``geo_hits`` is provided, ``_score_event_priority`` MUST NOT
+        open a SQLite connection — proves the fast path is wired.
+        """
+        teslacam, db_path = teslacam_with_geo
+        event_dir = os.path.join(
+            teslacam, "SentryClips", "2026-05-12_11-00-00")
+
+        # Tripwire: if sqlite3.connect targets the geodata DB while
+        # geo_hits is provided, raise. Other sqlite3 connections (rare in
+        # this code path, but test isolation requires the filter) are
+        # allowed.
+        original_connect = sqlite3.connect
+
+        def must_not_call_for_geo(target, *args, **kwargs):
+            if target == db_path:
+                raise AssertionError(
+                    "Scorer opened a SQLite connection to geodata.db "
+                    "despite geo_hits being provided — fast path is broken."
+                )
+            return original_connect(target, *args, **kwargs)
+
+        monkeypatch.setattr(sqlite3, "connect", must_not_call_for_geo,
+                            raising=True)
+
+        # Should succeed without touching SQLite.
+        score = svc._score_event_priority(
+            event_dir, geo_hits={"2026-05-12_11-00-00"})
+        assert 100 <= score < 200, score


### PR DESCRIPTION
# Phase 5.2 — score-priority connection batching (1+N → 1)

Closes part of #102 (Phase 5 — Performance Polish).

## Problem

`cloud_archive_service._discover_events` scores every candidate event
directory before sorting and filtering them. The scoring function,
`_score_event_priority`, contains a per-event geodata.db lookup:

```python
# Legacy — opens N fresh sqlite3 connections, runs N full-scan LIKE queries
for event in events:
    conn = get_db_connection(MAPPING_DB_PATH)
    safe_name = dir_name.replace('\\', '\\\\').replace('%', '\\%').replace('_', '\\_')
    row = conn.execute(
        "SELECT COUNT(*) as cnt FROM waypoints WHERE video_path LIKE ? ESCAPE '\\'",
        (f'%{safe_name}%',)
    ).fetchone()
    conn.close()
```

For a queue of N candidate events, that's **N connection opens + N
full-scan `LIKE '%dir%'` queries**. With ~200 candidate events on the
Pi (current state has ~3000 archive backlog, of which a sizeable
fraction become discover candidates), that's ~200 connection
open/close cycles per discover pass. Each one also runs the full v6
schema-init through `mapping_queries.get_db_connection`.

## Fix

Pre-fetch the geo-hit set ONCE before the comprehension:

```python
geo_hits = _load_geo_hits()  # 1 connection, 1 SELECT DISTINCT video_path
scored = [(t, _score_event_priority(t[0], geo_hits=geo_hits)) for t in events]
```

`_load_geo_hits()` does:

```python
SELECT DISTINCT video_path FROM waypoints WHERE video_path IS NOT NULL
```

then derives `os.path.basename(os.path.dirname(vp))` in Python to
build a `Set[str]` of event-directory names that have any waypoint
geolocation hit. The per-event scorer collapses to an O(1) `dir_name
in geo_hits` set lookup.

## Implementation notes

- **Raw `sqlite3.connect`, not `mapping_queries.get_db_connection`** —
  the latter runs the full v6 schema migration (`_init_db`) on every
  call. That's the wrong lifecycle for a one-shot read-only picker
  query. Skipping it also means `_load_geo_hits` doesn't crash when
  `geodata.db` is missing or partially initialized — it returns
  `None` and the scorer falls back to the legacy per-event path.
- **`geo_hits=None` fallback preserves the legacy code path
  byte-for-byte.** Direct callers of `_score_event_priority` (tests,
  future code) keep working without arrange.
- **`os.path.isfile()` guard prevents creating an empty geodata.db**
  as a side effect of the picker — the indexer is the only legal
  creator of that file.

## Tests

8 new tests in `tests/test_score_priority_batching.py`:

| Test | Pins |
|------|------|
| `test_geo_hits_lookup_matches_legacy_per_event_score` | semantic equivalence |
| `test_geo_hits_none_falls_back_to_per_event_query` | legacy path preservation |
| `test_discover_events_opens_single_geodata_connection` | single-connection regression guard |
| `test_load_geo_hits_returns_dirname_set` | parent-dir basename derivation |
| `test_load_geo_hits_returns_none_when_mapping_disabled` | mapping disabled fallback |
| `test_load_geo_hits_handles_missing_db_gracefully` | missing DB → None |
| `test_load_geo_hits_handles_missing_table_gracefully` | bare-DB → None |
| `test_score_via_geo_hits_skips_db_connection_entirely` | fast-path tripwire |

Test fixture provisions geodata.db via
`mapping_migrations._init_db` so the schema matches what the legacy
code path expects.

## Verification

```
$ python -m pytest tests/ -q
1223 passed, 3 skipped in 64.05s
```

(was 1215 + 3, +8 new.)

## Risk

Low. Functional invariants preserved:
- Score values for the same event dir match the legacy path.
- Geo-tier (100) reachable iff the event dir has a waypoint.
- Filter behaviour unchanged (sync_non_event_videos still drops the
  200+ tier).
- Failure modes (missing DB, mapping disabled, query raises) all
  fall back to legacy per-event lookup.

## Performance impact

For N candidate events:
- Before: N connection-opens + N schema-inits + N full-scan LIKE queries
- After: 1 connection-open + 1 sequential-scan SELECT DISTINCT + N O(1) set lookups

The DISTINCT scan is ~constant in row count (one waypoint per video
file), not in event-dir count, so the cost is bounded by index size,
not queue size.
