### PR TITLE
fix(task_coordinator): stop wiping skip-log throttle on acquire (#172)

### DIFF
--- a/scripts/web/services/task_coordinator.py
+++ b/scripts/web/services/task_coordinator.py
@@ -73,6 +73,15 @@ _MAX_TASK_AGE_SECONDS = 1800  # 30 minutes
 # boot catchup (issue #72). One log per (task, blocker) pair per minute
 # is plenty — the log shows you a contention is in progress, not a
 # blow-by-blow account.
+#
+# Issue #172: the throttle map is NEVER cleared on successful acquire.
+# The previous design did clear it (the theory being "new contention
+# period deserves a fresh INFO"), but on a backlogged device the
+# indexer↔archive interleave at sub-second granularity → every short
+# acquire wiped the throttle → spam returned. The fix is to let
+# entries naturally age out via the per-pair 60s window in
+# ``_should_log_skipped``. A genuinely new (task, blocker) pair has no
+# entry in the map so it still fires INFO on its first encounter.
 _SKIPPED_LOG_THROTTLE_SECONDS = 60.0
 # Per (task_name, blocker_name) -> monotonic time of last INFO log.
 # Guarded by ``_lock`` so concurrent acquire_task callers can't
@@ -231,11 +240,26 @@ def acquire_task(task_name: str, wait_seconds: float = 0.0,
                     if am_waiting:
                         _waiter_count = max(0, _waiter_count - 1)
                         am_waiting = False
-                    # On successful acquisition, reset the per-blocker
-                    # throttle map. The "skipped" log should fire on the
-                    # FIRST blocked attempt of the next contention
-                    # period, not stay throttled from the previous one.
-                    _skipped_log_last.clear()
+                    # Issue #172: do NOT clear ``_skipped_log_last`` on
+                    # successful acquire. The previous design cleared
+                    # the throttle map here on the theory that a new
+                    # contention period deserved a fresh INFO line —
+                    # but on a backlogged Pi the indexer↔archive
+                    # interleave at sub-second granularity, so every
+                    # short successful acquire wiped the throttle and
+                    # the very next "skipped" fired INFO again,
+                    # producing ~6 lines/min for the same (task,
+                    # blocker) pair. The per-pair 60 s window in
+                    # :func:`_should_log_skipped` already gives the
+                    # operator one INFO line per minute per pair which
+                    # is exactly the documented project rule (see
+                    # ``copilot-instructions.md`` "Logging routine
+                    # cyclic-worker activity at INFO"). A genuinely
+                    # NEW (task, blocker) pair has no entry in the
+                    # throttle map and will fire INFO on its first
+                    # encounter regardless. Stale entries cost ~64
+                    # bytes each and there are at most a handful of
+                    # pairs, so the dict stays trivially small.
                     # Per Phase 1 item 1.2: routine acquire/release
                     # were ~2 INFO lines/sec during normal operation,
                     # bloating the journal. Drop to DEBUG; the rolling

--- a/tests/test_task_coordinator.py
+++ b/tests/test_task_coordinator.py
@@ -395,9 +395,19 @@ class TestSkippedLogThrottling:
         finally:
             tc.release_task('archive')
 
-    def test_throttle_resets_on_lock_acquisition(self, caplog):
-        """When the lock changes hands, the throttle map clears so the
-        first skip of the next contention window logs at INFO again."""
+    def test_new_blocker_pair_logs_at_info_after_lock_change(self, caplog):
+        """Issue #172: when the lock changes hands, a SKIP against a
+        newly-encountered blocker should still fire INFO on its first
+        attempt (because no entry exists in the throttle map for that
+        ``(task, blocker)`` pair).
+
+        Note: prior to issue #172 the throttle map was wiped on every
+        successful acquire, which produced log spam under rapid task
+        interleave. The post-#172 behavior leaves the map intact and
+        relies on the per-pair 60s window, but a brand-new pair like
+        ``(indexer, cloud_sync)`` still has no entry → still fires
+        INFO. This test guards that property.
+        """
         # First contention period.
         tc.acquire_task('archive')
         try:
@@ -409,12 +419,15 @@ class TestSkippedLogThrottling:
 
         caplog.clear()
 
-        # Lock is now free → next acquire resets the throttle map.
+        # Lock is now free → next acquire does NOT clear the throttle
+        # map (post-#172). But the second contention's blocker is
+        # different, so the (indexer, cloud_sync) pair has no entry
+        # and still fires INFO.
         assert tc.acquire_task('cloud_sync') is True
         try:
             with caplog.at_level('INFO', logger='services.task_coordinator'):
                 # Second contention period: indexer's first skip vs
-                # the new blocker should fire at INFO again.
+                # the new blocker should fire at INFO.
                 assert tc.acquire_task('indexer') is False
 
             info_skips = [
@@ -441,8 +454,10 @@ class TestSkippedLogThrottling:
         finally:
             tc.release_task('archive')
 
-        # Lock acquisition cleared the throttle map for next contention.
         # New blocker (cloud_sync), same skipped task (indexer).
+        # Issue #172: the throttle map is no longer cleared on
+        # acquire, but ``(indexer, cloud_sync)`` is a brand-new pair
+        # with no entry, so it still fires INFO independently.
         caplog.clear()
         tc.acquire_task('cloud_sync')
         try:
@@ -457,6 +472,73 @@ class TestSkippedLogThrottling:
             assert "'cloud_sync' is running" in info_skips[0].getMessage()
         finally:
             tc.release_task('cloud_sync')
+
+    def test_rapid_interleave_does_not_spam_info(self, caplog):
+        """Issue #172 regression test — production hot path.
+
+        On a backlogged Pi, ``archive`` and ``indexer`` rapidly
+        interleave (each ~0.5 s of work). Pre-#172, every ``archive``
+        re-acquire wiped the throttle map → next ``indexer`` skip
+        re-fired INFO → ~6 lines/min for the same (indexer, archive)
+        pair. After #172, the throttle map persists across acquires
+        and the per-pair 60s window keeps ≤1 INFO per minute.
+        """
+        # Simulate 20 interleaved cycles of (archive acquires, indexer
+        # rebuffed, archive releases, indexer acquires, indexer releases).
+        # All within sub-second wall time, well inside the 60s throttle.
+        with caplog.at_level('INFO', logger='services.task_coordinator'):
+            for _ in range(20):
+                assert tc.acquire_task('archive') is True
+                # Indexer attempts and is rebuffed — this is the
+                # spam path under the old code.
+                assert tc.acquire_task('indexer') is False
+                tc.release_task('archive')
+                # Indexer acquires (would have wiped throttle pre-#172).
+                assert tc.acquire_task('indexer') is True
+                tc.release_task('indexer')
+
+        info_skips = [
+            r for r in caplog.records
+            if r.levelname == 'INFO' and 'skipped' in r.message
+        ]
+        assert len(info_skips) == 1, (
+            f"Expected exactly 1 INFO 'skipped' log across 20 rapid "
+            f"interleaves (per-pair 60s throttle), got "
+            f"{len(info_skips)}: {[r.getMessage() for r in info_skips]}"
+        )
+
+    def test_throttle_entry_persists_across_acquires(self, caplog):
+        """Issue #172 invariant: ``_skipped_log_last`` is no longer
+        wiped on successful acquire. Verify the entry survives a
+        full acquire/release cycle of the blocker."""
+        # Prime the throttle for (indexer, archive).
+        tc.acquire_task('archive')
+        try:
+            with caplog.at_level('INFO', logger='services.task_coordinator'):
+                tc.acquire_task('indexer')  # → INFO + entry written
+        finally:
+            tc.release_task('archive')
+
+        # Pre-#172 this entry would be wiped by the next successful
+        # acquire below. Post-#172 it persists.
+        original_ts = tc._skipped_log_last.get(('indexer', 'archive'))
+        assert original_ts is not None, "Throttle entry should be set"
+
+        # Fully unrelated task acquires + releases.
+        assert tc.acquire_task('cloud_sync') is True
+        tc.release_task('cloud_sync')
+
+        # Indexer also acquires + releases.
+        assert tc.acquire_task('indexer') is True
+        tc.release_task('indexer')
+
+        # The (indexer, archive) entry MUST still be present (the bug
+        # fix). Pre-#172 it would have been cleared by these acquires.
+        retained_ts = tc._skipped_log_last.get(('indexer', 'archive'))
+        assert retained_ts == original_ts, (
+            "Issue #172 regression: throttle entry was wiped on "
+            "successful acquire — log spam will return."
+        )
 
 
 class TestAcquireReleaseLogLevels:


### PR DESCRIPTION
## Summary

Fixes the `task_coordinator.py` log spam where the "Task X skipped: Y is running" INFO line was firing ~6 times per minute for the same `(task, blocker)` pair on a backlogged device, despite the per-pair 60s throttle.

## Live evidence (cybertruckusb.local)

```
$ journalctl -u gadget_web.service --since '10 minutes ago' \
    | grep -c "task_coordinator.*skipped"
57          # 181 total INFO lines in the same window
```

All 57 lines carried `(0s)` — meaning archive had JUST acquired each time. Pattern was sub-second `indexer↔archive` interleave during catch-up of a 1257-item archive backlog.

## Root cause

`acquire_task()` called `_skipped_log_last.clear()` on every successful acquire. The intent was "fresh contention period → fire INFO again", but on a backlogged Pi where archive grabs the lock for ~0.5s then releases:

1. `archive` acquires → wipes throttle map.
2. `archive` does work, releases.
3. `indexer` skipped because `archive` was running (well, just was) — but actually the lock is now free so… it works.
4. Next cycle: `archive` re-acquires → wipes throttle map AGAIN.
5. `indexer` skipped → fires INFO immediately because throttle was just wiped.

The per-pair 60s window in `_should_log_skipped` becomes a no-op under this hot path.

## Fix

Delete the `.clear()` call. The throttle map persists across acquires; a `(task, blocker)` pair fires INFO once per minute regardless of interleave frequency, matching the project rule (`copilot-instructions.md`: "Logging routine cyclic-worker activity at INFO").

A genuinely NEW pair has no entry in the map and still fires INFO on first encounter, so legitimate new contention episodes are still surfaced.

Memory cost is trivial (~64 bytes per pair, handful of pairs).

## Tests

- Renamed `test_throttle_resets_on_lock_acquisition` → `test_new_blocker_pair_logs_at_info_after_lock_change`. Same assertion, updated docstring to reflect the post-#172 reasoning.
- Updated `test_different_blocker_pair_logs_independently` comment.
- **Added `test_rapid_interleave_does_not_spam_info`**: simulates the production hot path (20 cycles of archive→indexer skip→archive release→indexer acquire) and asserts exactly 1 INFO log across all 20 cycles. Pre-fix this would emit ~20.
- **Added `test_throttle_entry_persists_across_acquires`**: explicit invariant guard — the `(task, blocker)` timestamp in `_skipped_log_last` MUST survive a full acquire/release cycle of the blocker.

```
$ pytest tests/ -q
1552 passed, 4 skipped in 74.25s
```

(was 1550, +2 new tests)

## Live verification plan

After deploy, expect ≤5 INFO `skipped` lines in 10min instead of 57.

Closes #172
