### PR TITLE
fix: drop_caches=2 instead of umount+remount in _refresh_ro_mount (#127)

### DIFF
--- a/scripts/web/services/mapping_service.py
+++ b/scripts/web/services/mapping_service.py
@@ -799,7 +799,19 @@ def _refresh_ro_mount(teslacam_path: str) -> None:
     The ``current_mode() != 'present'`` early return is preserved: in
     edit mode the local mount IS the write path, so the cache is fresh
     by definition and the call is a no-op.
+
+    .. note::
+
+        ``teslacam_path`` is retained as a parameter for API
+        compatibility with the legacy mount-specific implementation
+        and to document caller intent (which mount is being
+        refreshed). It is intentionally unreferenced — ``drop_caches``
+        is a process-global kernel knob that flushes caches for ALL
+        mounts on the system. This is harmless (only the RO gadget
+        mount actually has stale dentry entries; other mounts are
+        re-resolved from disk on next access at negligible cost).
     """
+    del teslacam_path  # unused — kept for API compat; see docstring
     from services.mode_service import current_mode
     if current_mode() != 'present':
         return  # Only meaningful in present mode

--- a/scripts/web/services/mapping_service.py
+++ b/scripts/web/services/mapping_service.py
@@ -776,46 +776,53 @@ def candidate_db_paths(canonical_key_value: str) -> List[str]:
 
 
 def _refresh_ro_mount(teslacam_path: str) -> None:
-    """Cycle the read-only mount to refresh exFAT filesystem cache.
+    """Invalidate the VFS slab cache so ``readdir`` sees Tesla's latest
+    writes via the gadget LUN.
 
-    When in present mode, Tesla writes to the USB image through the gadget
-    while the Pi has a read-only mount of the same image.  exFAT caches
-    directory entries and won't see new/changed files until the mount is
-    refreshed.  A quick umount + mount cycle (~200ms) fixes this.
+    Tesla writes to the USB image through the gadget while the Pi has a
+    read-only mount of the same image; the kernel's dentry + inode cache
+    on the Pi side hides those new files from ``readdir`` until evicted.
+
+    This used to ``umount + mount -o ro`` the RO mount to force the
+    eviction (issue #127) — but per ``.github/copilot-instructions.md``
+    that's forbidden: any disruption of the present-mode RO mount can
+    race with Tesla's gadget reads and produce a transient I/O error,
+    losing footage if Tesla is actively recording.
+
+    The kernel-supported replacement is ``echo 2 > /proc/sys/vm/drop_caches``
+    (slabs only — dentry + inode cache). It is sub-10ms, idempotent, and
+    does NOT touch the mount, loop device, image file, or gadget
+    binding. After the slab eviction, the next ``open`` / ``readdir``
+    re-resolves through the loop device and sees Tesla's freshly-written
+    metadata.
+
+    The ``current_mode() != 'present'`` early return is preserved: in
+    edit mode the local mount IS the write path, so the cache is fresh
+    by definition and the call is a no-op.
     """
     from services.mode_service import current_mode
     if current_mode() != 'present':
-        return  # Only needed in present mode
-
-    mount_point = os.path.dirname(teslacam_path)  # e.g. /mnt/gadget/part1-ro
-    if not os.path.ismount(mount_point):
-        return
+        return  # Only meaningful in present mode
 
     try:
-        # Find the loop device backing this mount
-        result = subprocess.run(
-            ["sudo", "nsenter", "--mount=/proc/1/ns/mnt",
-             "findmnt", "-n", "-o", "SOURCE", mount_point],
-            capture_output=True, text=True, timeout=5,
-        )
-        source = result.stdout.strip()
-        if not source:
-            return
-
-        # Umount and remount
+        # ``sudo tee`` is the standard pattern for writing to a root-owned
+        # /proc file from an unprivileged process. ``input="2\n"`` writes
+        # exactly the byte the kernel expects (slab-only invalidation).
         subprocess.run(
-            ["sudo", "nsenter", "--mount=/proc/1/ns/mnt",
-             "umount", mount_point],
-            capture_output=True, timeout=10,
+            ["sudo", "tee", "/proc/sys/vm/drop_caches"],
+            input="2\n",
+            text=True,
+            capture_output=True,
+            timeout=5,
+            check=True,
         )
-        subprocess.run(
-            ["sudo", "nsenter", "--mount=/proc/1/ns/mnt",
-             "mount", "-o", "ro", source, mount_point],
-            capture_output=True, timeout=10,
-        )
-        logger.info("Refreshed RO mount at %s", mount_point)
-    except Exception as e:
-        logger.warning("Failed to refresh RO mount (non-fatal): %s", e)
+        logger.debug("VFS cache refreshed (drop_caches=2)")
+    except Exception as e:  # noqa: BLE001
+        # Non-fatal — worst case is the next read path doesn't see Tesla's
+        # most recent files until the kernel evicts the cache on its own
+        # (memory pressure or normal LRU). All callers are read-only
+        # consumers that retry on the next worker tick.
+        logger.warning("VFS cache refresh failed (non-fatal): %s", e)
 
 
 def _find_front_camera_videos(teslacam_path: str) -> Generator[str, None, None]:

--- a/tests/test_refresh_ro_mount.py
+++ b/tests/test_refresh_ro_mount.py
@@ -1,0 +1,190 @@
+"""Issue #127 — _refresh_ro_mount must use drop_caches=2, not umount+mount.
+
+Pre-fix, ``mapping_service._refresh_ro_mount`` invalidated the kernel
+VFS cache by ``umount + mount -o ro`` on the present-mode RO mount.
+Per ``.github/copilot-instructions.md`` (Mount Safety section), that
+pattern is forbidden: any disruption of the present-mode RO mount can
+race with Tesla's gadget reads and cause a transient I/O error,
+losing footage if Tesla is actively recording.
+
+The kernel-supported replacement is ``echo 2 > /proc/sys/vm/drop_caches``
+(slabs only — dentry + inode cache). It does NOT touch the mount,
+loop device, image file, or gadget binding.
+
+These tests pin the new contract:
+
+1. ``_refresh_ro_mount`` issues exactly one subprocess call.
+2. That call writes ``"2\n"`` to ``/proc/sys/vm/drop_caches`` via
+   ``sudo tee`` (the standard pattern for writing to root-owned
+   /proc files from an unprivileged process).
+3. NO ``umount``, ``mount``, ``findmnt``, or ``nsenter`` invocation.
+4. The ``current_mode() != 'present'`` early return is preserved.
+5. A subprocess failure is non-fatal (legacy contract preserved).
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def _force_present_mode(monkeypatch):
+    """Force ``current_mode()`` to return 'present' so the function
+    actually executes its body (vs. early-returning)."""
+    import services.mode_service as ms
+
+    monkeypatch.setattr(ms, 'current_mode', lambda: 'present')
+    yield
+
+
+class TestRefreshRoMount:
+
+    def test_uses_drop_caches_via_sudo_tee(self, _force_present_mode):
+        """The function MUST write to /proc/sys/vm/drop_caches via
+        ``sudo tee`` — the standard pattern for writing to a
+        root-owned /proc file from an unprivileged process."""
+        from services.mapping_service import _refresh_ro_mount
+
+        with patch('services.mapping_service.subprocess.run') as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            _refresh_ro_mount("/mnt/gadget/part1-ro/TeslaCam")
+
+        assert mock_run.call_count == 1, (
+            f"Expected exactly 1 subprocess call (the slab-cache "
+            f"invalidation), got {mock_run.call_count}"
+        )
+        args, kwargs = mock_run.call_args
+        cmd = args[0] if args else kwargs.get('args')
+
+        # Command shape must be ['sudo', 'tee', '/proc/sys/vm/drop_caches'].
+        assert cmd == ["sudo", "tee", "/proc/sys/vm/drop_caches"], (
+            f"Wrong command shape: {cmd}. Expected the slab-cache "
+            f"invalidation pattern from copilot-instructions.md."
+        )
+
+        # Input must be exactly "2\n" (drop slab caches only).
+        assert kwargs.get('input') == "2\n", (
+            f"Expected input='2\\n' (slab-only invalidation), got "
+            f"{kwargs.get('input')!r}. drop_caches=1 invalidates page "
+            f"cache (heavy); =2 invalidates slabs only (cheap, what "
+            f"we want); =3 invalidates both."
+        )
+
+    def test_does_not_call_umount_or_mount(self, _force_present_mode):
+        """The function MUST NOT call umount, mount, findmnt, or
+        wrap any command in ``nsenter``. Those are exactly the
+        forbidden patterns this PR is removing."""
+        from services.mapping_service import _refresh_ro_mount
+
+        with patch('services.mapping_service.subprocess.run') as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            _refresh_ro_mount("/mnt/gadget/part1-ro/TeslaCam")
+
+        for call in mock_run.call_args_list:
+            args, _ = call
+            cmd = args[0] if args else []
+            cmd_str = ' '.join(cmd) if isinstance(cmd, list) else str(cmd)
+            for forbidden in ('umount', 'mount -o', 'findmnt', 'nsenter'):
+                assert forbidden not in cmd_str, (
+                    f"FORBIDDEN command pattern '{forbidden}' found in "
+                    f"_refresh_ro_mount: {cmd_str}. This is exactly "
+                    f"what issue #127 forbids — Tesla may be recording "
+                    f"and umount/remount of the gadget-shared RO mount "
+                    f"loses footage."
+                )
+
+    def test_early_returns_in_edit_mode(self, monkeypatch):
+        """When mode is 'edit', the call must be a no-op (no
+        subprocess invocation at all). The local mount IS the write
+        path in edit mode, so the cache is fresh by definition."""
+        import services.mode_service as ms
+        from services.mapping_service import _refresh_ro_mount
+
+        monkeypatch.setattr(ms, 'current_mode', lambda: 'edit')
+
+        with patch('services.mapping_service.subprocess.run') as mock_run:
+            _refresh_ro_mount("/mnt/gadget/part1/TeslaCam")
+
+        assert mock_run.call_count == 0, (
+            f"Expected 0 subprocess calls in edit mode, got "
+            f"{mock_run.call_count}. Edit-mode is a no-op."
+        )
+
+    def test_early_returns_in_unknown_mode(self, monkeypatch):
+        """Unknown mode (e.g. transitioning) is also a no-op."""
+        import services.mode_service as ms
+        from services.mapping_service import _refresh_ro_mount
+
+        monkeypatch.setattr(ms, 'current_mode', lambda: 'transitioning')
+
+        with patch('services.mapping_service.subprocess.run') as mock_run:
+            _refresh_ro_mount("/mnt/gadget/part1-ro/TeslaCam")
+
+        assert mock_run.call_count == 0
+
+    def test_subprocess_failure_is_non_fatal(self, _force_present_mode, caplog):
+        """``CalledProcessError`` from the slab-cache write is logged
+        as a warning but never re-raised. All callers wrap this in
+        try/except too, but defense-in-depth: it must NOT raise."""
+        import logging
+        from services.mapping_service import _refresh_ro_mount
+
+        caplog.set_level(logging.WARNING)
+        with patch('services.mapping_service.subprocess.run') as mock_run:
+            mock_run.side_effect = subprocess.CalledProcessError(
+                returncode=1, cmd=["sudo", "tee", "/proc/sys/vm/drop_caches"],
+            )
+            # Must NOT raise.
+            _refresh_ro_mount("/mnt/gadget/part1-ro/TeslaCam")
+
+        # And must have logged a warning.
+        warnings = [
+            r for r in caplog.records
+            if r.levelno == logging.WARNING and 'cache refresh failed' in r.message.lower()
+        ]
+        assert len(warnings) == 1, (
+            f"Expected exactly 1 warning log on subprocess failure, "
+            f"got {len(warnings)}. caplog: "
+            f"{[r.message for r in caplog.records]}"
+        )
+
+    def test_subprocess_timeout_is_non_fatal(self, _force_present_mode):
+        """``TimeoutExpired`` is also non-fatal (legacy contract)."""
+        from services.mapping_service import _refresh_ro_mount
+
+        with patch('services.mapping_service.subprocess.run') as mock_run:
+            mock_run.side_effect = subprocess.TimeoutExpired(
+                cmd=["sudo", "tee", "/proc/sys/vm/drop_caches"], timeout=5,
+            )
+            # Must NOT raise.
+            _refresh_ro_mount("/mnt/gadget/part1-ro/TeslaCam")
+
+    def test_source_does_not_contain_legacy_umount_pattern(self):
+        """Source-level tripwire: the legacy umount/remount fragments
+        must not reappear in ``_refresh_ro_mount``."""
+        import inspect
+        from services.mapping_service import _refresh_ro_mount
+
+        src = inspect.getsource(_refresh_ro_mount)
+        # Forbidden fragments — these were the umount+mount block.
+        for forbidden in (
+            '"umount"',
+            "'umount'",
+            'mount", "-o", "ro"',
+            "findmnt",
+        ):
+            assert forbidden not in src, (
+                f"Legacy umount/remount fragment '{forbidden}' "
+                f"resurfaced in _refresh_ro_mount. Issue #127 "
+                f"forbids this pattern."
+            )
+        # Required fragments.
+        assert "/proc/sys/vm/drop_caches" in src, (
+            "drop_caches=2 invalidation pattern missing"
+        )
+        assert '"2\\n"' in src or "'2\\n'" in src or '"2\\n",' in src, (
+            "drop_caches input value '2\\n' missing"
+        )


### PR DESCRIPTION
## Summary

Closes #127 — replaces the forbidden `umount + mount -o ro` block in `_refresh_ro_mount` with `drop_caches=2` (the canonical pattern documented in `.github/copilot-instructions.md`).

## Root cause (full details in [issue comment](https://github.com/mphacker/TeslaUSB/issues/127#issuecomment-4438541716))

`mapping_service._refresh_ro_mount` invalidated the kernel's exFAT VFS cache by `umount + mount -o ro` of the present-mode RO mount. This is forbidden by the Mount Safety section of `copilot-instructions.md`: any disruption of the present-mode RO mount races with Tesla's gadget reads and can cause a transient I/O error, losing footage if Tesla is actively recording.

PR #126's continuous worker fires this code path on every file-watcher arrival, every NM dispatcher call, every mode switch, every 5-min idle, and every wake — orders of magnitude more often than pre-PR.

## Fix

Use the kernel-supported VFS slab-cache invalidation primitive:

```python
subprocess.run(
    ["sudo", "tee", "/proc/sys/vm/drop_caches"],
    input="2\n", text=True, capture_output=True,
    timeout=5, check=True,
)
```

`drop_caches=2` is sub-10ms, idempotent, and does NOT touch the mount, loop device, image file, or gadget binding. After the slab eviction, the next `open` / `readdir` re-resolves through the loop device and sees Tesla's freshly-written metadata.

Preserved:
- `current_mode() != 'present'` early return (edit mode is a no-op).
- Non-fatal exception handling (warning logged, no re-raise).

## All callers verified

Reviewed each call site — none rely on the mount actually being recreated:
- `helpers/refresh_cloud_token.py:246`
- `cloud_rclone_service.py:530`
- `cloud_archive_service.py:1807`
- `live_event_sync_service.py:941`

All four want pure cache-refresh semantics.

## Tests (7 new) in `tests/test_refresh_ro_mount.py`

- **Contract:** writes `"2\n"` to `/proc/sys/vm/drop_caches` via `sudo tee` (one subprocess call).
- **Forbidden patterns:** no `umount`, `mount -o`, `findmnt`, or `nsenter` anywhere in subprocess calls.
- **Mode gate:** edit mode + unknown mode → 0 subprocess calls.
- **Failure paths:** `CalledProcessError` + `TimeoutExpired` both non-fatal; warning logged.
- **Source tripwire:** legacy fragments must not reappear in source.

## Suite

**1318 passed + 3 skipped** (was 1311 + 3, exactly +7 from this PR).

## Risk

Very low. Removes a known-unsafe operation; replaces with the canonical pattern documented in `copilot-instructions.md`. The change is dramatically safer at the post-PR-126 worker frequency.
