### PR TITLE
Add Dismiss control to footage-lost banner (#163)

### DIFF
--- a/scripts/web/blueprints/system_health.py
+++ b/scripts/web/blueprints/system_health.py
@@ -34,7 +34,7 @@ import threading
 import time
 from typing import Any, Callable, Dict, Tuple
 
-from flask import Blueprint, jsonify
+from flask import Blueprint, jsonify, request
 
 from config import (
     ARCHIVE_QUEUE_ENABLED,
@@ -659,3 +659,56 @@ def api_system_health():
     endpoint MUST stay sub-100 ms in the cached path.
     """
     return jsonify(_build_health())
+
+
+@system_health_bp.route('/api/system/clear_lost_clips', methods=['POST'])
+def api_clear_lost_clips():
+    """Dismiss the home-page "Footage may have been lost" banner (#163).
+
+    The banner counts ``archive_queue`` rows with
+    ``status='source_gone'`` (clips Tesla rotated out of RecentClips
+    before the worker could copy them) within the trailing 24 h
+    window. The count self-clears once those rows age past 24 h, but
+    after a major catch-up backlog (post-crash, archive worker fell
+    badly behind) that takes a full 24 h of staring at the red banner.
+    This endpoint lets the operator acknowledge the loss and clear the
+    count immediately.
+
+    Request body (JSON, optional):
+      * ``older_than_hours`` (optional int) — if provided, only delete
+        rows whose ``claimed_at`` is older than that many hours;
+        otherwise delete every ``source_gone`` row. The Dismiss button
+        passes nothing (delete all).
+
+    Returns ``{rows_deleted}`` (HTTP 200) on success, ``{rows_deleted: 0}``
+    when the archive subsystem is disabled or no rows matched, or
+    ``{error}`` (HTTP 500) on adapter crash.
+
+    ``source_gone`` is terminal — no retry, no downstream consumer —
+    so this delete has zero functional impact on the worker, indexer,
+    cloud-sync, or any other subsystem; only the banner number
+    changes. Does NOT touch ``dead_letter`` / ``pending`` / ``claimed``
+    / ``copied`` rows.
+    """
+    if not ARCHIVE_QUEUE_ENABLED:
+        return jsonify({'rows_deleted': 0, 'enabled': False})
+
+    payload = request.get_json(silent=True) or {}
+    older_than_hours = payload.get('older_than_hours')
+    if older_than_hours is not None:
+        try:
+            older_than_hours = int(older_than_hours)
+        except (TypeError, ValueError):
+            return jsonify({
+                'error': 'older_than_hours must be an integer',
+            }), 400
+
+    try:
+        from services import archive_queue
+        n = int(archive_queue.delete_source_gone(
+            older_than_hours=older_than_hours) or 0)
+    except Exception:  # noqa: BLE001
+        logger.exception("/api/system/clear_lost_clips crashed")
+        return jsonify({'error': 'clear failed'}), 500
+
+    return jsonify({'rows_deleted': n})

--- a/scripts/web/services/archive_queue.py
+++ b/scripts/web/services/archive_queue.py
@@ -454,6 +454,68 @@ def count_source_gone_recent(hours: int = 24,
                 pass
 
 
+def delete_source_gone(*, older_than_hours: Optional[int] = None,
+                       db_path: Optional[str] = None) -> int:
+    """Permanently delete ``source_gone`` rows from ``archive_queue``.
+
+    Issue #163 — companion to :func:`count_source_gone_recent`. The
+    "Footage may have been lost" home-page banner counts these rows
+    and is intentionally persistent for 24 h so the operator notices
+    the loss; this function powers the **Dismiss** affordance on that
+    banner so the operator can clear the count once they've
+    acknowledged it (instead of staring at the red banner for a full
+    24 h after the catch-up backlog drains).
+
+    ``source_gone`` is **terminal** — the source clip vanished before
+    the worker could copy it; there is no retry path, no downstream
+    table consumes the row, and the worker never re-claims it.
+    Deleting these rows therefore has zero functional impact on the
+    archive worker, indexer, cloud-sync, or any other subsystem; only
+    the banner number changes.
+
+    When ``older_than_hours`` is ``None`` (the default — what the
+    Dismiss button passes), every ``source_gone`` row is deleted
+    regardless of age. Callers that want to preserve very old rows for
+    forensics can pass an integer to delete only rows older than that
+    many hours (mirrors the ``hours`` parameter of
+    :func:`count_source_gone_recent`).
+
+    Returns the number of rows actually deleted (``0`` if nothing
+    matched). Returns ``0`` on any DB error so a UI Dismiss click
+    never blows up the request handler.
+    """
+    db_path = _resolve_db_path(db_path)
+    conn = None
+    try:
+        conn = _open_archive_conn(db_path)
+        if older_than_hours is None:
+            cur = conn.execute(
+                "DELETE FROM archive_queue WHERE status = 'source_gone'"
+            )
+        else:
+            cur = conn.execute(
+                """
+                DELETE FROM archive_queue
+                 WHERE status = 'source_gone'
+                   AND claimed_at IS NOT NULL
+                   AND CAST(strftime('%s', claimed_at) AS INTEGER) <
+                       CAST(strftime('%s', 'now') AS INTEGER) - ?
+                """,
+                (int(older_than_hours) * 3600,),
+            )
+        conn.commit()
+        return cur.rowcount or 0
+    except sqlite3.Error as e:
+        logger.warning("delete_source_gone failed: %s", e)
+        return 0
+    finally:
+        if conn is not None:
+            try:
+                conn.close()
+            except sqlite3.Error:
+                pass
+
+
 def get_queue_status(db_path: Optional[str] = None) -> Dict[str, int]:
     """Return per-status counts for the queue.
 

--- a/scripts/web/templates/index.html
+++ b/scripts/web/templates/index.html
@@ -97,6 +97,15 @@
                   padding:0 10px;">
             Details
         </a>
+        <button id="files-lost-dismiss" type="button"
+                aria-label="Dismiss footage-lost banner"
+                style="background:transparent; color:inherit;
+                       border:1px solid currentColor; border-radius:6px;
+                       cursor:pointer; font-size:0.9rem;
+                       min-height:44px; min-width:44px;
+                       padding:0 12px;">
+            Dismiss
+        </button>
     </div>
 
     <!-- System Health (Phase 4.2 — issue #101) -->
@@ -1958,7 +1967,51 @@ if (document.getElementById('fsck-status-container')) {
     var lostBanner   = document.getElementById('files-lost-banner');
     var lostDetail   = document.getElementById('files-lost-detail');
     var lostLink     = document.getElementById('files-lost-link');
+    var lostDismiss  = document.getElementById('files-lost-dismiss');
     if (lostLink && jobsUrl) lostLink.href = jobsUrl;
+
+    if (lostDismiss) {
+        lostDismiss.addEventListener('click', function() {
+            // Issue #163 — let the operator acknowledge the banner.
+            // Posts to /api/system/clear_lost_clips which deletes
+            // every source_gone row; the banner re-polls and hides
+            // when the count returns to 0. ``source_gone`` is
+            // terminal and has no downstream consumer, so this
+            // affects only the banner number.
+            if (!window.confirm(
+                    'Dismiss the lost-footage banner?\n\n' +
+                    'This permanently deletes the records of clips ' +
+                    'Tesla rotated out before they could be archived. ' +
+                    'The footage itself is already gone — this only ' +
+                    'clears the count from the banner.')) {
+                return;
+            }
+            lostDismiss.disabled = true;
+            fetch('/api/system/clear_lost_clips', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: '{}'
+            })
+            .then(function(resp) {
+                if (!resp.ok) {
+                    throw new Error('HTTP ' + resp.status);
+                }
+                return resp.json();
+            })
+            .then(function() {
+                // Force an immediate health re-poll; the banner
+                // will hide itself when lost_24h drops to 0.
+                loadHealth();
+            })
+            .catch(function(e) {
+                console.warn('clear_lost_clips failed:', e);
+                window.alert('Could not dismiss banner: ' + e.message);
+            })
+            .finally(function() {
+                lostDismiss.disabled = false;
+            });
+        });
+    }
 
     function renderFilesLostBanner(payload) {
         if (!lostBanner) return;

--- a/tests/test_archive_queue.py
+++ b/tests/test_archive_queue.py
@@ -1043,6 +1043,126 @@ class TestCountSourceGoneRecent:
         assert archive_queue.count_source_gone_recent(24, db_path=db) == 0
 
 
+class TestDeleteSourceGone:
+    """Issue #163 — Dismiss button for the "Footage may have been lost"
+    home-page banner. The companion to ``count_source_gone_recent``;
+    deletes the rows the banner counts so the operator can clear the
+    24-h banner immediately instead of waiting for the rows to age out.
+    """
+
+    def _seed_source_gone(self, db, tmp_path, n):
+        """Insert ``n`` ``source_gone`` rows; return list of row ids."""
+        ids = []
+        for i in range(n):
+            f = tmp_path / f"sg_{i}.mp4"
+            f.write_text("x")
+            enqueue_for_archive(str(f), db_path=db)
+            row = claim_next_for_worker(f'w{i}', db_path=db)
+            mark_source_gone(row['id'], db_path=db)
+            ids.append(row['id'])
+        return ids
+
+    def test_returns_zero_when_table_empty(self, db):
+        assert archive_queue.delete_source_gone(db_path=db) == 0
+
+    def test_deletes_every_source_gone_row_by_default(self, db, tmp_path):
+        self._seed_source_gone(db, tmp_path, 5)
+        assert archive_queue.count_source_gone_recent(
+            24, db_path=db) == 5
+        assert archive_queue.delete_source_gone(db_path=db) == 5
+        assert archive_queue.count_source_gone_recent(
+            24, db_path=db) == 0
+        # And the rows are physically gone, not just status-changed.
+        with sqlite3.connect(db) as conn:
+            n = conn.execute(
+                "SELECT COUNT(*) FROM archive_queue "
+                "WHERE status = 'source_gone'"
+            ).fetchone()[0]
+        assert n == 0
+
+    def test_preserves_non_source_gone_rows(self, db, tmp_path):
+        # 3 source_gone + 1 pending + 1 copied + 1 dead_letter.
+        self._seed_source_gone(db, tmp_path, 3)
+
+        f_pending = tmp_path / "pending.mp4"
+        f_pending.write_text("x")
+        enqueue_for_archive(str(f_pending), db_path=db)
+
+        f_copied = tmp_path / "copied.mp4"
+        f_copied.write_text("x")
+        enqueue_for_archive(str(f_copied), db_path=db)
+        r_copied = claim_next_for_worker('w_copied', db_path=db)
+        archive_queue.mark_copied(
+            r_copied['id'], '/tmp/copied.mp4', db_path=db)
+
+        f_dl = tmp_path / "dl.mp4"
+        f_dl.write_text("x")
+        enqueue_for_archive(str(f_dl), db_path=db)
+        r_dl = claim_next_for_worker('w_dl', db_path=db)
+        with sqlite3.connect(db) as c:
+            c.execute(
+                "UPDATE archive_queue SET attempts = 99 WHERE id = ?",
+                (r_dl['id'],),
+            )
+        mark_failed(r_dl['id'], 'simulated', db_path=db)
+
+        # Sanity: 3 source_gone, 1 pending, 1 copied, 1 dead_letter.
+        counts = archive_queue.get_queue_status(db_path=db)
+        assert counts['source_gone'] == 3
+        assert counts['pending'] == 1
+        assert counts['copied'] == 1
+        assert counts['dead_letter'] == 1
+
+        # Delete just the source_gone rows.
+        assert archive_queue.delete_source_gone(db_path=db) == 3
+
+        counts_after = archive_queue.get_queue_status(db_path=db)
+        assert counts_after['source_gone'] == 0
+        assert counts_after['pending'] == 1
+        assert counts_after['copied'] == 1
+        assert counts_after['dead_letter'] == 1
+
+    def test_older_than_hours_keeps_recent(self, db, tmp_path):
+        # 2 source_gone rows: one fresh, one backdated 48 h.
+        ids = self._seed_source_gone(db, tmp_path, 2)
+        with sqlite3.connect(db) as conn:
+            conn.execute(
+                "UPDATE archive_queue SET claimed_at = "
+                "datetime('now', '-48 hours') WHERE id = ?",
+                (ids[0],),
+            )
+            conn.commit()
+
+        # older_than_hours=24 should delete only the 48 h-old row.
+        assert archive_queue.delete_source_gone(
+            older_than_hours=24, db_path=db) == 1
+
+        # The recent row survives and is still counted.
+        assert archive_queue.count_source_gone_recent(
+            24, db_path=db) == 1
+        with sqlite3.connect(db) as conn:
+            remaining = conn.execute(
+                "SELECT id FROM archive_queue "
+                "WHERE status = 'source_gone'"
+            ).fetchall()
+        assert len(remaining) == 1
+        assert remaining[0][0] == ids[1]
+
+    def test_returns_zero_on_db_failure(self, db, monkeypatch):
+        def boom(*a, **kw):
+            raise sqlite3.OperationalError("disk I/O error")
+        monkeypatch.setattr(archive_queue, '_open_archive_conn', boom)
+        # Must never raise — Dismiss click on a broken DB just returns
+        # 0 rather than 500-ing the request.
+        assert archive_queue.delete_source_gone(db_path=db) == 0
+
+    def test_idempotent_second_call_returns_zero(self, db, tmp_path):
+        self._seed_source_gone(db, tmp_path, 2)
+        assert archive_queue.delete_source_gone(db_path=db) == 2
+        # Banner is now 0; clicking Dismiss again must be safe.
+        assert archive_queue.delete_source_gone(db_path=db) == 0
+
+
 class TestReleaseClaim:
     def test_returns_to_pending_without_metadata(self, db, sample_file):
         enqueue_for_archive(sample_file, db_path=db)

--- a/tests/test_system_health_blueprint.py
+++ b/tests/test_system_health_blueprint.py
@@ -1138,3 +1138,110 @@ def test_api_returns_json_payload(health_app, monkeypatch):
     assert 'generated_at' in body
     assert body['overall']['severity'] == 'ok'
     assert body['indexer']['severity'] == 'ok'
+
+
+# ---------------------------------------------------------------------------
+# /api/system/clear_lost_clips — issue #163 dismiss banner endpoint
+# ---------------------------------------------------------------------------
+
+def test_clear_lost_clips_disabled_returns_zero(health_app, monkeypatch):
+    """When ``ARCHIVE_QUEUE_ENABLED`` is False the endpoint must
+    short-circuit and never even import the queue module."""
+    import blueprints.system_health as sh
+    monkeypatch.setattr(sh, 'ARCHIVE_QUEUE_ENABLED', False)
+    client = health_app.test_client()
+    rv = client.post('/api/system/clear_lost_clips', json={})
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body['rows_deleted'] == 0
+    assert body['enabled'] is False
+
+
+def test_clear_lost_clips_calls_service(health_app, monkeypatch):
+    import blueprints.system_health as sh
+    import services
+    monkeypatch.setattr(sh, 'ARCHIVE_QUEUE_ENABLED', True)
+    captured = {}
+
+    class _FakeArchiveQueue:
+        @staticmethod
+        def delete_source_gone(*, older_than_hours=None, db_path=None):
+            captured['older_than_hours'] = older_than_hours
+            return 7
+
+    monkeypatch.setattr(services, 'archive_queue', _FakeArchiveQueue)
+    client = health_app.test_client()
+    rv = client.post('/api/system/clear_lost_clips', json={})
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body['rows_deleted'] == 7
+    assert captured['older_than_hours'] is None
+
+
+def test_clear_lost_clips_passes_older_than_hours(health_app, monkeypatch):
+    import blueprints.system_health as sh
+    import services
+    monkeypatch.setattr(sh, 'ARCHIVE_QUEUE_ENABLED', True)
+    captured = {}
+
+    class _FakeArchiveQueue:
+        @staticmethod
+        def delete_source_gone(*, older_than_hours=None, db_path=None):
+            captured['older_than_hours'] = older_than_hours
+            return 3
+
+    monkeypatch.setattr(services, 'archive_queue', _FakeArchiveQueue)
+    client = health_app.test_client()
+    rv = client.post(
+        '/api/system/clear_lost_clips', json={'older_than_hours': 48})
+    assert rv.status_code == 200
+    assert rv.get_json()['rows_deleted'] == 3
+    assert captured['older_than_hours'] == 48
+
+
+def test_clear_lost_clips_rejects_non_integer_hours(health_app, monkeypatch):
+    import blueprints.system_health as sh
+    monkeypatch.setattr(sh, 'ARCHIVE_QUEUE_ENABLED', True)
+    client = health_app.test_client()
+    rv = client.post(
+        '/api/system/clear_lost_clips',
+        json={'older_than_hours': 'forever'})
+    assert rv.status_code == 400
+    assert 'error' in rv.get_json()
+
+
+def test_clear_lost_clips_handles_service_crash(health_app, monkeypatch):
+    import blueprints.system_health as sh
+    import services
+    monkeypatch.setattr(sh, 'ARCHIVE_QUEUE_ENABLED', True)
+
+    class _Boom:
+        @staticmethod
+        def delete_source_gone(*, older_than_hours=None, db_path=None):
+            raise RuntimeError("disk on fire")
+
+    monkeypatch.setattr(services, 'archive_queue', _Boom)
+    client = health_app.test_client()
+    rv = client.post('/api/system/clear_lost_clips', json={})
+    assert rv.status_code == 500
+    assert 'error' in rv.get_json()
+
+
+def test_clear_lost_clips_accepts_empty_body(health_app, monkeypatch):
+    """The Dismiss button POSTs ``{}`` — and a missing/empty body
+    must also work (some HTTP clients send neither Content-Type nor
+    body for a no-arg POST)."""
+    import blueprints.system_health as sh
+    import services
+    monkeypatch.setattr(sh, 'ARCHIVE_QUEUE_ENABLED', True)
+
+    class _FakeArchiveQueue:
+        @staticmethod
+        def delete_source_gone(*, older_than_hours=None, db_path=None):
+            return 0
+
+    monkeypatch.setattr(services, 'archive_queue', _FakeArchiveQueue)
+    client = health_app.test_client()
+    rv = client.post('/api/system/clear_lost_clips')
+    assert rv.status_code == 200
+    assert rv.get_json()['rows_deleted'] == 0


### PR DESCRIPTION
## Summary

Adds a **Dismiss** button to the home-page "Footage may have been lost" banner so the operator can clear the 24 h count immediately after acknowledging a catch-up backlog (e.g., the May-13 crash that left 3544 lost clips). Failed Jobs "Delete all" only touches `dead_letter` rows, not `source_gone`, so it does not clear this banner — confirmed by direct user observation post-#162.

Closes #163.

## Changes

### Service layer (`scripts/web/services/archive_queue.py`)
- New `delete_source_gone(older_than_hours=None, db_path=None) -> int`:
  - `older_than_hours=None` (default) → DELETE every `status='source_gone'` row.
  - integer → DELETE only rows whose `claimed_at` is strictly older than N hours (mirrors `count_source_gone_recent`'s age filter).
- Returns rowcount; returns 0 on any `sqlite3.Error` so a UI Dismiss click never blows up the request handler.

### Route layer (`scripts/web/blueprints/system_health.py`)
- New `POST /api/system/clear_lost_clips`:
  - Body: `{}` or `{"older_than_hours": int}`.
  - Validates non-integer hours → 400.
  - Archive subsystem disabled → `{rows_deleted: 0, enabled: false}`.
  - Service crash → 500 with `{error}`.
  - Otherwise returns `{rows_deleted}`.

### UI (`scripts/web/templates/index.html`)
- Adds a "Dismiss" button next to the existing "Details" link in `#files-lost-banner`.
- `confirm()` dialog explains the underlying records are deleted (the footage itself is already gone — this only clears the count).
- POSTs to the new endpoint, then forces an immediate health re-poll. Banner auto-hides when `lost_24h` drops to 0.
- Surfaces fetch errors via `window.alert` (no toast helper exists on this page).
- Button uses 44×44 min target, transparent background with 1px border in current colour (consistent with banner style).

### Tests
- **+6** in `tests/test_archive_queue.py` (`TestDeleteSourceGone`): empty/default/preserves-other-statuses/age-scope/db-failure/idempotent.
- **+6** in `tests/test_system_health_blueprint.py`: disabled/calls-service/forwards-hours/400-on-bad-input/500-on-crash/empty-body.
- **Suite: 1447 passed, 3 skipped (was 1435; +12 new).**

## Why `source_gone` is safe to delete

`source_gone` is a terminal status. The worker never re-claims these rows; nothing downstream consumes them; their entire purpose is to feed the `count_source_gone_recent` health-card counter. Deleting them changes only the banner number — no functional impact on the worker, indexer, cloud-sync, LES, or any other subsystem. Does NOT touch `dead_letter` / `pending` / `claimed` / `copied` rows.

## Out of scope

- Per-row dismiss (the banner doesn't list individual rows).
- Suppress-for-N-hours mute (just delete; if Tesla rotates more clips out the next hour, the new `source_gone` rows correctly re-show the banner with fresh data).
- Bulk-clearing other terminal statuses (separate concerns; `dead_letter` already has #162's per-row + Delete-all UI on Failed Jobs).

## Deploy plan

After merge:
1. Wait for Pi `/proc/loadavg` 1-min < 2.5 (per `.github/copilot-instructions.md` SDIO crash mitigation).
2. `scp` 3 files: `archive_queue.py`, `system_health.py`, `index.html`.
3. `sudo systemctl restart gadget_web.service`.
4. Smoke: home page shows banner with current count → click Dismiss → confirm → banner disappears.

<!-- skill:resolve-issue:163 -->
