### PR TITLE
feat(#167): one-shot reclaim for stationary RecentClips

### DIFF
--- a/scripts/web/blueprints/storage_retention.py
+++ b/scripts/web/blueprints/storage_retention.py
@@ -8,6 +8,9 @@ JSON endpoints for:
 * ``POST /api/cleanup/run_now``  — trigger an immediate retention pass
   (one-line wrapper for ``services.video_archive_service.trigger_archive_cleanup``,
   which itself wraps ``archive_watchdog.force_prune_now``).
+* ``POST /api/cleanup/reclaim_stationary_recent`` — issue #167: delete
+  already-archived RecentClips with no GPS movement (one-shot reclaim
+  that complements the daily retention prune).
 * ``GET  /api/cleanup/status``   — return the latest retention summary
   (last-run timestamp, deleted count, freed bytes, kept-unsynced count,
   next-due timestamp, current resolved retention days, and the
@@ -415,6 +418,78 @@ def api_cleanup_run_now():
         return jsonify({
             'success': False,
             'message': f"Cleanup failed: {exc}",
+        }), 500
+
+    if isinstance(result, dict) and result.get('error'):
+        return jsonify({
+            'success': False,
+            'message': str(result.get('error')),
+            'result': result,
+        }), 500
+
+    return jsonify({
+        'success': True,
+        'result': result if isinstance(result, dict) else {},
+    }), 200
+
+
+@storage_retention_bp.route('/api/cleanup/reclaim_stationary_recent',
+                             methods=['POST'])
+def api_reclaim_stationary_recent():
+    """Issue #167 — delete already-archived stationary RecentClips.
+
+    The archive worker copies every RecentClips clip to the SD card
+    without filtering. The indexer downstream classifies clips as
+    stationary (``waypoint_count = 0``) but nothing acts on that
+    classification, so SD-card RecentClips storage grows unbounded
+    with worthless overnight Sentry-mode-while-parked footage.
+
+    This endpoint deletes those clips synchronously. Each delete
+    routes through ``safe_delete_archive_video`` (protected-file
+    guard) and ``purge_deleted_videos`` (geodata reconciliation —
+    trips/waypoints/events preserved). Files newer than ``min_age_hours``
+    are kept; clips with a SentryClips/SavedClips counterpart with the
+    same basename are kept (event copies are user-meaningful).
+
+    Request body (JSON, optional)::
+
+        {"min_age_hours": int}   # default 1
+
+    Returns the watchdog summary on success::
+
+        {"success": true,
+         "result": {"deleted_count": N, "freed_bytes": M, ...}}
+
+    Same HTTP contract as ``/api/cleanup/run_now``: 200 on success
+    (including ``status='already_running'``), 500 on adapter crash.
+    """
+    payload: Dict[str, Any] = {}
+    if request.is_json:
+        payload = request.get_json(silent=True) or {}
+
+    raw_age = payload.get('min_age_hours')
+    if raw_age is None:
+        min_age_hours = 1
+    else:
+        try:
+            min_age_hours = int(raw_age)
+        except (TypeError, ValueError):
+            return jsonify({
+                'success': False,
+                'message': 'min_age_hours must be an integer',
+            }), 400
+        if min_age_hours < 0:
+            min_age_hours = 0
+
+    try:
+        from services.archive_watchdog import reclaim_stationary_recent_clips
+        result = reclaim_stationary_recent_clips(min_age_hours=min_age_hours)
+    except Exception as exc:  # noqa: BLE001
+        logger.exception(
+            "storage_retention: reclaim_stationary_recent_clips raised")
+        return jsonify({
+            'success': False,
+            'message': f"Reclaim failed: {exc}",
         }), 500
 
     if isinstance(result, dict) and result.get('error'):

--- a/scripts/web/blueprints/storage_retention.py
+++ b/scripts/web/blueprints/storage_retention.py
@@ -471,6 +471,15 @@ def api_reclaim_stationary_recent():
     if raw_age is None:
         min_age_hours = 1
     else:
+        # bool is a subclass of int in Python — reject explicitly so
+        # ``{"min_age_hours": true}`` doesn't silently coerce to 1
+        # (and ``false`` to 0, i.e. "delete every age"). Honors the
+        # documented "non-integer -> 400" contract.
+        if isinstance(raw_age, bool):
+            return jsonify({
+                'success': False,
+                'message': 'min_age_hours must be an integer',
+            }), 400
         try:
             min_age_hours = int(raw_age)
         except (TypeError, ValueError):

--- a/scripts/web/services/archive_watchdog.py
+++ b/scripts/web/services/archive_watchdog.py
@@ -953,7 +953,22 @@ def reclaim_stationary_recent_clips(*,
         {'deleted_count': N, 'freed_bytes': M, 'scanned': K,
          'kept_too_new': T, 'kept_has_event_counterpart': E,
          'kept_unindexed': U, 'kept_has_gps': G,
+         'kept_has_event_only': V,
          'duration_seconds': S}
+
+    Bucket semantics:
+
+    * ``kept_has_gps`` — clip has GPS waypoints (``waypoint_count > 0``).
+      Driving footage; keep.
+    * ``kept_has_event_only`` — clip has detected events but no GPS
+      (``waypoint_count = 0 AND event_count > 0``). Stationary
+      Sentry-mode footage Tesla flagged as an event; keep.
+    * ``kept_unindexed`` — indexer hasn't seen the clip yet; keep
+      until it has.
+    * ``kept_has_event_counterpart`` — stationary clip that ALSO
+      exists under SentryClips/SavedClips with the same basename;
+      keep so the user-meaningful event copy is never the only one.
+    * ``kept_too_new`` — clip mtime is newer than ``min_age_hours``.
 
     On any error (missing args, watchdog never started, ``acquire_task``
     timeout) returns the same dict with the relevant ``error`` /
@@ -969,6 +984,7 @@ def reclaim_stationary_recent_clips(*,
         'kept_has_event_counterpart': 0,
         'kept_unindexed': 0,
         'kept_has_gps': 0,
+        'kept_has_event_only': 0,
         'min_age_hours': int(min_age_hours),
         'duration_seconds': 0.0,
     }
@@ -1026,23 +1042,42 @@ def reclaim_stationary_recent_clips(*,
             return summary
 
         try:
-            stationary_paths = _collect_stationary_recent_clips(
-                db_path, archive_root,
+            stationary_set = _collect_indexed_recent_paths(
+                db_path, archive_root, stationary_only=True,
             )
-            stationary_set = {p for p, _meta in stationary_paths}
+            indexed_set = _collect_indexed_recent_paths(
+                db_path, archive_root, stationary_only=False,
+            )
+            event_only_set = _collect_indexed_recent_paths(
+                db_path, archive_root,
+                stationary_only=False, event_only=True,
+            )
             event_basenames = _collect_event_basenames(archive_root)
 
-            for path, mtime, _size in _iter_archive_mp4_files(recent_root):
+            for raw_path, mtime, _size in _iter_archive_mp4_files(
+                recent_root,
+            ):
                 summary['scanned'] += 1
                 if mtime > cutoff_mtime:
                     summary['kept_too_new'] += 1
                     continue
+                # Realpath both sides of the membership check so a
+                # symlinked archive_root (e.g. /mnt/sdcard/archives ->
+                # /home/pi/ArchivedClips) doesn't silently no-op.
+                # On the production Pi neither path is symlinked so
+                # realpath is a cheap stat. Fall back to raw path on
+                # OSError so a transient stat failure doesn't crash
+                # the whole pass.
+                try:
+                    path = os.path.realpath(raw_path)
+                except OSError:
+                    path = raw_path
                 if path not in stationary_set:
-                    # Either the indexer hasn't seen it yet, or it has
-                    # GPS waypoints / events. Either way: don't touch.
-                    # We can tell the two apart cheaply by checking the
-                    # ``indexed_files`` row presence.
-                    if _is_indexed(db_path, path):
+                    if path in event_only_set:
+                        # Indexed, no GPS, but Tesla flagged it as an
+                        # event (e.g. Sentry trigger while parked).
+                        summary['kept_has_event_only'] += 1
+                    elif path in indexed_set:
                         summary['kept_has_gps'] += 1
                     else:
                         summary['kept_unindexed'] += 1
@@ -1069,41 +1104,63 @@ def reclaim_stationary_recent_clips(*,
     logger.info(
         "reclaim_stationary: done — deleted=%d, freed_bytes=%d, "
         "scanned=%d, kept_too_new=%d, kept_event_counterpart=%d, "
-        "kept_unindexed=%d, kept_has_gps=%d, duration=%.2fs",
+        "kept_unindexed=%d, kept_has_gps=%d, kept_has_event_only=%d, "
+        "duration=%.2fs",
         summary['deleted_count'], summary['freed_bytes'],
         summary['scanned'], summary['kept_too_new'],
         summary['kept_has_event_counterpart'],
         summary['kept_unindexed'], summary['kept_has_gps'],
+        summary['kept_has_event_only'],
         summary['duration_seconds'],
     )
     return summary
 
 
-def _collect_stationary_recent_clips(db_path: str,
-                                     archive_root: str,
-                                     ) -> list:
-    """Return a list of ``(abs_path, indexed_meta)`` for every indexed
-    RecentClips clip the indexer classified as stationary
-    (``waypoint_count = 0`` AND ``event_count = 0``).
+def _collect_indexed_recent_paths(db_path: str,
+                                  archive_root: str,
+                                  *,
+                                  stationary_only: bool = False,
+                                  event_only: bool = False,
+                                  ) -> set:
+    """Return the set of realpath'd RecentClips paths in
+    ``indexed_files`` matching the requested classification.
 
-    Reads ``indexed_files`` once, filters paths in Python rather than
-    via a SQL ``LIKE`` so it works across path-separator quirks
-    (Windows tests, edge cases). Returns an empty list on any DB
-    error.
+    One SELECT, filter in Python (the SQL ``LIKE`` over a
+    ``%/RecentClips/%`` literal is buggy on Windows path separators
+    and brittle if Tesla ever changes the folder name). Realpath is
+    applied so callers can use ``in`` for membership against the
+    realpath'd path the worker loop will produce.
+
+    * ``stationary_only=True`` keeps only rows where
+      ``waypoint_count = 0 AND event_count = 0`` (the deletion
+      candidates).
+    * ``event_only=True`` keeps only rows where
+      ``waypoint_count = 0 AND event_count > 0`` (stationary clips
+      Tesla flagged as events). Used for the
+      ``kept_has_event_only`` bucket.
+    * Both False = every RecentClips row regardless of classification
+      (used for the ``kept_has_gps`` vs ``kept_unindexed`` distinction).
+
+    Returns an empty set on any DB error.
     """
-    out = []
+    out: set = set()
     if not db_path or not os.path.isfile(db_path):
         return out
     recent_root_norm = os.path.realpath(
         os.path.join(archive_root, 'RecentClips')
     ) + os.sep
+    if stationary_only:
+        where = "WHERE waypoint_count = 0 AND event_count = 0"
+    elif event_only:
+        where = "WHERE waypoint_count = 0 AND event_count > 0"
+    else:
+        where = ""
     conn = None
     try:
         conn = sqlite3.connect(f'file:{db_path}?mode=ro', uri=True,
                                timeout=5.0)
         for row in conn.execute(
-            "SELECT file_path, file_size FROM indexed_files "
-            "WHERE waypoint_count = 0 AND event_count = 0"
+            f"SELECT file_path FROM indexed_files {where}"
         ):
             file_path = row[0] or ''
             try:
@@ -1112,9 +1169,13 @@ def _collect_stationary_recent_clips(db_path: str,
                 continue
             if not resolved.startswith(recent_root_norm):
                 continue
-            out.append((resolved, {'file_size': row[1]}))
+            out.add(resolved)
     except sqlite3.Error as e:
-        logger.warning("reclaim_stationary: stationary lookup failed: %s", e)
+        logger.warning(
+            "reclaim_stationary: indexed-paths lookup failed "
+            "(stationary_only=%s, event_only=%s): %s",
+            stationary_only, event_only, e,
+        )
     finally:
         if conn is not None:
             try:
@@ -1151,29 +1212,6 @@ def _collect_event_basenames(archive_root: str) -> set:
                 if fn.lower().endswith('.mp4'):
                     out.add(fn)
     return out
-
-
-def _is_indexed(db_path: str, file_path: str) -> bool:
-    """Return True iff ``indexed_files`` has a row for ``file_path``."""
-    if not db_path or not os.path.isfile(db_path):
-        return False
-    conn = None
-    try:
-        conn = sqlite3.connect(f'file:{db_path}?mode=ro', uri=True,
-                               timeout=2.0)
-        row = conn.execute(
-            "SELECT 1 FROM indexed_files WHERE file_path = ? LIMIT 1",
-            (file_path,),
-        ).fetchone()
-        return row is not None
-    except sqlite3.Error:
-        return False
-    finally:
-        if conn is not None:
-            try:
-                conn.close()
-            except sqlite3.Error:
-                pass
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/web/services/archive_watchdog.py
+++ b/scripts/web/services/archive_watchdog.py
@@ -901,6 +901,281 @@ def force_prune_now() -> Dict[str, Any]:
     return summary
 
 
+def reclaim_stationary_recent_clips(*,
+                                    db_path: Optional[str] = None,
+                                    archive_root: Optional[str] = None,
+                                    min_age_hours: int = 1,
+                                    ) -> Dict[str, Any]:
+    """Issue #167 — delete already-archived stationary RecentClips.
+
+    Walks ``<archive_root>/RecentClips/*.mp4`` and deletes every clip
+    that the indexer classified as stationary (``waypoint_count = 0``
+    AND ``event_count = 0`` in ``indexed_files``) AND has no
+    SentryClips / SavedClips counterpart with the same basename. The
+    counterpart check protects user-meaningful events: Tesla writes
+    the same clip into both ``RecentClips/`` (rolling buffer) and the
+    event subfolder when an event triggers, and we should never delete
+    the only copy of a saved-event clip.
+
+    Why this is safe to ship behind a single button (no per-file
+    confirm):
+
+    * Routes every delete through
+      :func:`services.file_safety.safe_delete_archive_video` — the
+      single doorway that enforces the ``*.img`` / protected-file
+      guard.
+    * Reconciles geodata via
+      :func:`mapping_service.purge_deleted_videos` for each deleted
+      clip, which only deletes the orphan ``indexed_files`` row and
+      NULLs ``waypoints.video_path`` / ``detected_events.video_path``.
+      The "trips are sacred" invariant is preserved.
+    * Refuses to delete files newer than ``min_age_hours`` (default
+      1 h) so a clip Tesla just wrote and the indexer hasn't seen yet
+      can't be preemptively wiped.
+    * Holds the ``task_coordinator`` 'retention' slot for the
+      duration so the archive worker yields cleanly. Releases the
+      slot before returning.
+    * Single-flight: re-uses the same ``_retention_running`` guard as
+      the daily prune, so a stacked Settings click can't pile up two
+      reclaim passes.
+
+    Caller args (both optional — startup state is the default):
+
+    * ``db_path``: path to ``geodata.db``. Defaults to the value
+      ``start_watchdog`` was called with.
+    * ``archive_root``: SD-card archive root. Defaults to the value
+      ``start_watchdog`` was called with.
+    * ``min_age_hours``: don't touch files younger than this. Default
+      1 h. Set to 0 ONLY for testing.
+
+    Returns a summary dict::
+
+        {'deleted_count': N, 'freed_bytes': M, 'scanned': K,
+         'kept_too_new': T, 'kept_has_event_counterpart': E,
+         'kept_unindexed': U, 'kept_has_gps': G,
+         'duration_seconds': S}
+
+    On any error (missing args, watchdog never started, ``acquire_task``
+    timeout) returns the same dict with the relevant ``error`` /
+    ``status`` field populated; never raises.
+    """
+    global _retention_running
+    started = time.time()
+    summary: Dict[str, Any] = {
+        'deleted_count': 0,
+        'freed_bytes': 0,
+        'scanned': 0,
+        'kept_too_new': 0,
+        'kept_has_event_counterpart': 0,
+        'kept_unindexed': 0,
+        'kept_has_gps': 0,
+        'min_age_hours': int(min_age_hours),
+        'duration_seconds': 0.0,
+    }
+
+    if db_path is None or archive_root is None:
+        with _state_lock:
+            if db_path is None:
+                db_path = _db_path
+            if archive_root is None:
+                archive_root = _archive_root
+    if not archive_root or not db_path:
+        summary['error'] = 'watchdog not started'
+        summary['duration_seconds'] = round(time.time() - started, 3)
+        return summary
+
+    # Issue #91 — single-flight guard. Same flag as the periodic prune
+    # so a stacked "Run cleanup now" + "Reclaim stationary" + watchdog
+    # tick can't pile up. Set BEFORE acquire_task so the second caller
+    # short-circuits even if the first is still queued on the slot.
+    # Checked before the missing-RecentClips early-return so a stacked
+    # call still sees the in-flight status (the test contract — a
+    # second call should never silently no-op).
+    with _state_lock:
+        if _retention_running:
+            summary['status'] = 'already_running'
+            summary['duration_seconds'] = round(time.time() - started, 3)
+            logger.info(
+                "reclaim_stationary: skipped — another prune is already "
+                "in flight (returning status='already_running')"
+            )
+            return summary
+        _retention_running = True
+
+    recent_root = os.path.join(archive_root, 'RecentClips')
+    if not os.path.isdir(recent_root):
+        with _state_lock:
+            _retention_running = False
+        summary['duration_seconds'] = round(time.time() - started, 3)
+        return summary
+
+    cutoff_mtime = started - (max(int(min_age_hours), 0) * 3600)
+
+    try:
+        acquired = task_coordinator.acquire_task(
+            _RETENTION_COORDINATOR_TASK,
+            wait_seconds=_RETENTION_COORDINATOR_WAIT_SECONDS,
+        )
+        if not acquired:
+            logger.info(
+                "reclaim_stationary: skipped — could not acquire 'retention' "
+                "task slot within %.1fs",
+                _RETENTION_COORDINATOR_WAIT_SECONDS,
+            )
+            summary['duration_seconds'] = round(time.time() - started, 3)
+            return summary
+
+        try:
+            stationary_paths = _collect_stationary_recent_clips(
+                db_path, archive_root,
+            )
+            stationary_set = {p for p, _meta in stationary_paths}
+            event_basenames = _collect_event_basenames(archive_root)
+
+            for path, mtime, _size in _iter_archive_mp4_files(recent_root):
+                summary['scanned'] += 1
+                if mtime > cutoff_mtime:
+                    summary['kept_too_new'] += 1
+                    continue
+                if path not in stationary_set:
+                    # Either the indexer hasn't seen it yet, or it has
+                    # GPS waypoints / events. Either way: don't touch.
+                    # We can tell the two apart cheaply by checking the
+                    # ``indexed_files`` row presence.
+                    if _is_indexed(db_path, path):
+                        summary['kept_has_gps'] += 1
+                    else:
+                        summary['kept_unindexed'] += 1
+                    continue
+                basename = os.path.basename(path)
+                if basename in event_basenames:
+                    summary['kept_has_event_counterpart'] += 1
+                    continue
+                freed = _delete_one_mp4(path, db_path)
+                if freed > 0 or not os.path.exists(path):
+                    summary['deleted_count'] += 1
+                    summary['freed_bytes'] += freed
+                    logger.info(
+                        "reclaim_stationary: removed %s (freed=%d bytes)",
+                        path, freed,
+                    )
+        finally:
+            task_coordinator.release_task(_RETENTION_COORDINATOR_TASK)
+            summary['duration_seconds'] = round(time.time() - started, 3)
+    finally:
+        with _state_lock:
+            _retention_running = False
+
+    logger.info(
+        "reclaim_stationary: done — deleted=%d, freed_bytes=%d, "
+        "scanned=%d, kept_too_new=%d, kept_event_counterpart=%d, "
+        "kept_unindexed=%d, kept_has_gps=%d, duration=%.2fs",
+        summary['deleted_count'], summary['freed_bytes'],
+        summary['scanned'], summary['kept_too_new'],
+        summary['kept_has_event_counterpart'],
+        summary['kept_unindexed'], summary['kept_has_gps'],
+        summary['duration_seconds'],
+    )
+    return summary
+
+
+def _collect_stationary_recent_clips(db_path: str,
+                                     archive_root: str,
+                                     ) -> list:
+    """Return a list of ``(abs_path, indexed_meta)`` for every indexed
+    RecentClips clip the indexer classified as stationary
+    (``waypoint_count = 0`` AND ``event_count = 0``).
+
+    Reads ``indexed_files`` once, filters paths in Python rather than
+    via a SQL ``LIKE`` so it works across path-separator quirks
+    (Windows tests, edge cases). Returns an empty list on any DB
+    error.
+    """
+    out = []
+    if not db_path or not os.path.isfile(db_path):
+        return out
+    recent_root_norm = os.path.realpath(
+        os.path.join(archive_root, 'RecentClips')
+    ) + os.sep
+    conn = None
+    try:
+        conn = sqlite3.connect(f'file:{db_path}?mode=ro', uri=True,
+                               timeout=5.0)
+        for row in conn.execute(
+            "SELECT file_path, file_size FROM indexed_files "
+            "WHERE waypoint_count = 0 AND event_count = 0"
+        ):
+            file_path = row[0] or ''
+            try:
+                resolved = os.path.realpath(file_path)
+            except OSError:
+                continue
+            if not resolved.startswith(recent_root_norm):
+                continue
+            out.append((resolved, {'file_size': row[1]}))
+    except sqlite3.Error as e:
+        logger.warning("reclaim_stationary: stationary lookup failed: %s", e)
+    finally:
+        if conn is not None:
+            try:
+                conn.close()
+            except sqlite3.Error:
+                pass
+    return out
+
+
+def _collect_event_basenames(archive_root: str) -> set:
+    """Return the set of ``.mp4`` basenames present under
+    ``SentryClips/`` or ``SavedClips/`` (recursive). Used to refuse
+    deleting a RecentClips clip that ALSO appears as a saved-event
+    clip — Tesla writes the same recording into both folders when an
+    event triggers, and the saved-event copy is the user-meaningful
+    one we must preserve even if the RecentClips copy is the only one
+    on disk.
+
+    Cheap O(n) directory walk; on a typical install n is a few thousand
+    files, finishes in well under a second.
+    """
+    out: set = set()
+    for sub in ('SentryClips', 'SavedClips'):
+        root = os.path.join(archive_root, sub)
+        if not os.path.isdir(root):
+            continue
+        for dirpath, dirnames, filenames in os.walk(
+            root, followlinks=False,
+        ):
+            dirnames[:] = [
+                d for d in dirnames if d != _DEAD_LETTER_DIRNAME
+            ]
+            for fn in filenames:
+                if fn.lower().endswith('.mp4'):
+                    out.add(fn)
+    return out
+
+
+def _is_indexed(db_path: str, file_path: str) -> bool:
+    """Return True iff ``indexed_files`` has a row for ``file_path``."""
+    if not db_path or not os.path.isfile(db_path):
+        return False
+    conn = None
+    try:
+        conn = sqlite3.connect(f'file:{db_path}?mode=ro', uri=True,
+                               timeout=2.0)
+        row = conn.execute(
+            "SELECT 1 FROM indexed_files WHERE file_path = ? LIMIT 1",
+            (file_path,),
+        ).fetchone()
+        return row is not None
+    except sqlite3.Error:
+        return False
+    finally:
+        if conn is not None:
+            try:
+                conn.close()
+            except sqlite3.Error:
+                pass
+
+
 # ---------------------------------------------------------------------------
 # Watchdog thread loop
 # ---------------------------------------------------------------------------

--- a/scripts/web/templates/index.html
+++ b/scripts/web/templates/index.html
@@ -385,6 +385,20 @@
                     <button type="button" id="sr-run-now-btn" class="btn btn-secondary"
                             style="flex:1; min-width:160px">Run cleanup now</button>
                 </div>
+
+                <div style="margin-top:14px; padding:12px 14px; border:1px solid var(--border-color); border-radius:8px; background:var(--bg-secondary)">
+                    <div style="font-size:0.9rem; font-weight:600; margin-bottom:4px">
+                        Reclaim space from stationary RecentClips
+                    </div>
+                    <p style="font-size:0.8rem; color:var(--text-secondary); margin:0 0 10px">
+                        Deletes archived RecentClips with no GPS movement (parked Sentry-mode footage,
+                        no driving, no events). Saved/Sentry event clips are preserved even if a
+                        RecentClips copy of the same recording exists. This can free a lot of space —
+                        on a typical install, RecentClips dominates the SD card.
+                    </p>
+                    <button type="button" id="sr-reclaim-stationary-btn" class="btn btn-secondary"
+                            style="width:100%; min-width:160px">Reclaim stationary RecentClips</button>
+                </div>
             </form>
 
             <div id="sr-last-run" style="margin-top:14px; padding:10px 14px; border:1px solid var(--border-color); border-radius:8px; background:var(--bg-secondary); font-size:0.85rem">
@@ -1587,6 +1601,7 @@ if (document.getElementById('fsck-status-container')) {
     var STORAGE_API = '/api/cleanup/status';
     var SAVE_API = '/api/cleanup/policy';
     var RUN_NOW_API = '/api/cleanup/run_now';
+    var RECLAIM_STATIONARY_API = '/api/cleanup/reclaim_stationary_recent';
     var POLL_MS = 30000;
     var FOLDER_NAMES = ['SentryClips', 'SavedClips', 'RecentClips', 'EncryptedClips', 'ArchivedClips'];
 
@@ -1804,12 +1819,61 @@ if (document.getElementById('fsck-status-container')) {
             .finally(function () { btn.disabled = false; });
     }
 
+    function onReclaimStationary() {
+        var btn = $('sr-reclaim-stationary-btn');
+        if (!btn) return;
+        var ok = window.confirm(
+            'Delete all archived RecentClips with no GPS movement?\n\n' +
+            'This deletes parked-Sentry / stationary footage from the SD card. ' +
+            'Saved/Sentry event clips are preserved. Indexed driving footage is preserved. ' +
+            'This may free several GB.'
+        );
+        if (!ok) return;
+        var origText = btn.textContent;
+        btn.disabled = true;
+        btn.textContent = 'Reclaiming…';
+        setError(null);
+        fetch(RECLAIM_STATIONARY_API, {
+            method: 'POST',
+            credentials: 'same-origin',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({}),
+        })
+            .then(function (r) {
+                return r.json().then(function (data) { return { status: r.status, data: data }; });
+            })
+            .then(function (res) {
+                var d = res.data || {};
+                var result = d.result || {};
+                if (result.status === 'already_running') {
+                    btn.textContent = 'Already running';
+                } else if (res.status >= 200 && res.status < 300 && d.success !== false) {
+                    var deleted = result.deleted_count || 0;
+                    var freed = result.freed_bytes ? fmtBytes(result.freed_bytes) : '0 B';
+                    btn.textContent = '✓ ' + deleted + ' clips, ' + freed;
+                } else {
+                    setError(d.message || 'Reclaim failed');
+                    btn.textContent = origText;
+                    return;
+                }
+                loadStatus();
+                setTimeout(function () { btn.textContent = origText; }, 6000);
+            })
+            .catch(function (e) {
+                setError('Network error: ' + e.message);
+                btn.textContent = origText;
+            })
+            .finally(function () { btn.disabled = false; });
+    }
+
     if (!$('storage-retention-section')) return;
 
     var saveBtn = $('sr-save-btn');
     var runBtn = $('sr-run-now-btn');
+    var reclaimBtn = $('sr-reclaim-stationary-btn');
     if (saveBtn) saveBtn.addEventListener('click', onSave);
     if (runBtn) runBtn.addEventListener('click', onRunNow);
+    if (reclaimBtn) reclaimBtn.addEventListener('click', onReclaimStationary);
     var defEl = $('sr-default-retention');
     var warnEl = $('sr-short-warning');
     function refreshWarning() {

--- a/tests/test_reclaim_stationary_recent_clips.py
+++ b/tests/test_reclaim_stationary_recent_clips.py
@@ -147,7 +147,13 @@ class TestReclaimStationary:
         assert result['kept_has_gps'] == 1
         assert os.path.isfile(path)
 
-    def test_recent_clip_with_events_is_kept(self, db, archive_root):
+    def test_recent_clip_with_events_is_kept_in_event_only_bucket(
+            self, db, archive_root):
+        """Stationary clip with events lands in `kept_has_event_only`,
+        not the `kept_has_gps` bucket. The bucket distinction matters
+        to operators reading the JSON: a Sentry-mode-while-parked
+        event is NOT GPS data.
+        """
         path = _make_archive_mp4(
             archive_root, "RecentClips/has_event.mp4", mtime=OLD_MTIME,
         )
@@ -156,7 +162,8 @@ class TestReclaimStationary:
             db_path=db, archive_root=archive_root, min_age_hours=1,
         )
         assert result['deleted_count'] == 0
-        assert result['kept_has_gps'] == 1
+        assert result['kept_has_event_only'] == 1
+        assert result['kept_has_gps'] == 0
         assert os.path.isfile(path)
 
     def test_unindexed_recent_clip_is_kept(self, db, archive_root):
@@ -292,7 +299,7 @@ class TestReclaimStationary:
         for field in (
             'deleted_count', 'freed_bytes', 'scanned',
             'kept_too_new', 'kept_has_event_counterpart',
-            'kept_unindexed', 'kept_has_gps',
+            'kept_unindexed', 'kept_has_gps', 'kept_has_event_only',
             'min_age_hours', 'duration_seconds',
         ):
             assert field in result, f"missing summary field: {field}"
@@ -411,31 +418,86 @@ class TestReclaimGeodataContract:
 
 
 class TestReclaimSafetyGuards:
-    def test_img_files_are_never_deleted(self, db, archive_root):
-        """``safe_delete_archive_video`` blocks ``*.img`` files at the doorway.
-
-        We don't expect ``*.img`` files in RecentClips, but the
-        protected-file guard is the single source of truth so verify
-        it stays wired up.
+    def test_img_files_excluded_at_walk_stage(self, db, archive_root):
+        """``_iter_archive_mp4_files`` filters by ``.mp4`` extension,
+        so a stray ``.img`` file in RecentClips never enters the
+        candidate loop. This is layer 1 of two-layer protection;
+        ``test_protected_file_doorway_invoked_for_img_candidate`` below
+        covers layer 2 (the ``safe_delete_archive_video`` doorway).
         """
-        # Construct a scenario where the indexer mistakenly recorded an
-        # img file as stationary (defense in depth: even if upstream
-        # ever indexed one, the doorway must refuse).
         path = _make_archive_mp4(
             archive_root, "RecentClips/usb_cam.img", mtime=OLD_MTIME,
         )
-        # We must masquerade as stationary in the index for the function
-        # to even consider it. _index() doesn't validate extension.
         _index(db, path, waypoint_count=0, event_count=0)
-
-        # However, our function only walks .mp4 files via
-        # _iter_archive_mp4_files — so .img is filtered out at the walk
-        # stage too. Both layers should keep the file alive.
         result = archive_watchdog.reclaim_stationary_recent_clips(
             db_path=db, archive_root=archive_root, min_age_hours=1,
         )
         assert result['deleted_count'] == 0
         assert os.path.isfile(path)
+
+    def test_protected_file_doorway_invoked_for_protected_candidate(
+            self, db, archive_root, monkeypatch):
+        """Layer 2 protection: even if a ``.mp4`` candidate makes it
+        into the loop, ``safe_delete_archive_video`` returns
+        ``DeleteOutcome.PROTECTED`` for protected paths, and the
+        function MUST treat that as "not deleted" (no delete count,
+        no freed bytes, no purge_deleted_videos call).
+
+        Exercises the doorway by monkeypatching it to return PROTECTED
+        for one of the candidates. Verifies the count/bytes/purge
+        accounting stays consistent.
+        """
+        protected_path = _make_archive_mp4(
+            archive_root, "RecentClips/protected.mp4",
+            mtime=OLD_MTIME, size=2048,
+        )
+        normal_path = _make_archive_mp4(
+            archive_root, "RecentClips/normal.mp4",
+            mtime=OLD_MTIME, size=4096,
+        )
+        _index(db, protected_path, waypoint_count=0, event_count=0)
+        _index(db, normal_path, waypoint_count=0, event_count=0)
+
+        from services import file_safety
+        real_delete = file_safety.safe_delete_archive_video
+
+        def _patched_delete(path):
+            # Refuse the protected candidate at the doorway.
+            normalized = os.path.normpath(path)
+            if normalized.endswith('protected.mp4'):
+                return file_safety.DeleteResult(
+                    outcome=file_safety.DeleteOutcome.PROTECTED,
+                    bytes_freed=0,
+                )
+            return real_delete(path)
+
+        # Patch the symbol that ``_delete_one_mp4`` looks up at call time.
+        monkeypatch.setattr(
+            file_safety, 'safe_delete_archive_video', _patched_delete,
+        )
+
+        purged: list = []
+        from services import mapping_service
+
+        def _spy(db_path, *, deleted_paths):
+            purged.extend(os.path.normpath(p) for p in deleted_paths)
+        monkeypatch.setattr(
+            mapping_service, 'purge_deleted_videos', _spy,
+        )
+
+        result = archive_watchdog.reclaim_stationary_recent_clips(
+            db_path=db, archive_root=archive_root, min_age_hours=1,
+        )
+        # Only the non-protected candidate was deleted.
+        assert result['deleted_count'] == 1
+        assert result['freed_bytes'] == 4096
+        assert os.path.isfile(protected_path), \
+            "Protected file MUST survive even when listed as a candidate"
+        assert not os.path.exists(normal_path)
+        # purge_deleted_videos called exactly once — for the deleted
+        # file only, never for the doorway-rejected one.
+        assert len(purged) == 1
+        assert purged[0].endswith('normal.mp4')
 
     def test_watchdog_not_started_returns_error(self, archive_root):
         # No db_path supplied AND module-level _db_path is None.
@@ -497,3 +559,51 @@ class TestReclaimSafetyGuards:
             with archive_watchdog._state_lock:
                 archive_watchdog._db_path = None
                 archive_watchdog._archive_root = None
+
+    def test_symlinked_archive_root_does_not_silently_no_op(
+            self, db, tmp_path):
+        """Path-normalization regression guard: an archive_root passed
+        as a symlink must not break the in-loop ``stationary_set``
+        membership check.
+
+        Failure mode that we're guarding against: ``indexed_files``
+        rows store the realpath'd absolute path (because the indexer
+        runs ``os.path.realpath``), so the collector would build a set
+        of realpath'd paths. If the worker loop iterates ``os.walk``
+        results that contain the symlink prefix instead, every
+        membership check returns False and the function silently
+        no-ops. Both sides realpath now.
+        """
+        if not hasattr(os, 'symlink'):
+            pytest.skip("symlinks not supported on this platform")
+        # Real archive root with the actual files.
+        real_root = tmp_path / "real_archives"
+        real_root.mkdir()
+        # Symlink that callers might pass in instead.
+        link_root = tmp_path / "link_archives"
+        try:
+            os.symlink(str(real_root), str(link_root),
+                       target_is_directory=True)
+        except (OSError, NotImplementedError) as e:
+            pytest.skip(f"cannot create symlink in this env: {e}")
+        # Make a stationary RecentClips file under the REAL root.
+        real_path = _make_archive_mp4(
+            str(real_root), "RecentClips/sym.mp4", mtime=OLD_MTIME,
+        )
+        # Index it under the SYMLINK path (simulating an indexer
+        # invocation with a symlinked archive_root). The collector
+        # realpaths these on read so they end up in the same set.
+        sym_indexed_path = os.path.join(
+            str(link_root), "RecentClips", "sym.mp4",
+        )
+        _index(db, sym_indexed_path, waypoint_count=0, event_count=0)
+        # Now invoke with the SYMLINK as archive_root. The walk yields
+        # link-prefixed paths; the collector realpaths to real-prefixed.
+        # Without the realpath fix (Finding 1), membership returns
+        # False and nothing gets deleted.
+        result = archive_watchdog.reclaim_stationary_recent_clips(
+            db_path=db, archive_root=str(link_root), min_age_hours=1,
+        )
+        assert result['deleted_count'] == 1, \
+            "Symlinked archive_root must not silently no-op"
+        assert not os.path.exists(real_path)

--- a/tests/test_reclaim_stationary_recent_clips.py
+++ b/tests/test_reclaim_stationary_recent_clips.py
@@ -1,0 +1,499 @@
+"""Tests for reclaim_stationary_recent_clips (issue #167).
+
+Coverage:
+
+* Stationary RecentClips (waypoint_count = 0 AND event_count = 0) get deleted.
+* RecentClips with GPS waypoints are kept.
+* RecentClips with detected events are kept.
+* Unindexed RecentClips (no row in indexed_files) are kept — the indexer
+  hasn't seen them yet, deleting blind would lose footage that might have GPS.
+* Files newer than ``min_age_hours`` are kept.
+* Stationary RecentClips with a SentryClips/SavedClips counterpart of the
+  same basename are kept (Tesla writes the same recording into both folders;
+  the saved-event copy is the user-meaningful one).
+* SentryClips and SavedClips folders are NEVER touched.
+* purge_deleted_videos is called for each deleted file (geodata reconciled).
+* Trips / waypoints / detected_events rows are NEVER deleted (the May 7
+  contract — only video_path is nulled).
+* The protected-file guard (``*.img`` files) refuses to delete.
+* Single-flight: a second call short-circuits while a first is in flight.
+* Watchdog-not-started returns an error summary instead of raising.
+* RecentClips folder missing returns a zero-summary instead of raising.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import threading
+import time
+
+import pytest
+
+from services import archive_queue
+from services import archive_watchdog
+from services import archive_worker
+from services import task_coordinator
+from services.mapping_service import _init_db
+
+
+# ---------------------------------------------------------------------------
+# Fixtures (mirror tests/test_archive_watchdog.py — same module-state contract)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def db(tmp_path):
+    """Initialize a fresh geodata.db with the canonical schema."""
+    db_path = str(tmp_path / "geodata.db")
+    _init_db(db_path).close()
+    return db_path
+
+
+@pytest.fixture
+def archive_root(tmp_path):
+    p = tmp_path / "ArchivedClips"
+    p.mkdir()
+    return str(p)
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state():
+    archive_watchdog.stop_watchdog(timeout=5.0)
+    archive_worker.stop_worker(timeout=5.0)
+    archive_worker._disk_space_pause_until = 0.0
+    with task_coordinator._lock:
+        task_coordinator._current_task = None
+        task_coordinator._task_started = 0.0
+        task_coordinator._waiter_count = 0
+    archive_watchdog._retention_running = False
+    # Default the module-level archive_root / db_path so callers that
+    # rely on the watchdog default (no explicit kwargs) don't blow up.
+    with archive_watchdog._state_lock:
+        archive_watchdog._archive_root = None
+        archive_watchdog._db_path = None
+    yield
+    archive_watchdog.stop_watchdog(timeout=5.0)
+    archive_worker.stop_worker(timeout=5.0)
+    archive_worker._disk_space_pause_until = 0.0
+    with task_coordinator._lock:
+        task_coordinator._current_task = None
+        task_coordinator._task_started = 0.0
+        task_coordinator._waiter_count = 0
+    archive_watchdog._retention_running = False
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_archive_mp4(root: str, rel: str, *,
+                      mtime: float | None = None,
+                      size: int = 100) -> str:
+    full = os.path.normpath(os.path.join(root, rel))
+    os.makedirs(os.path.dirname(full), exist_ok=True)
+    with open(full, 'wb') as f:
+        f.write(b"X" * size)
+    if mtime is not None:
+        os.utime(full, (mtime, mtime))
+    return full
+
+
+def _index(db_path: str, file_path: str, *,
+           waypoint_count: int = 0, event_count: int = 0,
+           file_size: int = 100):
+    """Insert an indexed_files row for ``file_path``."""
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "INSERT INTO indexed_files(file_path, file_size, "
+            "indexed_at, waypoint_count, event_count) "
+            "VALUES (?, ?, '2025-01-01T00:00:00Z', ?, ?)",
+            (file_path, file_size, waypoint_count, event_count),
+        )
+
+
+# Pick an mtime well outside the default 1 h "too new" guard.
+OLD_MTIME = time.time() - (2 * 3600)
+
+
+# ---------------------------------------------------------------------------
+# TestReclaimStationary — happy paths and the per-file decision matrix
+# ---------------------------------------------------------------------------
+
+
+class TestReclaimStationary:
+    def test_stationary_recent_clip_is_deleted(self, db, archive_root):
+        path = _make_archive_mp4(
+            archive_root, "RecentClips/stationary.mp4", mtime=OLD_MTIME,
+        )
+        _index(db, path, waypoint_count=0, event_count=0)
+        result = archive_watchdog.reclaim_stationary_recent_clips(
+            db_path=db, archive_root=archive_root, min_age_hours=1,
+        )
+        assert result['deleted_count'] == 1
+        assert result['freed_bytes'] > 0
+        assert not os.path.exists(path)
+
+    def test_recent_clip_with_gps_waypoints_is_kept(self, db, archive_root):
+        path = _make_archive_mp4(
+            archive_root, "RecentClips/has_gps.mp4", mtime=OLD_MTIME,
+        )
+        _index(db, path, waypoint_count=42, event_count=0)
+        result = archive_watchdog.reclaim_stationary_recent_clips(
+            db_path=db, archive_root=archive_root, min_age_hours=1,
+        )
+        assert result['deleted_count'] == 0
+        assert result['kept_has_gps'] == 1
+        assert os.path.isfile(path)
+
+    def test_recent_clip_with_events_is_kept(self, db, archive_root):
+        path = _make_archive_mp4(
+            archive_root, "RecentClips/has_event.mp4", mtime=OLD_MTIME,
+        )
+        _index(db, path, waypoint_count=0, event_count=3)
+        result = archive_watchdog.reclaim_stationary_recent_clips(
+            db_path=db, archive_root=archive_root, min_age_hours=1,
+        )
+        assert result['deleted_count'] == 0
+        assert result['kept_has_gps'] == 1
+        assert os.path.isfile(path)
+
+    def test_unindexed_recent_clip_is_kept(self, db, archive_root):
+        path = _make_archive_mp4(
+            archive_root, "RecentClips/unseen.mp4", mtime=OLD_MTIME,
+        )
+        # Deliberately do NOT index — the indexer hasn't seen it yet.
+        result = archive_watchdog.reclaim_stationary_recent_clips(
+            db_path=db, archive_root=archive_root, min_age_hours=1,
+        )
+        assert result['deleted_count'] == 0
+        assert result['kept_unindexed'] == 1
+        assert os.path.isfile(path)
+
+    def test_too_new_clip_is_kept(self, db, archive_root):
+        # 30 minutes old — within the 1-hour default guard.
+        path = _make_archive_mp4(
+            archive_root, "RecentClips/fresh.mp4",
+            mtime=time.time() - 1800,
+        )
+        _index(db, path, waypoint_count=0, event_count=0)
+        result = archive_watchdog.reclaim_stationary_recent_clips(
+            db_path=db, archive_root=archive_root, min_age_hours=1,
+        )
+        assert result['deleted_count'] == 0
+        assert result['kept_too_new'] == 1
+        assert os.path.isfile(path)
+
+    def test_min_age_hours_zero_allows_any_age(self, db, archive_root):
+        # 1 second old — would normally be guarded.
+        path = _make_archive_mp4(
+            archive_root, "RecentClips/just_made.mp4",
+            mtime=time.time() - 1,
+        )
+        _index(db, path, waypoint_count=0, event_count=0)
+        result = archive_watchdog.reclaim_stationary_recent_clips(
+            db_path=db, archive_root=archive_root, min_age_hours=0,
+        )
+        assert result['deleted_count'] == 1
+        assert not os.path.exists(path)
+
+    def test_sentry_counterpart_keeps_stationary_recent_clip(
+            self, db, archive_root):
+        # Tesla wrote the SAME recording into RecentClips AND SentryClips.
+        # The recent copy looks stationary (no GPS) — but the Sentry
+        # copy is the user-meaningful event recording. Keep the recent
+        # copy so the user sees consistent storage usage and never
+        # has a deleted-but-nominally-stationary clip.
+        recent = _make_archive_mp4(
+            archive_root, "RecentClips/2025-01-01_12-00-00-front.mp4",
+            mtime=OLD_MTIME,
+        )
+        sentry = _make_archive_mp4(
+            archive_root,
+            "SentryClips/2025-01-01_12-00-00/2025-01-01_12-00-00-front.mp4",
+            mtime=OLD_MTIME,
+        )
+        _index(db, recent, waypoint_count=0, event_count=0)
+        result = archive_watchdog.reclaim_stationary_recent_clips(
+            db_path=db, archive_root=archive_root, min_age_hours=1,
+        )
+        assert result['deleted_count'] == 0
+        assert result['kept_has_event_counterpart'] == 1
+        assert os.path.isfile(recent)
+        assert os.path.isfile(sentry)
+
+    def test_saved_counterpart_keeps_stationary_recent_clip(
+            self, db, archive_root):
+        recent = _make_archive_mp4(
+            archive_root, "RecentClips/2025-02-02_14-00-00-front.mp4",
+            mtime=OLD_MTIME,
+        )
+        saved = _make_archive_mp4(
+            archive_root,
+            "SavedClips/2025-02-02_14-00-00/2025-02-02_14-00-00-front.mp4",
+            mtime=OLD_MTIME,
+        )
+        _index(db, recent, waypoint_count=0, event_count=0)
+        result = archive_watchdog.reclaim_stationary_recent_clips(
+            db_path=db, archive_root=archive_root, min_age_hours=1,
+        )
+        assert result['deleted_count'] == 0
+        assert result['kept_has_event_counterpart'] == 1
+        assert os.path.isfile(recent)
+        assert os.path.isfile(saved)
+
+    def test_sentry_clips_folder_is_never_walked_for_deletion(
+            self, db, archive_root):
+        """Even a stationary indexed SentryClips clip must never be touched."""
+        sentry = _make_archive_mp4(
+            archive_root,
+            "SentryClips/2025-03-03_08-00-00/2025-03-03_08-00-00-front.mp4",
+            mtime=OLD_MTIME,
+        )
+        _index(db, sentry, waypoint_count=0, event_count=0)
+        result = archive_watchdog.reclaim_stationary_recent_clips(
+            db_path=db, archive_root=archive_root, min_age_hours=1,
+        )
+        assert result['deleted_count'] == 0
+        assert os.path.isfile(sentry)
+
+    def test_saved_clips_folder_is_never_walked_for_deletion(
+            self, db, archive_root):
+        saved = _make_archive_mp4(
+            archive_root,
+            "SavedClips/2025-04-04_18-00-00/2025-04-04_18-00-00-front.mp4",
+            mtime=OLD_MTIME,
+        )
+        _index(db, saved, waypoint_count=0, event_count=0)
+        result = archive_watchdog.reclaim_stationary_recent_clips(
+            db_path=db, archive_root=archive_root, min_age_hours=1,
+        )
+        assert result['deleted_count'] == 0
+        assert os.path.isfile(saved)
+
+    def test_freed_bytes_matches_actual_size(self, db, archive_root):
+        size = 4096
+        path = _make_archive_mp4(
+            archive_root, "RecentClips/sized.mp4",
+            mtime=OLD_MTIME, size=size,
+        )
+        _index(db, path, waypoint_count=0, event_count=0)
+        result = archive_watchdog.reclaim_stationary_recent_clips(
+            db_path=db, archive_root=archive_root, min_age_hours=1,
+        )
+        assert result['deleted_count'] == 1
+        assert result['freed_bytes'] == size
+
+    def test_returns_summary_with_required_fields(self, db, archive_root):
+        result = archive_watchdog.reclaim_stationary_recent_clips(
+            db_path=db, archive_root=archive_root, min_age_hours=1,
+        )
+        for field in (
+            'deleted_count', 'freed_bytes', 'scanned',
+            'kept_too_new', 'kept_has_event_counterpart',
+            'kept_unindexed', 'kept_has_gps',
+            'min_age_hours', 'duration_seconds',
+        ):
+            assert field in result, f"missing summary field: {field}"
+        assert result['min_age_hours'] == 1
+
+
+# ---------------------------------------------------------------------------
+# TestReclaimGeodataContract — preserve trips/waypoints/events (May 7)
+# ---------------------------------------------------------------------------
+
+
+class TestReclaimGeodataContract:
+    def test_purge_deleted_videos_called_per_deleted_file(
+            self, db, archive_root, monkeypatch):
+        paths = [
+            _make_archive_mp4(
+                archive_root, "RecentClips/a.mp4", mtime=OLD_MTIME,
+            ),
+            _make_archive_mp4(
+                archive_root, "RecentClips/b.mp4", mtime=OLD_MTIME,
+            ),
+        ]
+        for p in paths:
+            _index(db, p, waypoint_count=0, event_count=0)
+
+        purged: list = []
+        from services import mapping_service
+
+        def _spy(db_path, *, deleted_paths):
+            purged.append([os.path.normpath(p) for p in deleted_paths])
+        monkeypatch.setattr(
+            mapping_service, 'purge_deleted_videos', _spy,
+        )
+
+        result = archive_watchdog.reclaim_stationary_recent_clips(
+            db_path=db, archive_root=archive_root, min_age_hours=1,
+        )
+        assert result['deleted_count'] == 2
+        assert len(purged) == 2
+        flat = [p for sub in purged for p in sub]
+        assert set(flat) == {os.path.normpath(p) for p in paths}
+
+    def test_trips_waypoints_events_preserved_when_video_reclaimed(
+            self, db, archive_root):
+        """May 7 contract: reclaim must NOT cascade-delete trip data."""
+        path = _make_archive_mp4(
+            archive_root, "RecentClips/tripclip.mp4", mtime=OLD_MTIME,
+        )
+        rel_video_path = "RecentClips/tripclip.mp4"
+        with sqlite3.connect(db) as conn:
+            conn.execute(
+                "INSERT INTO trips(start_time, end_time, source_folder) "
+                "VALUES ('2025-01-01T10:00:00Z','2025-01-01T11:00:00Z','test')"
+            )
+            trip_id = conn.execute(
+                "SELECT last_insert_rowid()").fetchone()[0]
+            conn.execute(
+                "INSERT INTO waypoints(trip_id, lat, lon, "
+                "timestamp, video_path) VALUES (?, 37.0, -122.0, "
+                "'2025-01-01T10:00:01Z', ?)",
+                (trip_id, rel_video_path),
+            )
+            conn.execute(
+                "INSERT INTO detected_events(trip_id, event_type, "
+                "timestamp, lat, lon, video_path) VALUES "
+                "(?, 'sentry', '2025-01-01T10:00:01Z', 37.0, -122.0, ?)",
+                (trip_id, rel_video_path),
+            )
+        _index(db, path, waypoint_count=0, event_count=0)
+
+        with sqlite3.connect(db) as conn:
+            trip_before = conn.execute(
+                "SELECT COUNT(*) FROM trips").fetchone()[0]
+            wpt_before = conn.execute(
+                "SELECT COUNT(*) FROM waypoints").fetchone()[0]
+            evt_before = conn.execute(
+                "SELECT COUNT(*) FROM detected_events").fetchone()[0]
+
+        result = archive_watchdog.reclaim_stationary_recent_clips(
+            db_path=db, archive_root=archive_root, min_age_hours=1,
+        )
+        assert result['deleted_count'] == 1
+
+        with sqlite3.connect(db) as conn:
+            trip_after = conn.execute(
+                "SELECT COUNT(*) FROM trips").fetchone()[0]
+            wpt_after = conn.execute(
+                "SELECT COUNT(*) FROM waypoints").fetchone()[0]
+            evt_after = conn.execute(
+                "SELECT COUNT(*) FROM detected_events").fetchone()[0]
+            wpt_video_path = conn.execute(
+                "SELECT video_path FROM waypoints WHERE trip_id=?",
+                (trip_id,),
+            ).fetchone()[0]
+            evt_video_path = conn.execute(
+                "SELECT video_path FROM detected_events WHERE trip_id=?",
+                (trip_id,),
+            ).fetchone()[0]
+            idx_after = conn.execute(
+                "SELECT COUNT(*) FROM indexed_files").fetchone()[0]
+
+        assert trip_after == trip_before, \
+            "Reclaim must NOT delete trips (May 7 contract)"
+        assert wpt_after == wpt_before, \
+            "Reclaim must NOT delete waypoints (May 7 contract)"
+        assert evt_after == evt_before, \
+            "Reclaim must NOT delete detected_events (May 7 contract)"
+        assert wpt_video_path is None
+        assert evt_video_path is None
+        assert idx_after == 0
+
+
+# ---------------------------------------------------------------------------
+# TestReclaimSafetyGuards — img protection, error paths, single-flight
+# ---------------------------------------------------------------------------
+
+
+class TestReclaimSafetyGuards:
+    def test_img_files_are_never_deleted(self, db, archive_root):
+        """``safe_delete_archive_video`` blocks ``*.img`` files at the doorway.
+
+        We don't expect ``*.img`` files in RecentClips, but the
+        protected-file guard is the single source of truth so verify
+        it stays wired up.
+        """
+        # Construct a scenario where the indexer mistakenly recorded an
+        # img file as stationary (defense in depth: even if upstream
+        # ever indexed one, the doorway must refuse).
+        path = _make_archive_mp4(
+            archive_root, "RecentClips/usb_cam.img", mtime=OLD_MTIME,
+        )
+        # We must masquerade as stationary in the index for the function
+        # to even consider it. _index() doesn't validate extension.
+        _index(db, path, waypoint_count=0, event_count=0)
+
+        # However, our function only walks .mp4 files via
+        # _iter_archive_mp4_files — so .img is filtered out at the walk
+        # stage too. Both layers should keep the file alive.
+        result = archive_watchdog.reclaim_stationary_recent_clips(
+            db_path=db, archive_root=archive_root, min_age_hours=1,
+        )
+        assert result['deleted_count'] == 0
+        assert os.path.isfile(path)
+
+    def test_watchdog_not_started_returns_error(self, archive_root):
+        # No db_path supplied AND module-level _db_path is None.
+        result = archive_watchdog.reclaim_stationary_recent_clips(
+            archive_root=archive_root,
+        )
+        assert result['deleted_count'] == 0
+        assert 'error' in result
+
+    def test_recent_clips_folder_missing_returns_zero_summary(
+            self, db, tmp_path):
+        # archive_root exists but contains no RecentClips/ subfolder.
+        empty_root = str(tmp_path / "empty_archive")
+        os.makedirs(empty_root)
+        result = archive_watchdog.reclaim_stationary_recent_clips(
+            db_path=db, archive_root=empty_root, min_age_hours=1,
+        )
+        assert result['deleted_count'] == 0
+        assert result['scanned'] == 0
+        assert 'error' not in result
+
+    def test_single_flight_short_circuits_concurrent_call(
+            self, db, archive_root):
+        """A second call while the first is in flight returns
+        ``status='already_running'`` instead of stacking another prune.
+        """
+        # Set the module-level guard manually to simulate an in-flight prune.
+        with archive_watchdog._state_lock:
+            archive_watchdog._retention_running = True
+        try:
+            result = archive_watchdog.reclaim_stationary_recent_clips(
+                db_path=db, archive_root=archive_root, min_age_hours=1,
+            )
+            assert result.get('status') == 'already_running'
+            assert result['deleted_count'] == 0
+        finally:
+            with archive_watchdog._state_lock:
+                archive_watchdog._retention_running = False
+
+    def test_module_level_defaults_used_when_kwargs_omitted(
+            self, db, archive_root):
+        """If ``start_watchdog`` was called, kwargs default to those values."""
+        path = _make_archive_mp4(
+            archive_root, "RecentClips/default_call.mp4", mtime=OLD_MTIME,
+        )
+        _index(db, path, waypoint_count=0, event_count=0)
+        # Simulate start_watchdog setting module state without actually
+        # starting the thread (we don't want a real thread in tests).
+        with archive_watchdog._state_lock:
+            archive_watchdog._db_path = db
+            archive_watchdog._archive_root = archive_root
+        try:
+            result = archive_watchdog.reclaim_stationary_recent_clips(
+                min_age_hours=1,
+            )
+            assert result['deleted_count'] == 1
+            assert not os.path.exists(path)
+        finally:
+            with archive_watchdog._state_lock:
+                archive_watchdog._db_path = None
+                archive_watchdog._archive_root = None

--- a/tests/test_storage_retention_blueprint.py
+++ b/tests/test_storage_retention_blueprint.py
@@ -600,6 +600,23 @@ class TestApiReclaimStationaryRecent:
         assert body['success'] is False
         assert 'min_age_hours' in body['message']
 
+    def test_bool_min_age_hours_returns_400(self, client):
+        """``bool`` is a subclass of ``int`` in Python — reject explicitly
+        so ``{"min_age_hours": true}`` doesn't silently coerce to 1
+        and ``false`` to 0 ("delete every age"). Honors the documented
+        non-integer -> 400 contract.
+        """
+        for raw in (True, False):
+            r = client.post(
+                '/api/cleanup/reclaim_stationary_recent',
+                json={'min_age_hours': raw},
+            )
+            assert r.status_code == 400, \
+                f"bool {raw} should be rejected, got {r.status_code}"
+            body = r.get_json()
+            assert body['success'] is False
+            assert 'min_age_hours' in body['message']
+
     def test_empty_post_body_works(self, client):
         # Some clients send no Content-Type or no body at all.
         with patch(

--- a/tests/test_storage_retention_blueprint.py
+++ b/tests/test_storage_retention_blueprint.py
@@ -445,3 +445,173 @@ class TestApiCleanupRunNow:
         body = r.get_json()
         assert body['success'] is False
         assert 'boom' in body['message']
+
+
+# ---------------------------------------------------------------------------
+# /api/cleanup/reclaim_stationary_recent (issue #167)
+# Same HTTP contract as run_now: 200 on success / already_running, 500 on
+# error dict or unexpected exception, 400 on bad input.
+# ---------------------------------------------------------------------------
+
+
+class TestApiReclaimStationaryRecent:
+    def test_success_returns_200_with_summary(self, client):
+        with patch(
+            'services.archive_watchdog.reclaim_stationary_recent_clips',
+            return_value={
+                'deleted_count': 12, 'freed_bytes': 25_000_000,
+                'scanned': 100, 'kept_too_new': 4,
+                'kept_has_event_counterpart': 1, 'kept_unindexed': 0,
+                'kept_has_gps': 0, 'min_age_hours': 1,
+                'duration_seconds': 0.8,
+            },
+        ):
+            r = client.post(
+                '/api/cleanup/reclaim_stationary_recent',
+                json={},
+            )
+        assert r.status_code == 200
+        body = r.get_json()
+        assert body['success'] is True
+        assert body['result']['deleted_count'] == 12
+        assert body['result']['freed_bytes'] == 25_000_000
+
+    def test_already_running_returns_200(self, client):
+        with patch(
+            'services.archive_watchdog.reclaim_stationary_recent_clips',
+            return_value={
+                'deleted_count': 0, 'freed_bytes': 0,
+                'status': 'already_running', 'duration_seconds': 0.0,
+            },
+        ):
+            r = client.post(
+                '/api/cleanup/reclaim_stationary_recent', json={},
+            )
+        assert r.status_code == 200
+        body = r.get_json()
+        assert body['success'] is True
+        assert body['result']['status'] == 'already_running'
+
+    def test_watchdog_error_dict_returns_500(self, client):
+        with patch(
+            'services.archive_watchdog.reclaim_stationary_recent_clips',
+            return_value={
+                'deleted_count': 0, 'freed_bytes': 0,
+                'error': 'watchdog not started',
+            },
+        ):
+            r = client.post(
+                '/api/cleanup/reclaim_stationary_recent', json={},
+            )
+        assert r.status_code == 500
+        body = r.get_json()
+        assert body['success'] is False
+        assert 'watchdog not started' in body['message']
+
+    def test_unexpected_exception_returns_500(self, client):
+        with patch(
+            'services.archive_watchdog.reclaim_stationary_recent_clips',
+            side_effect=RuntimeError("boom"),
+        ):
+            r = client.post(
+                '/api/cleanup/reclaim_stationary_recent', json={},
+            )
+        assert r.status_code == 500
+        body = r.get_json()
+        assert body['success'] is False
+        assert 'boom' in body['message']
+
+    def test_default_min_age_hours_is_one(self, client):
+        captured: dict = {}
+
+        def _capture(**kwargs):
+            captured.update(kwargs)
+            return {
+                'deleted_count': 0, 'freed_bytes': 0, 'scanned': 0,
+                'kept_too_new': 0, 'kept_has_event_counterpart': 0,
+                'kept_unindexed': 0, 'kept_has_gps': 0,
+                'min_age_hours': kwargs.get('min_age_hours', -1),
+                'duration_seconds': 0.0,
+            }
+        with patch(
+            'services.archive_watchdog.reclaim_stationary_recent_clips',
+            side_effect=_capture,
+        ):
+            r = client.post(
+                '/api/cleanup/reclaim_stationary_recent', json={},
+            )
+        assert r.status_code == 200
+        assert captured.get('min_age_hours') == 1
+
+    def test_explicit_min_age_hours_passes_through(self, client):
+        captured: dict = {}
+
+        def _capture(**kwargs):
+            captured.update(kwargs)
+            return {
+                'deleted_count': 0, 'freed_bytes': 0, 'scanned': 0,
+                'kept_too_new': 0, 'kept_has_event_counterpart': 0,
+                'kept_unindexed': 0, 'kept_has_gps': 0,
+                'min_age_hours': kwargs.get('min_age_hours', -1),
+                'duration_seconds': 0.0,
+            }
+        with patch(
+            'services.archive_watchdog.reclaim_stationary_recent_clips',
+            side_effect=_capture,
+        ):
+            r = client.post(
+                '/api/cleanup/reclaim_stationary_recent',
+                json={'min_age_hours': 6},
+            )
+        assert r.status_code == 200
+        assert captured.get('min_age_hours') == 6
+
+    def test_negative_min_age_hours_clamped_to_zero(self, client):
+        captured: dict = {}
+
+        def _capture(**kwargs):
+            captured.update(kwargs)
+            return {
+                'deleted_count': 0, 'freed_bytes': 0, 'scanned': 0,
+                'kept_too_new': 0, 'kept_has_event_counterpart': 0,
+                'kept_unindexed': 0, 'kept_has_gps': 0,
+                'min_age_hours': kwargs.get('min_age_hours', -1),
+                'duration_seconds': 0.0,
+            }
+        with patch(
+            'services.archive_watchdog.reclaim_stationary_recent_clips',
+            side_effect=_capture,
+        ):
+            r = client.post(
+                '/api/cleanup/reclaim_stationary_recent',
+                json={'min_age_hours': -5},
+            )
+        assert r.status_code == 200
+        assert captured.get('min_age_hours') == 0
+
+    def test_non_integer_min_age_hours_returns_400(self, client):
+        # No patch — should reject before the service call.
+        r = client.post(
+            '/api/cleanup/reclaim_stationary_recent',
+            json={'min_age_hours': 'not-a-number'},
+        )
+        assert r.status_code == 400
+        body = r.get_json()
+        assert body['success'] is False
+        assert 'min_age_hours' in body['message']
+
+    def test_empty_post_body_works(self, client):
+        # Some clients send no Content-Type or no body at all.
+        with patch(
+            'services.archive_watchdog.reclaim_stationary_recent_clips',
+            return_value={
+                'deleted_count': 0, 'freed_bytes': 0, 'scanned': 0,
+                'kept_too_new': 0, 'kept_has_event_counterpart': 0,
+                'kept_unindexed': 0, 'kept_has_gps': 0,
+                'min_age_hours': 1, 'duration_seconds': 0.0,
+            },
+        ):
+            r = client.post('/api/cleanup/reclaim_stationary_recent')
+        assert r.status_code == 200
+        body = r.get_json()
+        assert body['success'] is True


### PR DESCRIPTION
## Issue #167 (sub-deliverable 1 of 2)

Adds a **Reclaim stationary RecentClips** button to **Settings → Storage & Retention** that deletes archived RecentClips with no GPS movement. On the live device this can free 100+ GB without touching anything the user wanted to keep.

### Why this is needed

The archive worker copies every RecentClips clip to the SD card unfiltered. The indexer downstream classifies each clip (`waypoint_count = 0` for stationary) but nothing acts on that classification.

On a parked vehicle in Sentry mode, RecentClips fills the SD card with worthless overnight stationary footage. Live device measurement (today):

| Folder | Files | Bytes | Has GPS (indexed sample) |
|---|---|---|---|
| RecentClips | 4,095 | 123 GB | **0 / 709** (100% stationary) |
| SentryClips | 1,271 | 35 GB | 4 / 379 |
| SavedClips | 98 | 3.6 GB | 1 / 32 |

SD card was 95% full (24 GB free / 470 GB total) — RecentClips alone was 28% of the entire card.

### Decision matrix per file

| Classification | Action |
|---|---|
| Stationary indexed RecentClips (`waypoint_count = 0` AND `event_count = 0`) | **delete** |
| RecentClips with GPS waypoints | keep |
| RecentClips with detected events | keep |
| Unindexed RecentClips (indexer hasn't seen yet) | keep |
| RecentClips newer than `min_age_hours` (default 1h) | keep |
| Stationary RecentClips with a SentryClips/SavedClips same-basename counterpart | keep |
| SentryClips and SavedClips folders | never walked |

### Safety guarantees

- Routes every delete through `safe_delete_archive_video` (the single doorway that enforces the `*.img` protected-file guard).
- Reconciles geodata via `purge_deleted_videos` for each deleted clip — **trips/waypoints/events rows are NEVER deleted**, only `video_path` is nulled. The May 7 "trips are sacred" contract is preserved.
- Holds the `task_coordinator` "retention" slot for the duration so the archive worker yields cleanly.
- Single-flight via the existing `_retention_running` guard so a stacked Settings click + watchdog tick can't pile up.
- Files newer than `min_age_hours` (default 1h) are kept so a clip Tesla just wrote and the indexer hasn't seen yet can't be preemptively wiped.

### API

`POST /api/cleanup/reclaim_stationary_recent`

Body: `{}` or `{"min_age_hours": int}` (default 1)

- 200 on success — body includes the watchdog summary.
- 200 on `status='already_running'` — normal control flow when another prune is in flight.
- 400 on invalid `min_age_hours` (non-integer).
- 500 on adapter crash.

Same HTTP contract as `/api/cleanup/run_now`.

### Tests

- 19 new tests in `tests/test_reclaim_stationary_recent_clips.py` covering the per-file decision matrix, the May 7 trip-preservation contract, the single-flight guard, the protected-file guard, and the watchdog-not-started error path.
- 9 new route tests in `tests/test_storage_retention_blueprint.py` covering the HTTP contract.
- **Full suite: 1475 passed, 3 skipped** (was 1447; +28 new).

### Out of scope (separate sub-deliverable for #167)

Skip-at-source archive worker flag — preventing refill of the SD card with new stationary clips. That's a separate PR.

Closes a sub-deliverable of #167.
