### PR TITLE
fix(ui): defeat inline display:flex so hidden attribute hides lost-clips banner (#174)

### DIFF
--- a/scripts/web/templates/index.html
+++ b/scripts/web/templates/index.html
@@ -64,6 +64,23 @@
          could archive them. Lost dashcam footage is unrecoverable, so
          this banner is intentionally loud (red) and links to the
          Failed Jobs page for the full archive history. -->
+    <style>
+        /* Issue #170 follow-up: the banner div carries an inline
+           ``display:flex`` (specificity 1,0,0,0) which overrides the
+           UA stylesheet's ``[hidden] { display:none }`` rule
+           (specificity 0,0,1,0). Without this scoped !important rule,
+           setting ``banner.hidden = true`` from JS leaves the banner
+           visible because the inline display wins — exactly what the
+           user reported when the Dismiss button "did not work" even
+           though the POST to /api/system/clear_lost_clips returned
+           200. Reproduced live with Playwright on
+           cybertruckusb.local: ``element.hidden === true`` but
+           ``getComputedStyle(el).display === "flex"``. The
+           !important + the [hidden] selector match exactly what the
+           UA rule would do, just with enough specificity to defeat
+           the inline style. */
+        #files-lost-banner[hidden] { display: none !important; }
+    </style>
     <div id="files-lost-banner" hidden
          style="margin:12px 0; padding:12px 14px;
                 border-radius:8px;

--- a/tests/test_files_lost_banner_dismiss_css.py
+++ b/tests/test_files_lost_banner_dismiss_css.py
@@ -1,0 +1,119 @@
+"""Regression test for the "Footage may have been lost" dismiss bug.
+
+Issue history:
+- #163 : add a Dismiss button to the home-page lost-footage banner.
+- #167 / #170 : tombstone-on-server so a worker burst can't repopulate
+  the dismissed banner.
+- This bug : after PR #169 shipped the tombstone, the user reported the
+  banner *still* did not disappear when Dismiss was clicked. Live
+  reproduction with Playwright on cybertruckusb.local showed:
+      element.hidden === true
+      getComputedStyle(element).display === 'flex'
+  The banner div carries an inline ``style="...display:flex;..."`` whose
+  CSS specificity (1,0,0,0) defeats the UA stylesheet's
+  ``[hidden] { display: none }`` rule (specificity 0,0,1,0). A scoped
+  ``#files-lost-banner[hidden] { display: none !important; }`` rule
+  was added to ``index.html`` to defeat the inline display.
+
+This test pins that fix so a future template cleanup can't silently
+re-introduce the bug. We do source-based assertions (reading
+index.html as text) because rendering the full template requires an
+app context with every blueprint registered — see ``test_settings_responsive.py``
+for the same trade-off.
+"""
+from __future__ import annotations
+
+import os
+import re
+
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+INDEX_HTML = os.path.join(
+    REPO_ROOT, 'scripts', 'web', 'templates', 'index.html',
+)
+
+
+def _read(path: str) -> str:
+    with open(path, encoding='utf-8') as f:
+        return f.read()
+
+
+class TestFilesLostBannerDismissCss:
+    """The banner must be hideable via the ``hidden`` attribute."""
+
+    def test_banner_element_exists(self):
+        html = _read(INDEX_HTML)
+        assert 'id="files-lost-banner"' in html
+
+    def test_banner_has_inline_display_flex(self):
+        """If this assertion ever flips to False, the
+        ``[hidden] !important`` rule below is no longer required and
+        the test below can be deleted. As long as inline ``display:flex``
+        is present, the override rule is mandatory."""
+        html = _read(INDEX_HTML)
+        # Find the banner div tag and verify display:flex appears in
+        # its inline style attribute.
+        match = re.search(
+            r'<div\s+id="files-lost-banner"[^>]*style="([^"]*)"',
+            html,
+            re.DOTALL,
+        )
+        assert match is not None, (
+            "Could not find <div id=\"files-lost-banner\" ... style=\"...\">"
+        )
+        style_attr = match.group(1)
+        has_inline_flex = re.search(r'display\s*:\s*flex', style_attr) is not None
+        # We don't fail the test on either branch — this is a
+        # diagnostic for the assertion below.
+        assert has_inline_flex, (
+            "Inline display:flex was removed from the banner. The "
+            "[hidden] !important override rule is no longer strictly "
+            "necessary; if you've moved the layout into a CSS class, "
+            "delete this test or update it to match. See dismiss-bug "
+            "history at the top of this file."
+        )
+
+    def test_hidden_attribute_overrides_inline_display(self):
+        """Issue #170 follow-up — the dismiss bug.
+
+        The CSS rule ``#files-lost-banner[hidden] { display: none !important; }``
+        MUST be present in the template to defeat the inline
+        ``display:flex`` style. Without it, ``banner.hidden = true``
+        from JavaScript leaves the banner visible because inline-style
+        specificity (1,0,0,0) beats the UA stylesheet's
+        ``[hidden] { display: none }`` rule (0,0,1,0).
+
+        The user-facing symptom: clicking the "Dismiss" button posts
+        successfully (200 OK from ``/api/system/clear_lost_clips``) but
+        the banner stays on screen — making the feature look broken.
+        """
+        html = _read(INDEX_HTML)
+        # Allow whitespace flexibility but require the exact selector,
+        # property, and !important.
+        pattern = re.compile(
+            r'#files-lost-banner\s*\[\s*hidden\s*\]\s*\{[^}]*'
+            r'display\s*:\s*none\s*!important',
+            re.DOTALL | re.IGNORECASE,
+        )
+        assert pattern.search(html), (
+            "Missing CSS rule:\n"
+            "    #files-lost-banner[hidden] { display: none !important; }\n"
+            "This rule is REQUIRED to defeat the inline ``display:flex`` "
+            "on the banner element. Without it, the JS Dismiss handler "
+            "(which sets ``banner.hidden = true``) cannot actually hide "
+            "the banner — see test docstring for the full bug history."
+        )
+
+    def test_dismiss_handler_still_sets_hidden_true(self):
+        """Belt and suspenders — the JS handler is the other half of
+        the fix. If a future refactor changes ``lostBanner.hidden = true``
+        to e.g. ``lostBanner.style.display = 'none'``, the CSS rule is
+        no longer strictly required and this whole file can be revisited.
+        Today we still rely on the .hidden assignment, so verify it.
+        """
+        html = _read(INDEX_HTML)
+        assert 'lostBanner.hidden = true' in html, (
+            "The JS dismiss handler no longer sets "
+            "``lostBanner.hidden = true`` — review whether the "
+            "[hidden] !important CSS rule is still needed."
+        )


### PR DESCRIPTION
## Summary

Fixes a CSS-specificity bug that prevented the home-page "Footage may have been lost" banner from being hidden by JavaScript. The dismiss POST already worked (200 OK, server tombstone written, next health poll returned `lost_24h: 0`) — but the banner stayed on screen because the inline `style="...display:flex; ..."` defeated the UA stylesheet's `[hidden] { display: none }` rule.

This is the third (and hopefully final) iteration of the "Footage may have been lost" dismiss flow:

| Issue | PR | What it fixed |
|------|----|---------------|
| #163 | #166 | Added the Dismiss button + endpoint |
| #167 / #170 | #169 | Server-side tombstone so worker bursts can't repopulate the banner |
| **#174** | **this PR** | **CSS specificity fix so JS can actually hide the banner** |

## Live reproduction (cybertruckusb.local @ `0e270b9`)

Via Playwright:

```js
> document.getElementById('files-lost-banner').hidden
true
> getComputedStyle(document.getElementById('files-lost-banner')).display
'flex'         // bug — should be 'none'
> document.getElementById('files-lost-banner').offsetParent !== null
true           // bug — banner still on screen
```

## Root cause

The banner div has an inline `style="...display:flex; ..."`. CSS specificity:

- Inline style: **(1, 0, 0, 0)**
- UA stylesheet `[hidden] { display: none }`: **(0, 0, 1, 0)**

Inline wins. So `element.hidden = true` set the attribute but the inline display kept the banner visible.

This bug is unique to this banner. The same template has ~10 other `.hidden`-toggled elements (etaWrap, activeRow, errRow, summaryEl, dlModal, etc.) — all of which work because none of them carry inline `display:flex`.

## Fix

Add a scoped CSS rule with `!important` immediately above the banner element:

```css
#files-lost-banner[hidden] { display: none !important; }
```

Scoped to one element, only kicks in when `hidden` is present, exactly mirrors the UA stylesheet's intent — just with enough specificity to defeat inline.

## Live verification

After deploy:

```js
banner.hidden = false → display:flex, visible:true   ✅
banner.hidden = true  → display:none, visible:false  ✅
```

Reproduced the user's exact bug, applied the fix, deployed via SCP + `systemctl restart gadget_web.service`, re-tested with Playwright — Dismiss now actually hides the banner.

## Tests

`tests/test_files_lost_banner_dismiss_css.py` (4 cases) pins the fix:

- `test_banner_element_exists` — pin the banner ID
- `test_banner_has_inline_display_flex` — diagnostic; if inline flex is ever removed, the override rule can be deleted (test will tell us)
- `test_hidden_attribute_overrides_inline_display` — the actual regression guard
- `test_dismiss_handler_still_sets_hidden_true` — guards the JS half of the contract

Source-based pattern (same as `test_settings_responsive.py`) because rendering `index.html` requires a full Flask app context.

```
$ pytest tests/ -q
1556 passed, 4 skipped in 73.04s
```

(was 1552, +4 new tests)

Closes #174
