### PR TITLE
fix(archive): cap SEI peek mdat walk to fix worker stall on parked clips

### DIFF
--- a/scripts/web/services/archive_worker.py
+++ b/scripts/web/services/archive_worker.py
@@ -1347,20 +1347,37 @@ def _stable_write_age_seconds() -> float:
 
 # ---------------------------------------------------------------------------
 # Issue #167 sub-deliverable 2 — skip-at-source for stationary RecentClips
+# Issue #176 — fast-peek tuning
 # ---------------------------------------------------------------------------
 
 # Cap on SEI messages scanned by ``_clip_has_gps_signal`` before declaring
 # "no GPS". Tesla writes one SEI NAL per frame at ~30 fps; with sample_rate=30
-# one SeiMessage is yielded per ~1 s of video. A typical RecentClips clip is
-# 60 s of video (one minute), so 60 messages covers the whole clip. We cap at
-# 90 to allow a small safety margin for slightly-longer clips and clips that
-# yield SEI at slightly higher cadence, but bail out fast on degenerate inputs
-# (e.g., a corrupted clip that yields tens of thousands of SEI NALs).
+# one SeiMessage is yielded per ~1 s of video. The cap is mainly a defensive
+# bound for degenerate inputs (e.g., a corrupted clip that yields tens of
+# thousands of SEI NALs); the dominant termination signal for a moving clip
+# is the early ``return True`` on the first GPS-bearing message, and for a
+# stationary clip is ``_SKIP_GPS_PEEK_MAX_WALK_BYTES`` (below).
 _SKIP_GPS_PEEK_MAX_MESSAGES = 90
 # Sample rate for the peek. ``30`` matches what the indexer uses — one SEI
 # per ~1 s of video — so the I/O footprint of the peek is on the same order
 # as one indexer pass.
 _SKIP_GPS_PEEK_SAMPLE_RATE = 30
+# Issue #176 — hard cap on bytes walked through the ``mdat`` box during the
+# stationary peek. Tesla writes ZERO SEI NAL units in parked Sentry clips
+# (no telemetry to record), so the message-count cap above never fires on
+# parked footage — the parser would otherwise walk the entire ``mdat`` box
+# (~25-50 MB on Tesla cameras) and page in the whole file via mmap to
+# confirm "no SEI exists". Bench results on cybertruckusb.local (Pi
+# Zero 2 W) showed 1.2-3.7 s of cold-cache wall time per parked clip in
+# the unlimited case versus ~20 ms with a 2 MB cap — a ~200x speedup that
+# eliminates the load-pause throttle the worker was hitting every 7 clips.
+# 2 MB is enough to comfortably catch the first GPS-bearing SEI in any
+# moving clip (Tesla writes 1 SEI per frame at 30 fps; at ~3 Mbit/s that's
+# ~30 SEI messages in 1 s of video ≈ ~370 KB into ``mdat``). A driving
+# clip that has zero GPS lock for the first 5 seconds would be
+# misclassified as stationary, but the user already opted in to skipping
+# stationary clips and that edge case is far rarer than the stall it cures.
+_SKIP_GPS_PEEK_MAX_WALK_BYTES = 2 * 1024 * 1024
 
 
 def _skip_stationary_recent_clips_enabled() -> bool:
@@ -1400,15 +1417,16 @@ def _clip_has_gps_signal(source_path: str) -> Optional[bool]:
         are never silently dropped — the existing copy-then-index
         path will handle them safely.
 
-    Memory model: re-uses the same ``mmap``-backed
+    Memory and I/O model: re-uses the same ``mmap``-backed
     :func:`sei_parser.extract_sei_messages` generator the indexer
-    uses, with an early ``break`` on the first GPS-bearing message.
-    For a moving clip the peek returns after ~1 s of video; for a
-    stationary 60-s clip the peek scans the whole clip, but the
-    walker only pages in SEI NAL bytes (skipping past video NAL
-    payloads), so the actual I/O footprint stays in the low MB
-    range. Net I/O is dramatically lower than the 30-50 MB write +
-    sync we avoid by skipping the copy.
+    uses, with an early ``break`` on the first GPS-bearing message
+    AND a ``max_walk_bytes`` cap so a parked clip with zero SEI does
+    NOT have to page in the entire ``mdat`` box to confirm absence.
+    Issue #176 — without the byte cap, the parser walks the whole
+    ``mdat`` box (~25-50 MB) for every parked clip because the
+    message-count cap never fires when Tesla emits zero SEI messages
+    in stationary footage. Bench: 1.2-3.7 s per peek without cap,
+    ~20 ms per peek with a 2 MB cap.
     """
     try:
         from services import sei_parser
@@ -1424,7 +1442,9 @@ def _clip_has_gps_signal(source_path: str) -> Optional[bool]:
     scanned = 0
     try:
         for msg in sei_parser.extract_sei_messages(
-                source_path, sample_rate=_SKIP_GPS_PEEK_SAMPLE_RATE):
+                source_path,
+                sample_rate=_SKIP_GPS_PEEK_SAMPLE_RATE,
+                max_walk_bytes=_SKIP_GPS_PEEK_MAX_WALK_BYTES):
             scanned += 1
             if msg.has_gps:
                 return True
@@ -1613,8 +1633,9 @@ def process_one_claim(row: Dict[str, Any], db_path: str,
             archive_queue.mark_skipped_stationary(row_id, db_path=db_path)
             logger.info(
                 "archive_worker: skipped stationary RecentClips %s "
-                "(no GPS-bearing SEI in first ~%d s)",
+                "(no GPS-bearing SEI in first %d KB / %d msgs)",
                 source_path,
+                _SKIP_GPS_PEEK_MAX_WALK_BYTES // 1024,
                 _SKIP_GPS_PEEK_MAX_MESSAGES,
             )
             return 'skipped_stationary'

--- a/scripts/web/services/sei_parser.py
+++ b/scripts/web/services/sei_parser.py
@@ -439,7 +439,8 @@ def _get_timescale_and_durations(data: bytes) -> tuple:
 
 def extract_sei_messages(
     video_path: str,
-    sample_rate: int = 1
+    sample_rate: int = 1,
+    max_walk_bytes: Optional[int] = None,
 ) -> Generator[SeiMessage, None, None]:
     """Extract SEI telemetry messages from a Tesla dashcam MP4 file.
 
@@ -450,6 +451,15 @@ def extract_sei_messages(
         video_path: Path to the MP4 file.
         sample_rate: Only process every Nth frame (1=all, 30=~1/sec at 30fps).
             Use 1 for maximum resolution, 30 for route mapping.
+        max_walk_bytes: Optional hard cap on the number of bytes walked
+            inside the ``mdat`` box. When set, the generator stops after
+            the cumulative ``cursor`` advance through ``mdat`` exceeds
+            this many bytes. Use this for "is this clip stationary?"
+            peeks where the caller will break out on the first
+            GPS-bearing message anyway — capping the walk turns a
+            full-file mmap page-in (25-50 MB cold-cache I/O) into a
+            fixed-size read. Default ``None`` preserves the historical
+            walk-to-end behavior used by the indexer.
 
     Yields:
         SeiMessage objects with GPS, speed, acceleration, and control data.
@@ -529,6 +539,16 @@ def extract_sei_messages(
         # Walk through NAL units in mdat
         cursor = mdat['start']
         end = mdat['end']
+        # Apply ``max_walk_bytes`` as a hard cap on the cumulative
+        # cursor advance through ``mdat``. We compute a stop-cursor
+        # once and check it on each loop iteration; this keeps the
+        # hot path branch-free for the unbounded indexer case (where
+        # ``max_walk_bytes is None`` collapses to the original
+        # ``cursor + 4 <= end`` predicate).
+        if max_walk_bytes is not None:
+            walk_stop = mdat['start'] + max(0, int(max_walk_bytes))
+            if walk_stop < end:
+                end = walk_stop
         frame_index = 0
         cumulative_time_ms = 0.0
 

--- a/tests/test_archive_worker.py
+++ b/tests/test_archive_worker.py
@@ -909,7 +909,7 @@ class TestClipHasGpsSignal:
         clip.write_bytes(b"x" * 100)
         seen = []
 
-        def fake_extract(path, sample_rate):
+        def fake_extract(path, sample_rate, max_walk_bytes=None):
             assert path == str(clip)
             for i in range(100):
                 seen.append(i)
@@ -937,7 +937,7 @@ class TestClipHasGpsSignal:
         clip = tmp_path / "stationary.mp4"
         clip.write_bytes(b"x" * 100)
 
-        def fake_extract(path, sample_rate):
+        def fake_extract(path, sample_rate, max_walk_bytes=None):
             # Yield one less than the cap to confirm we walk normally
             # to exhaustion when no GPS appears.
             for _ in range(archive_worker._SKIP_GPS_PEEK_MAX_MESSAGES - 1):
@@ -955,7 +955,7 @@ class TestClipHasGpsSignal:
         clip = tmp_path / "no-sei.mp4"
         clip.write_bytes(b"x" * 100)
 
-        def fake_extract(path, sample_rate):
+        def fake_extract(path, sample_rate, max_walk_bytes=None):
             return
             yield  # unreachable; makes this a generator
 
@@ -976,7 +976,7 @@ class TestClipHasGpsSignal:
         clip.write_bytes(b"x" * 100)
         pulled = []
 
-        def fake_extract(path, sample_rate):
+        def fake_extract(path, sample_rate, max_walk_bytes=None):
             for i in range(10000):
                 pulled.append(i)
                 yield fake_msg(False)
@@ -995,7 +995,7 @@ class TestClipHasGpsSignal:
         clip = tmp_path / "broken.mp4"
         clip.write_bytes(b"x" * 100)
 
-        def fake_extract(path, sample_rate):
+        def fake_extract(path, sample_rate, max_walk_bytes=None):
             raise ValueError("not a valid MP4")
             yield  # unreachable
 
@@ -1014,7 +1014,7 @@ class TestClipHasGpsSignal:
         clip = tmp_path / "vanished.mp4"
         clip.write_bytes(b"x" * 100)
 
-        def fake_extract(path, sample_rate):
+        def fake_extract(path, sample_rate, max_walk_bytes=None):
             raise FileNotFoundError(path)
             yield  # unreachable
 
@@ -1025,6 +1025,45 @@ class TestClipHasGpsSignal:
         # File vanished mid-peek → ambiguous → caller will re-stat
         # and mark source_gone via the existing copy path.
         assert archive_worker._clip_has_gps_signal(str(clip)) is None
+
+    def test_passes_max_walk_bytes_cap_to_parser(
+        self, monkeypatch, tmp_path, fake_msg,
+    ):
+        # Issue #176 — the peek MUST forward ``max_walk_bytes`` to the
+        # parser so the parker exits after a bounded mmap walk on
+        # parked clips (where Tesla emits zero SEI). Without this, the
+        # message-count cap never fires for stationary footage and the
+        # parser walks the entire 25-50 MB ``mdat`` box.
+        clip = tmp_path / "parked.mp4"
+        clip.write_bytes(b"x" * 100)
+        captured_kwargs: list = []
+
+        def fake_extract(path, sample_rate, max_walk_bytes=None):
+            captured_kwargs.append({
+                'sample_rate': sample_rate,
+                'max_walk_bytes': max_walk_bytes,
+            })
+            return
+            yield  # unreachable; makes this a generator
+
+        from services import sei_parser
+        monkeypatch.setattr(
+            sei_parser, 'extract_sei_messages', fake_extract,
+        )
+        archive_worker._clip_has_gps_signal(str(clip))
+        assert len(captured_kwargs) == 1
+        assert captured_kwargs[0]['sample_rate'] == (
+            archive_worker._SKIP_GPS_PEEK_SAMPLE_RATE
+        )
+        # The cap must be a positive integer of bytes (the parser
+        # interprets ``None`` as "walk to end" — that would defeat the
+        # whole point of issue #176, so this assertion is the
+        # regression guard).
+        assert captured_kwargs[0]['max_walk_bytes'] == (
+            archive_worker._SKIP_GPS_PEEK_MAX_WALK_BYTES
+        )
+        assert captured_kwargs[0]['max_walk_bytes'] is not None
+        assert captured_kwargs[0]['max_walk_bytes'] > 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_archive_worker.py
+++ b/tests/test_archive_worker.py
@@ -1030,7 +1030,7 @@ class TestClipHasGpsSignal:
         self, monkeypatch, tmp_path, fake_msg,
     ):
         # Issue #176 — the peek MUST forward ``max_walk_bytes`` to the
-        # parser so the parker exits after a bounded mmap walk on
+        # parser so the parser exits after a bounded mmap walk on
         # parked clips (where Tesla emits zero SEI). Without this, the
         # message-count cap never fires for stationary footage and the
         # parser walks the entire 25-50 MB ``mdat`` box.

--- a/tests/test_sei_parser.py
+++ b/tests/test_sei_parser.py
@@ -473,6 +473,77 @@ class TestExtractSeiMessages:
         with pytest.raises(ValueError, match="mdat"):
             list(extract_sei_messages(str(f)))
 
+    def test_max_walk_bytes_caps_mdat_walk(self, tmp_path):
+        """Issue #176 — ``max_walk_bytes`` caps the mdat walk so the
+        parser exits early on long files instead of paging in the
+        whole ``mdat`` box.
+
+        We use 100 SEI payloads to grow the mdat box well past any
+        small cap, then assert that:
+
+          * ``max_walk_bytes=None`` (default) yields all 100 messages.
+          * A small cap yields strictly fewer messages.
+          * The capped result is a strict prefix of the unlimited
+            result (i.e., we stop early — we don't skip ahead).
+          * A cap of 0 yields zero messages without raising.
+        """
+        payloads = [
+            _make_sei_protobuf(lat=float(i + 1), lon=float(i + 1))
+            for i in range(100)
+        ]
+        mp4_data = self._make_synthetic_mp4(payloads)
+        video_file = tmp_path / "long.mp4"
+        video_file.write_bytes(mp4_data)
+
+        unlimited = list(extract_sei_messages(
+            str(video_file), sample_rate=1,
+        ))
+        assert len(unlimited) == 100
+
+        # 1 KB is far smaller than the mdat we just built (each NAL
+        # pair is dozens of bytes), so the cap MUST short-circuit.
+        capped = list(extract_sei_messages(
+            str(video_file), sample_rate=1, max_walk_bytes=1024,
+        ))
+        assert 0 < len(capped) < len(unlimited), (
+            f"capped peek did not actually cap: "
+            f"capped={len(capped)} unlimited={len(unlimited)}"
+        )
+        # Capped result must be a prefix of the unlimited result —
+        # we early-exit, we do not skip ahead.
+        for i, msg in enumerate(capped):
+            assert abs(msg.latitude_deg - unlimited[i].latitude_deg) < 1e-6
+
+        # Zero-byte cap is a degenerate but legal call. We must not
+        # raise; we just yield nothing because the walk never enters
+        # the body. This matches the documented "treat None as
+        # walk-to-end, anything else as a hard cap" contract.
+        zero = list(extract_sei_messages(
+            str(video_file), sample_rate=1, max_walk_bytes=0,
+        ))
+        assert zero == []
+
+    def test_max_walk_bytes_default_is_unlimited(self, tmp_path):
+        """The default value for ``max_walk_bytes`` MUST preserve
+        the historical walk-to-end behavior the indexer depends on.
+
+        Regression guard: a future refactor that flipped the default
+        to a small cap would silently truncate every indexer pass.
+        """
+        payloads = [_make_sei_protobuf() for _ in range(10)]
+        mp4_data = self._make_synthetic_mp4(payloads)
+        video_file = tmp_path / "default_unlimited.mp4"
+        video_file.write_bytes(mp4_data)
+
+        # Default call (no ``max_walk_bytes`` kwarg) must yield all.
+        msgs = list(extract_sei_messages(str(video_file), sample_rate=1))
+        assert len(msgs) == 10
+        # Explicit None must behave identically.
+        msgs2 = list(extract_sei_messages(
+            str(video_file), sample_rate=1, max_walk_bytes=None,
+        ))
+        assert len(msgs2) == 10
+
 
 class TestParseVideoSei:
     def test_returns_list(self, tmp_path):


### PR DESCRIPTION
## Summary

Fixes the archive worker stall described in #176 by capping the SEI peek's `mdat` walk to 2 MB. Cold-cache peek time on the Pi Zero 2 W drops from **1.2-3.7 s** to **~20 ms** per parked clip — a ~200x speedup that eliminates the load-pause cycle and lets SentryClips events drain promptly.

## What changed

* **`scripts/web/services/sei_parser.py`** — added an optional `max_walk_bytes` parameter to `extract_sei_messages`. When set, the generator stops walking once the cursor exceeds `mdat['start'] + max_walk_bytes`. Default `None` preserves the historical walk-to-end behavior used by the indexer.

* **`scripts/web/services/archive_worker.py`** — passes `_SKIP_GPS_PEEK_MAX_WALK_BYTES = 2 MB` to the parser from `_clip_has_gps_signal`. Also corrects a misleading comment block that claimed the walker "skips past video NAL payloads" (it does not — it touches every NAL header, which is what made the cold-cache walk so expensive).

* **`tests/test_sei_parser.py`** — 2 new tests:
  * `test_max_walk_bytes_caps_mdat_walk` — capped result is a strict prefix of the unlimited result; zero-byte cap yields zero messages without raising.
  * `test_max_walk_bytes_default_is_unlimited` — regression guard against a future flip-the-default refactor that would silently truncate every indexer pass.

* **`tests/test_archive_worker.py`** — 1 new test (`test_passes_max_walk_bytes_cap_to_parser`) asserting that `_clip_has_gps_signal` forwards the cap to the parser. Existing `fake_extract` stubs updated to accept the new keyword arg.

## Live evidence (cybertruckusb.local)

Before the fix, the worker had been stalled for 100 minutes:

```json
{
  "copied": 8241, "pending": 516, "skipped_stationary": 228,
  "queue_depth_p1": 445, "queue_depth_p2": 71,
  "last_successful_copy_age_seconds": 6023,
  "load_pause": {"is_paused_now": true, "last_loadavg": 4.85},
  "message": "Archive worker is STALLED: no copy in 100 min (492 pending) — videos are being lost!",
  "severity": "critical"
}
```

Bench with `drop_caches=2` between each call (proves cold-cache cost, not warm-cache):

| File (size) | `max_walk_bytes` | time (ms) |
|---|---|---|
| back.mp4 (25 MB) | unlimited | 3554 |
| back.mp4 (25 MB) | 2 MB | 19 |
| front.mp4 (49 MB) | unlimited | 3657 |
| front.mp4 (49 MB) | 2 MB | 14 |
| left_pillar.mp4 (25 MB) | unlimited | 1233 |
| left_pillar.mp4 (25 MB) | 2 MB | 15 |

## Tests

`pytest tests/ -q`: **1559 passed, 4 skipped** (was 1556 / 4 pre-fix; +3 new tests).

## Risk

A driving clip with NO GPS-bearing SEI in the first 2 MB of `mdat` would be misclassified as stationary. At typical Tesla bitrates (~3 Mbit/s = ~375 KB/s), 2 MB is ~5 s of video, and Tesla writes 1 SEI per frame from second 1, so this requires GPS lock to be missing for the first 5 seconds of a clip the worker would otherwise have copied. Acceptable trade-off for opt-in users who already chose to skip stationary clips.

## Out of scope

The pick-query priority order (`priority ASC` → RecentClips P1 before SentryClips P2) is unchanged. With the slow peek, this caused starvation; with the fast peek, RecentClips drains in seconds, so SentryClips no longer wait meaningfully. No priority-order change needed in this PR.

Closes #176
