### PR TITLE
fix(#109): disk-fullness-adaptive throttling for the archive worker

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -230,7 +230,7 @@ archive:
   enabled: true                          # Enable RecentClips archival
   interval_minutes: 2                    # How often to check for new clips (tighter = less data loss)
   retention_days: 30                     # Delete archived clips older than this
-  min_free_space_gb: 10                  # Hard floor — stop archiving if SD card < this free
+  min_free_space_gb: 20                  # Hard floor — stop archiving if SD card < this free. Issue #109: raised from 10 → 20 GiB. On a typical 470 GiB SD card, 10 GiB ≈ 2.1% free, which is well below the point at which ext4 free-block-group search starts thrashing and inflates per-write cost 10–100×, starving the watchdog daemon. 20 GiB ≈ 4.2% gives ext4 enough headroom to keep writes cheap.
   max_size_gb: 0                         # 0 = auto (use all available space minus reserved)
   only_driving: true                     # Only archive clips from active driving trips (skip idle/parked)
   path: ""                               # Archive path (default: ~/ArchivedClips, set by web app)

--- a/scripts/web/services/archive_worker.py
+++ b/scripts/web/services/archive_worker.py
@@ -70,7 +70,7 @@ import sys
 import threading
 import time
 import uuid
-from typing import Any, Callable, Deque, Dict, Optional
+from typing import Any, Callable, Deque, Dict, Optional, Tuple
 
 from services import archive_queue
 from services import task_coordinator
@@ -775,6 +775,7 @@ def _atomic_copy(source_path: str, dest_path: str,
                  chunk_size: int, *,
                  load_pause_threshold: float = 0.0,
                  chunk_pause_seconds: float = 0.25,
+                 chunk_pause_always: bool = False,
                  time_budget_seconds: float = 0.0,
                  now_fn: Callable[[], float] = time.monotonic,
                  sleep_fn: Callable[[float], None] = time.sleep) -> int:
@@ -787,11 +788,19 @@ def _atomic_copy(source_path: str, dest_path: str,
     Verifies the rendered size matches the source's stat() size; any
     mismatch raises ``OSError`` so the caller bumps attempts.
 
-    Mid-copy SDIO-contention safeguards (issue #104):
+    Mid-copy SDIO-contention safeguards (issue #104, extended in #109):
 
-    * If ``load_pause_threshold > 0``, between chunks sample
-      ``os.getloadavg()[0]`` and sleep ``chunk_pause_seconds`` when
-      it exceeds the threshold. The Pi Zero 2 W shares one SDIO
+    * If ``chunk_pause_always`` is True (issue #109 — disk fullness
+      ≥ 80%), sleep ``chunk_pause_seconds`` between EVERY chunk
+      regardless of current loadavg. At very high fullness ext4
+      thrashing makes every write slow; by the time loadavg crosses
+      ``load_pause_threshold`` the SDIO bus is already saturated.
+      Proactively yielding every chunk gives the userspace
+      ``watchdog`` daemon a reliable scheduling slot.
+    * Otherwise (``chunk_pause_always`` is False, the pre-#109
+      behavior): if ``load_pause_threshold > 0``, between chunks
+      sample ``os.getloadavg()[0]`` and sleep ``chunk_pause_seconds``
+      when it exceeds the threshold. The Pi Zero 2 W shares one SDIO
       controller between SD card and WiFi; sustained heavy archive
       I/O can starve the userspace ``watchdog`` daemon long enough
       to trigger the BCM2835 hardware watchdog (90s timeout). This
@@ -844,8 +853,13 @@ def _atomic_copy(source_path: str, dest_path: str,
                         f"copy exceeded {time_budget_seconds:.1f}s budget "
                         f"after {written}/{expected} bytes"
                     )
-                # Mid-copy load-aware backoff (issue #104 mitigation A).
-                if load_pause_threshold > 0:
+                # Mid-copy load-aware backoff (issue #104 mitigation A,
+                # extended by issue #109 mitigation #4 with always-apply
+                # mode at high disk fullness).
+                if chunk_pause_always:
+                    if chunk_pause_seconds > 0:
+                        sleep_fn(chunk_pause_seconds)
+                elif load_pause_threshold > 0:
                     try:
                         load1 = os.getloadavg()[0]
                     except (AttributeError, OSError):
@@ -1002,6 +1016,100 @@ def _resolve_disk_thresholds_mb() -> tuple:
         )
     except Exception:  # noqa: BLE001
         return (500, 100)
+
+
+# ---------------------------------------------------------------------------
+# Issue #109 — disk-fullness-adaptive throttling helpers
+# ---------------------------------------------------------------------------
+#
+# At very high disk fullness (95%+ on ext4) the free-block-group search
+# inflates per-write cost 10–100×, so the same 1-min loadavg represents
+# far more SDIO contention than it would at 50% disk. The post-#106
+# guards (load_pause_threshold + chunk_pause + per-file budget) are
+# calibrated against healthy disk performance — they pause/abort
+# correctly, but the in-flight copy can still hold the SDIO bus long
+# enough to starve the userspace ``watchdog`` daemon's 90 s ping
+# window before the next iteration's guard fires.
+#
+# These helpers scale the throttling MORE AGGRESSIVELY as fullness
+# climbs, so the worker pauses sooner AND every chunk yields some
+# SDIO time without waiting for load to spike.
+
+def _disk_fullness_pct(path: str) -> Optional[float]:
+    """Return ``used / total * 100`` for the filesystem at ``path``.
+
+    Returns ``None`` if the stat fails (transient filesystem hiccup,
+    path missing, etc.). Callers MUST treat ``None`` as "no adaptive
+    adjustment" so a stat failure can't accidentally lock the worker
+    out — the pre-#109 guards still apply.
+    """
+    try:
+        usage = shutil.disk_usage(path)
+    except OSError:
+        return None
+    if usage.total <= 0:
+        return None
+    return (usage.used / usage.total) * 100.0
+
+
+def _adaptive_load_threshold(base: float, fullness_pct: Optional[float]) -> float:
+    """Issue #109 mitigation #2 — scale ``load_pause_threshold`` down
+    by disk fullness.
+
+    The same loadavg of 4.0 is a very different situation at 50% disk
+    (healthy ext4, fast writes) vs 98% disk (ext4 thrashing, every
+    write 10–100× slower). At high fullness, pause sooner so a single
+    in-flight copy doesn't starve the watchdog daemon.
+
+    Returns ``base`` unchanged when:
+      * ``base <= 0`` (guard disabled by config),
+      * ``fullness_pct`` is ``None`` (stat failed),
+      * fullness is below 80% (healthy regime).
+
+    Otherwise subtracts 0.5 / 1.0 / 1.5 at 80 / 90 / 95% fullness and
+    floors at 1.0 — even a misconfigured low base can never fully
+    disable the guard.
+    """
+    if base <= 0 or fullness_pct is None:
+        return base
+    if fullness_pct >= 95.0:
+        return max(base - 1.5, 1.0)
+    if fullness_pct >= 90.0:
+        return max(base - 1.0, 1.0)
+    if fullness_pct >= 80.0:
+        return max(base - 0.5, 1.0)
+    return base
+
+
+def _adaptive_chunk_pause(
+        base: float, fullness_pct: Optional[float]) -> Tuple[float, bool]:
+    """Issue #109 mitigation #4 — scale ``chunk_pause_seconds`` and
+    flip its trigger to "always-apply" at high disk fullness.
+
+    Pre-#109 the per-chunk pause inside ``_atomic_copy`` only fires
+    when ``loadavg > load_pause_threshold``. At very high fullness the
+    damage is done by the time loadavg crosses; we need a proactive
+    pause that yields SDIO time on EVERY chunk regardless of current
+    load.
+
+    Returns ``(pause_seconds, always_apply)``:
+      * ``< 80%`` fullness or ``base <= 0`` or unknown fullness:
+        ``(base, False)`` — current behavior, gated on loadavg.
+      * ``80–95%`` fullness: ``(base, True)`` — same duration but
+        applied EVERY chunk (proactive yield).
+      * ``≥ 95%`` fullness: ``(base * 2, True)`` — doubled and
+        always-applied (heaviest yield).
+
+    Floors at 0.05 s when always-applied so a misconfigured 0.0 base
+    can't flat-out disable the proactive yield.
+    """
+    if base <= 0 or fullness_pct is None:
+        return (base, False)
+    if fullness_pct >= 95.0:
+        return (max(base * 2.0, 0.05), True)
+    if fullness_pct >= 80.0:
+        return (max(base, 0.05), True)
+    return (base, False)
 
 
 def _check_disk_space_guard(archive_root: str) -> str:
@@ -1305,6 +1413,13 @@ def process_one_claim(row: Dict[str, Any], db_path: str,
     safeguards. Defaults are conservative (off / 0.25 s / off) so
     callers that don't opt in get pre-#104 behavior.
 
+    Issue #109: the ``load_pause_threshold`` and ``chunk_pause_seconds``
+    actually forwarded to ``_atomic_copy`` are derived from the BASE
+    values via :func:`_adaptive_load_threshold` and
+    :func:`_adaptive_chunk_pause` so the throttling becomes more
+    aggressive as the SD card fills (less load tolerance, longer
+    always-applied chunk pauses at 80%+ fullness).
+
     Pure dispatch logic kept separate from the loop so tests can drive
     it directly without a thread or task_coordinator.
     """
@@ -1389,10 +1504,26 @@ def process_one_claim(row: Dict[str, Any], db_path: str,
         return 'error'
 
     try:
+        # Issue #109 — derive adaptive throttling values from current
+        # SD-card fullness. ``shutil.disk_usage`` is one syscall; cheap
+        # to do once per file. At 80%+ we raise the always-apply flag;
+        # at 95%+ we both raise the flag AND double the chunk pause.
+        # The forwarded ``load_pause_threshold`` is also lowered so
+        # later iterations of the worker loop (which re-reads it
+        # per iteration) pause sooner — but inside _atomic_copy the
+        # always-apply chunk pause supersedes the load-gated path.
+        _fullness = _disk_fullness_pct(archive_root)
+        _adaptive_load = _adaptive_load_threshold(
+            load_pause_threshold, _fullness,
+        )
+        _adaptive_pause, _pause_always = _adaptive_chunk_pause(
+            chunk_pause_seconds, _fullness,
+        )
         _atomic_copy(
             source_path, dest_path, chunk_size,
-            load_pause_threshold=load_pause_threshold,
-            chunk_pause_seconds=chunk_pause_seconds,
+            load_pause_threshold=_adaptive_load,
+            chunk_pause_seconds=_adaptive_pause,
+            chunk_pause_always=_pause_always,
             time_budget_seconds=time_budget_seconds,
         )
     except FileNotFoundError:
@@ -1523,7 +1654,13 @@ def _run_worker_loop(db_path: str, archive_root: str,
                 load1 = os.getloadavg()[0]
             except (AttributeError, OSError):
                 load1 = 0.0
-            if load1 > load_pause_threshold:
+            # Issue #109 — adapt the trigger threshold to current SD
+            # fullness BEFORE comparing. At 95%+ disk the same loadavg
+            # of 4.0 represents far more SDIO contention than at 50%.
+            _adaptive_threshold = _adaptive_load_threshold(
+                load_pause_threshold, _disk_fullness_pct(archive_root),
+            )
+            if load1 > _adaptive_threshold:
                 # Only log INFO on the leading edge of the pause
                 # window so back-to-back high-load iterations don't
                 # spam the journal. ``_load_pause_until`` is the
@@ -1542,9 +1679,11 @@ def _run_worker_loop(db_path: str, archive_root: str,
                         _state['last_load_pause_at'] = time.time()
                         _state['last_load_pause_loadavg'] = float(load1)
                     logger.info(
-                        "archive_worker: 1-min loadavg %.2f > %.2f — "
-                        "pausing %.0fs to relieve SDIO/CPU contention",
-                        load1, load_pause_threshold, load_pause_seconds,
+                        "archive_worker: 1-min loadavg %.2f > %.2f "
+                        "(adaptive; base=%.2f) — pausing %.0fs to "
+                        "relieve SDIO/CPU contention",
+                        load1, _adaptive_threshold, load_pause_threshold,
+                        load_pause_seconds,
                     )
                 _idle_event.set()
                 # Stop-only wait. Producers' wake() must NOT cut this
@@ -1557,9 +1696,9 @@ def _run_worker_loop(db_path: str, archive_root: str,
                 # Trailing edge: log once when we leave the pause
                 # window so the user can see "back to normal".
                 logger.info(
-                    "archive_worker: 1-min loadavg %.2f back below %.2f — "
-                    "resuming archive drain",
-                    load1, load_pause_threshold,
+                    "archive_worker: 1-min loadavg %.2f back below %.2f "
+                    "(adaptive; base=%.2f) — resuming archive drain",
+                    load1, _adaptive_threshold, load_pause_threshold,
                 )
                 _load_pause_until = 0.0
 

--- a/tests/test_archive_worker.py
+++ b/tests/test_archive_worker.py
@@ -1957,6 +1957,14 @@ class TestProcessOneClaimSdioSafeguards:
         self, db, archive_root, teslacam_root, make_clip, monkeypatch,
     ):
         # Capture the kwargs that process_one_claim passes through.
+        # Issue #109: pin disk_usage to a low-fullness fixture so the
+        # adaptive helpers added in #109 don't silently rescale the
+        # base values on a host whose real filesystem is ≥ 80% full.
+        # (Mirrors the pattern in TestProcessOneClaimAdaptiveWiring.)
+        monkeypatch.setattr(
+            archive_worker.shutil, 'disk_usage',
+            lambda p: _FakeDiskUsage(used_pct=50.0),
+        )
         clip = make_clip("RecentClips/forward-front.mp4")
         enqueue_for_archive(clip, db_path=db)
         captured: List[dict] = []
@@ -1985,6 +1993,9 @@ class TestProcessOneClaimSdioSafeguards:
         assert captured[0]['load_pause_threshold'] == 3.5
         assert captured[0]['chunk_pause_seconds'] == 0.25
         assert captured[0]['time_budget_seconds'] == 60.0
+        # Issue #109 — at <80% fullness, always-apply must be False
+        # so the load-gated path is preserved.
+        assert captured[0]['chunk_pause_always'] is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_archive_worker.py
+++ b/tests/test_archive_worker.py
@@ -2507,3 +2507,332 @@ class TestPauseStateExtensions:
                 assert archive_worker._state['last_disk_pause_total_mb'] is None
         finally:
             archive_worker.stop_worker(timeout=5)
+
+
+# ---------------------------------------------------------------------------
+# Issue #109 — disk-fullness-adaptive throttling helpers + integration
+# ---------------------------------------------------------------------------
+
+
+class _FakeDiskUsage:
+    """Mimic :func:`shutil.disk_usage` return value.
+
+    Default total is 100 GiB so even at 99% used the free space stays
+    well above the 100 MB ``disk_space_critical_mb`` guard floor.
+    """
+
+    def __init__(self, used_pct: float, total_bytes: int = 100 * 1024 * 1024 * 1024):
+        self.total = total_bytes
+        self.used = int(total_bytes * used_pct / 100.0)
+        self.free = total_bytes - self.used
+
+
+class TestDiskFullnessHelper:
+    """Issue #109 — ``_disk_fullness_pct`` returns used%-of-total or None."""
+
+    def test_returns_correct_percentage(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(
+            archive_worker.shutil, 'disk_usage',
+            lambda p: _FakeDiskUsage(used_pct=42.0),
+        )
+        assert archive_worker._disk_fullness_pct(str(tmp_path)) == pytest.approx(42.0)
+
+    def test_returns_none_on_oserror(self, monkeypatch, tmp_path):
+        def _raise(_p):
+            raise OSError("simulated stat failure")
+        monkeypatch.setattr(archive_worker.shutil, 'disk_usage', _raise)
+        assert archive_worker._disk_fullness_pct(str(tmp_path)) is None
+
+    def test_returns_none_on_zero_total(self, monkeypatch, tmp_path):
+        # Defensive — a degenerate disk_usage report mustn't divide by 0.
+        class _Zero:
+            total = 0
+            used = 0
+            free = 0
+        monkeypatch.setattr(
+            archive_worker.shutil, 'disk_usage', lambda p: _Zero(),
+        )
+        assert archive_worker._disk_fullness_pct(str(tmp_path)) is None
+
+
+class TestAdaptiveLoadThreshold:
+    """Issue #109 mitigation #2 — load_pause_threshold scales DOWN as
+    disk fills."""
+
+    def test_below_80_returns_base_unchanged(self):
+        assert archive_worker._adaptive_load_threshold(3.5, 50.0) == 3.5
+        assert archive_worker._adaptive_load_threshold(3.5, 79.9) == 3.5
+
+    def test_80_to_90_subtracts_half(self):
+        assert archive_worker._adaptive_load_threshold(3.5, 80.0) == 3.0
+        assert archive_worker._adaptive_load_threshold(3.5, 89.9) == 3.0
+
+    def test_90_to_95_subtracts_one(self):
+        assert archive_worker._adaptive_load_threshold(3.5, 90.0) == 2.5
+        assert archive_worker._adaptive_load_threshold(3.5, 94.9) == 2.5
+
+    def test_at_or_above_95_subtracts_one_and_a_half(self):
+        assert archive_worker._adaptive_load_threshold(3.5, 95.0) == 2.0
+        assert archive_worker._adaptive_load_threshold(3.5, 99.0) == 2.0
+        assert archive_worker._adaptive_load_threshold(3.5, 100.0) == 2.0
+
+    def test_floor_at_one_for_low_base(self):
+        # Misconfigured low base must never let the guard fully disable.
+        assert archive_worker._adaptive_load_threshold(1.5, 95.0) == 1.0
+        assert archive_worker._adaptive_load_threshold(2.0, 90.0) == 1.0
+        # base=2.5 at 90%: 2.5 - 1.0 = 1.5, no floor needed
+        assert archive_worker._adaptive_load_threshold(2.5, 90.0) == 1.5
+
+    def test_zero_base_disables_returns_zero(self):
+        assert archive_worker._adaptive_load_threshold(0.0, 95.0) == 0.0
+
+    def test_negative_base_returns_unchanged(self):
+        # Caller treats <=0 as "disabled", helper must not mangle it.
+        assert archive_worker._adaptive_load_threshold(-1.0, 95.0) == -1.0
+
+    def test_unknown_fullness_returns_base_unchanged(self):
+        assert archive_worker._adaptive_load_threshold(3.5, None) == 3.5
+
+
+class TestAdaptiveChunkPause:
+    """Issue #109 mitigation #4 — chunk_pause_seconds scales UP and
+    flips to always-apply at high disk fullness."""
+
+    def test_below_80_returns_base_and_load_gated(self):
+        # Pre-#109 behavior: unchanged duration, gated on loadavg.
+        pause, always = archive_worker._adaptive_chunk_pause(0.25, 50.0)
+        assert pause == 0.25
+        assert always is False
+
+    def test_80_to_95_keeps_duration_but_always_applies(self):
+        pause, always = archive_worker._adaptive_chunk_pause(0.25, 80.0)
+        assert pause == 0.25
+        assert always is True
+        pause, always = archive_worker._adaptive_chunk_pause(0.25, 94.9)
+        assert pause == 0.25
+        assert always is True
+
+    def test_at_or_above_95_doubles_duration_and_always_applies(self):
+        pause, always = archive_worker._adaptive_chunk_pause(0.25, 95.0)
+        assert pause == 0.5
+        assert always is True
+        pause, always = archive_worker._adaptive_chunk_pause(0.25, 99.0)
+        assert pause == 0.5
+        assert always is True
+
+    def test_zero_base_disables_at_all_fullness_levels(self):
+        # base==0 means user explicitly disabled the chunk pause —
+        # respect that even at 99% fullness.
+        pause, always = archive_worker._adaptive_chunk_pause(0.0, 99.0)
+        assert pause == 0.0
+        assert always is False
+
+    def test_floor_for_very_small_base_when_always_apply(self):
+        # 0.001 s base at 80% → max(0.001, 0.05) = 0.05
+        pause, always = archive_worker._adaptive_chunk_pause(0.001, 80.0)
+        assert pause == 0.05
+        assert always is True
+        # 0.001 s base at 95% → max(0.002, 0.05) = 0.05
+        pause, always = archive_worker._adaptive_chunk_pause(0.001, 95.0)
+        assert pause == 0.05
+        assert always is True
+
+    def test_unknown_fullness_returns_base_and_load_gated(self):
+        pause, always = archive_worker._adaptive_chunk_pause(0.25, None)
+        assert pause == 0.25
+        assert always is False
+
+
+class TestAtomicCopyChunkPauseAlways:
+    """Issue #109 mitigation #4 wired through ``_atomic_copy``: when
+    ``chunk_pause_always=True`` the per-chunk pause fires every chunk
+    regardless of current loadavg."""
+
+    def test_always_apply_sleeps_every_chunk(self, tmp_path):
+        # 32 KiB file copied in 8 KiB chunks → 4 chunks → 4 sleeps,
+        # regardless of loadavg (set to 0 here).
+        src = tmp_path / "src.bin"
+        src.write_bytes(b"x" * 32_768)
+        dst = tmp_path / "dst.bin"
+        sleeps: List[float] = []
+        archive_worker._atomic_copy(
+            str(src), str(dst), chunk_size=8192,
+            load_pause_threshold=0.0,
+            chunk_pause_seconds=0.5,
+            chunk_pause_always=True,
+            sleep_fn=lambda s: sleeps.append(s),
+        )
+        assert dst.read_bytes() == b"x" * 32_768
+        assert sleeps == [0.5, 0.5, 0.5, 0.5], (
+            "always_apply must sleep on every chunk"
+        )
+
+    def test_always_apply_skipped_when_pause_zero(self, tmp_path):
+        # If base pause is 0 even in always-apply mode, no sleep.
+        src = tmp_path / "src.bin"
+        src.write_bytes(b"y" * 16_384)
+        dst = tmp_path / "dst.bin"
+        sleeps: List[float] = []
+        archive_worker._atomic_copy(
+            str(src), str(dst), chunk_size=8192,
+            load_pause_threshold=0.0,
+            chunk_pause_seconds=0.0,
+            chunk_pause_always=True,
+            sleep_fn=lambda s: sleeps.append(s),
+        )
+        assert sleeps == []
+
+    def test_load_gated_path_unchanged_when_always_apply_false(self, tmp_path,
+                                                                monkeypatch):
+        # With chunk_pause_always=False, the pre-#109 load-gated path
+        # runs: sleep only when loadavg > load_pause_threshold.
+        # raising=False because Windows ``os`` lacks ``getloadavg``.
+        monkeypatch.setattr(
+            archive_worker.os, 'getloadavg',
+            lambda: (5.0, 0.0, 0.0), raising=False,
+        )
+        src = tmp_path / "src.bin"
+        src.write_bytes(b"z" * 16_384)
+        dst = tmp_path / "dst.bin"
+        sleeps: List[float] = []
+        archive_worker._atomic_copy(
+            str(src), str(dst), chunk_size=8192,
+            load_pause_threshold=3.5,
+            chunk_pause_seconds=0.25,
+            chunk_pause_always=False,
+            sleep_fn=lambda s: sleeps.append(s),
+        )
+        # 16384 / 8192 = 2 chunks → 2 sleeps because load 5.0 > 3.5.
+        assert sleeps == [0.25, 0.25]
+
+    def test_load_gated_path_skips_when_load_low(self, tmp_path, monkeypatch):
+        # Same as above but loadavg below threshold → no sleeps.
+        monkeypatch.setattr(
+            archive_worker.os, 'getloadavg',
+            lambda: (1.0, 0.0, 0.0), raising=False,
+        )
+        src = tmp_path / "src.bin"
+        src.write_bytes(b"q" * 16_384)
+        dst = tmp_path / "dst.bin"
+        sleeps: List[float] = []
+        archive_worker._atomic_copy(
+            str(src), str(dst), chunk_size=8192,
+            load_pause_threshold=3.5,
+            chunk_pause_seconds=0.25,
+            chunk_pause_always=False,
+            sleep_fn=lambda s: sleeps.append(s),
+        )
+        assert sleeps == []
+
+
+class TestProcessOneClaimAdaptiveWiring:
+    """Integration — process_one_claim derives adaptive values from
+    ``shutil.disk_usage`` and forwards them to ``_atomic_copy``."""
+
+    def test_high_fullness_enables_always_apply_chunk_pause(
+            self, monkeypatch, db, archive_root, tmp_path,
+    ):
+        # 95% disk fullness → adaptive chunk pause is doubled (0.5s)
+        # AND always-apply. Verify _atomic_copy is invoked with those
+        # values.
+        monkeypatch.setattr(
+            archive_worker.shutil, 'disk_usage',
+            lambda p: _FakeDiskUsage(used_pct=95.0),
+        )
+        captured: dict = {}
+
+        def _spy(*args, **kwargs):
+            captured.update(kwargs)
+            return 1024  # bytes written
+
+        monkeypatch.setattr(archive_worker, '_atomic_copy', _spy)
+        monkeypatch.setattr(
+            archive_worker, 'compute_dest_path',
+            lambda src, root, tcam: os.path.join(root, "dest.mp4"),
+        )
+        monkeypatch.setattr(
+            archive_worker.archive_queue, 'mark_copied',
+            lambda *a, **kw: None,
+        )
+        monkeypatch.setattr(
+            archive_worker, '_enqueue_indexed', lambda *a, **kw: None,
+        )
+
+        # Build a synthetic claimed row with fresh stable mtime so the
+        # stable-write gate doesn't preempt the copy.
+        src = tmp_path / "clip.mp4"
+        src.write_bytes(b"X" * 1024)
+        old_mtime = time.time() - 3600  # 1 hr old → past stable gate
+        os.utime(str(src), (old_mtime, old_mtime))
+
+        row = {
+            'id': 1,
+            'source_path': str(src),
+            'expected_size': 1024,
+            'expected_mtime': old_mtime,
+        }
+        outcome = archive_worker.process_one_claim(
+            row, db, archive_root, teslacam_root=None,
+            chunk_size=8192, max_attempts=3,
+            load_pause_threshold=3.5,
+            chunk_pause_seconds=0.25,
+            time_budget_seconds=0.0,
+        )
+        assert outcome == 'copied'
+        assert captured['chunk_pause_always'] is True, (
+            "95% fullness must enable always-apply"
+        )
+        assert captured['chunk_pause_seconds'] == 0.5, (
+            "95% fullness must double the chunk pause"
+        )
+        # adaptive load threshold = max(3.5 - 1.5, 1.0) = 2.0
+        assert captured['load_pause_threshold'] == 2.0
+
+    def test_low_fullness_preserves_pre_109_behavior(
+            self, monkeypatch, db, archive_root, tmp_path,
+    ):
+        monkeypatch.setattr(
+            archive_worker.shutil, 'disk_usage',
+            lambda p: _FakeDiskUsage(used_pct=50.0),
+        )
+        captured: dict = {}
+
+        def _spy(*args, **kwargs):
+            captured.update(kwargs)
+            return 1024
+
+        monkeypatch.setattr(archive_worker, '_atomic_copy', _spy)
+        monkeypatch.setattr(
+            archive_worker, 'compute_dest_path',
+            lambda src, root, tcam: os.path.join(root, "dest.mp4"),
+        )
+        monkeypatch.setattr(
+            archive_worker.archive_queue, 'mark_copied',
+            lambda *a, **kw: None,
+        )
+        monkeypatch.setattr(
+            archive_worker, '_enqueue_indexed', lambda *a, **kw: None,
+        )
+
+        src = tmp_path / "clip.mp4"
+        src.write_bytes(b"Y" * 1024)
+        old_mtime = time.time() - 3600
+        os.utime(str(src), (old_mtime, old_mtime))
+
+        row = {
+            'id': 1,
+            'source_path': str(src),
+            'expected_size': 1024,
+            'expected_mtime': old_mtime,
+        }
+        archive_worker.process_one_claim(
+            row, db, archive_root, teslacam_root=None,
+            chunk_size=8192, max_attempts=3,
+            load_pause_threshold=3.5,
+            chunk_pause_seconds=0.25,
+            time_budget_seconds=0.0,
+        )
+        # 50% fullness → no adaptive scaling.
+        assert captured['chunk_pause_always'] is False
+        assert captured['chunk_pause_seconds'] == 0.25
+        assert captured['load_pause_threshold'] == 3.5


### PR DESCRIPTION
## Root cause (forensic-confirmed in issue body)

At 95-99% disk fullness on ext4, the free-block-group search inflates per-write cost 10-100×. The post-#106 throttling guards (load-pause, per-chunk pause gated on load, per-file budget) all pause/abort correctly — the issue's forensic shows them firing 4× in 3 minutes — but the in-flight `_atomic_copy` can still hold the SDIO bus past the userspace `watchdog` daemon's 90 s ping window before the next iteration's guard gets a chance to fire. The result is the same hardware-watchdog reset signature as #104 (no OOM, no AP-toggle errors, lock-holds 100× over baseline).

## Fix — three mitigations from the issue

### Mitigation 1 — raise `archive.min_free_space_gb` 10 → 20

Smallest-blast-radius. On a 470 GiB SD card, 10 GiB ≈ 2.1% free which is well below the ext4 thrashing point; 20 GiB ≈ 4.2% gives ext4 enough free block groups to keep writes cheap. `config.yaml` change with an updated comment explaining the rationale.

### Mitigation 2 — adaptive `load_pause_threshold`

New helper `_adaptive_load_threshold(base, fullness_pct)` scales the configured threshold DOWN as fullness climbs, applied at BOTH the worker-loop between-files guard and the `_atomic_copy` mid-copy guard:

| Disk usage | Adaptive threshold (base 3.5) |
|------------|------------------------------|
| < 80% | 3.5 (unchanged) |
| 80–90% | 3.0 |
| 90–95% | 2.5 |
| ≥ 95% | 2.0 |

Floored at 1.0 so a misconfigured low base can never disable the guard.

### Mitigation 4 — adaptive `chunk_pause_seconds` with always-apply at high fullness

New helper `_adaptive_chunk_pause(base, fullness_pct)` returns `(seconds, always_apply)` and flips the per-chunk pause from "gated on loadavg" to "always apply" at ≥ 80% fullness, doubling the duration at ≥ 95%:

| Disk usage | Pause | Always apply? |
|------------|-------|---------------|
| < 80% | base (0.25 s) | gated on loadavg (current behavior) |
| 80–95% | base (0.25 s) | **always** (proactive) |
| ≥ 95% | base × 2 (0.5 s) | **always** (proactive) |

`_atomic_copy` learns a new `chunk_pause_always` keyword; when `True` the per-chunk pause runs unconditionally between every chunk, giving the SDIO bus and watchdog daemon a reliable scheduling slot even when the disk is thrashing.

## Mitigation 3 — intentionally deferred

Disk-fullness-aware retention (high-watermark prune at >90% disk) is intentionally **NOT** in this PR. It overlaps with #98 Phase 3a's planned Settings "Free-space target" slider; landing it twice would create two competing retention controls. This PR keeps the existing daily age-based retention; the high-watermark behavior belongs in #98.

## Tests (23 new)

- `TestDiskFullnessHelper` (3) — correct percentage, `OSError` returns `None`, zero-total guard.
- `TestAdaptiveLoadThreshold` (8) — every fullness band, floor enforcement, zero/negative base, unknown fullness.
- `TestAdaptiveChunkPause` (6) — every fullness band, zero base disables, very-small-base floor, unknown fullness.
- `TestAtomicCopyChunkPauseAlways` (4) — `_atomic_copy` sleep spy verifies always-apply triggers per-chunk; load-gated path unchanged when `always_apply=False`.
- `TestProcessOneClaimAdaptiveWiring` (2) — end-to-end through `process_one_claim` with a synthetic disk-usage at 50% and 95%; verifies the adaptive kwargs forwarded to `_atomic_copy`.

**1383 passed, 3 skipped** (was 1360 + 3).

## Production verification

Deployed to cybertruckusb.local (currently 86% disk usage). Adaptive helpers correctly engaged:

`
Disk fullness: 86.0%
Adaptive load threshold (base 3.5): 3.00
Adaptive chunk pause: 0.250s always_apply=True
`

Service active, NRestarts=0, HTTP 200, no errors in journal.

The acceptance-criteria 24 h test at 95%+ disk requires a synthetic ext4 thrash workload which can't be run in CI; field validation will be the next 24-48 h on the live device through the next sustained backlog catch-up.

## Refs

- #104 — original SDIO/watchdog reset failure mode (closed by #106)
- #106 — first-round mitigations (per-chunk pause, per-file budget, load-pause threshold)
- #98 — Phase 3a "Unify Retention" (HOLD) where mitigation #3 belongs
- `.github/copilot-instructions.md` — pitfalls section (do NOT remove these guards)

Closes #109

<!-- skill:resolve-issue:resolution:109 -->