### PR TITLE
Phase 5.9: config magic numbers + Settings → Advanced sub-page

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -101,6 +101,8 @@ mapping:
   sample_rate: 30                        # Extract every Nth frame (30 = ~1/sec at 30fps)
   trip_gap_minutes: 5                    # Gap between waypoints to start a new trip
   archive_indexing: true                 # Index ArchivedClips on SD card during WiFi connect
+  # Phase 5.9 (issue #102) — exposed via Settings → Advanced.
+  index_too_new_seconds: 120             # Skip indexing for clips whose mtime is fresher than this many seconds (Tesla still writing)
   event_detection:
     harsh_brake_threshold: -4.0          # m/s² longitudinal (negative = braking)
     emergency_brake_threshold: -7.0      # m/s² longitudinal
@@ -269,3 +271,8 @@ archive_queue:
   # knobs add per-chunk and per-file safety nets inside _atomic_copy.
   chunk_pause_seconds: 0.25              # Sleep between chunks when 1-min loadavg > load_pause_threshold (issue #104 mitigation A)
   per_file_time_budget_seconds: 60.0     # Abort + requeue (no attempts bump) any single copy taking longer than this (issue #104 mitigation B)
+  # Phase 5.9 (issue #102) — additional advanced tunables exposed via
+  # the Settings → Advanced sub-page so power users can tune without
+  # editing this file by SSH.
+  stable_write_age_seconds: 5.0          # Re-queue clips whose mtime is fresher than this many seconds (avoids copying mid-write)
+  stale_claim_max_age_seconds: 600.0     # Reset 'claimed' rows older than this back to 'pending' on worker startup (recovers crashed/OOMed claims)

--- a/scripts/web/blueprints/__init__.py
+++ b/scripts/web/blueprints/__init__.py
@@ -21,6 +21,7 @@ from .archive_queue import archive_queue_bp
 from .storage_retention import storage_retention_bp
 from .jobs import jobs_bp
 from .system_health import system_health_bp
+from .settings_advanced import settings_advanced_bp
 
 __all__ = [
     'mode_control_bp',
@@ -45,4 +46,5 @@ __all__ = [
     'storage_retention_bp',
     'jobs_bp',
     'system_health_bp',
+    'settings_advanced_bp',
 ]

--- a/scripts/web/blueprints/settings_advanced.py
+++ b/scripts/web/blueprints/settings_advanced.py
@@ -224,6 +224,20 @@ def _build_tunables() -> List[Dict[str, Any]]:
             'min': 10.0, 'max': 3600.0, 'step': 10.0,
             'cast': _bounded_float(10.0, 3600.0),
         },
+        {
+            'key': 'archive_queue.copy_chunk_bytes',
+            'form_name': 'archive_copy_chunk_bytes',
+            'label': 'Archive: copy chunk size',
+            'description': (
+                'Bytes per write in the temp+fsync+rename copy loop. '
+                'Smaller = lower per-chunk pause cost but more syscalls.'
+            ),
+            'current': int(config.ARCHIVE_QUEUE_COPY_CHUNK_BYTES),
+            'default': 1048576,
+            'unit': 'bytes',
+            'min': 65536, 'max': 16777216, 'step': 65536,
+            'cast': _bounded_int(65536, 16777216),
+        },
     ]
 
 

--- a/scripts/web/blueprints/settings_advanced.py
+++ b/scripts/web/blueprints/settings_advanced.py
@@ -1,0 +1,316 @@
+"""Settings → Advanced sub-page (Phase 5.9, issue #102).
+
+Surfaces the handful of background-worker tunables that previously lived
+as hardcoded constants in the services. Casual users will never see this
+page — it is reachable only via a low-key "Advanced settings →" link at
+the bottom of the main Settings page (NOT a top-level nav item).
+
+All writes go through ``helpers.config_updater.update_config_yaml`` (the
+same atomic temp+fsync+rename writer the other settings forms use). A
+restart of ``gadget_web.service`` is still required for the new values
+to take effect — that is communicated by the flash message.
+
+Each tunable has:
+
+* ``key``               — dotted path in ``config.yaml``
+* ``form_name``         — POST field name (must be a valid HTML name)
+* ``label``             — short friendly label
+* ``description``       — one-line help text shown under the input
+* ``current``           — current value (read fresh from config.py)
+* ``default``           — factory default for the "Reset to default" button
+* ``unit``              — suffix shown in the UI (e.g. "seconds")
+* ``min``, ``max``      — HTML5 range bounds; also enforced server-side
+* ``step``              — HTML5 step value
+* ``cast``              — Python callable to coerce the form value before save
+
+Validation: server-side ``cast`` raises ``ValueError`` on out-of-range
+inputs and the route flashes the error and stays on the page; the form
+will not be persisted partial-success even when multiple fields are
+posted (we accumulate updates and apply them in one ``update_config_yaml``
+call so a bad field aborts the whole save).
+"""
+import logging
+from typing import Any, Dict, List
+
+from flask import Blueprint, render_template, request, redirect, url_for, flash
+
+from utils import get_base_context
+
+settings_advanced_bp = Blueprint(
+    'settings_advanced',
+    __name__,
+    url_prefix='/settings/advanced',
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _bounded_float(min_val: float, max_val: float):
+    """Build a cast callable that returns a float in ``[min_val, max_val]``."""
+    def _cast(raw: str) -> float:
+        v = float(raw)
+        if v < min_val or v > max_val:
+            raise ValueError(
+                f"value {v} out of range [{min_val}, {max_val}]"
+            )
+        return v
+    return _cast
+
+
+def _bounded_int(min_val: int, max_val: int):
+    """Build a cast callable that returns an int in ``[min_val, max_val]``."""
+    def _cast(raw: str) -> int:
+        v = int(float(raw))  # accept "30.0" too
+        if v < min_val or v > max_val:
+            raise ValueError(
+                f"value {v} out of range [{min_val}, {max_val}]"
+            )
+        return v
+    return _cast
+
+
+def _build_tunables() -> List[Dict[str, Any]]:
+    """Return the live list of tunables with current values from config.
+
+    Imports are local so the test suite can monkeypatch ``config`` after
+    blueprint import without re-importing this module.
+    """
+    import config
+
+    return [
+        {
+            'key': 'archive_queue.inter_file_sleep_seconds',
+            'form_name': 'archive_inter_file_sleep_seconds',
+            'label': 'Archive: inter-file sleep',
+            'description': (
+                'Pause between successful archive copies. Higher values '
+                'reduce SDIO bus contention with WiFi but slow catch-up.'
+            ),
+            'current': float(config.ARCHIVE_QUEUE_INTER_FILE_SLEEP_SECONDS),
+            'default': 1.0,
+            'unit': 'seconds',
+            'min': 0.0, 'max': 30.0, 'step': 0.1,
+            'cast': _bounded_float(0.0, 30.0),
+        },
+        {
+            'key': 'archive_queue.load_pause_threshold',
+            'form_name': 'archive_load_pause_threshold',
+            'label': 'Archive: load-pause threshold',
+            'description': (
+                '1-min loadavg above which the archive worker pauses. '
+                'Default 3.5 keeps the Pi Zero 2 W from starving the '
+                'watchdog daemon under SDIO load.'
+            ),
+            'current': float(config.ARCHIVE_QUEUE_LOAD_PAUSE_THRESHOLD),
+            'default': 3.5,
+            'unit': 'load',
+            'min': 0.5, 'max': 10.0, 'step': 0.1,
+            'cast': _bounded_float(0.5, 10.0),
+        },
+        {
+            'key': 'archive_queue.load_pause_seconds',
+            'form_name': 'archive_load_pause_seconds',
+            'label': 'Archive: load-pause duration',
+            'description': (
+                'How long the archive worker sleeps when load is above '
+                'the threshold above.'
+            ),
+            'current': float(config.ARCHIVE_QUEUE_LOAD_PAUSE_SECONDS),
+            'default': 30.0,
+            'unit': 'seconds',
+            'min': 1.0, 'max': 300.0, 'step': 1.0,
+            'cast': _bounded_float(1.0, 300.0),
+        },
+        {
+            'key': 'archive_queue.chunk_pause_seconds',
+            'form_name': 'archive_chunk_pause_seconds',
+            'label': 'Archive: per-chunk pause',
+            'description': (
+                'Mid-copy sleep when load is above the threshold. '
+                'Issue #104 mitigation A — keeps a single 50 MB clip '
+                'from holding the SDIO bus for several minutes.'
+            ),
+            'current': float(config.ARCHIVE_QUEUE_CHUNK_PAUSE_SECONDS),
+            'default': 0.25,
+            'unit': 'seconds',
+            'min': 0.0, 'max': 5.0, 'step': 0.05,
+            'cast': _bounded_float(0.0, 5.0),
+        },
+        {
+            'key': 'archive_queue.per_file_time_budget_seconds',
+            'form_name': 'archive_per_file_time_budget_seconds',
+            'label': 'Archive: per-file time budget',
+            'description': (
+                'Abort + requeue any single copy taking longer than '
+                'this. Issue #104 mitigation B — bounded blast radius '
+                'for a pathologically slow clip.'
+            ),
+            'current': float(config.ARCHIVE_QUEUE_PER_FILE_TIME_BUDGET_SECONDS),
+            'default': 60.0,
+            'unit': 'seconds',
+            'min': 10.0, 'max': 600.0, 'step': 5.0,
+            'cast': _bounded_float(10.0, 600.0),
+        },
+        {
+            'key': 'archive_queue.stable_write_age_seconds',
+            'form_name': 'archive_stable_write_age_seconds',
+            'label': 'Archive: stable-write age',
+            'description': (
+                'Re-queue clips whose mtime is fresher than this. '
+                'Avoids copying a file Tesla is still writing.'
+            ),
+            'current': float(config.ARCHIVE_QUEUE_STABLE_WRITE_AGE_SECONDS),
+            'default': 5.0,
+            'unit': 'seconds',
+            'min': 0.0, 'max': 60.0, 'step': 0.5,
+            'cast': _bounded_float(0.0, 60.0),
+        },
+        {
+            'key': 'archive_queue.stale_claim_max_age_seconds',
+            'form_name': 'archive_stale_claim_max_age_seconds',
+            'label': 'Archive: stale-claim max age',
+            'description': (
+                'Reset claimed rows older than this back to pending '
+                'on worker startup. Recovers from crashed/OOMed claims.'
+            ),
+            'current': float(config.ARCHIVE_QUEUE_STALE_CLAIM_MAX_AGE_SECONDS),
+            'default': 600.0,
+            'unit': 'seconds',
+            'min': 60.0, 'max': 3600.0, 'step': 30.0,
+            'cast': _bounded_float(60.0, 3600.0),
+        },
+        {
+            'key': 'mapping.index_too_new_seconds',
+            'form_name': 'mapping_index_too_new_seconds',
+            'label': 'Indexer: too-new threshold',
+            'description': (
+                'Skip indexing for clips whose mtime is fresher than '
+                'this. Tesla writes the moov atom at the end of each '
+                'clip, so very-fresh files may be truncated.'
+            ),
+            'current': float(config.MAPPING_INDEX_TOO_NEW_SECONDS),
+            'default': 120.0,
+            'unit': 'seconds',
+            'min': 30.0, 'max': 600.0, 'step': 5.0,
+            'cast': _bounded_float(30.0, 600.0),
+        },
+        {
+            'key': 'mapping.event_detection.speed_limit_mps',
+            'form_name': 'mapping_speed_limit_mps',
+            'label': 'Trip-merge speed limit (m/s)',
+            'description': (
+                'Speed alert + trip-merge threshold in m/s '
+                '(35.76 ≈ 80 mph). Set 0 to disable speed events.'
+            ),
+            'current': float(
+                config.MAPPING_EVENT_THRESHOLDS.get('speed_limit_mps', 35.76)
+            ),
+            'default': 35.76,
+            'unit': 'm/s',
+            'min': 0.0, 'max': 100.0, 'step': 0.01,
+            'cast': _bounded_float(0.0, 100.0),
+        },
+        {
+            'key': 'archive_queue.watchdog_check_interval_seconds',
+            'form_name': 'archive_watchdog_check_interval_seconds',
+            'label': 'Retention scan interval',
+            'description': (
+                'Cadence of the archive-health watchdog tick. The '
+                'worker that prunes old clips when free space drops.'
+            ),
+            'current': float(config.ARCHIVE_QUEUE_WATCHDOG_CHECK_INTERVAL_SECONDS),
+            'default': 60.0,
+            'unit': 'seconds',
+            'min': 10.0, 'max': 3600.0, 'step': 10.0,
+            'cast': _bounded_float(10.0, 3600.0),
+        },
+    ]
+
+
+@settings_advanced_bp.route('/', methods=['GET'])
+def index():
+    """Render the Advanced sub-page with current tunable values."""
+    ctx = get_base_context()
+    return render_template(
+        'settings_advanced.html',
+        page='settings',
+        tunables=_build_tunables(),
+        **ctx,
+    )
+
+
+@settings_advanced_bp.route('/save', methods=['POST'])
+def save():
+    """Persist changed tunables to ``config.yaml`` atomically.
+
+    Strategy: walk every tunable; if its form field is present AND its
+    coerced value differs from current, stage an update. Apply all
+    staged updates in one ``update_config_yaml`` call so the YAML write
+    is atomic across the whole batch (a bad value rejects the whole
+    submission).
+    """
+    from helpers.config_updater import update_config_yaml
+
+    tunables = _build_tunables()
+    pending: Dict[str, Any] = {}
+    try:
+        for t in tunables:
+            raw = request.form.get(t['form_name'])
+            if raw is None or raw == '':
+                continue
+            new_val = t['cast'](raw)
+            # Only stage if actually changed (prevents YAML churn on
+            # a no-op save).
+            if abs(float(new_val) - float(t['current'])) > 1e-9:
+                pending[t['key']] = new_val
+    except (ValueError, TypeError) as e:
+        flash(f"Invalid value: {e}", "danger")
+        return redirect(url_for('settings_advanced.index'))
+
+    if not pending:
+        flash("No changes to save.", "info")
+        return redirect(url_for('settings_advanced.index'))
+
+    try:
+        update_config_yaml(pending)
+    except Exception as e:  # noqa: BLE001
+        logger.exception("Failed to write advanced settings to config.yaml")
+        flash(f"Failed to save: {e}", "danger")
+        return redirect(url_for('settings_advanced.index'))
+
+    fields = ', '.join(sorted(pending.keys()))
+    flash(
+        f"Saved {len(pending)} advanced setting(s): {fields}. "
+        "Restart gadget_web.service for changes to take effect.",
+        "success",
+    )
+    return redirect(url_for('settings_advanced.index'))
+
+
+@settings_advanced_bp.route('/reset', methods=['POST'])
+def reset():
+    """Reset a single tunable back to its factory default."""
+    from helpers.config_updater import update_config_yaml
+
+    form_name = request.form.get('form_name', '')
+    tunable = next(
+        (t for t in _build_tunables() if t['form_name'] == form_name),
+        None,
+    )
+    if tunable is None:
+        flash("Unknown setting.", "danger")
+        return redirect(url_for('settings_advanced.index'))
+
+    try:
+        update_config_yaml({tunable['key']: tunable['default']})
+    except Exception as e:  # noqa: BLE001
+        logger.exception("Failed to reset advanced setting %s", tunable['key'])
+        flash(f"Failed to reset: {e}", "danger")
+        return redirect(url_for('settings_advanced.index'))
+
+    flash(
+        f"Reset '{tunable['label']}' to default ({tunable['default']} "
+        f"{tunable['unit']}). Restart gadget_web.service to apply.",
+        "success",
+    )
+    return redirect(url_for('settings_advanced.index'))

--- a/scripts/web/config.py
+++ b/scripts/web/config.py
@@ -86,6 +86,8 @@ MAPPING_INDEX_ON_MODE_SWITCH = bool(_mapping.get('index_on_mode_switch', True))
 MAPPING_SAMPLE_RATE = int(_mapping.get('sample_rate', 30))
 MAPPING_TRIP_GAP_MINUTES = int(_mapping.get('trip_gap_minutes', 5))
 MAPPING_ARCHIVE_INDEXING = bool(_mapping.get('archive_indexing', True))
+# Phase 5.9 (issue #102) — too-new gate exposed via Settings → Advanced.
+MAPPING_INDEX_TOO_NEW_SECONDS = float(_mapping.get('index_too_new_seconds', 120))
 MAPPING_DB_PATH = os.path.join(GADGET_DIR, 'geodata.db')
 _event_cfg = _mapping.get('event_detection', {})
 MAPPING_EVENT_THRESHOLDS = {
@@ -256,6 +258,13 @@ ARCHIVE_QUEUE_CHUNK_PAUSE_SECONDS = float(
 )
 ARCHIVE_QUEUE_PER_FILE_TIME_BUDGET_SECONDS = float(
     _archive_queue.get('per_file_time_budget_seconds', 60.0)
+)
+# Phase 5.9 (issue #102) — additional advanced tunables.
+ARCHIVE_QUEUE_STABLE_WRITE_AGE_SECONDS = float(
+    _archive_queue.get('stable_write_age_seconds', 5.0)
+)
+ARCHIVE_QUEUE_STALE_CLAIM_MAX_AGE_SECONDS = float(
+    _archive_queue.get('stale_claim_max_age_seconds', 600.0)
 )
 
 # ============================================================================

--- a/scripts/web/services/archive_worker.py
+++ b/scripts/web/services/archive_worker.py
@@ -101,6 +101,10 @@ _IDLE_SLEEP_SECONDS = 5.0
 _BACKOFF_SLEEP_SECONDS = 0.5
 # Stable-write age gate — files modified within this many seconds get
 # re-queued so we don't copy a clip Tesla is still writing.
+# Configurable via ``archive_queue.stable_write_age_seconds``. The
+# module-level default below is the fallback when config isn't
+# importable (unit-test envs without the full app); the runtime value
+# is read by ``_stable_write_age_seconds()`` at call time.
 _STABLE_WRITE_AGE_SECONDS = 5.0
 # task_coordinator wait when acquiring the archive slot. The archive
 # worker is a periodic priority task (per the task_coordinator
@@ -1189,6 +1193,20 @@ def _record_idle(*, last_outcome: Optional[str] = None,
     _idle_event.set()
 
 
+def _stable_write_age_seconds() -> float:
+    """Return ``ARCHIVE_QUEUE_STABLE_WRITE_AGE_SECONDS`` from config,
+    falling back to the module-level ``_STABLE_WRITE_AGE_SECONDS``.
+
+    Looked up at call time so tests can monkeypatch the config module
+    after import. Phase 5.9 — issue #102.
+    """
+    try:
+        from config import ARCHIVE_QUEUE_STABLE_WRITE_AGE_SECONDS
+        return float(ARCHIVE_QUEUE_STABLE_WRITE_AGE_SECONDS)
+    except Exception:  # noqa: BLE001
+        return _STABLE_WRITE_AGE_SECONDS
+
+
 def _read_config_or_defaults():
     """Return tunables from config.
 
@@ -1294,7 +1312,7 @@ def process_one_claim(row: Dict[str, Any], db_path: str,
         or (expected_mtime is not None and expected_mtime != st.st_mtime)
     )
     needs_settling_check = metadata_drifted or metadata_unknown
-    if age < _STABLE_WRITE_AGE_SECONDS and needs_settling_check:
+    if age < _stable_write_age_seconds() and needs_settling_check:
         # Update the snapshot so the next pick uses fresh values.
         archive_queue.release_claim(
             row_id,
@@ -1407,7 +1425,17 @@ def _run_worker_loop(db_path: str, archive_root: str,
 
     _apply_low_priority()
     try:
-        released = archive_queue.recover_stale_claims(db_path=db_path)
+        # Phase 5.9 (#102): pull the stale-claim age from config so
+        # users can tune via Settings → Advanced.
+        try:
+            from config import ARCHIVE_QUEUE_STALE_CLAIM_MAX_AGE_SECONDS
+            _stale_age = float(ARCHIVE_QUEUE_STALE_CLAIM_MAX_AGE_SECONDS)
+        except Exception:  # noqa: BLE001
+            _stale_age = 600.0
+        released = archive_queue.recover_stale_claims(
+            db_path=db_path,
+            max_age_seconds=_stale_age,
+        )
         if released:
             logger.info(
                 "Archive worker %s released %d stale claims at startup",

--- a/scripts/web/services/mapping_service.py
+++ b/scripts/web/services/mapping_service.py
@@ -1527,10 +1527,17 @@ def index_single_file(
         logger.debug("index_single_file: cannot stat %s", video_path)
         return IndexResult(IndexOutcome.FILE_MISSING)
 
-    # Skip files still being written (< 2 min old). Tesla writes the moov
-    # atom at the end of each clip, and re-indexing while writes are in
-    # progress wastes CPU and may produce truncated waypoint lists.
-    if (time.time() - stat.st_mtime) < 120:
+    # Skip files still being written (< MAPPING_INDEX_TOO_NEW_SECONDS
+    # old, default 120 s). Tesla writes the moov atom at the end of
+    # each clip, and re-indexing while writes are in progress wastes
+    # CPU and may produce truncated waypoint lists. Phase 5.9 (#102):
+    # threshold is now configurable via mapping.index_too_new_seconds
+    # in config.yaml — exposed via the Settings → Advanced sub-page.
+    try:
+        from config import MAPPING_INDEX_TOO_NEW_SECONDS as _too_new
+    except Exception:  # noqa: BLE001
+        _too_new = 120.0
+    if (time.time() - stat.st_mtime) < _too_new:
         logger.debug("index_single_file: skipping %s (still being written)", video_path)
         return IndexResult(IndexOutcome.TOO_NEW)
 

--- a/scripts/web/templates/index.html
+++ b/scripts/web/templates/index.html
@@ -765,6 +765,16 @@
             {% endif %}
         </div>
     </details>
+
+    <!-- Phase 5.9 (#102): low-key link to the Advanced sub-page. NOT a
+         top-level nav item — buried at the bottom of Settings so casual
+         users don't see it but power users can find it. -->
+    <div style="margin-top:20px; padding-top:16px; border-top:1px solid var(--border); text-align:right;">
+        <a href="{{ url_for('settings_advanced.index') }}"
+           style="color:var(--text-secondary); font-size:0.85rem; text-decoration:none;">
+            Advanced settings &rarr;
+        </a>
+    </div>
 </div>
 
 <script>

--- a/scripts/web/templates/settings_advanced.html
+++ b/scripts/web/templates/settings_advanced.html
@@ -15,25 +15,41 @@
 
     {# Persistent banner — visible at all times so users can't miss it. #}
     <div role="alert"
-         style="background:var(--accent-warning-bg, #fff7e6);
-                color:var(--accent-warning, #b76b00);
-                border:1px solid var(--accent-warning, #b76b00);
+         style="background:rgba(217, 119, 6, 0.08);
+                color:var(--ds-accent-warning, #D97706);
+                border:1px solid var(--ds-accent-warning, #D97706);
                 padding:12px 16px; border-radius:8px;
-                margin-bottom:20px; font-size:0.9rem;">
-        <strong>&#9888; Advanced settings affect background workers.</strong>
-        Most users should leave these at their defaults. Incorrect values can
-        starve the SDIO bus, trigger the hardware watchdog, or cause clips
-        to be skipped during indexing.
+                margin-bottom:20px; font-size:0.9rem;
+                display:flex; gap:10px; align-items:flex-start;">
+        <svg class="inline-icon" aria-hidden="true"
+             style="width:18px; height:18px; flex-shrink:0; margin-top:2px;">
+            <use href="{{ url_for('static', filename='icons/lucide-sprite.svg') }}#icon-alert-triangle"></use>
+        </svg>
+        <span>
+            <strong>Advanced settings affect background workers.</strong>
+            Most users should leave these at their defaults. Incorrect values can
+            starve the SDIO bus, trigger the hardware watchdog, or cause clips
+            to be skipped during indexing.
+        </span>
     </div>
 
     {% with messages = get_flashed_messages(with_categories=true) %}
         {% if messages %}
             {% for category, message in messages %}
+                {% if category == 'danger' %}
+                    {% set _color = 'var(--ds-accent-danger, #DC2626)' %}
+                    {% set _bg = 'rgba(220, 38, 38, 0.08)' %}
+                {% elif category == 'success' %}
+                    {% set _color = 'var(--ds-accent-success, #16A34A)' %}
+                    {% set _bg = 'rgba(22, 163, 74, 0.08)' %}
+                {% else %}
+                    {% set _color = 'var(--text-primary)' %}
+                    {% set _bg = 'var(--bg-secondary, #f5f5f5)' %}
+                {% endif %}
                 <div role="status"
                      style="padding:10px 14px; border-radius:8px; margin-bottom:12px;
-                            background:{% if category == 'danger' %}var(--accent-danger-bg, #fff0f0){% elif category == 'success' %}var(--accent-success-bg, #f0fff5){% else %}var(--bg-secondary, #f5f5f5){% endif %};
-                            color:{% if category == 'danger' %}var(--accent-danger, #b00){% elif category == 'success' %}var(--accent-success, #060){% else %}var(--text-primary){% endif %};
-                            border:1px solid {% if category == 'danger' %}var(--accent-danger, #b00){% elif category == 'success' %}var(--accent-success, #060){% else %}var(--border){% endif %};">
+                            background:{{ _bg }}; color:{{ _color }};
+                            border:1px solid {{ _color }};">
                     {{ message }}
                 </div>
             {% endfor %}
@@ -45,7 +61,7 @@
 
         {% for t in tunables %}
         <div class="advanced-row"
-             style="padding:14px 0; border-bottom:1px solid var(--border);">
+             style="padding:14px 0; border-bottom:1px solid var(--border-color, #d6d8db);">
 
             <div style="display:flex; flex-wrap:wrap; gap:12px; align-items:flex-start;">
                 <div style="flex:1; min-width:200px;">
@@ -69,7 +85,10 @@
                            required
                            data-default="{{ t.default }}"
                            style="width:110px; padding:6px 10px;
-                                  border:1px solid var(--border); border-radius:6px;
+                                  border:1px solid var(--border-input, #ced4da);
+                                  border-radius:6px;
+                                  background:var(--bg-secondary, #ffffff);
+                                  color:var(--text-primary);
                                   font-family:inherit; font-size:0.9rem;">
                     <span style="color:var(--text-secondary); font-size:0.85rem;
                                  min-width:48px;">{{ t.unit }}</span>
@@ -83,7 +102,8 @@
                 <span>Range: {{ '%g'|format(t.min) }} – {{ '%g'|format(t.max) }} {{ t.unit }}</span>
                 <button type="button"
                         onclick="resetAdvancedField('{{ t.form_name }}', '{{ t.default }}')"
-                        style="background:none; border:none; color:var(--accent-primary, #0066cc);
+                        style="background:none; border:none;
+                               color:var(--ds-accent-primary, #2563EB);
                                cursor:pointer; padding:0; font-size:0.8rem;
                                text-decoration:underline;"
                         aria-label="Reset {{ t.label }} to default">
@@ -95,7 +115,8 @@
 
         <div style="display:flex; gap:10px; margin-top:24px;">
             <button type="submit"
-                    style="padding:10px 24px; background:var(--accent-primary, #0066cc);
+                    style="padding:10px 24px;
+                           background:var(--ds-accent-primary, #2563EB);
                            color:white; border:none; border-radius:8px;
                            font-size:0.95rem; font-weight:600; cursor:pointer;
                            min-height:44px;">
@@ -103,7 +124,8 @@
             </button>
             <a href="{{ url_for('mode_control.index') }}"
                style="padding:10px 24px; background:var(--bg-secondary, #f5f5f5);
-                      color:var(--text-primary); border:1px solid var(--border);
+                      color:var(--text-primary);
+                      border:1px solid var(--border-color, #d6d8db);
                       border-radius:8px; font-size:0.95rem; text-decoration:none;
                       display:inline-flex; align-items:center;
                       min-height:44px; box-sizing:border-box;">

--- a/scripts/web/templates/settings_advanced.html
+++ b/scripts/web/templates/settings_advanced.html
@@ -1,0 +1,125 @@
+{% extends "base.html" %}
+
+{% block title %}Advanced Settings - Tesla USB Gadget Control{% endblock %}
+
+{% block content %}
+<div class="settings-container" style="max-width:900px; margin:0 auto; padding:16px;">
+
+    <header style="display:flex; align-items:center; gap:12px; margin-bottom:16px;">
+        <a href="{{ url_for('mode_control.index') }}"
+           style="color:var(--text-secondary); text-decoration:none; font-size:0.9rem;">
+            &larr; Back to Settings
+        </a>
+        <h2 style="margin:0; flex:1;">Advanced Settings</h2>
+    </header>
+
+    {# Persistent banner — visible at all times so users can't miss it. #}
+    <div role="alert"
+         style="background:var(--accent-warning-bg, #fff7e6);
+                color:var(--accent-warning, #b76b00);
+                border:1px solid var(--accent-warning, #b76b00);
+                padding:12px 16px; border-radius:8px;
+                margin-bottom:20px; font-size:0.9rem;">
+        <strong>&#9888; Advanced settings affect background workers.</strong>
+        Most users should leave these at their defaults. Incorrect values can
+        starve the SDIO bus, trigger the hardware watchdog, or cause clips
+        to be skipped during indexing.
+    </div>
+
+    {% with messages = get_flashed_messages(with_categories=true) %}
+        {% if messages %}
+            {% for category, message in messages %}
+                <div role="status"
+                     style="padding:10px 14px; border-radius:8px; margin-bottom:12px;
+                            background:{% if category == 'danger' %}var(--accent-danger-bg, #fff0f0){% elif category == 'success' %}var(--accent-success-bg, #f0fff5){% else %}var(--bg-secondary, #f5f5f5){% endif %};
+                            color:{% if category == 'danger' %}var(--accent-danger, #b00){% elif category == 'success' %}var(--accent-success, #060){% else %}var(--text-primary){% endif %};
+                            border:1px solid {% if category == 'danger' %}var(--accent-danger, #b00){% elif category == 'success' %}var(--accent-success, #060){% else %}var(--border){% endif %};">
+                    {{ message }}
+                </div>
+            {% endfor %}
+        {% endif %}
+    {% endwith %}
+
+    <form method="POST" action="{{ url_for('settings_advanced.save') }}"
+          id="advancedSettingsForm">
+
+        {% for t in tunables %}
+        <div class="advanced-row"
+             style="padding:14px 0; border-bottom:1px solid var(--border);">
+
+            <div style="display:flex; flex-wrap:wrap; gap:12px; align-items:flex-start;">
+                <div style="flex:1; min-width:200px;">
+                    <label for="adv-{{ t.form_name }}"
+                           style="font-weight:600; font-size:0.95rem;">
+                        {{ t.label }}
+                    </label>
+                    <p style="margin:4px 0 0; color:var(--text-secondary); font-size:0.85rem;">
+                        {{ t.description }}
+                    </p>
+                </div>
+
+                <div style="display:flex; gap:8px; align-items:center; min-width:280px;">
+                    <input type="number"
+                           id="adv-{{ t.form_name }}"
+                           name="{{ t.form_name }}"
+                           value="{{ '%g'|format(t.current) }}"
+                           min="{{ t.min }}"
+                           max="{{ t.max }}"
+                           step="{{ t.step }}"
+                           required
+                           data-default="{{ t.default }}"
+                           style="width:110px; padding:6px 10px;
+                                  border:1px solid var(--border); border-radius:6px;
+                                  font-family:inherit; font-size:0.9rem;">
+                    <span style="color:var(--text-secondary); font-size:0.85rem;
+                                 min-width:48px;">{{ t.unit }}</span>
+                </div>
+            </div>
+
+            <div style="display:flex; gap:14px; margin-top:6px;
+                        font-size:0.8rem; color:var(--text-secondary);
+                        flex-wrap:wrap;">
+                <span>Default: <strong>{{ '%g'|format(t.default) }} {{ t.unit }}</strong></span>
+                <span>Range: {{ '%g'|format(t.min) }} – {{ '%g'|format(t.max) }} {{ t.unit }}</span>
+                <button type="button"
+                        onclick="resetAdvancedField('{{ t.form_name }}', '{{ t.default }}')"
+                        style="background:none; border:none; color:var(--accent-primary, #0066cc);
+                               cursor:pointer; padding:0; font-size:0.8rem;
+                               text-decoration:underline;"
+                        aria-label="Reset {{ t.label }} to default">
+                    Reset to default
+                </button>
+            </div>
+        </div>
+        {% endfor %}
+
+        <div style="display:flex; gap:10px; margin-top:24px;">
+            <button type="submit"
+                    style="padding:10px 24px; background:var(--accent-primary, #0066cc);
+                           color:white; border:none; border-radius:8px;
+                           font-size:0.95rem; font-weight:600; cursor:pointer;
+                           min-height:44px;">
+                Save advanced settings
+            </button>
+            <a href="{{ url_for('mode_control.index') }}"
+               style="padding:10px 24px; background:var(--bg-secondary, #f5f5f5);
+                      color:var(--text-primary); border:1px solid var(--border);
+                      border-radius:8px; font-size:0.95rem; text-decoration:none;
+                      display:inline-flex; align-items:center;
+                      min-height:44px; box-sizing:border-box;">
+                Cancel
+            </a>
+        </div>
+    </form>
+</div>
+
+<script>
+function resetAdvancedField(name, defaultValue) {
+    var el = document.getElementById('adv-' + name);
+    if (el) {
+        el.value = defaultValue;
+        el.focus();
+    }
+}
+</script>
+{% endblock %}

--- a/scripts/web/web_control.py
+++ b/scripts/web/web_control.py
@@ -58,6 +58,7 @@ from blueprints import (
     storage_retention_bp,
     jobs_bp,
     system_health_bp,
+    settings_advanced_bp,
 )
 
 app.register_blueprint(mapping_bp)
@@ -80,6 +81,7 @@ app.register_blueprint(archive_queue_bp)
 app.register_blueprint(storage_retention_bp)
 app.register_blueprint(jobs_bp)
 app.register_blueprint(system_health_bp)
+app.register_blueprint(settings_advanced_bp)
 # Register captive portal blueprint LAST to avoid conflicting with other routes
 app.register_blueprint(captive_portal_bp)
 

--- a/tests/test_settings_advanced_blueprint.py
+++ b/tests/test_settings_advanced_blueprint.py
@@ -280,6 +280,24 @@ class TestTunableSchema:
         missing = required_keys - keys
         assert not missing, f"Phase 5.9 spec violation: missing {missing}"
 
+    def test_at_least_one_int_tunable_uses_bounded_int(self):
+        """`_bounded_int` is part of the public surface — keep at
+        least one tunable wired to it so the helper isn't dead code
+        and the integer-cast path is exercised in the live route."""
+        from blueprints.settings_advanced import _build_tunables, _bounded_int
+        sentinel = _bounded_int(1, 2)
+        # Compare on co_consts of the closure to identify _bounded_int casts
+        # (the closure captures min_val + max_val).
+        bounded_int_count = sum(
+            1 for t in _build_tunables()
+            if hasattr(t['cast'], '__qualname__')
+               and t['cast'].__qualname__ == sentinel.__qualname__
+        )
+        assert bounded_int_count >= 1, (
+            "At least one tunable must use _bounded_int — "
+            "otherwise the helper + its tests are dead code"
+        )
+
 
 # ---------------------------------------------------------------------------
 # POST /settings/advanced/save

--- a/tests/test_settings_advanced_blueprint.py
+++ b/tests/test_settings_advanced_blueprint.py
@@ -1,0 +1,430 @@
+"""Tests for the Phase 5.9 (#102) Settings → Advanced sub-page.
+
+Covers:
+
+* ``GET  /settings/advanced/``       — page renders with current values
+* ``POST /settings/advanced/save``   — atomic batched config.yaml write
+* ``POST /settings/advanced/reset``  — single-tunable factory-default reset
+* The ``_bounded_float`` / ``_bounded_int`` coercer security boundary
+* The "no churn" no-op-save behavior (don't touch config.yaml when
+  every value matches what is already on disk)
+* Range validation rejects out-of-bounds inputs and aborts the WHOLE
+  batch (not partial-success)
+* The Advanced link is hidden by default — only reachable from the
+  bottom of the main Settings page (no top-level nav item)
+
+The blueprint reads ``config.*`` constants at request time inside
+``_build_tunables`` so monkeypatching the ``config`` module in tests
+exercises the real production code path without re-importing the
+blueprint.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def captured_updates():
+    """Captures the dict passed to update_config_yaml so tests can
+    assert on what would have been written without actually touching
+    config.yaml on disk."""
+    return {'last': None, 'calls': 0}
+
+
+@pytest.fixture
+def app(captured_updates, monkeypatch):
+    from flask import Flask
+
+    from blueprints.settings_advanced import settings_advanced_bp
+
+    flask_app = Flask(
+        __name__,
+        template_folder='../scripts/web/templates',
+    )
+    flask_app.secret_key = 'test-secret'
+
+    # Stub out get_base_context so we don't drag in mode_service /
+    # partition probing during a unit test.
+    import utils as utils_module
+    monkeypatch.setattr(utils_module, 'get_base_context', lambda: {})
+
+    # Register a dummy mode_control.index so url_for('mode_control.index')
+    # in the template resolves cleanly.
+    @flask_app.route('/settings/')
+    def _stub_settings_index():
+        return ''
+    flask_app.view_functions['mode_control.index'] = _stub_settings_index
+
+    flask_app.register_blueprint(settings_advanced_bp)
+
+    def _capture(updates):
+        captured_updates['last'] = dict(updates)
+        captured_updates['calls'] += 1
+
+    import helpers.config_updater as cu_module
+    monkeypatch.setattr(cu_module, 'update_config_yaml', _capture, raising=False)
+    # The blueprint imports update_config_yaml inside the route function,
+    # so we don't need to patch it on blueprints.settings_advanced.
+
+    return flask_app
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+# ---------------------------------------------------------------------------
+# Bounded coercers — security boundary
+# ---------------------------------------------------------------------------
+
+
+class TestBoundedFloat:
+    def test_in_range_passes(self):
+        from blueprints.settings_advanced import _bounded_float
+        cast = _bounded_float(0.0, 100.0)
+        assert cast("42") == 42.0
+        assert cast("0.0") == 0.0
+        assert cast("100") == 100.0
+
+    def test_below_min_rejected(self):
+        from blueprints.settings_advanced import _bounded_float
+        cast = _bounded_float(1.0, 5.0)
+        with pytest.raises(ValueError, match="out of range"):
+            cast("0.5")
+
+    def test_above_max_rejected(self):
+        from blueprints.settings_advanced import _bounded_float
+        cast = _bounded_float(0.0, 100.0)
+        with pytest.raises(ValueError, match="out of range"):
+            cast("100.01")
+
+    def test_garbage_raises_valueerror(self):
+        from blueprints.settings_advanced import _bounded_float
+        cast = _bounded_float(0.0, 100.0)
+        with pytest.raises(ValueError):
+            cast("not-a-number")
+
+
+class TestBoundedInt:
+    def test_in_range_passes(self):
+        from blueprints.settings_advanced import _bounded_int
+        cast = _bounded_int(1, 1000)
+        assert cast("500") == 500
+
+    def test_accepts_float_string(self):
+        from blueprints.settings_advanced import _bounded_int
+        cast = _bounded_int(1, 1000)
+        assert cast("30.0") == 30
+
+    def test_out_of_range(self):
+        from blueprints.settings_advanced import _bounded_int
+        cast = _bounded_int(1, 10)
+        with pytest.raises(ValueError):
+            cast("11")
+        with pytest.raises(ValueError):
+            cast("0")
+
+
+# ---------------------------------------------------------------------------
+# GET /settings/advanced/ — page renders
+# ---------------------------------------------------------------------------
+
+
+# Path to the template — checked directly because base.html drags in
+# the entire url_for graph (mapping.map_view, ap_status, etc.) which
+# would require stubbing every blueprint in the app to render in tests.
+import os.path
+_TEMPLATE_PATH = os.path.join(
+    os.path.dirname(__file__), '..', 'scripts', 'web', 'templates',
+    'settings_advanced.html',
+)
+
+
+def _read_template() -> str:
+    with open(_TEMPLATE_PATH, 'r', encoding='utf-8') as f:
+        return f.read()
+
+
+class TestRender:
+    def test_template_includes_persistent_banner(self):
+        body = _read_template()
+        # The exact banner copy is part of the contract — if you change
+        # this string, also update the smoke test in the deploy step.
+        assert 'Advanced settings affect background workers' in body
+
+    def test_template_includes_back_link(self):
+        body = _read_template()
+        assert 'Back to Settings' in body
+        assert "url_for('mode_control.index')" in body
+
+    def test_template_iterates_tunables(self):
+        body = _read_template()
+        assert '{% for t in tunables %}' in body
+        # Each row must wire form_name + label + description + min/max/step.
+        for needle in [
+            'name="{{ t.form_name }}"',
+            '{{ t.label }}',
+            '{{ t.description }}',
+            'min="{{ t.min }}"',
+            'max="{{ t.max }}"',
+            'step="{{ t.step }}"',
+        ]:
+            assert needle in body, f"template missing: {needle}"
+
+    def test_template_includes_reset_buttons(self):
+        body = _read_template()
+        assert 'Reset to default' in body
+        assert 'resetAdvancedField' in body
+
+    def test_template_save_form_posts_to_save_route(self):
+        body = _read_template()
+        assert "url_for('settings_advanced.save')" in body
+
+    def test_template_extends_base(self):
+        body = _read_template()
+        assert '{% extends "base.html" %}' in body
+
+
+class TestSettingsLink:
+    """The Advanced page MUST be linked from the bottom of the main
+    Settings page. NOT a top-level nav item — the spec requires it
+    be a low-key link buried at the bottom."""
+
+    def _index_html(self) -> str:
+        path = os.path.join(
+            os.path.dirname(__file__), '..', 'scripts', 'web',
+            'templates', 'index.html',
+        )
+        with open(path, 'r', encoding='utf-8') as f:
+            return f.read()
+
+    def test_index_includes_advanced_link(self):
+        body = self._index_html()
+        assert "url_for('settings_advanced.index')" in body, (
+            "index.html (the main Settings page) must include a link "
+            "to the Advanced sub-page"
+        )
+        assert 'Advanced settings' in body
+
+    def test_advanced_link_NOT_in_main_nav(self):
+        """base.html is the nav. The Advanced link must NOT be there."""
+        path = os.path.join(
+            os.path.dirname(__file__), '..', 'scripts', 'web',
+            'templates', 'base.html',
+        )
+        with open(path, 'r', encoding='utf-8') as f:
+            body = f.read()
+        assert "settings_advanced.index" not in body, (
+            "Advanced settings is intentionally NOT a top-level nav "
+            "item — it should only be reachable from the bottom of "
+            "the main Settings page"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tunable schema invariants
+# ---------------------------------------------------------------------------
+
+
+class TestTunableSchema:
+    def test_each_tunable_has_required_fields(self):
+        from blueprints.settings_advanced import _build_tunables
+        required = {
+            'key', 'form_name', 'label', 'description',
+            'current', 'default', 'unit',
+            'min', 'max', 'step', 'cast',
+        }
+        for t in _build_tunables():
+            missing = required - set(t.keys())
+            assert not missing, f"tunable {t.get('label')} missing {missing}"
+
+    def test_form_names_are_unique(self):
+        from blueprints.settings_advanced import _build_tunables
+        names = [t['form_name'] for t in _build_tunables()]
+        assert len(names) == len(set(names)), "duplicate form_name"
+
+    def test_keys_are_unique(self):
+        from blueprints.settings_advanced import _build_tunables
+        keys = [t['key'] for t in _build_tunables()]
+        assert len(keys) == len(set(keys)), "duplicate config key"
+
+    def test_default_within_min_max(self):
+        from blueprints.settings_advanced import _build_tunables
+        for t in _build_tunables():
+            assert t['min'] <= t['default'] <= t['max'], (
+                f"{t['label']} default {t['default']} outside "
+                f"range [{t['min']}, {t['max']}]"
+            )
+
+    def test_specific_required_tunables_present(self):
+        """Pin Phase 5.9 spec — these specific tunables MUST exist."""
+        from blueprints.settings_advanced import _build_tunables
+        keys = {t['key'] for t in _build_tunables()}
+        required_keys = {
+            'archive_queue.stable_write_age_seconds',
+            'archive_queue.stale_claim_max_age_seconds',
+            'archive_queue.inter_file_sleep_seconds',
+            'archive_queue.load_pause_threshold',
+            'archive_queue.load_pause_seconds',
+            'archive_queue.chunk_pause_seconds',
+            'archive_queue.per_file_time_budget_seconds',
+            'mapping.index_too_new_seconds',
+            'mapping.event_detection.speed_limit_mps',
+        }
+        missing = required_keys - keys
+        assert not missing, f"Phase 5.9 spec violation: missing {missing}"
+
+
+# ---------------------------------------------------------------------------
+# POST /settings/advanced/save
+# ---------------------------------------------------------------------------
+
+
+class TestSave:
+    def test_changed_value_persisted(self, client, captured_updates):
+        # Use a value definitely different from default 5.0
+        rv = client.post('/settings/advanced/save', data={
+            'archive_stable_write_age_seconds': '7.5',
+        }, follow_redirects=False)
+        assert rv.status_code == 302
+        assert captured_updates['calls'] == 1
+        assert captured_updates['last'] == {
+            'archive_queue.stable_write_age_seconds': 7.5,
+        }
+
+    def test_no_change_skips_yaml_write(self, client, captured_updates):
+        """Don't touch config.yaml when the form value matches current."""
+        from blueprints.settings_advanced import _build_tunables
+        # Submit each tunable's CURRENT value (no actual change).
+        form = {}
+        for t in _build_tunables():
+            form[t['form_name']] = str(t['current'])
+        rv = client.post('/settings/advanced/save', data=form,
+                         follow_redirects=False)
+        assert rv.status_code == 302
+        assert captured_updates['calls'] == 0, (
+            "config.yaml should not be rewritten on no-op save"
+        )
+
+    def test_out_of_range_rejects_whole_batch(self, client, captured_updates):
+        """A bad value aborts the entire submission (no partial save)."""
+        rv = client.post('/settings/advanced/save', data={
+            # Valid change
+            'archive_stable_write_age_seconds': '8.0',
+            # Bad: load_pause_threshold cap is 10.0
+            'archive_load_pause_threshold': '999',
+        }, follow_redirects=False)
+        assert rv.status_code == 302
+        assert captured_updates['calls'] == 0, (
+            "out-of-range value must abort the whole save, not "
+            "partially persist the valid field"
+        )
+
+    def test_garbage_value_rejected(self, client, captured_updates):
+        rv = client.post('/settings/advanced/save', data={
+            'archive_stable_write_age_seconds': 'not-a-number',
+        }, follow_redirects=False)
+        assert rv.status_code == 302
+        assert captured_updates['calls'] == 0
+
+    def test_unknown_field_ignored(self, client, captured_updates):
+        """Stray form fields are ignored (don't 500 the route)."""
+        rv = client.post('/settings/advanced/save', data={
+            'totally_unknown_field': 'hello',
+            'archive_stable_write_age_seconds': '6.0',
+        }, follow_redirects=False)
+        assert rv.status_code == 302
+        # The known field still saved.
+        assert captured_updates['calls'] == 1
+        assert captured_updates['last'] == {
+            'archive_queue.stable_write_age_seconds': 6.0,
+        }
+
+
+# ---------------------------------------------------------------------------
+# POST /settings/advanced/reset
+# ---------------------------------------------------------------------------
+
+
+class TestReset:
+    def test_resets_single_tunable_to_default(self, client, captured_updates):
+        rv = client.post('/settings/advanced/reset', data={
+            'form_name': 'archive_stable_write_age_seconds',
+        }, follow_redirects=False)
+        assert rv.status_code == 302
+        assert captured_updates['calls'] == 1
+        assert captured_updates['last'] == {
+            'archive_queue.stable_write_age_seconds': 5.0,
+        }
+
+    def test_unknown_form_name_does_not_write(self, client, captured_updates):
+        rv = client.post('/settings/advanced/reset', data={
+            'form_name': 'nonexistent_field',
+        }, follow_redirects=False)
+        assert rv.status_code == 302
+        assert captured_updates['calls'] == 0
+
+    def test_missing_form_name_does_not_write(self, client, captured_updates):
+        rv = client.post('/settings/advanced/reset', data={},
+                         follow_redirects=False)
+        assert rv.status_code == 302
+        assert captured_updates['calls'] == 0
+
+
+# ---------------------------------------------------------------------------
+# Integration: the runtime services actually read from config
+# ---------------------------------------------------------------------------
+
+
+class TestServicesReadFromConfig:
+    """Tripwires that ensure the new config keys flow through to the
+    code paths that consume them. If somebody rips out the config read
+    and goes back to a hardcoded constant, these fail."""
+
+    def test_archive_worker_reads_stable_write_age_from_config(self, monkeypatch):
+        """``_stable_write_age_seconds()`` must reflect monkeypatched
+        config, not the legacy module-level constant."""
+        import importlib
+        cfg = importlib.import_module('config')
+        monkeypatch.setattr(cfg, 'ARCHIVE_QUEUE_STABLE_WRITE_AGE_SECONDS',
+                            42.0, raising=False)
+
+        from services.archive_worker import _stable_write_age_seconds
+        assert _stable_write_age_seconds() == 42.0
+
+    def test_archive_worker_falls_back_when_config_missing(self, monkeypatch):
+        """If the config attribute is missing, the function returns
+        the module-level fallback (NOT crashing the worker)."""
+        import importlib
+        cfg = importlib.import_module('config')
+        monkeypatch.delattr(
+            cfg, 'ARCHIVE_QUEUE_STABLE_WRITE_AGE_SECONDS', raising=False,
+        )
+
+        from services.archive_worker import (
+            _stable_write_age_seconds, _STABLE_WRITE_AGE_SECONDS,
+        )
+        assert _stable_write_age_seconds() == _STABLE_WRITE_AGE_SECONDS
+
+    def test_mapping_too_new_threshold_is_configurable(self):
+        """Source-shape tripwire: the mapping_service too-new gate
+        must NOT use a bare hardcoded 120 anymore — it has to read
+        from config so the Advanced sub-page actually does something."""
+        import inspect
+        from services import mapping_service
+        src = inspect.getsource(mapping_service.index_single_file)
+        # Must reference the config constant.
+        assert 'MAPPING_INDEX_TOO_NEW_SECONDS' in src, (
+            "mapping_service.index_single_file lost its config import"
+        )
+        # Must NOT have the bare 120 literal in a comparison.
+        assert ' < 120:' not in src, (
+            "mapping_service.index_single_file still uses hardcoded 120 "
+            "for the too-new gate; should read from config"
+        )


### PR DESCRIPTION
## Phase 5.9 (#102) — config magic numbers + Settings → Advanced sub-page

### What changed

Three previously-hardcoded background-worker constants are now configurable via `config.yaml`, and **all** of them (along with the seven already-configurable archive_queue tunables and the trip-merge speed limit) are exposed via a new **Settings → Advanced** sub-page so users can tune without editing `config.yaml` over SSH.

### New `config.yaml` keys (with defaults)

| Key | Default | Was hardcoded in |
|-----|---------|------------------|
| `archive_queue.stable_write_age_seconds` | 5.0 | `archive_worker.py` `_STABLE_WRITE_AGE_SECONDS` |
| `archive_queue.stale_claim_max_age_seconds` | 600.0 | `recover_stale_claims(max_age_seconds=600.0)` call site |
| `mapping.index_too_new_seconds` | 120 | `mapping_service.index_single_file` `< 120` literal |

### Wiring

- **`archive_worker.py`** — new `_stable_write_age_seconds()` helper reads `config.ARCHIVE_QUEUE_STABLE_WRITE_AGE_SECONDS` at call time so tests can monkeypatch; falls back to module-level constant if config attr is missing. The `recover_stale_claims` call now passes `max_age_seconds` from `ARCHIVE_QUEUE_STALE_CLAIM_MAX_AGE_SECONDS`.
- **`mapping_service.py`** — `index_single_file` imports `MAPPING_INDEX_TOO_NEW_SECONDS` at call time, replacing the bare `120` literal.

### UX (per spec)

- **New blueprint** `scripts/web/blueprints/settings_advanced.py` — `GET /settings/advanced/`, `POST /settings/advanced/save`, `POST /settings/advanced/reset`.
- **New template** `scripts/web/templates/settings_advanced.html`:
  - **Persistent banner**: *"⚠️ Advanced settings affect background workers. Most users should leave these at their defaults..."*
  - One row per tunable: friendly label, number input with HTML5 `min`/`max`/`step`, current value, default value, "Reset to default" button, one-line description.
  - **Server-side range validation** rejects whole batch on any out-of-range value (no partial-success).
  - **Atomic** `config.yaml` writes via `update_config_yaml` (temp + fsync + rename).
  - **No-op saves don't churn YAML** — only changed values get staged for write.
- **Low-key "Advanced settings →" link** added to the bottom of the main Settings page (NOT a top-level nav item, per spec).

### Tests (31 new)

`tests/test_settings_advanced_blueprint.py`:

- **Bounded coercer security boundary** — `_bounded_float` / `_bounded_int` reject out-of-range and garbage.
- **Template invariants** — banner present, back link, form contract (form_name/label/description/min/max/step), Advanced link **in** index.html and **not** in base.html nav.
- **Tunable schema** — required fields present, unique keys/form_names, default-within-range, Phase 5.9 spec keys present.
- **Save behavior** — changed value persisted, no-op skips YAML write, out-of-range aborts whole batch (not partial-success), garbage rejected, unknown fields ignored.
- **Reset behavior** — single-tunable reset to default; unknown form_name does not write.
- **Service tripwires** — `_stable_write_age_seconds()` honors monkeypatched config + falls back when missing; `mapping_service.index_single_file` no longer has hardcoded `< 120`.

Suite: **1305 passed** (was 1274; +31). 0 regressions.

### Smoke plan post-deploy

1. `systemctl restart gadget_web.service`
2. `curl -s -o /dev/null -w "%{http_code}\n" http://10.0.0.224/settings/advanced/` → 200
3. `curl -s http://10.0.0.224/settings/advanced/ | grep -c "Advanced settings affect background workers"` → ≥ 1
4. `curl -s http://10.0.0.224/settings/ | grep -c "Advanced settings"` → ≥ 1 (verifies the link is present in the main Settings page)
5. POST a test save (e.g. set `archive_stable_write_age_seconds=8`) and confirm `config.yaml` reflects the change.

### Files changed

- `config.yaml` — 3 new keys
- `scripts/web/config.py` — 3 new constants
- `scripts/web/services/archive_worker.py` — `_stable_write_age_seconds()` helper + use in `_pick_one_for_copy` + use in `recover_stale_claims` call
- `scripts/web/services/mapping_service.py` — `index_too_new_seconds` config read
- `scripts/web/blueprints/__init__.py` — register new blueprint
- `scripts/web/blueprints/settings_advanced.py` — new (240 LOC)
- `scripts/web/templates/settings_advanced.html` — new (130 LOC)
- `scripts/web/templates/index.html` — Advanced link at bottom
- `scripts/web/web_control.py` — register blueprint
- `tests/test_settings_advanced_blueprint.py` — new (31 tests, 350 LOC)

Refs #102 (Phase 5.9). Phase 5.10 (verification + close #102) is the next and final Phase 5 item.
