### PR TITLE
fix: swap archive queue priority constants so events drain before RecentClips (#178)

### DIFF
--- a/scripts/web/services/archive_queue.py
+++ b/scripts/web/services/archive_queue.py
@@ -139,12 +139,19 @@ def _infer_priority(path: str) -> int:
     Uses the same lowercase folder-name heuristic as
     ``indexing_queue_service.priority_for_path`` so behavior is
     consistent across the indexing and archive subsystems.
+
+    Checks are ordered highest-priority-first to mirror the
+    "lower number = picked first" semantics post-#178: events are
+    checked before RecentClips. Production paths are mutually
+    exclusive between the three folders, so check order only
+    affects synthetic edge cases — but the explicit ordering makes
+    the function self-documenting for the priority swap.
     """
     norm = (path or '').replace('\\', '/').lower()
-    if '/recentclips/' in norm:
-        return PRIORITY_RECENT_CLIPS
     if '/sentryclips/' in norm or '/savedclips/' in norm:
         return PRIORITY_EVENTS
+    if '/recentclips/' in norm:
+        return PRIORITY_RECENT_CLIPS
     return PRIORITY_OTHER
 
 

--- a/scripts/web/services/archive_queue.py
+++ b/scripts/web/services/archive_queue.py
@@ -88,15 +88,34 @@ logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
-# Priority inference (from the issue spec)
+# Priority inference (issue #178)
 # ---------------------------------------------------------------------------
 #
 # Lower number = more urgent. The Phase 2b worker picks rows in
 # (priority ASC, expected_mtime ASC) order — the partial index
 # ``archive_queue_ready`` covers exactly that ORDER BY.
+#
+# **Issue #178 — priority swap.** Pre-#178 the order was inverted:
+# ``RECENT_CLIPS=1, EVENTS=2``. The original reasoning ("Tesla rotates
+# RecentClips out after ~60 min, so they're the most urgent") was
+# correct when the worker copied every RecentClip. After issue #167
+# (``skip_stationary_recent_clips``) shipped, most RecentClips on a
+# parked car became low-value skip-decisions and the priority order
+# starved real Sentry events: live evidence on cybertruckusb showed
+# 71 SentryClips events untouched for 130+ minutes while the worker
+# burned its SDIO budget on parked-Sentry RecentClips skip decisions.
+# Events are the highest-value footage (something physically happened
+# to the car); RecentClips driving footage is dashcam-grade and gets
+# the second tier; the SEI-peek skip-stationary path handles the
+# parked-no-event case at copy time so it never competes with events
+# for the queue head.
+#
+# A v13 schema migration (``mapping_migrations.py``) flips existing
+# non-terminal rows on the first run after upgrade so the in-flight
+# backlog also benefits.
 
-PRIORITY_RECENT_CLIPS = 1     # Tesla rotates these out after ~60 min — highest urgency
-PRIORITY_EVENTS = 2           # SentryClips / SavedClips — user wants these soon
+PRIORITY_EVENTS = 1           # SentryClips / SavedClips — events are the highest-value footage
+PRIORITY_RECENT_CLIPS = 2     # Driving / dashcam footage; SEI-peek skips parked-no-event clips
 PRIORITY_OTHER = 3            # Default for anything else (e.g. ArchivedClips back-fill)
 
 # Status values stored in the ``status`` column. Phase 2a only ever
@@ -1024,10 +1043,10 @@ def claim_next_for_worker(claimed_by: str, *,
     missing RETURNING.
 
     The pick order matches the partial index ``archive_queue_ready``:
-    ``priority ASC, expected_mtime ASC NULLS LAST, id ASC``. RecentClips
-    (P1) drains before Sentry/Saved (P2) which drains before everything
-    else (P3); within a priority band, files closer to Tesla's rotation
-    deadline go first (oldest mtime).
+    ``priority ASC, expected_mtime ASC NULLS LAST, id ASC``. Sentry/
+    Saved events (P1) drain before RecentClips (P2) which drain before
+    everything else (P3) — issue #178. Within a priority band, files
+    closer to Tesla's rotation deadline go first (oldest mtime).
 
     Args:
         claimed_by: Stamped into ``claimed_by`` for diagnostics
@@ -1493,7 +1512,8 @@ def get_pending_counts_by_priority(db_path: Optional[str] = None) -> Dict[int, i
     Always includes the canonical priorities (1, 2, 3) in the result so
     callers don't need to deal with missing keys. Phase 2c surfaces this
     in ``/api/archive/status`` as ``queue_depth_p1/p2/p3`` so the UI can
-    show RecentClips backlog separately from event/other backlogs.
+    show event backlog separately from RecentClips/other backlogs.
+    Per issue #178: P1=events, P2=RecentClips, P3=other.
     """
     counts: Dict[int, int] = {1: 0, 2: 0, 3: 0}
     db_path = _resolve_db_path(db_path)

--- a/scripts/web/services/mapping_migrations.py
+++ b/scripts/web/services/mapping_migrations.py
@@ -46,7 +46,7 @@ logger = logging.getLogger(__name__)
 # Database Schema & Management
 # ---------------------------------------------------------------------------
 
-_SCHEMA_VERSION = 12
+_SCHEMA_VERSION = 13
 _BACKUP_RETENTION = 3  # Keep this many migration backups before pruning oldest
 
 _SCHEMA_SQL = """
@@ -181,11 +181,14 @@ CREATE INDEX IF NOT EXISTS idx_queue_claimed_at
 -- then. Keyed by ``source_path`` (UNIQUE) so the inotify producer, the
 -- 60-s rescan producer, and the boot catch-up scan can all use
 -- ``INSERT OR IGNORE`` for cheap idempotent enqueue. ``priority``
--- follows the issue spec: 1=RecentClips (Tesla rotates these out
--- after ~60 min, highest urgency), 2=SentryClips/SavedClips
--- (event clips the user wants ASAP), 3=anything else. ``status``
--- transitions through pending → claimed → copied (terminal) or
--- → source_gone / error / dead_letter (terminal). ``expected_size``
+-- follows the issue spec (post-#178 mapping):
+-- 1=SentryClips/SavedClips event clips (highest-value footage —
+--   something physically happened to the car),
+-- 2=RecentClips (driving / dashcam footage; SEI-peek skip-stationary
+--   handles parked-no-event clips at copy time so they don't compete),
+-- 3=anything else (e.g. ArchivedClips back-fill).
+-- ``status`` transitions through pending → claimed → copied (terminal)
+-- or → source_gone / error / dead_letter (terminal). ``expected_size``
 -- and ``expected_mtime`` are captured at enqueue time so the Phase
 -- 2b worker can detect "Tesla still writing" by re-stat-ing before
 -- the copy.
@@ -428,6 +431,56 @@ def _init_db(db_path: str) -> sqlite3.Connection:
                     )
                 except sqlite3.OperationalError:
                     pass
+        if current > 0 and current < 13:
+            # v13 (#178): swap archive_queue priority constants so
+            # SentryClips/SavedClips events drain BEFORE RecentClips.
+            # Pre-#178: P1=RecentClips, P2=Events. Post-#178: P1=Events,
+            # P2=RecentClips. Producers re-tag new rows with the correct
+            # constant once the code update lands; this migration flips
+            # the existing in-flight backlog so users don't have to wait
+            # for the old rows to drain the slow way.
+            #
+            # Only non-terminal statuses are touched — pending/claimed/
+            # error rows will be re-inspected by the worker, so their
+            # priority must reflect the new mapping. Terminal-status
+            # rows (copied, source_gone, skipped_stationary, dead_letter)
+            # are left alone: their ``priority`` value is historical and
+            # mutating it would mislead future debugging of "what got
+            # picked when".
+            #
+            # CASE form is symmetric and idempotent — running the
+            # statement twice is a no-op modulo a second swap. The
+            # ``current < 13`` gate prevents that anyway.
+            try:
+                conn.execute("SAVEPOINT migrate_v13")
+                cur = conn.execute(
+                    """
+                    UPDATE archive_queue
+                       SET priority = CASE priority
+                                          WHEN 1 THEN 2
+                                          WHEN 2 THEN 1
+                                          ELSE priority
+                                      END
+                     WHERE status IN ('pending', 'claimed', 'error')
+                       AND priority IN (1, 2)
+                    """
+                )
+                flipped = cur.rowcount
+                conn.execute("RELEASE SAVEPOINT migrate_v13")
+                if flipped:
+                    logger.info(
+                        "Migration v12->v13: flipped priority on %d "
+                        "non-terminal archive_queue row(s) "
+                        "(events now P1, RecentClips now P2)", flipped,
+                    )
+            except Exception as e:
+                conn.execute("ROLLBACK TO SAVEPOINT migrate_v13")
+                conn.execute("RELEASE SAVEPOINT migrate_v13")
+                logger.error(
+                    "Migration v12->v13 failed, leaving schema at v12: %s", e,
+                )
+                conn.commit()
+                return conn
         conn.execute("DELETE FROM schema_version")
         conn.execute(
             "INSERT INTO schema_version (version) VALUES (?)",

--- a/tests/test_archive_producer.py
+++ b/tests/test_archive_producer.py
@@ -160,8 +160,10 @@ class TestRunBootCatchupOnce:
         archive_producer.run_boot_catchup_once(teslacam, db_path=db)
         rows = archive_queue.list_queue(limit=100, db_path=db)
         priorities = sorted(r['priority'] for r in rows)
-        # 2 RecentClips (priority 1), 3 events (priority 2)
-        assert priorities == [1, 1, 2, 2, 2]
+        # Issue #178: events (P1) and RecentClips (P2). The catch-up
+        # fixture seeds 3 SentryClips events and 2 RecentClips, so
+        # the sorted priority list is [1, 1, 1, 2, 2].
+        assert priorities == [1, 1, 1, 2, 2]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_archive_queue.py
+++ b/tests/test_archive_queue.py
@@ -216,18 +216,19 @@ class TestEnqueueManyForArchive:
         assert all(r['priority'] == 1 for r in rows)
 
     def test_batch_priority_inferred_when_none(self, db, tmp_path):
-        # Mix of priorities: RecentClips and a generic path
-        recent_dir = tmp_path / "RecentClips"
-        recent_dir.mkdir()
-        recent_clip = recent_dir / "r.mp4"
-        recent_clip.write_bytes(b"r")
+        # Mix of priorities: SentryClips event (P1 post-#178) and a
+        # generic path (P3). Sorted output puts the event first.
+        sentry_dir = tmp_path / "SentryClips" / "evt"
+        sentry_dir.mkdir(parents=True)
+        sentry_clip = sentry_dir / "front.mp4"
+        sentry_clip.write_bytes(b"s")
         other = tmp_path / "other.mp4"
         other.write_bytes(b"o")
-        enqueue_many_for_archive([str(recent_clip), str(other)], db_path=db)
+        enqueue_many_for_archive([str(sentry_clip), str(other)], db_path=db)
         # Sorted by priority
         rows = list_queue(db_path=db)
-        assert rows[0]['priority'] == PRIORITY_RECENT_CLIPS
-        assert rows[0]['source_path'] == str(recent_clip)
+        assert rows[0]['priority'] == PRIORITY_EVENTS
+        assert rows[0]['source_path'] == str(sentry_clip)
         assert rows[1]['priority'] == PRIORITY_OTHER
 
 
@@ -676,19 +677,21 @@ class TestListQueue:
         assert copied[0]['source_path'].endswith('a.mp4')
 
     def test_sorted_by_priority_then_mtime(self, db, tmp_path):
-        # Three files with controlled priorities
-        recent_dir = tmp_path / "RecentClips"; recent_dir.mkdir()
-        r1 = recent_dir / "r1.mp4"; r1.write_bytes(b"x")
+        # Three files with controlled priorities (issue #178: events
+        # are P1 and drain first, RecentClips are P2).
+        sentry_dir = tmp_path / "SentryClips" / "evt"
+        sentry_dir.mkdir(parents=True)
+        s1 = sentry_dir / "s1.mp4"; s1.write_bytes(b"x")
         time.sleep(0.01)  # mtime ordering
-        r2 = recent_dir / "r2.mp4"; r2.write_bytes(b"x")
+        s2 = sentry_dir / "s2.mp4"; s2.write_bytes(b"x")
         other = tmp_path / "other.mp4"; other.write_bytes(b"x")
         enqueue_many_for_archive(
-            [str(other), str(r2), str(r1)], db_path=db,
+            [str(other), str(s2), str(s1)], db_path=db,
         )
         rows = list_queue(db_path=db)
-        # RecentClips (priority 1) come first, oldest mtime first within tier.
-        assert rows[0]['source_path'] == str(r1)
-        assert rows[1]['source_path'] == str(r2)
+        # Events (priority 1) come first, oldest mtime first within tier.
+        assert rows[0]['source_path'] == str(s1)
+        assert rows[1]['source_path'] == str(s2)
         assert rows[2]['source_path'] == str(other)
 
     def test_limit_caps_results(self, db, tmp_path):
@@ -837,12 +840,13 @@ class TestClaimNextForWorker:
         assert row['claimed_at'] is not None
 
     def test_picks_priority_one_first(self, db, tmp_path):
-        # Mix of priorities: P3 enqueued first, then P2, then P1.
-        # Worker MUST pick P1 first.
+        # Mix of priorities (issue #178: P1=events, P2=RecentClips,
+        # P3=other). P3 is enqueued first, then P2, then P1. Worker
+        # MUST pick P1 (event) first regardless of insertion order.
         p3 = tmp_path / "other.mp4"; p3.write_bytes(b'x')
-        p2 = tmp_path / "SentryClips" / "evt" / "front.mp4"
+        p2 = tmp_path / "RecentClips" / "front.mp4"
         p2.parent.mkdir(parents=True); p2.write_bytes(b'x')
-        p1 = tmp_path / "RecentClips" / "front.mp4"
+        p1 = tmp_path / "SentryClips" / "evt" / "front.mp4"
         p1.parent.mkdir(parents=True); p1.write_bytes(b'x')
         enqueue_for_archive(str(p3), db_path=db)
         enqueue_for_archive(str(p2), db_path=db)
@@ -856,9 +860,10 @@ class TestClaimNextForWorker:
         assert row['source_path'] == str(p3)
 
     def test_picks_oldest_mtime_within_priority(self, db, tmp_path):
-        a = tmp_path / "RecentClips" / "a-front.mp4"
-        b = tmp_path / "RecentClips" / "b-front.mp4"
-        a.parent.mkdir(parents=True); a.write_bytes(b'a'); b.write_bytes(b'b')
+        a = tmp_path / "SentryClips" / "evt-a" / "front.mp4"
+        b = tmp_path / "SentryClips" / "evt-b" / "front.mp4"
+        a.parent.mkdir(parents=True); a.write_bytes(b'a')
+        b.parent.mkdir(parents=True); b.write_bytes(b'b')
         # Make 'a' older than 'b' on disk.
         os.utime(str(a), (1000.0, 1000.0))
         os.utime(str(b), (2000.0, 2000.0))
@@ -2269,3 +2274,285 @@ class TestDeleteSourceGoneWritesTombstone:
         assert archive_queue.count_source_gone_recent(
             24, db_path=db, dismissed_at=ts,
         ) == 1
+
+
+# ===========================================================================
+# Issue #178 — priority swap: events drain before RecentClips
+# ===========================================================================
+#
+# Pre-#178 the archive queue had ``PRIORITY_RECENT_CLIPS=1`` and
+# ``PRIORITY_EVENTS=2``, so RecentClips drained ahead of Sentry/Saved
+# events. Live evidence on cybertruckusb.local showed 71 SentryClips
+# events untouched for 130+ minutes while the worker burned its SDIO
+# budget on parked-Sentry RecentClips skip-decisions. PR for #178
+# swaps the constants (events=1, RecentClips=2) and adds a v12->v13
+# schema migration that flips existing non-terminal queue rows so the
+# in-flight backlog also benefits.
+
+class TestPriorityConstantsPostIssue178:
+    """Issue #178: events MUST drain before RecentClips."""
+
+    def test_events_priority_is_lowest_number(self):
+        # Lower number = picked first. Events must be priority 1.
+        assert PRIORITY_EVENTS == 1, (
+            "Issue #178: SentryClips/SavedClips events are the "
+            "highest-value footage and MUST drain first. "
+            "PRIORITY_EVENTS must be 1."
+        )
+        assert PRIORITY_RECENT_CLIPS == 2, (
+            "Issue #178: RecentClips driving footage is second-tier "
+            "(SEI-peek skip-stationary handles parked-no-event case). "
+            "PRIORITY_RECENT_CLIPS must be 2."
+        )
+        assert PRIORITY_OTHER == 3, (
+            "Other (e.g. ArchivedClips back-fill) is the lowest "
+            "priority. PRIORITY_OTHER must be 3."
+        )
+        # Strict ordering — events strictly drain before RecentClips
+        # which strictly drain before other.
+        assert PRIORITY_EVENTS < PRIORITY_RECENT_CLIPS < PRIORITY_OTHER
+
+    def test_inference_maps_sentryclips_to_events(self):
+        for path in (
+            '/mnt/gadget/part1-ro/TeslaCam/SentryClips/2026-05-12_'
+            '08-00-00/front.mp4',
+            '/mnt/gadget/part1-ro/TeslaCam/SavedClips/2026-05-12_'
+            '08-00-00/back.mp4',
+            '/mnt/gadget/part1-ro/TeslaCam/sentryclips/lower/x.mp4',
+        ):
+            assert _infer_priority(path) == PRIORITY_EVENTS == 1, (
+                f"Path {path!r} must map to PRIORITY_EVENTS (=1) "
+                f"post-#178"
+            )
+
+    def test_inference_maps_recentclips_to_recent(self):
+        for path in (
+            '/mnt/gadget/part1-ro/TeslaCam/RecentClips/2026-05-12_'
+            '08-00-00-front.mp4',
+            r'C:\TeslaCam\RecentClips\clip.mp4',
+        ):
+            assert _infer_priority(path) == PRIORITY_RECENT_CLIPS == 2, (
+                f"Path {path!r} must map to PRIORITY_RECENT_CLIPS (=2) "
+                f"post-#178"
+            )
+
+    def test_pick_order_event_before_recent_clip(self, db, tmp_path):
+        """Acceptance test: with one event and one RecentClip both
+        pending, the worker MUST claim the event first regardless of
+        insertion order or mtime."""
+        recent = tmp_path / "RecentClips" / "front.mp4"
+        recent.parent.mkdir(parents=True)
+        recent.write_bytes(b"r")
+        event = tmp_path / "SentryClips" / "evt" / "front.mp4"
+        event.parent.mkdir(parents=True)
+        event.write_bytes(b"e")
+        # Make the RecentClip OLDER (closer to TTL deadline) so the
+        # only thing that picks the event first is the priority band —
+        # if the priority swap is wrong, the older RecentClip would win.
+        os.utime(str(recent), (1000.0, 1000.0))
+        os.utime(str(event), (2000.0, 2000.0))
+        enqueue_for_archive(str(recent), db_path=db)
+        enqueue_for_archive(str(event), db_path=db)
+
+        first = claim_next_for_worker('w', db_path=db)
+        assert first['source_path'] == str(event), (
+            "Issue #178 acceptance test: with both an event AND a "
+            "RecentClip pending (RecentClip even being OLDER), the "
+            "event MUST be claimed first."
+        )
+        assert int(first['priority']) == PRIORITY_EVENTS == 1
+        # And the RecentClip drains second.
+        second = claim_next_for_worker('w', db_path=db)
+        assert second['source_path'] == str(recent)
+        assert int(second['priority']) == PRIORITY_RECENT_CLIPS == 2
+
+
+class TestPriorityMigrationV12ToV13:
+    """Issue #178: the v12 -> v13 migration MUST flip existing
+    non-terminal queue rows so the in-flight backlog drains in the
+    new (correct) order — otherwise users would have to wait for the
+    old rows to drain the slow way before seeing the benefit.
+
+    Terminal-status rows (copied, source_gone, etc.) MUST be left
+    alone — their priority is historical and mutating it would
+    mislead future debugging.
+    """
+
+    def _build_v12_db_with_old_priorities(self, tmp_path, rows):
+        """Build a fresh DB and seed archive_queue rows BEFORE running
+        the migration. Returns (db_path, list of (source_path, status,
+        starting_priority)) tuples for assertion lookups.
+
+        We can't easily roll the schema back to v12 from v13, so we
+        build the DB at the current schema and then INSERT rows
+        carrying the pre-#178 priority values, then call the migration
+        helper directly to confirm it's idempotent and flips correctly.
+        """
+        db_path = str(tmp_path / "geodata.db")
+        conn = _init_db(db_path)
+        try:
+            # Force schema_version back to 12 so we can re-run the
+            # v12 -> v13 block as if upgrading from v12. Idempotent
+            # by design: the SQL has ``priority IN (1, 2)`` and only
+            # touches non-terminal statuses.
+            conn.execute("DELETE FROM schema_version")
+            conn.execute(
+                "INSERT INTO schema_version (version) VALUES (12)"
+            )
+            for source_path, status, starting_priority in rows:
+                conn.execute(
+                    "INSERT INTO archive_queue "
+                    "(source_path, priority, status, enqueued_at) "
+                    "VALUES (?, ?, ?, datetime('now'))",
+                    (source_path, starting_priority, status),
+                )
+            conn.commit()
+        finally:
+            conn.close()
+        return db_path
+
+    def _read_priority(self, db_path, source_path):
+        conn = sqlite3.connect(db_path)
+        try:
+            row = conn.execute(
+                "SELECT priority FROM archive_queue WHERE source_path = ?",
+                (source_path,),
+            ).fetchone()
+            return row[0] if row else None
+        finally:
+            conn.close()
+
+    def test_migration_flips_pending_priorities(self, tmp_path):
+        # Seed rows at the OLD priority mapping (RecentClips=1,
+        # Events=2) and pretend we're at v12. Re-run _init_db to
+        # trigger the v12 -> v13 migration.
+        rows = [
+            # source_path, status, starting_priority
+            ('/tc/RecentClips/r.mp4', 'pending', 1),     # was P1, must flip to 2
+            ('/tc/SentryClips/e/f.mp4', 'pending', 2),    # was P2, must flip to 1
+            ('/tc/Other/o.mp4', 'pending', 3),             # P3 untouched
+        ]
+        db_path = self._build_v12_db_with_old_priorities(tmp_path, rows)
+        # Trigger the migration by re-initializing.
+        conn = _init_db(db_path)
+        conn.close()
+
+        assert self._read_priority(db_path, '/tc/RecentClips/r.mp4') == 2
+        assert self._read_priority(
+            db_path, '/tc/SentryClips/e/f.mp4',
+        ) == 1
+        assert self._read_priority(db_path, '/tc/Other/o.mp4') == 3
+
+    def test_migration_flips_claimed_and_error_rows_too(self, tmp_path):
+        # Non-terminal statuses ALL get flipped — when release_claim
+        # / mark_failed restore them to pending, they must already
+        # carry the new priority.
+        rows = [
+            ('/tc/RecentClips/r-claimed.mp4', 'claimed', 1),
+            ('/tc/SentryClips/e-claimed/f.mp4', 'claimed', 2),
+            ('/tc/RecentClips/r-error.mp4', 'error', 1),
+            ('/tc/SentryClips/e-error/f.mp4', 'error', 2),
+        ]
+        db_path = self._build_v12_db_with_old_priorities(tmp_path, rows)
+        conn = _init_db(db_path)
+        conn.close()
+
+        assert self._read_priority(
+            db_path, '/tc/RecentClips/r-claimed.mp4',
+        ) == 2
+        assert self._read_priority(
+            db_path, '/tc/SentryClips/e-claimed/f.mp4',
+        ) == 1
+        assert self._read_priority(
+            db_path, '/tc/RecentClips/r-error.mp4',
+        ) == 2
+        assert self._read_priority(
+            db_path, '/tc/SentryClips/e-error/f.mp4',
+        ) == 1
+
+    def test_migration_leaves_terminal_rows_untouched(self, tmp_path):
+        # Terminal statuses (copied, source_gone, skipped_stationary,
+        # dead_letter) keep their historical priority — mutating it
+        # would mislead future debugging of "what got picked when".
+        rows = [
+            ('/tc/RecentClips/r-copied.mp4', 'copied', 1),
+            ('/tc/SentryClips/e-copied/f.mp4', 'copied', 2),
+            ('/tc/RecentClips/r-gone.mp4', 'source_gone', 1),
+            ('/tc/SentryClips/e-gone/f.mp4', 'source_gone', 2),
+            (
+                '/tc/RecentClips/r-skipped.mp4',
+                'skipped_stationary',
+                1,
+            ),
+            ('/tc/RecentClips/r-dl.mp4', 'dead_letter', 1),
+            ('/tc/SentryClips/e-dl/f.mp4', 'dead_letter', 2),
+        ]
+        db_path = self._build_v12_db_with_old_priorities(tmp_path, rows)
+        conn = _init_db(db_path)
+        conn.close()
+
+        # Each row keeps its ORIGINAL priority value.
+        for source_path, _status, starting_priority in rows:
+            actual = self._read_priority(db_path, source_path)
+            assert actual == starting_priority, (
+                f"Terminal-status row {source_path!r} had its priority "
+                f"changed from {starting_priority} to {actual} — the "
+                f"v12->v13 migration MUST leave terminal rows alone."
+            )
+
+    def test_migration_is_idempotent(self, tmp_path):
+        # Running _init_db a second time on a v13 database is a no-op
+        # for the priority-swap migration (already at v13, so the
+        # ``current < 13`` gate is False). Verify by seeding rows at
+        # the NEW (post-migration) priority mapping and confirming
+        # they are NOT flipped back.
+        db_path = str(tmp_path / "geodata.db")
+        conn = _init_db(db_path)
+        try:
+            # Insert a row at the post-migration mapping.
+            conn.execute(
+                "INSERT INTO archive_queue "
+                "(source_path, priority, status, enqueued_at) "
+                "VALUES (?, 1, 'pending', datetime('now'))",
+                ('/tc/SentryClips/e/f.mp4',),
+            )
+            conn.execute(
+                "INSERT INTO archive_queue "
+                "(source_path, priority, status, enqueued_at) "
+                "VALUES (?, 2, 'pending', datetime('now'))",
+                ('/tc/RecentClips/r.mp4',),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        # Re-initialize — already at v13, should be a no-op for
+        # priorities.
+        conn = _init_db(db_path)
+        conn.close()
+
+        assert self._read_priority(
+            db_path, '/tc/SentryClips/e/f.mp4',
+        ) == 1
+        assert self._read_priority(db_path, '/tc/RecentClips/r.mp4') == 2
+
+    def test_migration_does_nothing_when_no_old_rows(self, tmp_path):
+        # Fresh install: no rows at all. Migration must complete
+        # cleanly without errors.
+        db_path = str(tmp_path / "geodata.db")
+        conn = _init_db(db_path)
+        # Force back to v12 to exercise the migration block.
+        conn.execute("DELETE FROM schema_version")
+        conn.execute("INSERT INTO schema_version (version) VALUES (12)")
+        conn.commit()
+        conn.close()
+
+        # Should not raise.
+        conn = _init_db(db_path)
+        try:
+            row = conn.execute(
+                "SELECT MAX(version) AS v FROM schema_version"
+            ).fetchone()
+            assert row['v'] == 13
+        finally:
+            conn.close()

--- a/tests/test_archive_queue.py
+++ b/tests/test_archive_queue.py
@@ -99,8 +99,12 @@ class TestInferPriority:
         assert _infer_priority(path) == expected
 
     def test_recent_clips_beats_archive_when_both_present(self):
-        # If both substrings appear (synthetic edge case), RecentClips wins
-        # because it's checked first.
+        # If a path contains ``/recentclips/`` but no event substring,
+        # the function returns PRIORITY_RECENT_CLIPS regardless of
+        # what other folder names appear (e.g. ArchivedClips, which is
+        # not in the heuristic). Behavior is unaffected by the post-#178
+        # check-order reorder because events and RecentClips are
+        # mutually exclusive in production paths.
         path = '/var/ArchivedClips/RecentClips/clip.mp4'
         assert _infer_priority(path) == PRIORITY_RECENT_CLIPS
 

--- a/tests/test_archive_status_endpoint.py
+++ b/tests/test_archive_status_endpoint.py
@@ -183,17 +183,18 @@ class TestArchiveStatusShape:
         self, client, db, archive_root, monkeypatch,
     ):
         # Enqueue rows of different priorities and verify counts.
+        # Issue #178: P1=events, P2=RecentClips, P3=other.
         archive_queue.enqueue_for_archive(
-            "/tc/RecentClips/p1.mp4", db_path=db, priority=1,
+            "/tc/SentryClips/evt/p1.mp4", db_path=db, priority=1,
         )
         archive_queue.enqueue_for_archive(
-            "/tc/RecentClips/p1b.mp4", db_path=db, priority=1,
+            "/tc/SentryClips/evt/p1b.mp4", db_path=db, priority=1,
         )
         archive_queue.enqueue_for_archive(
-            "/tc/SentryClips/evt/p2.mp4", db_path=db, priority=2,
+            "/tc/RecentClips/p2.mp4", db_path=db, priority=2,
         )
         archive_queue.enqueue_for_archive(
-            "/tc/SavedClips/evt/p3.mp4", db_path=db, priority=3,
+            "/tc/ArchivedClips/p3.mp4", db_path=db, priority=3,
         )
         # Pin the DB resolver so the endpoint reads our test DB.
         monkeypatch.setattr(

--- a/tests/test_archive_worker.py
+++ b/tests/test_archive_worker.py
@@ -721,10 +721,10 @@ class TestArchiveWorkerSkipStationary:
     def test_event_clips_never_skipped_even_with_no_gps(
         self, db, archive_root, teslacam_root, make_clip, monkeypatch,
     ):
-        # Sentry/Saved clips have priority 2 and MUST bypass the skip
-        # branch entirely — even if the SEI peek would say "no GPS"
-        # (which is the common case for stationary Sentry events).
-        # Losing event footage is unacceptable.
+        # Sentry/Saved clips have priority 1 (issue #178) and MUST
+        # bypass the skip branch entirely — even if the SEI peek would
+        # say "no GPS" (which is the common case for stationary Sentry
+        # events). Losing event footage is unacceptable.
         clip = make_clip("SentryClips/2024-01-01_12-00-00/front.mp4")
         enqueue_for_archive(clip, db_path=db)
         row = claim_next_for_worker('w', db_path=db)
@@ -746,8 +746,8 @@ class TestArchiveWorkerSkipStationary:
             row, db, archive_root, teslacam_root,
             chunk_size=4096, max_attempts=3,
         )
-        # Event clips are PRIORITY_EVENTS (=2), not PRIORITY_RECENT_CLIPS.
-        # They must NEVER enter the skip branch.
+        # Event clips are PRIORITY_EVENTS (=1 post-#178), not
+        # PRIORITY_RECENT_CLIPS. They must NEVER enter the skip branch.
         assert outcome == 'copied'
         assert peek_called == [], (
             "Event clips must NEVER call the SEI peek — "
@@ -1175,19 +1175,19 @@ class TestArchiveWorkerPriority:
     def test_p1_drains_before_p2_before_p3(self, db, archive_root,
                                             teslacam_root, make_clip):
         """Phase 2b acceptance criterion: priority ordering across the
-        wire — RecentClips first, then Sentry/Saved, then everything
-        else. The partial index ``archive_queue_ready`` covers this
-        exact ORDER BY."""
+        wire — Sentry/Saved events first (P1 post-#178), then
+        RecentClips, then everything else. The partial index
+        ``archive_queue_ready`` covers this exact ORDER BY."""
         # Enqueue in REVERSE priority order to make sure we're testing
         # ORDER BY, not insertion order.
         p3 = make_clip(
             "Other/other-front.mp4", mtime=1000.0,
         )
         p2 = make_clip(
-            "SentryClips/evt/sentry-front.mp4", mtime=1000.0,
+            "RecentClips/recent-front.mp4", mtime=1000.0,
         )
         p1 = make_clip(
-            "RecentClips/recent-front.mp4", mtime=1000.0,
+            "SentryClips/evt/sentry-front.mp4", mtime=1000.0,
         )
         enqueue_for_archive(p3, db_path=db)
         enqueue_for_archive(p2, db_path=db)

--- a/tests/test_failed_jobs_history.py
+++ b/tests/test_failed_jobs_history.py
@@ -138,7 +138,8 @@ class TestMappingMigrationV11toV12:
 
     def test_legacy_v11_db_gets_column_via_alter(self, tmp_path):
         """A pre-existing v11 DB (without the column) must be ALTERed
-        on first open and end up at v12 with the column present."""
+        on first open and end up at the current schema version with
+        the column present (#178 bumped this to v13)."""
         from services import mapping_migrations
         db = str(tmp_path / "geodata.db")
         # Hand-build a minimal v11 DB. Column list mirrors v11 schema
@@ -190,7 +191,7 @@ class TestMappingMigrationV11toV12:
             ver = new_conn.execute(
                 "SELECT MAX(version) FROM schema_version"
             ).fetchone()[0]
-            assert ver == 12
+            assert ver == mapping_migrations._SCHEMA_VERSION
             assert 'previous_last_error' in _column_names(new_conn, 'archive_queue')
             assert 'previous_last_error' in _column_names(new_conn, 'indexing_queue')
         finally:


### PR DESCRIPTION
## Summary

Closes #178. Fixes the archive queue priority inversion that left **71 SentryClips events untouched for 130+ minutes** on cybertruckusb.local while the worker burned its SDIO budget on parked-Sentry RecentClips skip-decisions.

## Root cause

`PRIORITY_RECENT_CLIPS = 1` and `PRIORITY_EVENTS = 2` (lower number = picked first). The original ordering was correct when the worker copied every RecentClip — they rotate at ~60 min so they were the most TTL-sensitive. After issue #167 (`skip_stationary_recent_clips`) shipped, most parked-Sentry RecentClips became sub-second skip-decisions and the priority order started starving real events. Per the user clarification on issue #178: "Priority recent clips are ones that have GPS or event data; we don''t want to prioritize parked-vehicle Sentry RecentClips with no event."

Both `claim_next_for_worker` paths (the RETURNING fast path and the SELECT-then-UPDATE fallback) already use `ORDER BY priority ASC`. No SQL changes needed. `archive_worker._is_recent_clips_priority` uses the symbolic constant, so the swap is safe — verified during investigation.

## Changes

**Production code:**
- `scripts/web/services/archive_queue.py` — swapped `PRIORITY_EVENTS = 1` / `PRIORITY_RECENT_CLIPS = 2`. Expanded the comment block above the constants documenting the issue rationale and the relationship to #167. Updated docstrings on `claim_next_for_worker` and `get_pending_counts_by_priority`.
- `scripts/web/services/mapping_migrations.py` — bumped `_SCHEMA_VERSION` 12→13. Added v12→v13 migration in `_init_db` using the same SAVEPOINT/ROLLBACK pattern as v3/v4/v9: `UPDATE archive_queue SET priority = CASE WHEN 1 THEN 2 WHEN 2 THEN 1 ELSE priority END WHERE status IN (''pending'', ''claimed'', ''error'') AND priority IN (1, 2)`. Terminal-status rows (`copied`, `source_gone`, `skipped_stationary`, `dead_letter`) are intentionally NOT touched — their priority is historical audit data. On migration failure: ROLLBACK + return-conn (skipping `schema_version` bump) so the next boot retries cleanly.

**Tests (10 new, 6 updated):**
- `TestPriorityConstantsPostIssue178` — 4 tests: constant values, `_infer_priority` for SentryClips/SavedClips/RecentClips, acceptance case (event picked before older RecentClip).
- `TestPriorityMigrationV12ToV13` — 5 tests: pending/claimed/error rows flip, terminal rows untouched, idempotency, empty-queue no-op, fresh-install path.
- 6 existing tests updated whose assertions or variable names embedded the old priority semantics.

## Migration safety

- **Idempotent.** `current < 13` gate prevents double-application; the CASE expression is symmetric (running twice would swap back, but the gate prevents that).
- **In-flight claimed rows are safe.** A row claimed at priority=1 (old=RecentClips) gets bumped to priority=2 mid-flight. On next `release_claim` (e.g., mode-switch pause), it re-enters pending at priority=2 — correct new mapping.
- **Terminal rows preserved.** `copied`, `source_gone`, `skipped_stationary`, `dead_letter` priority values are historical audit data — mutating them would mislead future debugging of "what got picked when".
- **Failure path retries on next boot.** ROLLBACK + skip `schema_version` bump — same pattern as v3/v4/v9.
- **Backups taken automatically** by `_backup_db` before migration when `current > 0 and current < _SCHEMA_VERSION` (existing infrastructure). `_BACKUP_RETENTION = 3`.

## Verification

- `python -m py_compile` clean on all 5 modified Python files.
- `python -c "from web_control import app"` clean.
- `python -m pytest -q` — **1568 passed, 4 skipped** (same baseline + 10 new tests for #178; 0 failures).
- Self code review against TeslaUSB conventions — no findings of any severity (Critical, Warning, or Info).

## Post-deploy verification (on Pi)

After `git pull` + `sudo systemctl restart gadget_web.service`:

1. `journalctl -u gadget_web.service --since "1 minute ago" | grep "Migration v12->v13"` — confirm migration ran and reports the flipped row count.
2. `sqlite3 ~/geodata.db "SELECT priority, status, COUNT(*) FROM archive_queue GROUP BY 1, 2 ORDER BY 1, 2"` — confirm pending/claimed/error rows have priority 1 for SentryClips/SavedClips paths and priority 2 for RecentClips paths.
3. Watch `/api/archive/status` — `queue_depth_p1` should drain first; `queue_depth_p2` (RecentClips) waits while events drain.
4. Confirm `_is_recent_clips_priority` still triggers SEI-peek on RecentClips: `journalctl -u gadget_web.service | grep "skipped_stationary"` should still show skip-decisions for parked RecentClips.

## Out of scope

- UI chip labels in `templates/index.html` ("Pending P1/P2/P3") are abstract priority numbers; the semantic interpretation lives in the constant docstrings. Relabeling to "Pending Events / RecentClips / Other" is a UX improvement but doesn''t affect the bug.
- Round-robin draining or concurrent workers — Pi Zero 2 W''s SDIO contention rules out concurrent rclone/copy workers; the priority swap fixes the starvation without needing either.