### PR TITLE
Phase 5.4: batch rclone reconcile listing into a single recursive call

### DIFF
--- a/scripts/web/services/cloud_archive_service.py
+++ b/scripts/web/services/cloud_archive_service.py
@@ -1248,6 +1248,77 @@ def _load_provider_creds() -> dict:
 # Cloud Reconciliation
 # ---------------------------------------------------------------------------
 
+def _list_remote_tree(
+    conf_path: str,
+    remote_path: str,
+    mem_flags: list,
+) -> Optional[Dict[str, Set[str]]]:
+    """Phase 5.4 — single-call batched remote listing.
+
+    Replaces 3 separate ``rclone lsf`` invocations (one per parent folder
+    in ``CLOUD_ARCHIVE_SYNC_FOLDERS`` plus one for ``ArchivedClips``) with
+    a single ``rclone lsf --recursive --max-depth=2`` call. Each rclone
+    invocation costs roughly 100–500 ms in subprocess + auth-handshake +
+    network round-trip overhead; collapsing them shaves ~1 s off every
+    reconcile pass and matches the spec in #102 (item 5.4).
+
+    Returns a dict keyed by parent folder name (e.g. ``"SentryClips"``,
+    ``"SavedClips"``, ``"ArchivedClips"``) mapping to a set of relative
+    entries directly under that parent. For event folders the entries
+    are sub-directory names (with the trailing slash that ``rclone lsf``
+    appends — used by the caller to distinguish dirs from files);
+    for ``ArchivedClips`` the entries are file basenames.
+
+    Returns ``None`` if the rclone call fails — the caller falls through
+    to the legacy per-folder path so reconciliation still happens (just
+    slower). Returns an empty dict if the remote is reachable but empty.
+    """
+    interest = list(CLOUD_ARCHIVE_SYNC_FOLDERS) + ["ArchivedClips"]
+    try:
+        result = subprocess.run(
+            ["rclone", "lsf", "--config", conf_path,
+             "--recursive", "--max-depth", "2",
+             *mem_flags,
+             f"teslausb:{remote_path}/"],
+            capture_output=True, text=True, timeout=120,
+        )
+    except subprocess.TimeoutExpired:
+        logger.warning("Reconcile timeout listing remote tree (>120s)")
+        return None
+    except Exception as e:
+        logger.warning("Reconcile error listing remote tree: %s", e)
+        return None
+
+    if result.returncode != 0:
+        logger.warning(
+            "rclone lsf --recursive returned %d; falling back to per-folder",
+            result.returncode,
+        )
+        return None
+
+    out: Dict[str, Set[str]] = {p: set() for p in interest}
+    for raw in result.stdout.split("\n"):
+        line = raw.strip()
+        if not line:
+            continue
+        # rclone lsf --recursive emits paths relative to the listed dir,
+        # e.g. "SentryClips/2026-05-12_10-00-00/" or
+        # "ArchivedClips/2026-05-12_10-00-00-front.mp4". --max-depth=2
+        # ensures we get exactly one slash inside ArchivedClips and at
+        # most one slash inside event folders (the trailing one for dirs).
+        parts = line.split("/", 1)
+        if len(parts) != 2:
+            continue
+        parent, rest = parts
+        if parent not in out:
+            continue
+        if not rest:
+            # Bare parent dir entry — skip.
+            continue
+        out[parent].add(rest)
+    return out
+
+
 def _reconcile_with_remote(
     conn: sqlite3.Connection,
     conf_path: str,
@@ -1256,11 +1327,130 @@ def _reconcile_with_remote(
 ) -> int:
     """Mark locally-pending files as synced if they already exist on the remote.
 
-    Uses ``rclone lsf`` to list directories and files on the remote,
-    then updates matching DB entries from pending/failed → synced, and
+    Phase 5.4 — uses ``_list_remote_tree`` for a single batched
+    ``rclone lsf --recursive --max-depth=2`` call, replacing the legacy
+    one-call-per-parent loop. Falls back to the legacy per-folder path
+    if the batched call fails so reconciliation still happens.
+
+    Updates matching DB entries from pending/failed → synced, and
     inserts new 'synced' entries for remote files not yet tracked in the DB
     (e.g., files uploaded before tracking was implemented).
     Returns the number of entries reconciled.
+    """
+    now_iso = datetime.now(timezone.utc).isoformat()
+    reconciled = 0
+
+    tree = _list_remote_tree(conf_path, remote_path, mem_flags)
+    if tree is None:
+        # Fallback: legacy per-folder listing keeps reconcile working
+        # even when the batched call fails (network blip, rclone version
+        # mismatch, etc.). Same behaviour as before this PR.
+        return _reconcile_with_remote_legacy(
+            conn, conf_path, remote_path, mem_flags,
+        )
+
+    # List event directories on remote (SentryClips/*, SavedClips/*) — now
+    # served from the single batched listing.
+    for folder in CLOUD_ARCHIVE_SYNC_FOLDERS:
+        try:
+            entries = tree.get(folder, set())
+            # event-dir entries have a trailing slash from rclone lsf;
+            # files (which shouldn't appear in event parents but might
+            # from earlier corruption) get filtered out here.
+            remote_dirs = {e.rstrip('/') for e in entries if e.endswith('/')}
+            if not remote_dirs:
+                continue
+
+            for dirname in remote_dirs:
+                rel_path = canonical_cloud_path(f"{folder}/{dirname}")
+                remote_dest = f"teslausb:{remote_path}/{rel_path}"
+
+                # Update existing pending/failed entries
+                cur = conn.execute(
+                    """UPDATE cloud_synced_files
+                       SET status = 'synced', synced_at = ?,
+                           remote_path = ?, last_error = NULL
+                       WHERE file_path = ? AND status IN ('pending', 'failed')""",
+                    (now_iso, remote_dest, rel_path)
+                )
+                if cur.rowcount > 0:
+                    reconciled += cur.rowcount
+                    continue
+
+                # If not in DB at all, insert as synced (pre-tracking upload)
+                existing = conn.execute(
+                    "SELECT status FROM cloud_synced_files WHERE file_path = ?",
+                    (rel_path,)
+                ).fetchone()
+                if not existing:
+                    conn.execute(
+                        """INSERT INTO cloud_synced_files
+                           (file_path, status, synced_at, remote_path)
+                           VALUES (?, 'synced', ?, ?)""",
+                        (rel_path, now_iso, remote_dest)
+                    )
+                    reconciled += 1
+        except Exception as e:
+            logger.warning("Reconcile error for %s: %s", folder, e)
+
+    # ArchivedClips files — also from the same batched listing.
+    try:
+        entries = tree.get("ArchivedClips", set())
+        # Strip trailing slashes too — rclone lsf may return directory
+        # entries when a folder gets mistakenly created on the remote
+        # (PRE-2.7 this produced corrupt rows like
+        # ``ArchivedClips/foo.mp4/`` that broke later dedup checks).
+        remote_files = {e.rstrip('/') for e in entries if e.strip()}
+        for filename in remote_files:
+            if not filename:
+                continue
+            rel_path = canonical_cloud_path(f"ArchivedClips/{filename}")
+            remote_dest = f"teslausb:{remote_path}/{rel_path}"
+
+            cur = conn.execute(
+                """UPDATE cloud_synced_files
+                   SET status = 'synced', synced_at = ?,
+                       remote_path = ?, last_error = NULL
+                   WHERE file_path = ? AND status IN ('pending', 'failed')""",
+                (now_iso, remote_dest, rel_path)
+            )
+            if cur.rowcount > 0:
+                reconciled += cur.rowcount
+                continue
+
+            existing = conn.execute(
+                "SELECT status FROM cloud_synced_files WHERE file_path = ?",
+                (rel_path,)
+            ).fetchone()
+            if not existing:
+                conn.execute(
+                    """INSERT INTO cloud_synced_files
+                       (file_path, status, synced_at, remote_path)
+                       VALUES (?, 'synced', ?, ?)""",
+                    (rel_path, now_iso, remote_dest)
+                )
+                reconciled += 1
+    except Exception as e:
+        logger.warning("Reconcile error for ArchivedClips: %s", e)
+
+    if reconciled:
+        conn.commit()
+        logger.info("Cloud reconciliation: marked %d already-uploaded entries as synced", reconciled)
+
+    return reconciled
+
+
+def _reconcile_with_remote_legacy(
+    conn: sqlite3.Connection,
+    conf_path: str,
+    remote_path: str,
+    mem_flags: list,
+) -> int:
+    """Pre-Phase-5.4 reconcile: one ``rclone lsf`` call per parent folder.
+
+    Kept as a fallback for ``_reconcile_with_remote`` when the single
+    batched ``--recursive --max-depth=2`` call fails — slower but
+    proven against every rclone version this device has shipped with.
     """
     now_iso = datetime.now(timezone.utc).isoformat()
     reconciled = 0
@@ -1365,7 +1555,10 @@ def _reconcile_with_remote(
 
     if reconciled:
         conn.commit()
-        logger.info("Cloud reconciliation: marked %d already-uploaded entries as synced", reconciled)
+        logger.info(
+            "Cloud reconciliation (legacy fallback): marked %d already-uploaded entries as synced",
+            reconciled,
+        )
 
     return reconciled
 

--- a/tests/test_rclone_lsf_batched.py
+++ b/tests/test_rclone_lsf_batched.py
@@ -322,7 +322,6 @@ class TestNoPerParentLsfRegression:
             "ArchivedClips/2026-05-12_10-00-00-front.mp4\n"
         )
         calls: List[List[str]] = []
-        original_run = subprocess.run
 
         def tracing_run(cmd, *args, **kwargs):
             calls.append(list(cmd))

--- a/tests/test_rclone_lsf_batched.py
+++ b/tests/test_rclone_lsf_batched.py
@@ -1,0 +1,345 @@
+"""Phase 5.4 — rclone lsf batched listing regression tests.
+
+Pins the contract of ``_list_remote_tree`` and verifies
+``_reconcile_with_remote`` issues exactly ONE rclone subprocess call
+(rather than the legacy 2 + 1 = 3 calls — one per parent folder).
+
+Legacy implementation: per-parent ``rclone lsf`` loop:
+
+    for folder in CLOUD_ARCHIVE_SYNC_FOLDERS:    # ["SentryClips", "SavedClips"]
+        rclone lsf --dirs-only teslausb:remote/<folder>/
+    rclone lsf teslausb:remote/ArchivedClips/
+
+Phase 5.4 collapses these into one call:
+
+    rclone lsf --recursive --max-depth=2 teslausb:remote/
+
+…shaving roughly 1 s of subprocess + auth-handshake + network
+overhead off every reconcile pass. The new ``_list_remote_tree``
+returns a per-parent dict that downstream code consumes; legacy
+fallback (``_reconcile_with_remote_legacy``) is preserved for
+robustness (used when the batched call fails — e.g. older rclone
+version without --recursive support, network blip).
+
+Tests cover:
+* parsing of recursive lsf output into per-parent buckets
+* directory entries (trailing slash) vs file entries
+* failure modes — non-zero rc / timeout / generic exception → None
+* single-call invariant — exactly ONE subprocess.run("rclone", "lsf", ...)
+* fallback: when batched call returns None, legacy path runs and
+  reconciles correctly
+* end-to-end: pending → synced when remote dir exists; new INSERT
+  when remote file is unknown to DB
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import subprocess
+from typing import List
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from services import cloud_archive_service as svc
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _make_cloud_db(tmp_path) -> sqlite3.Connection:
+    db_path = str(tmp_path / "cloud_sync.db")
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    conn.executescript(svc._CLOUD_TABLES_SQL)
+    return conn
+
+
+def _seed(conn, rows):
+    """rows: (file_path, status)"""
+    for fp, st in rows:
+        conn.execute(
+            "INSERT INTO cloud_synced_files (file_path, status) VALUES (?, ?)",
+            (fp, st),
+        )
+    conn.commit()
+
+
+def _completed(stdout: str, returncode: int = 0):
+    cp = MagicMock(spec=subprocess.CompletedProcess)
+    cp.stdout = stdout
+    cp.stderr = ""
+    cp.returncode = returncode
+    return cp
+
+
+@pytest.fixture
+def cloud_conn(tmp_path):
+    conn = _make_cloud_db(tmp_path)
+    yield conn
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# _list_remote_tree — unit
+# ---------------------------------------------------------------------------
+
+class TestListRemoteTree:
+
+    def test_parses_recursive_output_into_per_parent_buckets(self):
+        # Synthetic rclone lsf --recursive --max-depth=2 output. Event
+        # dirs end in / (it's how rclone lsf marks dirs); ArchivedClips
+        # files are bare filenames.
+        rclone_out = (
+            "SentryClips/2026-05-12_10-00-00/\n"
+            "SentryClips/2026-05-12_11-00-00/\n"
+            "SavedClips/2026-05-12_12-00-00/\n"
+            "ArchivedClips/2026-05-12_10-00-00-front.mp4\n"
+            "ArchivedClips/2026-05-12_10-00-00-back.mp4\n"
+        )
+        with patch.object(subprocess, "run",
+                          return_value=_completed(rclone_out)) as mock_run:
+            tree = svc._list_remote_tree(
+                "/tmp/conf", "tesla/dashcam", [],
+            )
+        assert tree is not None
+        # Exactly ONE rclone call:
+        assert mock_run.call_count == 1
+        args, _kw = mock_run.call_args
+        cmd = args[0]
+        assert cmd[0] == "rclone" and cmd[1] == "lsf"
+        assert "--recursive" in cmd
+        assert "--max-depth" in cmd
+        # Parent buckets:
+        assert tree["SentryClips"] == {
+            "2026-05-12_10-00-00/",
+            "2026-05-12_11-00-00/",
+        }
+        assert tree["SavedClips"] == {"2026-05-12_12-00-00/"}
+        assert tree["ArchivedClips"] == {
+            "2026-05-12_10-00-00-front.mp4",
+            "2026-05-12_10-00-00-back.mp4",
+        }
+
+    def test_empty_remote_returns_empty_buckets(self):
+        with patch.object(subprocess, "run", return_value=_completed("")):
+            tree = svc._list_remote_tree("/tmp/conf", "tesla/dashcam", [])
+        assert tree is not None
+        for parent in (list(svc.CLOUD_ARCHIVE_SYNC_FOLDERS) + ["ArchivedClips"]):
+            assert tree[parent] == set()
+
+    def test_unknown_parent_in_output_is_ignored(self):
+        # A future remote layout might include other dirs we don't sync;
+        # the function must not crash and must drop them silently.
+        rclone_out = (
+            "SentryClips/2026-05-12_10-00-00/\n"
+            "RandomFolder/something/\n"
+            "Unrelated/file.txt\n"
+        )
+        with patch.object(subprocess, "run",
+                          return_value=_completed(rclone_out)):
+            tree = svc._list_remote_tree("/tmp/conf", "tesla/dashcam", [])
+        assert tree is not None
+        assert tree["SentryClips"] == {"2026-05-12_10-00-00/"}
+        # Unknown parents not in the dict
+        assert "RandomFolder" not in tree
+        assert "Unrelated" not in tree
+
+    def test_nonzero_returncode_returns_none(self):
+        with patch.object(subprocess, "run",
+                          return_value=_completed("", returncode=1)):
+            tree = svc._list_remote_tree("/tmp/conf", "tesla/dashcam", [])
+        assert tree is None
+
+    def test_timeout_returns_none(self):
+        def _raise_timeout(*a, **kw):
+            raise subprocess.TimeoutExpired(cmd=a[0], timeout=120)
+        with patch.object(subprocess, "run", side_effect=_raise_timeout):
+            tree = svc._list_remote_tree("/tmp/conf", "tesla/dashcam", [])
+        assert tree is None
+
+    def test_generic_exception_returns_none(self):
+        with patch.object(subprocess, "run", side_effect=OSError("boom")):
+            tree = svc._list_remote_tree("/tmp/conf", "tesla/dashcam", [])
+        assert tree is None
+
+    def test_blank_lines_and_bare_parent_dirs_are_skipped(self):
+        rclone_out = (
+            "\n"
+            "SentryClips/\n"
+            "SentryClips/2026-05-12_10-00-00/\n"
+            "  \n"
+        )
+        with patch.object(subprocess, "run",
+                          return_value=_completed(rclone_out)):
+            tree = svc._list_remote_tree("/tmp/conf", "tesla/dashcam", [])
+        assert tree is not None
+        # The bare "SentryClips/" entry has no rest after the split.
+        # The actual event dir does land in the bucket.
+        assert tree["SentryClips"] == {"2026-05-12_10-00-00/"}
+
+
+# ---------------------------------------------------------------------------
+# _reconcile_with_remote — single-call + end-to-end
+# ---------------------------------------------------------------------------
+
+class TestReconcileBatched:
+
+    def test_single_subprocess_call_per_reconcile(self, cloud_conn):
+        """The hot path of Phase 5.4: ONE rclone subprocess call per
+        reconcile pass, regardless of how many parent folders there are.
+        The legacy code issued one per parent (2 + 1 = 3); this guards
+        the win."""
+        _seed(cloud_conn, [
+            ("SentryClips/2026-05-12_10-00-00", "pending"),
+        ])
+        rclone_out = "SentryClips/2026-05-12_10-00-00/\n"
+        with patch.object(subprocess, "run",
+                          return_value=_completed(rclone_out)) as mock_run:
+            n = svc._reconcile_with_remote(
+                cloud_conn, "/tmp/conf", "tesla/dashcam", [],
+            )
+        assert mock_run.call_count == 1, (
+            f"Expected exactly 1 rclone call (Phase 5.4 batched listing), "
+            f"got {mock_run.call_count}. The legacy per-parent loop must "
+            f"not be reintroduced."
+        )
+        # And the entry got flipped to synced.
+        assert n == 1
+        row = cloud_conn.execute(
+            "SELECT status FROM cloud_synced_files WHERE file_path = ?",
+            ("SentryClips/2026-05-12_10-00-00",),
+        ).fetchone()
+        assert row["status"] == "synced"
+
+    def test_pending_event_dir_marked_synced(self, cloud_conn):
+        _seed(cloud_conn, [
+            ("SentryClips/2026-05-12_10-00-00", "pending"),
+            ("SavedClips/2026-05-12_11-00-00", "failed"),
+        ])
+        rclone_out = (
+            "SentryClips/2026-05-12_10-00-00/\n"
+            "SavedClips/2026-05-12_11-00-00/\n"
+        )
+        with patch.object(subprocess, "run",
+                          return_value=_completed(rclone_out)):
+            n = svc._reconcile_with_remote(
+                cloud_conn, "/tmp/conf", "tesla/dashcam", [],
+            )
+        assert n == 2
+        statuses = {
+            r["file_path"]: r["status"]
+            for r in cloud_conn.execute(
+                "SELECT file_path, status FROM cloud_synced_files"
+            ).fetchall()
+        }
+        assert statuses["SentryClips/2026-05-12_10-00-00"] == "synced"
+        assert statuses["SavedClips/2026-05-12_11-00-00"] == "synced"
+
+    def test_unknown_remote_file_inserted_as_synced(self, cloud_conn):
+        # Pre-tracking upload — file is on remote but not in our DB.
+        rclone_out = "ArchivedClips/2026-05-12_10-00-00-front.mp4\n"
+        with patch.object(subprocess, "run",
+                          return_value=_completed(rclone_out)):
+            n = svc._reconcile_with_remote(
+                cloud_conn, "/tmp/conf", "tesla/dashcam", [],
+            )
+        assert n == 1
+        row = cloud_conn.execute(
+            "SELECT status FROM cloud_synced_files WHERE file_path = ?",
+            ("ArchivedClips/2026-05-12_10-00-00-front.mp4",),
+        ).fetchone()
+        assert row["status"] == "synced"
+
+    def test_already_synced_entry_not_double_counted(self, cloud_conn):
+        # Defends against a bug where a reconcile pass re-counts already-
+        # synced rows. The UPDATE has WHERE status IN ('pending', 'failed')
+        # so synced rows are skipped — but a future refactor could break
+        # that.
+        _seed(cloud_conn, [
+            ("SentryClips/2026-05-12_10-00-00", "synced"),
+        ])
+        rclone_out = "SentryClips/2026-05-12_10-00-00/\n"
+        with patch.object(subprocess, "run",
+                          return_value=_completed(rclone_out)):
+            n = svc._reconcile_with_remote(
+                cloud_conn, "/tmp/conf", "tesla/dashcam", [],
+            )
+        # 0 reconciled — already synced and no INSERT (the SELECT fires
+        # before INSERT to check existence).
+        assert n == 0
+
+    def test_falls_back_to_legacy_when_batched_call_fails(self, cloud_conn):
+        """When ``_list_remote_tree`` returns None (rclone failure), the
+        legacy per-parent path MUST run so reconcile still works."""
+        _seed(cloud_conn, [
+            ("SentryClips/2026-05-12_10-00-00", "pending"),
+        ])
+
+        # First rclone call (the batched --recursive one) returns rc=1
+        # → _list_remote_tree returns None → fallback path runs.
+        # The fallback path issues one call per parent (3 total) — those
+        # all return successful event-dir listings.
+        call_outputs = [
+            _completed("", returncode=1),               # batched call → fail
+            _completed("2026-05-12_10-00-00/\n"),       # SentryClips
+            _completed(""),                             # SavedClips
+            _completed(""),                             # ArchivedClips
+        ]
+        with patch.object(subprocess, "run", side_effect=call_outputs):
+            n = svc._reconcile_with_remote(
+                cloud_conn, "/tmp/conf", "tesla/dashcam", [],
+            )
+        # Reconcile happened via legacy.
+        assert n == 1
+        row = cloud_conn.execute(
+            "SELECT status FROM cloud_synced_files WHERE file_path = ?",
+            ("SentryClips/2026-05-12_10-00-00",),
+        ).fetchone()
+        assert row["status"] == "synced"
+
+
+# ---------------------------------------------------------------------------
+# Tripwire: NO per-parent lsf calls in the batched happy path
+# ---------------------------------------------------------------------------
+
+class TestNoPerParentLsfRegression:
+
+    def test_batched_path_never_calls_per_parent_lsf(self, cloud_conn):
+        """A future refactor MUST NOT add per-parent rclone lsf calls
+        back into the batched happy path. Trace every subprocess.run
+        call and assert exactly one (the --recursive batched listing).
+        """
+        _seed(cloud_conn, [
+            ("SentryClips/2026-05-12_10-00-00", "pending"),
+            ("SavedClips/2026-05-12_11-00-00", "pending"),
+            ("ArchivedClips/2026-05-12_10-00-00-front.mp4", "pending"),
+        ])
+        rclone_out = (
+            "SentryClips/2026-05-12_10-00-00/\n"
+            "SavedClips/2026-05-12_11-00-00/\n"
+            "ArchivedClips/2026-05-12_10-00-00-front.mp4\n"
+        )
+        calls: List[List[str]] = []
+        original_run = subprocess.run
+
+        def tracing_run(cmd, *args, **kwargs):
+            calls.append(list(cmd))
+            return _completed(rclone_out)
+
+        with patch.object(subprocess, "run", side_effect=tracing_run):
+            svc._reconcile_with_remote(
+                cloud_conn, "/tmp/conf", "tesla/dashcam", [],
+            )
+        # Exactly one call.
+        assert len(calls) == 1, (
+            f"Expected 1 rclone call in batched happy path, got "
+            f"{len(calls)}. Calls: {calls}"
+        )
+        # And it's the recursive one (not a per-parent --dirs-only).
+        cmd = calls[0]
+        assert "--recursive" in cmd, (
+            f"Per-parent --dirs-only call detected — Phase 5.4 batched "
+            f"listing has been bypassed. Cmd: {cmd}"
+        )


### PR DESCRIPTION
## Phase 5.4 — `p5-rclone-lsf-batched`: collapse 3 reconcile lsf calls into 1

Closes part of #102.

### Problem

`_reconcile_with_remote` issued **three** separate `rclone lsf` subprocess calls per reconcile pass:

```python
for folder in CLOUD_ARCHIVE_SYNC_FOLDERS:                 # ["SentryClips", "SavedClips"]
    rclone lsf --dirs-only teslausb:remote/<folder>/      # 2 calls

rclone lsf teslausb:remote/ArchivedClips/                  # 1 call
```

Each rclone invocation costs roughly 100–500 ms (subprocess + auth-handshake + network round-trip). At the start of every sync pass that's ~1 s of pure overhead.

### Fix

New helper `_list_remote_tree` issues **one** call:

```bash
rclone lsf --recursive --max-depth=2 teslausb:remote/
```

…then partitions the output into a per-parent dict (`{"SentryClips": {…}, "SavedClips": {…}, "ArchivedClips": {…}}`). The reconcile loop consumes that dict — no further subprocess calls.

`_reconcile_with_remote_legacy` preserves the old per-parent loop verbatim and is used as a fallback when the batched call fails (older rclone versions, network blip, parse error). Reconciliation always happens — just slightly slower in the rare degraded case.

### Behaviour preserved

- Same DB updates: `pending`/`failed` → `synced` for matching rel_paths.
- Same INSERT semantics: unknown remote files inserted as `synced`.
- Same skip semantics: already-`synced` rows are untouched.
- Same trailing-slash handling for ArchivedClips (legacy corrupt entries from PRE-2.7 still cleaned).
- Same error handling: timeout/exception → log warning, continue.

### Tests

13 new tests in `tests/test_rclone_lsf_batched.py`:

- **`_list_remote_tree` unit (7):** parses recursive output, empty remote, unknown-parent silently dropped, non-zero rc → None, timeout → None, generic exception → None, blank/bare-parent filtering.
- **`_reconcile_with_remote` end-to-end (5):** single-subprocess-call invariant, pending event-dir → synced, unknown remote file inserted, already-synced not double-counted, fallback to legacy when batched call returns None.
- **Tripwire (1):** traces every `subprocess.run` in the batched happy path and asserts exactly one call with `--recursive` (catches any regression that adds per-parent `--dirs-only` calls back).

Full suite: **1250 passed, 3 skipped** (was 1237 + 3, +13 new).

### Verification on device

After deploy:

- `journalctl -u gadget_web.service | grep -E "Cloud reconciliation|rclone lsf"` — should show single batched listing per pass; `_reconcile_with_remote_legacy` log line should NOT appear under normal conditions.
- Time-to-first-`/cloud/api/queue`-update after a sync trigger should drop noticeably.
- `/cloud/api/status` totals before/after must match (no rows lost or double-counted).

### Risk

Low. Single new helper, single call-site rewrite, full legacy fallback preserved. The behavioural envelope is a strict subset of the old code (same updates, same inserts, same skip semantics). Tripwire test guards against regression.
