### PR TITLE
fix(#166): prevent gadget_web.service crash on first boot when /run/samba missing

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -73,7 +73,7 @@ These devices run in a vehicle; power can drop at any time. Prioritize atomic wr
 - **Tesla cache invalidation**: Tesla caches USB file contents and won't detect changes unless the USB device is re-enumerated. After replacing `LockChime.wav`, MUST unbind/rebind the USB gadget (see `partition_mount_service.rebind_usb_gadget()`). This simulates unplug/replug and forces Tesla to clear cache and re-scan the drive. The `set_active_chime()` function handles this automatically in present mode.
 
 ## Key Workflows
-- Switch modes: `sudo /home/pi/TeslaUSB/present_usb.sh` or `edit_usb.sh`; check `state.txt`.
+- Switch modes: `sudo /home/pi/TeslaUSB/scripts/present_usb.sh` or `scripts/edit_usb.sh`; check `state.txt`.
 - Logs: `sudo journalctl -u gadget_web.service -f`; scheduler `chime_scheduler.service`; monitor quick-edit lock at `~/.quick_edit_part2.lock`.
 - Manual web run: `cd /home/pi/TeslaUSB && python3 web_control.py` (use configured paths after setup).
 

--- a/readme.md
+++ b/readme.md
@@ -243,8 +243,8 @@ The web interface abstracts the underlying modes behind user-friendly labels:
 
 **Switch modes** via the device status card on the Settings page ("Enable Network Sharing" / "Reconnect to Tesla" buttons) or command line:
 ```bash
-sudo ~/TeslaUSB/present_usb.sh  # Reconnect to Tesla
-sudo ~/TeslaUSB/edit_usb.sh     # Enable Network Sharing
+sudo ~/TeslaUSB/scripts/present_usb.sh  # Reconnect to Tesla
+sudo ~/TeslaUSB/scripts/edit_usb.sh     # Enable Network Sharing
 ```
 
 ### Network Access

--- a/templates/gadget_web.service
+++ b/templates/gadget_web.service
@@ -28,7 +28,11 @@ OOMScoreAdjust=-500
 # Security settings - relaxed for sudo operations
 # Note: Disabled mount namespace isolation so mounts are visible system-wide
 MountFlags=shared
-ReadWritePaths=__GADGET_DIR__ __MNT_DIR__ /run/samba /tmp
+# /run/samba is prefixed with `-` so systemd silently ignores it when
+# missing on a fresh boot. smbd auto-start is disabled (issue #74); the
+# directory only exists after edit_usb.sh starts smbd. Without `-` the
+# unit fails with `Failed to set up mount namespacing` / status=226/NAMESPACE.
+ReadWritePaths=__GADGET_DIR__ __MNT_DIR__ -/run/samba /tmp
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Summary

Fixes #166 — `gadget_web.service` fails on first boot with `Failed to set up mount namespacing: /run/samba: No such file or directory` and exits `226/NAMESPACE`. Self-heals only after the user runs `edit_usb.sh` (which starts smbd and creates `/run/samba`) and restarts the service.

Also fixes the docs path bug reported in the same issue (`present_usb.sh` / `edit_usb.sh` are under `scripts/`, not at the repo root).

## Root Cause

The systemd unit at `templates/gadget_web.service:31` declared

```ini
ReadWritePaths=__GADGET_DIR__ __MNT_DIR__ /run/samba /tmp
```

systemd requires every path in `ReadWritePaths=` to exist when the unit's mount namespace is constructed; otherwise namespace setup fails with `status=226/NAMESPACE`. On a fresh boot `/run/samba` does **not** exist because issue #74 deliberately disables `smbd` auto-start (`setup_usb.sh:1329-1346`, ~4 s boot-time savings) — that directory is only created when `edit_usb.sh` brings up `smbd nmbd` on demand.

## Fix

Prefix `/run/samba` with `-` — the documented systemd idiom for "silently ignore this path if it does not exist" (`systemd.exec(5)`):

```ini
ReadWritePaths=__GADGET_DIR__ __MNT_DIR__ -/run/samba /tmp
```

Behavior preserved for the post-edit-mode case: once `smbd` later creates `/run/samba`, `MountFlags=shared` (already set on the unit) ensures `gadget_web` sees the system-wide directory through normal mount propagation. `gadget_web` itself never opens anything under `/run/samba` directly anyway — all samba interactions go through `sudo -n smbcontrol` subprocesses (`scripts/web/services/samba_service.py`), so this listing was always defensive/forward-compat rather than a hard requirement.

A 4-line comment block above the line documents the rationale so the next person doesn't strip it back out.

## Docs path fix

Reporter also flagged that the README and the AI coding guide point at the wrong location:

- `readme.md:246-247` — the documented mode-switch commands `sudo ~/TeslaUSB/present_usb.sh` and `sudo ~/TeslaUSB/edit_usb.sh` are wrong; the scripts live under `scripts/` (confirmed by `setup_usb.sh:2024,1968-1969` and the sudoers rules at `setup_usb.sh:1408-1409`).
- `.github/copilot-instructions.md:76` — same incorrect path in the Key Workflows section.

Both corrected to `~/TeslaUSB/scripts/present_usb.sh` / `~/TeslaUSB/scripts/edit_usb.sh`.

## Files changed

| File | Change |
|------|--------|
| `templates/gadget_web.service` | `+5/-1` — `-` prefix on `/run/samba` + 4-line rationale comment |
| `readme.md` | `+2/-2` — script paths corrected |
| `.github/copilot-instructions.md` | `+1/-1` — script paths corrected |

3 files, +8 / −4.

## Verification

- Self code review against TeslaUSB conventions (config usage, mount safety, mode awareness, path safety, subprocess safety, image gating, atomic writes, quick-edit cleanup, template placeholders) — **no findings of any severity**.
- The `-` prefix is the documented systemd idiom (see `man 5 systemd.exec` under `ReadWritePaths=`).
- Live smoke test on the target Pi planned: stop smbd → `rm -rf /run/samba` → `daemon-reload` → restart `gadget_web.service` → confirm `active (running)` with no NAMESPACE errors. (Reboot avoided — the device is in active use.)

## Assumptions stated

1. **Minimal fix preferred over `After=smbd.service` ordering** — adding ordering would do nothing on this system because `smbd` is `disabled` (issue #74); a `Requires=` would force it to start, undoing the deliberate boot-time savings. The `-` prefix is the lowest-impact change that keeps the existing boot model intact.
2. **`/run/samba` was kept in the list (with `-`) rather than removed** — `gadget_web` doesn't write there directly today, so removal would also work, but keeping it documents the intent that this path may be relevant when the unit is in edit-mode posture and is the more conservative diff.
3. **`copilot-instructions.md` is in scope for the docs fix** — it carries the same factual error as the README (wrong script path); fixing it in the same PR avoids a stale internal doc.
