### PR TITLE
fix(#110): require moov AND mdat in archive verifier; purge orphaned dead-letter queue rows

### DIFF
--- a/scripts/web/services/archive_worker.py
+++ b/scripts/web/services/archive_worker.py
@@ -654,7 +654,8 @@ _MOOV_VERIFY_MAX_HEADER_READS = 512
 
 
 def _verify_destination_complete(dest_path: str) -> bool:
-    """Return True iff ``dest_path`` is an MP4 with both ``ftyp`` and ``moov``.
+    """Return True iff ``dest_path`` is an MP4 with ``ftyp``, ``moov``,
+    AND ``mdat`` boxes all present.
 
     Phase 2.4 — A "successful" copy of an unplayable MP4 is worse than
     a failed copy: the bad file looks complete (size matches), gets
@@ -662,6 +663,14 @@ def _verify_destination_complete(dest_path: str) -> bool:
     Tesla writes the ``moov`` atom at the END of the file, so a copy
     that started before Tesla finished writing will have everything up
     to and including ``mdat`` but be missing ``moov``.
+
+    Issue #110 — Tesla's RecentClips writer also produces clips with
+    ``moov`` near the START of the file (before ``mdat``). A copy
+    snapshotted between the moov and mdat writes has moov but no mdat,
+    and the pre-#110 verifier (which returned True on the first moov
+    box) accepted these. The indexer's SEI parser then bailed with
+    "No mdat box found" and the row eventually dead-lettered. Both
+    boxes are now required.
 
     Implementation notes (Pi Zero 2 W constraints):
 
@@ -693,10 +702,12 @@ def _verify_destination_complete(dest_path: str) -> bool:
             if len(head) < 12 or head[4:8] != b'ftyp':
                 return False
 
-            # Walk top-level boxes from offset 0 looking for moov.
+            # Walk top-level boxes from offset 0 looking for moov + mdat.
             f.seek(0)
             pos = 0
             reads = 0
+            seen_moov = False
+            seen_mdat = False
             while pos + 8 <= file_size:
                 if reads >= _MOOV_VERIFY_MAX_HEADER_READS:
                     # Bounded walk — pathological input.
@@ -722,26 +733,40 @@ def _verify_destination_complete(dest_path: str) -> bool:
                     if size < 16:
                         return False  # Malformed extended box.
                 elif size == 0:
-                    # Box extends to end of file. If this IS moov, found.
-                    # Otherwise nothing follows so we're done.
+                    # Box extends to end of file. If it IS one of the
+                    # required boxes, mark it seen — but nothing can
+                    # follow, so we must already have the OTHER required
+                    # box for the file to be complete.
                     if box_type == b'moov':
-                        return True
-                    return False
+                        seen_moov = True
+                    elif box_type == b'mdat':
+                        seen_mdat = True
+                    return seen_moov and seen_mdat
                 elif size < 8:
                     return False  # Malformed normal box.
 
                 if box_type == b'moov':
                     # Sanity-check the box doesn't claim to extend past EOF.
-                    return pos + size <= file_size
+                    if pos + size > file_size:
+                        return False
+                    seen_moov = True
+                elif box_type == b'mdat':
+                    if pos + size > file_size:
+                        return False
+                    seen_mdat = True
+                else:
+                    # Defensive — a non-required box claiming to extend
+                    # past EOF is truncated; nothing useful follows.
+                    if pos + size > file_size:
+                        return False
 
-                # Defensive — a box claiming to extend past EOF is
-                # truncated. Bail out (moov can't follow).
-                if pos + size > file_size:
-                    return False
+                if seen_moov and seen_mdat:
+                    return True
 
                 pos += size
 
-            return False  # Walked to EOF without finding moov.
+            # Walked to EOF without seeing both required boxes.
+            return seen_moov and seen_mdat
     except (OSError, IOError):
         return False
 
@@ -847,7 +872,7 @@ def _atomic_copy(source_path: str, dest_path: str,
         if dest_path.lower().endswith('.mp4'):
             if not _verify_destination_complete(partial):
                 raise OSError(
-                    f"destination MP4 missing moov atom — "
+                    f"destination MP4 missing moov or mdat box — "
                     f"source may still be writing: {source_path}"
                 )
         # Copy mtime so downstream consumers (indexer, ZIP exporter)

--- a/scripts/web/services/indexing_queue_service.py
+++ b/scripts/web/services/indexing_queue_service.py
@@ -932,43 +932,36 @@ def purge_orphaned_dead_letters(db_path: str) -> int:
                 pass
         return 0
 
-    orphans = [r['canonical_key'] for r in rows
+    # Capture (canonical_key, file_path) so the DELETE can pin BOTH —
+    # closes the narrow SELECT→DELETE race where a row could in theory
+    # be DELETEd + re-INSERTed under the same canonical_key with a
+    # different file_path between our isfile check and the DELETE.
+    orphans = [(r['canonical_key'], r['file_path']) for r in rows
                if r['file_path'] and not os.path.isfile(r['file_path'])]
 
+    try:
+        conn.close()
+    except sqlite3.Error:
+        pass
+
     if not orphans:
-        try:
-            conn.close()
-        except sqlite3.Error:
-            pass
         return 0
 
     purged = 0
     try:
-        conn.execute("BEGIN IMMEDIATE")
-        try:
+        with _atomic_indexing_op(db_path) as conn:
             cur = conn.executemany(
                 "DELETE FROM indexing_queue "
                 "WHERE canonical_key = ? "
+                "  AND file_path = ? "
                 "  AND attempts >= ? "
                 "  AND claimed_by IS NULL",
-                [(k, _PARSE_ERROR_MAX_ATTEMPTS) for k in orphans],
+                [(k, p, _PARSE_ERROR_MAX_ATTEMPTS) for (k, p) in orphans],
             )
             purged = cur.rowcount or 0
-            conn.execute("COMMIT")
-        except BaseException:
-            try:
-                conn.execute("ROLLBACK")
-            except sqlite3.Error:
-                pass
-            raise
     except sqlite3.Error as e:
         logger.warning("purge_orphaned_dead_letters delete failed: %s", e)
         return 0
-    finally:
-        try:
-            conn.close()
-        except sqlite3.Error:
-            pass
 
     if purged:
         logger.info(

--- a/scripts/web/services/indexing_queue_service.py
+++ b/scripts/web/services/indexing_queue_service.py
@@ -41,6 +41,7 @@ discipline that prevents the constantly-flashing "Indexing…" banner.
 from __future__ import annotations
 
 import logging
+import os
 import sqlite3
 import time
 from contextlib import contextmanager
@@ -876,3 +877,103 @@ def clear_all_queue(db_path: str) -> int:
 # Backward-compat alias — same dangerous semantics as the original
 # (deletes claimed rows). New code should pick one of the two above.
 clear_queue = clear_all_queue
+
+
+def purge_orphaned_dead_letters(db_path: str) -> int:
+    """Delete dead-letter rows whose ``file_path`` no longer exists.
+
+    Issue #110 — When the archive watchdog's retention prune deletes a
+    truncated archive copy, it calls
+    :func:`mapping_service.purge_deleted_videos` to clean
+    ``indexed_files``, but it does NOT touch ``indexing_queue``.
+    Dead-letter rows (``attempts >= _PARSE_ERROR_MAX_ATTEMPTS``) for
+    those deleted files would otherwise linger forever, inflating
+    ``dead_letter_count`` and showing stale paths in
+    :func:`list_dead_letters`.
+
+    Wired into :func:`mapping_service._run_stale_scan_blocking` so it
+    runs alongside the existing ``indexed_files`` orphan sweep on the
+    same daily cadence (with the 5–10 min initial delay after boot).
+
+    Safety contract:
+
+    * Only ``attempts >= _PARSE_ERROR_MAX_ATTEMPTS`` rows are eligible.
+      Live or in-flight rows (``claimed_by IS NOT NULL`` or
+      ``attempts < _PARSE_ERROR_MAX_ATTEMPTS``) are NEVER touched —
+      the worker's normal ``FILE_MISSING`` outcome handles them on
+      next claim.
+    * Dead-letter rows whose source file STILL exists are preserved
+      (the file might be re-processable after a future fix).
+    * One ``os.path.isfile`` per dead-letter row — same shape as the
+      ``indexed_files`` stale scan. Orders of magnitude faster than
+      re-attempting the parse.
+
+    Returns the number of rows purged.
+    """
+    if not db_path:
+        return 0
+
+    conn = None
+    try:
+        conn = _open_queue_conn(db_path)
+        rows = conn.execute(
+            """SELECT canonical_key, file_path
+               FROM indexing_queue
+               WHERE attempts >= ?
+                 AND claimed_by IS NULL""",
+            (_PARSE_ERROR_MAX_ATTEMPTS,),
+        ).fetchall()
+    except sqlite3.Error as e:
+        logger.warning("purge_orphaned_dead_letters select failed: %s", e)
+        if conn is not None:
+            try:
+                conn.close()
+            except sqlite3.Error:
+                pass
+        return 0
+
+    orphans = [r['canonical_key'] for r in rows
+               if r['file_path'] and not os.path.isfile(r['file_path'])]
+
+    if not orphans:
+        try:
+            conn.close()
+        except sqlite3.Error:
+            pass
+        return 0
+
+    purged = 0
+    try:
+        conn.execute("BEGIN IMMEDIATE")
+        try:
+            cur = conn.executemany(
+                "DELETE FROM indexing_queue "
+                "WHERE canonical_key = ? "
+                "  AND attempts >= ? "
+                "  AND claimed_by IS NULL",
+                [(k, _PARSE_ERROR_MAX_ATTEMPTS) for k in orphans],
+            )
+            purged = cur.rowcount or 0
+            conn.execute("COMMIT")
+        except BaseException:
+            try:
+                conn.execute("ROLLBACK")
+            except sqlite3.Error:
+                pass
+            raise
+    except sqlite3.Error as e:
+        logger.warning("purge_orphaned_dead_letters delete failed: %s", e)
+        return 0
+    finally:
+        try:
+            conn.close()
+        except sqlite3.Error:
+            pass
+
+    if purged:
+        logger.info(
+            "purge_orphaned_dead_letters: removed %d dead-letter row(s) "
+            "whose source file no longer exists",
+            purged,
+        )
+    return purged

--- a/scripts/web/services/mapping_service.py
+++ b/scripts/web/services/mapping_service.py
@@ -2061,15 +2061,36 @@ def _run_stale_scan_blocking(db_path: str, teslacam_path_provider,
             tc = teslacam_path_provider
         if tc and os.path.isdir(tc):
             result = purge_deleted_videos(db_path, teslacam_path=tc)
+            # Issue #110 — also clean up orphaned indexer dead-letter
+            # rows whose source file is gone (e.g., retention pruned
+            # a truncated archive copy that the indexer dead-lettered
+            # for "No mdat box found"). Same problem class as the
+            # ``indexed_files`` orphan sweep, same place to handle it.
+            try:
+                from services.indexing_queue_service import (
+                    purge_orphaned_dead_letters,
+                )
+                orphan_dl = purge_orphaned_dead_letters(db_path)
+            except Exception as e:  # noqa: BLE001
+                logger.warning(
+                    "Stale scan (%s): purge_orphaned_dead_letters "
+                    "failed: %s",
+                    source, e,
+                )
+                orphan_dl = 0
             logger.info(
                 "Stale scan (%s): purged %d indexed_files rows, "
-                "orphaned %d waypoints and %d events "
+                "orphaned %d waypoints and %d events, "
+                "removed %d orphaned dead-letter row(s) "
                 "(trips/waypoints preserved)",
                 source,
                 result.get('purged_files', 0),
                 result.get('purged_waypoints', 0),
                 result.get('purged_events', 0),
+                orphan_dl,
             )
+            if isinstance(result, dict):
+                result['purged_dead_letters'] = orphan_dl
             return result
         logger.debug(
             "Stale scan (%s): TeslaCam not accessible — skipping",

--- a/scripts/web/services/mapping_service.py
+++ b/scripts/web/services/mapping_service.py
@@ -2067,6 +2067,12 @@ def _run_stale_scan_blocking(db_path: str, teslacam_path_provider,
             # for "No mdat box found"). Same problem class as the
             # ``indexed_files`` orphan sweep, same place to handle it.
             try:
+                # Local import: ``indexing_queue_service`` is at the
+                # bottom of the import graph (depended on by mapping_
+                # service callers in workers); importing it at module
+                # top would create an indirect cycle through worker
+                # boot. Lazy import here is intentional and matches
+                # the pattern used elsewhere in this module.
                 from services.indexing_queue_service import (
                     purge_orphaned_dead_letters,
                 )

--- a/tests/test_archive_worker.py
+++ b/tests/test_archive_worker.py
@@ -2128,6 +2128,65 @@ class TestMoovVerifyAfterCopy:
             "dest must NOT exist after a moov-verify failure"
 
 
+    def test_atomic_copy_succeeds_for_well_formed_mp4(self, tmp_path):
+        src = tmp_path / "source.mp4"
+        content = _build_minimal_mp4(payload=b"hello-world" * 50)
+        src.write_bytes(content)
+        dst = tmp_path / "dest.mp4"
+        archive_worker._atomic_copy(
+            str(src), str(dst), chunk_size=4096,
+        )
+        assert dst.exists()
+        assert dst.read_bytes() == content
+        assert not (tmp_path / "dest.mp4.partial").exists()
+
+    def test_non_mp4_extension_skips_verification(self, tmp_path):
+        # ``.ts`` and other archive types must NOT be moov-verified —
+        # they aren't MP4s. A successful size-matching copy is enough.
+        src = tmp_path / "source.ts"
+        src.write_bytes(b"\x47" * 1024)  # MPEG-TS sync byte stream
+        dst = tmp_path / "dest.ts"
+        archive_worker._atomic_copy(
+            str(src), str(dst), chunk_size=4096,
+        )
+        assert dst.exists()
+        assert dst.read_bytes() == b"\x47" * 1024
+
+    def test_process_one_claim_re_queues_on_moov_failure(
+            self, db, archive_root, teslacam_root, make_clip,
+    ):
+        # End-to-end through process_one_claim: a source file that
+        # passes the size check but fails moov-verify must flow through
+        # the OSError handler → mark_failed → status 'pending' (with
+        # one bumped attempt). The dest must not exist.
+        bad_mp4 = (
+            b'\x00\x00\x00\x20ftypisom\x00\x00\x02\x00isomiso2avc1mp41'
+            + b'\x00\x00\x00\x10mdat' + b'\x00' * 8
+        )
+        clip = make_clip("RecentClips/halfwritten-front.mp4", content=bad_mp4)
+        enqueue_for_archive(clip, db_path=db)
+        row = claim_next_for_worker('w', db_path=db)
+        outcome = archive_worker.process_one_claim(
+            row, db, archive_root, teslacam_root,
+            chunk_size=4096, max_attempts=3,
+        )
+        assert outcome == 'pending', (
+            "moov-missing copy must transition back to pending so it can "
+            "be retried after Tesla finishes writing"
+        )
+        rows = list_queue(db_path=db)
+        assert rows[0]['status'] == 'pending'
+        assert rows[0]['attempts'] == 1
+        assert 'moov' in (rows[0]['last_error'] or '')
+        # No dest file landed in ArchivedClips.
+        dest = os.path.join(
+            archive_root, "RecentClips", "halfwritten-front.mp4",
+        )
+        assert not os.path.exists(dest), (
+            "Incomplete MP4 must not leak into ArchivedClips"
+        )
+
+
 class TestMdatRequiredAfterCopy:
     """Issue #110 — verifier must reject MP4s that have ``moov`` but
     are missing ``mdat``. Tesla's RecentClips writer can produce this
@@ -2194,64 +2253,6 @@ class TestMdatRequiredAfterCopy:
             )
         assert not (tmp_path / "dest.mp4.partial").exists()
         assert not dst.exists()
-
-    def test_atomic_copy_succeeds_for_well_formed_mp4(self, tmp_path):
-        src = tmp_path / "source.mp4"
-        content = _build_minimal_mp4(payload=b"hello-world" * 50)
-        src.write_bytes(content)
-        dst = tmp_path / "dest.mp4"
-        archive_worker._atomic_copy(
-            str(src), str(dst), chunk_size=4096,
-        )
-        assert dst.exists()
-        assert dst.read_bytes() == content
-        assert not (tmp_path / "dest.mp4.partial").exists()
-
-    def test_non_mp4_extension_skips_verification(self, tmp_path):
-        # ``.ts`` and other archive types must NOT be moov-verified —
-        # they aren't MP4s. A successful size-matching copy is enough.
-        src = tmp_path / "source.ts"
-        src.write_bytes(b"\x47" * 1024)  # MPEG-TS sync byte stream
-        dst = tmp_path / "dest.ts"
-        archive_worker._atomic_copy(
-            str(src), str(dst), chunk_size=4096,
-        )
-        assert dst.exists()
-        assert dst.read_bytes() == b"\x47" * 1024
-
-    def test_process_one_claim_re_queues_on_moov_failure(
-            self, db, archive_root, teslacam_root, make_clip,
-    ):
-        # End-to-end through process_one_claim: a source file that
-        # passes the size check but fails moov-verify must flow through
-        # the OSError handler → mark_failed → status 'pending' (with
-        # one bumped attempt). The dest must not exist.
-        bad_mp4 = (
-            b'\x00\x00\x00\x20ftypisom\x00\x00\x02\x00isomiso2avc1mp41'
-            + b'\x00\x00\x00\x10mdat' + b'\x00' * 8
-        )
-        clip = make_clip("RecentClips/halfwritten-front.mp4", content=bad_mp4)
-        enqueue_for_archive(clip, db_path=db)
-        row = claim_next_for_worker('w', db_path=db)
-        outcome = archive_worker.process_one_claim(
-            row, db, archive_root, teslacam_root,
-            chunk_size=4096, max_attempts=3,
-        )
-        assert outcome == 'pending', (
-            "moov-missing copy must transition back to pending so it can "
-            "be retried after Tesla finishes writing"
-        )
-        rows = list_queue(db_path=db)
-        assert rows[0]['status'] == 'pending'
-        assert rows[0]['attempts'] == 1
-        assert 'moov' in (rows[0]['last_error'] or '')
-        # No dest file landed in ArchivedClips.
-        dest = os.path.join(
-            archive_root, "RecentClips", "halfwritten-front.mp4",
-        )
-        assert not os.path.exists(dest), (
-            "Incomplete MP4 must not leak into ArchivedClips"
-        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_archive_worker.py
+++ b/tests/test_archive_worker.py
@@ -2064,11 +2064,13 @@ class TestMoovVerifyAfterCopy:
         assert archive_worker._verify_destination_complete(str(f)) is True
 
     def test_size_zero_box_at_end_handled(self, tmp_path):
-        # box size==0 means: extends to EOF. If it IS moov, valid.
+        # box size==0 means: extends to EOF. If it IS moov AND we have
+        # already seen mdat (pre-#110: moov alone was sufficient), valid.
         ftyp = b'\x00\x00\x00\x20ftypisom\x00\x00\x02\x00isomiso2avc1mp41'
+        mdat = b'\x00\x00\x00\x10mdat' + b'\x00' * 8
         moov_eof = (0).to_bytes(4, 'big') + b'moov' + b'\x00' * 100
         f = tmp_path / "moov_eof.mp4"
-        f.write_bytes(ftyp + moov_eof)
+        f.write_bytes(ftyp + mdat + moov_eof)
         assert archive_worker._verify_destination_complete(str(f)) is True
 
     def test_size_zero_non_moov_fails(self, tmp_path):
@@ -2116,7 +2118,7 @@ class TestMoovVerifyAfterCopy:
             + b'\x00\x00\x00\x10mdat' + b'\x00' * 8
         )
         dst = tmp_path / "dest.mp4"
-        with pytest.raises(OSError, match="missing moov"):
+        with pytest.raises(OSError, match="missing moov or mdat"):
             archive_worker._atomic_copy(
                 str(src), str(dst), chunk_size=4096,
             )
@@ -2124,6 +2126,74 @@ class TestMoovVerifyAfterCopy:
             "partial must be cleaned up on moov-verify failure"
         assert not dst.exists(), \
             "dest must NOT exist after a moov-verify failure"
+
+
+class TestMdatRequiredAfterCopy:
+    """Issue #110 — verifier must reject MP4s that have ``moov`` but
+    are missing ``mdat``. Tesla's RecentClips writer can produce this
+    layout transiently; pre-#110 the verifier accepted it and the
+    indexer dead-lettered the file with "No mdat box found"."""
+
+    def test_no_mdat_with_moov_first_fails(self, tmp_path):
+        # ftyp + moov ONLY — the issue #110 case. Pre-fix this passed.
+        ftyp = b'\x00\x00\x00\x20ftypisom\x00\x00\x02\x00isomiso2avc1mp41'
+        moov = b'\x00\x00\x00\x08moov'
+        f = tmp_path / "no_mdat.mp4"
+        f.write_bytes(ftyp + moov)
+        assert archive_worker._verify_destination_complete(str(f)) is False
+
+    def test_mdat_then_moov_passes(self, tmp_path):
+        # Standard layout: ftyp + mdat + moov (moov at end).
+        ftyp = b'\x00\x00\x00\x20ftypisom\x00\x00\x02\x00isomiso2avc1mp41'
+        mdat = b'\x00\x00\x00\x10mdat' + b'\x00' * 8
+        moov = b'\x00\x00\x00\x08moov'
+        f = tmp_path / "std_layout.mp4"
+        f.write_bytes(ftyp + mdat + moov)
+        assert archive_worker._verify_destination_complete(str(f)) is True
+
+    def test_moov_then_mdat_passes(self, tmp_path):
+        # Tesla RecentClips layout: ftyp + moov + mdat (moov at start).
+        # When BOTH boxes are present this is also valid.
+        ftyp = b'\x00\x00\x00\x20ftypisom\x00\x00\x02\x00isomiso2avc1mp41'
+        moov = b'\x00\x00\x00\x08moov'
+        mdat = b'\x00\x00\x00\x10mdat' + b'\x00' * 8
+        f = tmp_path / "moov_first.mp4"
+        f.write_bytes(ftyp + moov + mdat)
+        assert archive_worker._verify_destination_complete(str(f)) is True
+
+    def test_size_zero_mdat_at_end_with_prior_moov_passes(self, tmp_path):
+        # mdat extends to EOF, moov already seen → valid.
+        ftyp = b'\x00\x00\x00\x20ftypisom\x00\x00\x02\x00isomiso2avc1mp41'
+        moov = b'\x00\x00\x00\x08moov'
+        mdat_eof = (0).to_bytes(4, 'big') + b'mdat' + b'\x00' * 100
+        f = tmp_path / "mdat_eof_after_moov.mp4"
+        f.write_bytes(ftyp + moov + mdat_eof)
+        assert archive_worker._verify_destination_complete(str(f)) is True
+
+    def test_size_zero_moov_at_end_with_prior_mdat_passes(self, tmp_path):
+        # moov extends to EOF, mdat already seen → valid.
+        ftyp = b'\x00\x00\x00\x20ftypisom\x00\x00\x02\x00isomiso2avc1mp41'
+        mdat = b'\x00\x00\x00\x10mdat' + b'\x00' * 8
+        moov_eof = (0).to_bytes(4, 'big') + b'moov' + b'\x00' * 100
+        f = tmp_path / "moov_eof_after_mdat.mp4"
+        f.write_bytes(ftyp + mdat + moov_eof)
+        assert archive_worker._verify_destination_complete(str(f)) is True
+
+    def test_atomic_copy_raises_when_source_lacks_mdat(self, tmp_path):
+        # End-to-end variant for the issue #110 layout: source has
+        # ftyp + moov but no mdat. ``_atomic_copy`` must raise.
+        src = tmp_path / "source.mp4"
+        src.write_bytes(
+            b'\x00\x00\x00\x20ftypisom\x00\x00\x02\x00isomiso2avc1mp41'
+            + b'\x00\x00\x00\x08moov'
+        )
+        dst = tmp_path / "dest.mp4"
+        with pytest.raises(OSError, match="missing moov or mdat"):
+            archive_worker._atomic_copy(
+                str(src), str(dst), chunk_size=4096,
+            )
+        assert not (tmp_path / "dest.mp4.partial").exists()
+        assert not dst.exists()
 
     def test_atomic_copy_succeeds_for_well_formed_mp4(self, tmp_path):
         src = tmp_path / "source.mp4"

--- a/tests/test_indexing_queue_orphan_cleanup.py
+++ b/tests/test_indexing_queue_orphan_cleanup.py
@@ -1,0 +1,250 @@
+"""Tests for indexing_queue_service.purge_orphaned_dead_letters.
+
+Issue #110 — When the archive watchdog's retention prune deletes a
+truncated archive copy, it cleans ``indexed_files`` via
+``purge_deleted_videos`` but leaves orphaned dead-letter rows in
+``indexing_queue``. Those rows linger forever, inflating
+``dead_letter_count`` and showing stale paths in
+``list_dead_letters``. The new helper sweeps them up.
+"""
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from services import indexing_queue_service
+from services.indexing_queue_service import (
+    _PARSE_ERROR_MAX_ATTEMPTS,
+    enqueue_for_indexing,
+    get_queue_status,
+    purge_orphaned_dead_letters,
+)
+from services.mapping_service import _init_db
+
+
+@pytest.fixture
+def db(tmp_path):
+    db_path = str(tmp_path / "geodata.db")
+    conn = _init_db(db_path)
+    conn.close()
+    return db_path
+
+
+def _make_clip(tmp_path, name: str) -> str:
+    f = tmp_path / f"{name}-front.mp4"
+    f.write_bytes(b"x")
+    return str(f)
+
+
+def _force_dead_letter(db_path: str, file_path: str) -> None:
+    """Bump a queue row to dead-letter (attempts >= _PARSE_ERROR_MAX_ATTEMPTS)
+    by direct DB update, simulating the worker burning through retries."""
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            "UPDATE indexing_queue SET attempts = ?, last_error = ?, "
+            "claimed_by = NULL, claimed_at = NULL "
+            "WHERE file_path = ?",
+            (_PARSE_ERROR_MAX_ATTEMPTS, "No mdat box found", file_path),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+class TestPurgeOrphanedDeadLetters:
+    """Issue #110 — periodic cleanup of orphaned dead-letter rows."""
+
+    def test_orphaned_dead_letter_row_is_purged(self, db, tmp_path):
+        """Dead-letter row + missing source file -> purged."""
+        clip = _make_clip(tmp_path, "orphan")
+        assert enqueue_for_indexing(db, clip) is True
+        _force_dead_letter(db, clip)
+        # File deleted (simulates retention prune).
+        import os
+        os.remove(clip)
+        assert os.path.isfile(clip) is False
+
+        purged = purge_orphaned_dead_letters(db)
+        assert purged == 1
+
+        status = get_queue_status(db)
+        assert status['dead_letter_count'] == 0
+        assert status['queue_depth'] == 0
+
+    def test_dead_letter_with_existing_file_is_preserved(self, db, tmp_path):
+        """Dead-letter row + file STILL on disk -> preserved.
+
+        Operator might fix the parser and re-process, or the file
+        might become valid after a future write. Don't delete just
+        because the row hit the attempt cap.
+        """
+        clip = _make_clip(tmp_path, "still_here")
+        assert enqueue_for_indexing(db, clip) is True
+        _force_dead_letter(db, clip)
+        assert __import__('os').path.isfile(clip)  # still there
+
+        purged = purge_orphaned_dead_letters(db)
+        assert purged == 0
+
+        status = get_queue_status(db)
+        assert status['dead_letter_count'] == 1
+
+    def test_non_dead_letter_with_missing_file_is_preserved(
+        self, db, tmp_path,
+    ):
+        """attempts < _PARSE_ERROR_MAX_ATTEMPTS rows are NEVER touched.
+
+        The worker's normal FILE_MISSING outcome will handle them on
+        the next claim — that's its job, not the orphan sweeper's.
+        Removing them here would risk racing the worker mid-claim.
+        """
+        clip = _make_clip(tmp_path, "live")
+        assert enqueue_for_indexing(db, clip) is True
+        # attempts stays at 0 — NOT dead-letter.
+        import os
+        os.remove(clip)
+
+        purged = purge_orphaned_dead_letters(db)
+        assert purged == 0
+
+        status = get_queue_status(db)
+        assert status['queue_depth'] == 1
+        assert status['dead_letter_count'] == 0
+
+    def test_claimed_dead_letter_is_preserved(self, db, tmp_path):
+        """claimed_by IS NOT NULL rows are NEVER touched, even at the
+        dead-letter threshold. The worker is mid-processing — let it
+        finish."""
+        clip = _make_clip(tmp_path, "claimed")
+        assert enqueue_for_indexing(db, clip) is True
+        _force_dead_letter(db, clip)
+        # Manually mark claimed AFTER the dead-letter bump.
+        conn = sqlite3.connect(db)
+        try:
+            conn.execute(
+                "UPDATE indexing_queue SET claimed_by = 'w1', "
+                "claimed_at = ? WHERE file_path = ?",
+                (1234567890.0, clip),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+        import os
+        os.remove(clip)
+
+        purged = purge_orphaned_dead_letters(db)
+        assert purged == 0  # claimed - skip even though file is gone
+
+    def test_mixed_batch_purges_only_orphans(self, db, tmp_path):
+        """Mix of orphans + alive files + non-dead-letter rows. Only
+        the dead-letter+missing rows get purged."""
+        # 5 orphans (dead-letter, file gone)
+        orphans = [_make_clip(tmp_path, f"orphan_{i}") for i in range(5)]
+        for o in orphans:
+            assert enqueue_for_indexing(db, o) is True
+            _force_dead_letter(db, o)
+        # 3 alive (dead-letter, file present)
+        alive = [_make_clip(tmp_path, f"alive_{i}") for i in range(3)]
+        for a in alive:
+            assert enqueue_for_indexing(db, a) is True
+            _force_dead_letter(db, a)
+        # 2 fresh (attempts=0)
+        fresh = [_make_clip(tmp_path, f"fresh_{i}") for i in range(2)]
+        for f in fresh:
+            assert enqueue_for_indexing(db, f) is True
+
+        # Delete just the orphans.
+        import os
+        for o in orphans:
+            os.remove(o)
+
+        purged = purge_orphaned_dead_letters(db)
+        assert purged == 5
+
+        status = get_queue_status(db)
+        # 3 dead-letter alive + 2 fresh = 5 total
+        assert status['dead_letter_count'] == 3
+        assert status['queue_depth'] == 2
+
+    def test_empty_queue_is_a_noop(self, db):
+        purged = purge_orphaned_dead_letters(db)
+        assert purged == 0
+
+    def test_no_dead_letters_is_a_noop(self, db, tmp_path):
+        clip = _make_clip(tmp_path, "fresh_only")
+        assert enqueue_for_indexing(db, clip) is True
+        purged = purge_orphaned_dead_letters(db)
+        assert purged == 0
+
+    def test_handles_missing_file_path_gracefully(self, db, tmp_path):
+        """The current schema enforces NOT NULL on file_path, but the
+        purge code defensively skips rows with falsy file_path
+        (`if r['file_path'] and not os.path.isfile(...)`). This test
+        sanity-checks that defensive code: an empty-string file_path
+        (which the NOT NULL constraint allows) isn't treated as a
+        missing-on-disk file — would otherwise raise OSError or
+        produce a confusing DELETE."""
+        import time as _time
+        conn = sqlite3.connect(db)
+        try:
+            conn.execute(
+                "INSERT INTO indexing_queue "
+                "(canonical_key, file_path, source, attempts, "
+                "next_attempt_at, enqueued_at, last_error, "
+                "claimed_by, claimed_at) "
+                "VALUES (?, '', ?, ?, 0, ?, ?, NULL, NULL)",
+                ("weird-key.mp4", "test", _PARSE_ERROR_MAX_ATTEMPTS,
+                 _time.time(), "synthetic"),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        # Defensive `if r['file_path']` check skips this row → 0.
+        purged = purge_orphaned_dead_letters(db)
+        assert purged == 0
+
+    def test_idempotent(self, db, tmp_path):
+        """Running purge twice in a row doesn't error and the second
+        call is a no-op."""
+        import os
+        clip = _make_clip(tmp_path, "twice")
+        assert enqueue_for_indexing(db, clip) is True
+        _force_dead_letter(db, clip)
+        os.remove(clip)
+
+        first = purge_orphaned_dead_letters(db)
+        second = purge_orphaned_dead_letters(db)
+        assert first == 1
+        assert second == 0
+
+    def test_db_error_returns_zero(self, db, tmp_path, monkeypatch):
+        """DB error during the SELECT phase returns 0, doesn't raise."""
+        clip = _make_clip(tmp_path, "err")
+        assert enqueue_for_indexing(db, clip) is True
+        _force_dead_letter(db, clip)
+        import os
+        os.remove(clip)
+
+        original_open = indexing_queue_service._open_queue_conn
+
+        class _RaisingOnSelect:
+            def __init__(self, real):
+                self._c = real
+
+            def __getattr__(self, name):
+                return getattr(self._c, name)
+
+            def execute(self, sql, *args):
+                if 'SELECT' in sql.upper():
+                    raise sqlite3.OperationalError("simulated select fail")
+                return self._c.execute(sql, *args)
+
+        monkeypatch.setattr(
+            indexing_queue_service, '_open_queue_conn',
+            lambda p: _RaisingOnSelect(original_open(p)),
+        )
+        purged = purge_orphaned_dead_letters(db)
+        assert purged == 0

--- a/tests/test_mapping_service.py
+++ b/tests/test_mapping_service.py
@@ -3533,6 +3533,45 @@ class TestStaleScanTrigger:
         )
         assert result is None
 
+    def test_blocking_helper_purges_orphaned_dead_letters(self, tmp_path):
+        """Issue #110 — _run_stale_scan_blocking also removes
+        ``indexing_queue`` dead-letter rows whose source file no
+        longer exists (typically because retention deleted a
+        truncated archive copy)."""
+        from services.indexing_queue_service import (
+            _PARSE_ERROR_MAX_ATTEMPTS,
+            enqueue_for_indexing,
+            get_queue_status,
+        )
+
+        db = str(tmp_path / "g.db")
+        _init_db(db)
+        tc = tmp_path / "TeslaCam"
+        tc.mkdir()
+
+        # Create a "front" clip, enqueue it for indexing, force it
+        # to dead-letter, then delete the file (simulating retention).
+        clip = tmp_path / "2026-05-11_08-41-58-front.mp4"
+        clip.write_bytes(b"fake")
+        assert enqueue_for_indexing(db, str(clip)) is True
+        with sqlite3.connect(db) as c:
+            c.execute(
+                "UPDATE indexing_queue SET attempts = ?, "
+                "last_error = 'No mdat box found' "
+                "WHERE file_path = ?",
+                (_PARSE_ERROR_MAX_ATTEMPTS, str(clip)),
+            )
+            c.commit()
+        assert get_queue_status(db)['dead_letter_count'] == 1
+        clip.unlink()
+
+        result = _run_stale_scan_blocking(db, str(tc), source='test')
+        assert result is not None
+        assert result.get('purged_dead_letters') == 1
+
+        # Row should be gone after the sweep.
+        assert get_queue_status(db)['dead_letter_count'] == 0
+
 
 
 class TestGapDetectionHelpers:


### PR DESCRIPTION
## Root cause

Three causes contributed to the indexer being stuck on 77 dead-letter `No mdat box found` rows on cybertruckusb.local:

1. **Copy-while-writing race** — Tesla writes `ftyp + moov + mdat` as separate block writes. `_atomic_copy` could snapshot a file that had ftyp + moov but not yet mdat. The copy passed verification (which only required moov) but later parsing failed with `No mdat box found`. **Phase 5.9 (#149)** already mitigated this for *new* files via the `stable_write_age_seconds` gate (default 5.0s), but legacy stuck rows accumulated before that landed.
2. **Verifier accepted moov-only files** — `_verify_destination_complete()` required only `moov`, so a half-written copy passed.
3. **Orphan dead-letter rows never cleaned up** — when the source file was later retention-pruned, `purge_deleted_videos` cleaned the `indexed_files` row but the `indexing_queue` row lingered forever. `dead_letter_count` only ever grew.

## Fixes in this PR

### Fix A — verifier requires both moov AND mdat
`_verify_destination_complete()` now walks all top-level boxes, tracking `seen_moov` and `seen_mdat` flags, and returns True only when both are seen. Updated `_atomic_copy` error message: `missing moov atom` -> `missing moov or mdat box`.

### Fix B — orphan dead-letter cleanup
New `purge_orphaned_dead_letters(db_path)` in `indexing_queue_service.py`:
- Selects only rows with `attempts >= _PARSE_ERROR_MAX_ATTEMPTS` AND `claimed_by IS NULL`.
- For each, checks `os.path.isfile(file_path)` — keeps the row if the file still exists.
- Batch DELETE inside `BEGIN IMMEDIATE / COMMIT`.
- Live rows (attempts below threshold) and claimed rows are never touched, so the worker's normal `FILE_MISSING` path is unaffected.

Wired into `mapping_service._run_stale_scan_blocking` so it runs alongside `purge_deleted_videos` on the same daily cadence.

## Tests

| Suite | New tests |
|-------|-----------|
| `test_archive_worker.py::TestMdatRequiredAfterCopy` | 6 (moov-only rejected, both orders pass, size-zero with prior other passes, `_atomic_copy` raises for moov-only) |
| `test_indexing_queue_orphan_cleanup.py` | 10 (orphan purged, file-still-exists preserved, non-dead-letter preserved, claimed preserved, mixed batch, empty noop, no-dead-letters noop, empty-string defensive skip, idempotent, db error returns 0) |
| `test_mapping_service.py::TestStaleScanScheduler::test_blocking_helper_purges_orphaned_dead_letters` | 1 end-to-end integration |

**Result:** 1360 passed, 3 skipped (was 1343 + 3).

## Production verification (cybertruckusb.local)

- Pre-deploy: `dead_letter_count: 77`, all `No mdat box found`, `attempts: 3`, source files retention-pruned.
- Manually invoked `purge_orphaned_dead_letters` post-deploy: returned `77`.
- Post-cleanup: `/api/index/status` -> `dead_letter_count: 0`, `queue_depth: 0`, `worker_running: true`.
- Service active, `NRestarts=0`, no errors in journal.

## Safety contract for `purge_orphaned_dead_letters`

| Condition | Behavior |
|-----------|----------|
| `attempts < threshold` | Untouched (worker handles via FILE_MISSING) |
| `attempts >= threshold` AND `claimed_by IS NOT NULL` | Untouched (worker mid-processing) |
| `attempts >= threshold` AND unclaimed AND file exists | Untouched (genuine parse failure to inspect) |
| `attempts >= threshold` AND unclaimed AND file gone | DELETED |
| empty/null `file_path` | Defensive skip |

Closes #110

<!-- skill:resolve-issue:resolution:110 -->