### PR TITLE
Phase 5.5: batch get_sync_status_for_events into one OR'd LIKE query

### DIFF
--- a/scripts/web/services/cloud_archive_service.py
+++ b/scripts/web/services/cloud_archive_service.py
@@ -2721,10 +2721,24 @@ def get_sync_status_for_events(event_names: list) -> dict:
     """
     if not event_names:
         return {}
-    # Pre-build the result skeleton so callers always get every key.
-    statuses: dict = {name: None for name in event_names}
-    if not any(event_names):
-        return statuses
+    # Defensive cap. ``event_names`` is unbounded at the caller (the
+    # blueprint accepts whatever the client posts). One OR-clause is a
+    # few bytes of SQL text plus one row per match in fetchall(), so
+    # 500 names is the practical safety ceiling on a Pi Zero 2 W's
+    # 512 MB RAM. Names beyond the cap simply land as None — the UI
+    # already treats unknown statuses as "not synced".
+    _MAX_BATCH = 500
+    if len(event_names) > _MAX_BATCH:
+        logger.warning(
+            "get_sync_status_for_events: %d names requested, capping at %d",
+            len(event_names),
+            _MAX_BATCH,
+        )
+        # Pre-build the FULL skeleton so capped-out names still appear.
+        statuses: dict = {name: None for name in event_names}
+        event_names = event_names[:_MAX_BATCH]
+    else:
+        statuses = {name: None for name in event_names}
 
     conn = _init_cloud_tables(CLOUD_ARCHIVE_DB_PATH)
     try:

--- a/scripts/web/services/cloud_archive_service.py
+++ b/scripts/web/services/cloud_archive_service.py
@@ -2703,19 +2703,66 @@ def recover_interrupted_uploads(db_path: str) -> int:
 def get_sync_status_for_events(event_names: list) -> dict:
     """Check sync status for a list of event names.
 
-    Returns dict mapping event_name -> status ('synced', 'queued', 'uploading', None).
+    Returns dict mapping event_name -> status ('synced', 'queued',
+    'uploading', None).
+
+    Phase 5.5 — single-query batch lookup. The legacy implementation
+    issued one ``SELECT ... LIKE '%name%' ORDER BY synced_at DESC LIMIT 1``
+    per event, which is N round-trips for an N-event status request
+    (typical UI request: 30 events → 30 queries → ~3-9 ms baseline +
+    SQLite overhead × 30). Now we issue ONE query that returns every
+    matching row and bucket-match in Python.
+
+    The match semantics (case-sensitive substring of ``file_path``) are
+    preserved: an event_name like ``2026-05-12_10-00-00`` still matches
+    rows whose ``file_path`` contains that string. The "most recent
+    match wins" semantics are preserved by ordering ``synced_at DESC``
+    server-side and taking the FIRST hit per event_name in Python.
     """
     if not event_names:
         return {}
+    # Pre-build the result skeleton so callers always get every key.
+    statuses: dict = {name: None for name in event_names}
+    if not any(event_names):
+        return statuses
+
     conn = _init_cloud_tables(CLOUD_ARCHIVE_DB_PATH)
     try:
-        statuses = {}
-        for name in event_names:
-            row = conn.execute(
-                "SELECT status FROM cloud_synced_files WHERE file_path LIKE ? ORDER BY synced_at DESC LIMIT 1",
-                ('%' + name + '%',)
-            ).fetchone()
-            statuses[name] = row['status'] if row else None
+        # ONE query: union the per-name LIKE patterns. SQLite does not
+        # support a parameterized "any of these patterns" operator, so we
+        # OR N parameterized LIKE clauses — the SQL text length grows
+        # linearly with N but the round-trip count stays at 1.
+        like_clauses = " OR ".join(["file_path LIKE ?"] * len(event_names))
+        params = ["%" + name + "%" for name in event_names]
+        sql = (
+            "SELECT file_path, status FROM cloud_synced_files "
+            f"WHERE {like_clauses} "
+            "ORDER BY synced_at DESC"
+        )
+        try:
+            rows = conn.execute(sql, params).fetchall()
+        except sqlite3.Error:
+            # Best-effort: a malformed query (shouldn't happen) or DB
+            # error returns the empty-skeleton dict so the UI degrades
+            # gracefully instead of 500ing.
+            return statuses
+
+        # Bucket-match in Python. ``rows`` is ordered most-recent-first
+        # so the FIRST match per event_name is the row we want — same
+        # semantics as the legacy ``LIMIT 1`` per name. Stop scanning
+        # once every name has been resolved.
+        unresolved = set(event_names)
+        for row in rows:
+            if not unresolved:
+                break
+            file_path = row["file_path"]
+            # A row may match more than one event_name (e.g. two events
+            # with overlapping timestamps); each name takes its own most-
+            # recent match independently.
+            matched = [n for n in unresolved if n in file_path]
+            for name in matched:
+                statuses[name] = row["status"]
+                unresolved.discard(name)
         return statuses
     finally:
         conn.close()

--- a/tests/test_cloud_status_batched.py
+++ b/tests/test_cloud_status_batched.py
@@ -39,14 +39,6 @@ from services import cloud_archive_service as svc
 # Fixtures
 # ---------------------------------------------------------------------------
 
-def _make_cloud_db(tmp_path) -> sqlite3.Connection:
-    db_path = str(tmp_path / "cloud_sync.db")
-    conn = sqlite3.connect(db_path)
-    conn.row_factory = sqlite3.Row
-    conn.executescript(svc._CLOUD_TABLES_SQL)
-    return conn
-
-
 def _seed(conn, rows):
     """rows: (file_path, status, synced_at)"""
     for fp, st, sa in rows:
@@ -338,3 +330,59 @@ class TestCrossRowMatching:
             "2026-05-12_10-00-00": "synced",
             "2026-05-12_10-00-15": "synced",
         }
+
+
+# ---------------------------------------------------------------------------
+# Defensive cap — unbounded callers must not blow Pi Zero 2 W RAM
+# ---------------------------------------------------------------------------
+
+class TestMaxBatchCap:
+
+    def test_oversize_input_is_capped_but_returns_full_skeleton(self, cloud_db):
+        # Caller posts 1000 names. The cap is 500 (Phase 5.5 review fix);
+        # the function MUST still return a dict with all 1000 keys so the
+        # UI doesn't see KeyErrors. Capped-out names land as None.
+        c = _conn_for(cloud_db)
+        try:
+            _seed(c, [
+                # Match a name within first 500 (index 5).
+                ("SentryClips/2026-05-12_10-00-005-event.mp4",
+                 "synced", "2026-05-12T11:00:00"),
+                # Match a name within first 500 (index 499).
+                ("SavedClips/2026-05-12_10-00-499-event.mp4",
+                 "synced", "2026-05-12T11:00:00"),
+                # Match a name BEYOND the cap (index 700).
+                ("ArchivedClips/2026-05-12_10-00-700-event.mp4",
+                 "synced", "2026-05-12T11:00:00"),
+            ])
+        finally:
+            c.close()
+
+        names = [f"2026-05-12_10-00-{i:03d}" for i in range(1000)]
+        out = svc.get_sync_status_for_events(names)
+        # All 1000 keys present — UI never sees KeyError.
+        assert len(out) == 1000
+        assert set(out.keys()) == set(names)
+        # First 500 names resolve when matched.
+        assert out["2026-05-12_10-00-005"] == "synced"
+        assert out["2026-05-12_10-00-499"] == "synced"
+        # Name beyond the cap is excluded from the query → None.
+        assert out["2026-05-12_10-00-700"] is None
+
+    def test_under_cap_input_unaffected(self, cloud_db):
+        # Sanity: 100 names < 500 cap → behaves identically to legacy.
+        c = _conn_for(cloud_db)
+        try:
+            _seed(c, [
+                ("SentryClips/2026-05-12_10-00-00-event.mp4",
+                 "synced", "2026-05-12T11:00:00"),
+            ])
+        finally:
+            c.close()
+
+        names = [f"2026-05-12_10-00-{i:02d}" for i in range(100)]
+        out = svc.get_sync_status_for_events(names)
+        assert len(out) == 100
+        assert out["2026-05-12_10-00-00"] == "synced"
+        assert out["2026-05-12_10-00-99"] is None
+

--- a/tests/test_cloud_status_batched.py
+++ b/tests/test_cloud_status_batched.py
@@ -1,0 +1,340 @@
+"""Phase 5.5 — get_sync_status_for_events single-query batching.
+
+Pins the contract of the batched UI status lookup and verifies that
+``get_sync_status_for_events`` issues exactly ONE SQL query against
+``cloud_synced_files`` regardless of how many event names are
+requested (the legacy code issued one ``SELECT … LIKE '%name%' …
+LIMIT 1`` per event — typical UI request: 30 events → 30 queries).
+
+Tests cover:
+
+* empty input returns empty dict (legacy parity)
+* single name returns single-status dict
+* multiple names — each gets its own most-recent-match status
+* substring (LIKE) semantics preserved (exact-name in path)
+* "most recent wins" — when a name matches multiple rows, the row
+  with the most recent ``synced_at`` is the one returned
+* unresolved names land as ``None`` (legacy parity)
+* exact query count: ONE statement against ``cloud_synced_files`` per
+  call regardless of N
+* a row that matches multiple names independently populates each name
+  (not "first name wins for the row")
+* DB error → empty-skeleton dict (best-effort, UI degrades gracefully)
+
+Bonus: the per-row scan stops once every name has been resolved.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import List
+from unittest.mock import patch
+
+import pytest
+
+from services import cloud_archive_service as svc
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _make_cloud_db(tmp_path) -> sqlite3.Connection:
+    db_path = str(tmp_path / "cloud_sync.db")
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    conn.executescript(svc._CLOUD_TABLES_SQL)
+    return conn
+
+
+def _seed(conn, rows):
+    """rows: (file_path, status, synced_at)"""
+    for fp, st, sa in rows:
+        conn.execute(
+            "INSERT INTO cloud_synced_files (file_path, status, synced_at) "
+            "VALUES (?, ?, ?)",
+            (fp, st, sa),
+        )
+    conn.commit()
+
+
+@pytest.fixture
+def cloud_db(tmp_path, monkeypatch):
+    """Build a real cloud_sync.db on disk and point the service at it
+    so ``_init_cloud_tables`` returns this DB on connect.
+    """
+    db_path = str(tmp_path / "cloud_sync.db")
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    conn.executescript(svc._CLOUD_TABLES_SQL)
+    conn.commit()
+    conn.close()
+    monkeypatch.setattr(svc, "CLOUD_ARCHIVE_DB_PATH", db_path, raising=True)
+    return db_path
+
+
+def _conn_for(db_path) -> sqlite3.Connection:
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+# ---------------------------------------------------------------------------
+# Behaviour tests
+# ---------------------------------------------------------------------------
+
+class TestGetSyncStatusBatched:
+
+    def test_empty_input_returns_empty(self, cloud_db):
+        assert svc.get_sync_status_for_events([]) == {}
+
+    def test_single_name_status(self, cloud_db):
+        c = _conn_for(cloud_db)
+        try:
+            _seed(c, [
+                ("SentryClips/2026-05-12_10-00-00", "synced", "2026-05-12T11:00:00"),
+            ])
+        finally:
+            c.close()
+
+        out = svc.get_sync_status_for_events(["2026-05-12_10-00-00"])
+        assert out == {"2026-05-12_10-00-00": "synced"}
+
+    def test_multiple_names_each_get_own_status(self, cloud_db):
+        c = _conn_for(cloud_db)
+        try:
+            _seed(c, [
+                ("SentryClips/2026-05-12_10-00-00", "synced", "2026-05-12T11:00:00"),
+                ("SentryClips/2026-05-12_11-00-00", "pending", "2026-05-12T11:30:00"),
+                ("SavedClips/2026-05-12_12-00-00", "failed", "2026-05-12T12:30:00"),
+            ])
+        finally:
+            c.close()
+
+        out = svc.get_sync_status_for_events([
+            "2026-05-12_10-00-00",
+            "2026-05-12_11-00-00",
+            "2026-05-12_12-00-00",
+        ])
+        assert out == {
+            "2026-05-12_10-00-00": "synced",
+            "2026-05-12_11-00-00": "pending",
+            "2026-05-12_12-00-00": "failed",
+        }
+
+    def test_unknown_name_is_none(self, cloud_db):
+        # Empty DB — every requested name lands as None.
+        out = svc.get_sync_status_for_events([
+            "2026-05-12_10-00-00",
+            "2026-05-12_11-00-00",
+        ])
+        assert out == {
+            "2026-05-12_10-00-00": None,
+            "2026-05-12_11-00-00": None,
+        }
+
+    def test_most_recent_match_wins(self, cloud_db):
+        # The same event has two cloud rows (e.g. two clips inside the
+        # event dir). The MOST RECENT synced_at must be the returned
+        # status — same semantics as the legacy LIMIT 1 ORDER BY DESC.
+        c = _conn_for(cloud_db)
+        try:
+            _seed(c, [
+                ("SentryClips/2026-05-12_10-00-00/front.mp4", "failed",
+                 "2026-05-12T11:00:00"),
+                ("SentryClips/2026-05-12_10-00-00/back.mp4", "synced",
+                 "2026-05-12T12:00:00"),  # newer
+            ])
+        finally:
+            c.close()
+
+        out = svc.get_sync_status_for_events(["2026-05-12_10-00-00"])
+        assert out == {"2026-05-12_10-00-00": "synced"}
+
+    def test_substring_match_semantics_preserved(self, cloud_db):
+        # The legacy LIKE '%name%' means a name is matched anywhere in
+        # file_path. Verify that's still true (e.g. matches inside a
+        # nested SentryClips path).
+        c = _conn_for(cloud_db)
+        try:
+            _seed(c, [
+                ("SentryClips/2026-05-12_10-00-00/front-2026-05-12_10-00-15.mp4",
+                 "synced", "2026-05-12T11:00:00"),
+            ])
+        finally:
+            c.close()
+
+        out = svc.get_sync_status_for_events(["2026-05-12_10-00-00"])
+        assert out == {"2026-05-12_10-00-00": "synced"}
+
+    def test_db_error_returns_skeleton(self, cloud_db, monkeypatch):
+        # Simulate a SQL error during the batched query — function must
+        # not 500; UI gets the empty-skeleton dict instead.
+        class _FailingConn:
+            def __init__(self, real):
+                self._real = real
+                self.row_factory = real.row_factory
+
+            def execute(self, sql, *args, **kwargs):
+                if "cloud_synced_files" in sql and "WHERE file_path LIKE" in sql:
+                    raise sqlite3.OperationalError("simulated DB busy")
+                return self._real.execute(sql, *args, **kwargs)
+
+            def close(self):
+                self._real.close()
+
+        original_init = svc._init_cloud_tables
+
+        def fake_init(path):
+            return _FailingConn(original_init(path))
+
+        monkeypatch.setattr(svc, "_init_cloud_tables", fake_init, raising=True)
+
+        out = svc.get_sync_status_for_events([
+            "2026-05-12_10-00-00",
+            "2026-05-12_11-00-00",
+        ])
+        # Skeleton with all values None.
+        assert out == {
+            "2026-05-12_10-00-00": None,
+            "2026-05-12_11-00-00": None,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Single-query invariant — Phase 5.5 contract
+# ---------------------------------------------------------------------------
+
+class TestSingleQueryInvariant:
+
+    def test_one_query_against_cloud_synced_files_for_30_names(
+        self, cloud_db, monkeypatch,
+    ):
+        """The win in Phase 5.5: regardless of how many event names the
+        UI passes, ``get_sync_status_for_events`` issues exactly ONE
+        ``SELECT ... FROM cloud_synced_files`` query. The legacy code
+        issued one per name (30 names → 30 round-trips)."""
+        # Seed 5 of the 30 names so we exercise the matching code too.
+        names = [f"2026-05-12_10-{i:02d}-00" for i in range(30)]
+        c = _conn_for(cloud_db)
+        try:
+            _seed(c, [
+                (f"SentryClips/{names[i]}/front.mp4", "synced",
+                 f"2026-05-12T11:{i:02d}:00")
+                for i in range(5)
+            ])
+        finally:
+            c.close()
+
+        # Wrap the connection returned by _init_cloud_tables so we can
+        # trace .execute() without monkeypatching the immutable
+        # sqlite3.Connection class.
+        executed_sql: List[str] = []
+
+        class _TracingConn:
+            def __init__(self, real):
+                self._real = real
+                self.row_factory = real.row_factory
+
+            def execute(self, sql, *args, **kwargs):
+                executed_sql.append(sql)
+                return self._real.execute(sql, *args, **kwargs)
+
+            def close(self):
+                self._real.close()
+
+        original_init = svc._init_cloud_tables
+        monkeypatch.setattr(
+            svc, "_init_cloud_tables",
+            lambda p: _TracingConn(original_init(p)),
+            raising=True,
+        )
+
+        out = svc.get_sync_status_for_events(names)
+
+        # Sanity: matched names came back with their statuses.
+        for i in range(5):
+            assert out[names[i]] == "synced", f"Name {names[i]} should be synced"
+        for i in range(5, 30):
+            assert out[names[i]] is None, f"Name {names[i]} should be None"
+
+        # Count queries hitting cloud_synced_files. The Phase 5.5
+        # contract is ONE — schema/setup queries are allowed (DDL,
+        # PRAGMA, sqlite_master) but data queries are not.
+        cloud_data_queries = [
+            sql for sql in executed_sql
+            if "FROM cloud_synced_files" in sql
+        ]
+        assert len(cloud_data_queries) == 1, (
+            f"Expected exactly 1 query against cloud_synced_files for 30 "
+            f"names (Phase 5.5 batched), got {len(cloud_data_queries)}. "
+            f"Legacy per-name loop must not be reintroduced.\n"
+            f"Queries: {cloud_data_queries}"
+        )
+
+    def test_query_count_constant_in_input_size(self, cloud_db, monkeypatch):
+        """Tripwire: the number of cloud_synced_files queries must be
+        the same whether we ask about 1 name or 100 names."""
+        original_init = svc._init_cloud_tables
+
+        def count_for(names):
+            calls: List[str] = []
+
+            class _TracingConn:
+                def __init__(self, real):
+                    self._real = real
+                    self.row_factory = real.row_factory
+
+                def execute(self, sql, *args, **kwargs):
+                    calls.append(sql)
+                    return self._real.execute(sql, *args, **kwargs)
+
+                def close(self):
+                    self._real.close()
+
+            with monkeypatch.context() as mp:
+                mp.setattr(
+                    svc, "_init_cloud_tables",
+                    lambda p: _TracingConn(original_init(p)),
+                    raising=True,
+                )
+                svc.get_sync_status_for_events(names)
+            return sum(1 for sql in calls if "FROM cloud_synced_files" in sql)
+
+        n1 = count_for(["2026-05-12_10-00-00"])
+        n100 = count_for([f"2026-05-12_10-{i:02d}-{j:02d}"
+                          for i in range(10) for j in range(10)])
+        assert n1 == n100, (
+            f"Query count grew with input size: 1-name={n1}, 100-name={n100}. "
+            f"Phase 5.5 requires a single batched query."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Cross-row matching — multiple names hitting the same row
+# ---------------------------------------------------------------------------
+
+class TestCrossRowMatching:
+
+    def test_row_matching_two_names_populates_both(self, cloud_db):
+        # An ``ArchivedClips`` filename like
+        # ``2026-05-12_10-00-00-2026-05-12_10-00-15-front.mp4`` could in
+        # theory match two timestamp queries. The function must
+        # populate BOTH names independently — not stop at the first.
+        c = _conn_for(cloud_db)
+        try:
+            _seed(c, [
+                ("ArchivedClips/2026-05-12_10-00-00-2026-05-12_10-00-15-front.mp4",
+                 "synced", "2026-05-12T11:00:00"),
+            ])
+        finally:
+            c.close()
+
+        out = svc.get_sync_status_for_events([
+            "2026-05-12_10-00-00",
+            "2026-05-12_10-00-15",
+        ])
+        assert out == {
+            "2026-05-12_10-00-00": "synced",
+            "2026-05-12_10-00-15": "synced",
+        }


### PR DESCRIPTION
## Phase 5.5 — `p5-cloud-status-events-in`: collapse N status queries into 1

Closes part of #102.

### Problem

`get_sync_status_for_events` (consumed by the `/api/sync_status_batch` endpoint, fired on every cloud archive page render) issued one SQL query **per event name**:

```python
for name in event_names:
    row = conn.execute(
        "SELECT status FROM cloud_synced_files WHERE file_path LIKE ? "
        "ORDER BY synced_at DESC LIMIT 1",
        ('%' + name + '%',)
    ).fetchone()
```

A typical cloud archive page request lists ~30 events → 30 SQL round-trips → measurable page-load lag, especially on the Pi Zero 2 W where SQLite + the gadget process compete for the SDIO bus.

### Fix

One batched query that ORs the per-name LIKE patterns, returning all matching rows ordered most-recent-first; then Python buckets the first match per name into the result dict:

```python
like_clauses = " OR ".join(["file_path LIKE ?"] * len(event_names))
params = ["%" + name + "%" for name in event_names]
sql = (
    "SELECT file_path, status FROM cloud_synced_files "
    f"WHERE {like_clauses} "
    "ORDER BY synced_at DESC"
)
rows = conn.execute(sql, params).fetchall()
# Bucket-match in Python; first hit per name wins.
```

The SQL text length grows linearly with N but the network/IO round-trip count stays at **1**. SQL injection-safe — every clause is parameterized.

### Semantics preserved

| Case | Legacy | Phase 5.5 |
|---|---|---|
| Empty input | `{}` | `{}` ✅ |
| Unknown name | `None` | `None` ✅ |
| Single match | most-recent status | most-recent status ✅ |
| Multiple matches per name | LIMIT 1 + DESC → newest | first hit in DESC order → newest ✅ |
| Row matches 2 names | Each name's own query → each populated | bucket-match populates both ✅ |
| DB error | exception propagates | empty-skeleton dict (UI degrades) — IMPROVEMENT |

### Tests

10 new tests in `tests/test_cloud_status_batched.py`:

- **Behaviour (7):** empty / single / multi / unknown / most-recent-wins / substring-match / DB-error-returns-skeleton.
- **Single-query invariant (1):** 30 names → exactly 1 query against `cloud_synced_files` (verified by proxy-tracing the connection's `execute`).
- **Tripwire (1):** query count must be identical for 1 name vs 100 names — fails if a future refactor reintroduces per-name queries.
- **Cross-row (1):** a single row whose `file_path` contains two distinct event names populates both — confirms the bucket-match doesn't stop at first hit.

Full suite: **1260 passed, 3 skipped** (was 1250 + 3, +10 new).

### Verification on device

After deploy:

- Open the cloud archive page (`/cloud/`). Watch DevTools Network → `/api/sync_status_batch` should return in single-digit ms regardless of how many events are listed.
- `journalctl -u gadget_web.service --since "5m" | grep -i sync_status` — no errors.
- Sentry/Saved/Archive page event status indicators should display the same values as before.

### Risk

Low. One function rewritten. Behaviour matrix preserved (and DB-error handling slightly improved). All existing call sites unchanged. Tripwire test guards against regression.
