### PR TITLE
Fix #180 — Failed Jobs UX + Archive health stability

### DIFF
--- a/scripts/web/blueprints/archive_queue.py
+++ b/scripts/web/blueprints/archive_queue.py
@@ -107,6 +107,11 @@ def archive_status():
         # Top-level health (severity, message, banner trigger).
         'severity': health.get('severity', 'ok'),
         'message': health.get('message', ''),
+        # Issue #180 follow-up — banner gate. Only fire the big
+        # "footage may be lost" banner when the operator can actually
+        # do something. Defaults to True for backward compat if the
+        # watchdog payload is missing the field (older deployments).
+        'actionable': bool(health.get('actionable', True)),
         'enabled': bool(ARCHIVE_QUEUE_ENABLED),
         'checked_at': health.get('checked_at'),
         'watchdog_running': health.get('watchdog_running', False),

--- a/scripts/web/blueprints/jobs.py
+++ b/scripts/web/blueprints/jobs.py
@@ -54,7 +54,7 @@ from __future__ import annotations
 
 import logging
 import re
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from flask import Blueprint, jsonify, render_template, request
 
@@ -64,6 +64,7 @@ from config import (
     MAPPING_DB_PATH,
     MAPPING_ENABLED,
 )
+from utils import get_base_context
 
 logger = logging.getLogger(__name__)
 
@@ -142,15 +143,268 @@ def _safe(fn, default):
 
 
 # ---------------------------------------------------------------------------
+# Per-row guidance (issue #180)
+# ---------------------------------------------------------------------------
+#
+# These helpers add two fields to each failed-job row that the UI uses
+# to show the operator what they're looking at and what to do about
+# it:
+#
+#   ``value`` — a deterministic "what is this clip / row" classifier
+#               based on the identifier path. Tells the operator at a
+#               glance whether the underlying data is unique-and-
+#               valuable (an event clip Tesla recorded because
+#               something happened) or commodity (60-min driving
+#               footage that Tesla rotates out anyway, or a
+#               re-derivable index row).
+#
+#   ``recommendation`` — a deterministic action recommendation based
+#               on the redacted ``last_error`` string. The operator
+#               always has the final say (both Retry and Delete
+#               buttons are always rendered); this just steers them
+#               toward the right one for the most common error
+#               patterns and makes "I have no idea what to do" failure
+#               modes much rarer.
+#
+# Both helpers are pure / deterministic — no DB access, no side
+# effects — so they're cheap to call on every list row and trivial to
+# unit-test. Update the heuristics below to add new categories; the
+# UI consumes the resulting dicts opaquely.
+
+# Clip-value tiers ordered most-irreplaceable first. The UI renders
+# the badge color from the tier name (event=red, recent=amber,
+# index/cloud/live_event=blue, archived=neutral).
+_VALUE_TIERS: Dict[str, Tuple[str, str]] = {
+    'event': (
+        'Event clip',
+        'Tesla recorded this because something happened to the car '
+        '(impact, alarm, or manual save). Usually irreplaceable.',
+    ),
+    'recent': (
+        'Driving footage',
+        'Last hour of dashcam (RecentClips). Tesla rotates these out '
+        'automatically — losing one row is usually fine.',
+    ),
+    'archived': (
+        'Already on SD card',
+        'This clip is in ArchivedClips, so the source file is already '
+        'preserved on the Pi even if the queue row is dropped.',
+    ),
+    'live_event': (
+        'Live event upload',
+        'Same value as an event clip — Tesla recorded this because '
+        'something happened. The Live Event Sync subsystem only ever '
+        'handles events.',
+    ),
+    'cloud': (
+        'Cloud upload',
+        'The file itself is still on the SD card; only the cloud '
+        'upload failed. Re-uploading later is always safe.',
+    ),
+    'index': (
+        'Map / trip data',
+        'Just the trip-DB index row for this clip. The video file is '
+        'untouched; deleting the row only loses the map waypoint, '
+        'not the footage.',
+    ),
+    'unknown': (
+        'Background task',
+        'The subsystem did not provide enough information to classify '
+        'the underlying data.',
+    ),
+}
+
+
+def _classify_clip_value(subsystem: str, identifier: str) -> Dict[str, str]:
+    """Return ``{tier, label, description}`` for a failed-job row.
+
+    Pure / deterministic — looks only at the subsystem name and the
+    identifier string. Suitable for the row-list response and for
+    unit tests. Never raises: an unrecognised input falls through to
+    the ``unknown`` tier so the UI still renders something.
+    """
+    ident = (identifier or '').lower()
+
+    # LES is always an event upload — its queue rows are populated by
+    # the inotify watcher firing on Tesla event.json arrivals only.
+    if subsystem == 'live_event_sync':
+        tier = 'live_event'
+    # SentryClips / SavedClips identifiers are event clips regardless
+    # of which subsystem holds the row (archive, indexer, cloud_sync).
+    elif '/sentryclips/' in ident or '/savedclips/' in ident:
+        tier = 'event'
+    elif '/recentclips/' in ident:
+        tier = 'recent'
+    elif '/archivedclips/' in ident:
+        tier = 'archived'
+    elif subsystem == 'indexer':
+        tier = 'index'
+    elif subsystem == 'cloud_sync':
+        tier = 'cloud'
+    else:
+        tier = 'unknown'
+
+    label, description = _VALUE_TIERS[tier]
+    return {'tier': tier, 'label': label, 'description': description}
+
+
+# Recommendation actions:
+#   'retry'   — the underlying file is fine; the failure is transient
+#               or fixable (network, permission, lock contention).
+#   'delete'  — the underlying file is gone or unparseable; further
+#               retries will hit the same error. Safe to drop.
+#   'either'  — the row could go either way; default fallback.
+#
+# Order of pattern checks matters: more specific patterns first.
+# Each entry is (regex, action, reason). The first match wins.
+_RECOMMENDATION_RULES: Tuple[Tuple[re.Pattern, str, str], ...] = (
+    # Source file is gone — Tesla rotated the clip, the operator
+    # deleted it, or a quick-edit pass removed it. Retrying will hit
+    # the same FileNotFoundError every time.
+    (re.compile(r'(?i)\b(?:no such file|file (?:not found|missing)|'
+                r'enoent|source[_ ]?gone|does not exist)\b'),
+     'delete',
+     'The source file is gone. Retrying will fail the same way.'),
+
+    # Permanent parse / format errors — the file is on disk but the
+    # parser can't make sense of it. Retrying won't change the
+    # bitstream.
+    (re.compile(r'(?i)\b(?:moov atom|invalid (?:data|argument)|'
+                r'corrupt|truncat\w*|parse[_ ]?error|unsupported '
+                r'(?:codec|format)|not a valid )\b'),
+     'delete',
+     'The file is on disk but cannot be parsed. The clip itself is '
+     'corrupt — retrying will hit the same error.'),
+
+    # Transient I/O failures — bus contention, USB hotplug glitch,
+    # SDIO timeout. The next archive cycle will probably succeed.
+    (re.compile(r'(?i)\b(?:i/?o ?error|input/output error|stale file '
+                r'handle|device or resource busy|read[_ ]?error|'
+                r'write[_ ]?error)\b'),
+     'retry',
+     'Transient I/O glitch. Often fixed by waiting for the SDIO bus '
+     'or USB gadget to settle, then retrying.'),
+
+    # Network / cloud upload failures — wait for WiFi to recover and
+    # retry. Almost never the right call to delete these.
+    (re.compile(r'(?i)\b(?:connection (?:refused|reset|timed? ?out|'
+                r'aborted)|network (?:is )?(?:unreachable|down)|'
+                r'temporary (?:failure|name resolution)|'
+                r'no route to host|enotconn|name or service|'
+                r'tls handshake|ssl handshake|x509|getaddrinfo|'
+                r'dial tcp)\b'),
+     'retry',
+     'Network failure. Retry once WiFi is healthy. The file itself '
+     'is fine.'),
+
+    # Cloud auth / quota / config — operator must fix the root cause
+    # (rotate creds, free quota) before retrying. Don't delete.
+    (re.compile(r'(?i)\b(?:401|403|access denied|forbidden|invalid '
+                r'(?:credential|token|api[_ ]?key|signature)|quota '
+                r'exceeded|out of space|over capacity|insufficient '
+                r'storage|payment required|429|rate ?limit)\b'),
+     'retry',
+     'Cloud-side auth / quota / rate-limit error. Fix the root cause '
+     '(rotate creds, free space, wait for quota window) then retry.'),
+
+    # Permission denied on the local filesystem — usually a stale
+    # mount or wrong owner; retry after fixing.
+    (re.compile(r'(?i)\b(?:permission denied|operation not permitted|'
+                r'eacces|read[-_ ]?only file ?system|erofs)\b'),
+     'retry',
+     'Permission / read-only-mount error. Check the disk image is '
+     'in edit mode (or the file is unlocked) then retry.'),
+
+    # Lock contention against the gadget / quick-edit / coordinator —
+    # always transient.
+    (re.compile(r'(?i)\b(?:lock (?:contention|timeout|busy)|could not '
+                r'acquire|coordinator (?:busy|timeout))\b'),
+     'retry',
+     'Another subsystem held the lock during the previous attempt. '
+     'Retrying once the lock is free almost always succeeds.'),
+)
+
+
+def _classify_recommendation(subsystem: str,
+                             last_error: Optional[str],
+                             attempts: int = 0,
+                             identifier: Optional[str] = None
+                             ) -> Dict[str, Any]:
+    """Return ``{action, reason}`` advising Retry vs Delete.
+
+    Pure / deterministic — looks only at the redacted ``last_error``
+    string and (for the high-attempt fallback) the attempt count.
+    The operator can always override; this just nudges the most
+    common cases toward the obvious correct button.
+
+    ``action`` is one of ``'retry'``, ``'delete'``, or ``'either'``.
+    ``reason`` is a short human-readable sentence (≤ 120 chars).
+    ``attempts`` is informational — used only for the
+    "many-attempts-with-no-known-pattern" fallback so the operator
+    isn't told to retry forever on a row that's already retried 5
+    times against an unrecognised error.
+    """
+    err = (last_error or '').strip()
+    if not err:
+        return {
+            'action': 'either',
+            'reason': ('No error message recorded. Retry once to see '
+                       'a fresh failure, or delete if the source is '
+                       'no longer needed.'),
+        }
+
+    for pat, action, reason in _RECOMMENDATION_RULES:
+        if pat.search(err):
+            return {'action': action, 'reason': reason}
+
+    # Unknown error pattern. If the row has retried many times without
+    # hitting a known pattern, the underlying issue is probably stuck
+    # — recommend delete so the operator doesn't hammer the worker.
+    if attempts >= 5:
+        return {
+            'action': 'delete',
+            'reason': ('This row has retried {0} times without '
+                       'matching any known recoverable pattern. '
+                       'Likely stuck — delete and let the watcher '
+                       're-enqueue if the source is still valid.'
+                       .format(attempts)),
+        }
+
+    return {
+        'action': 'either',
+        'reason': ('Error pattern not recognised. Retry once; if the '
+                   'same error returns, delete is safe (the source '
+                   'file stays on disk).'),
+    }
+
+
+# ---------------------------------------------------------------------------
 # Subsystem-specific list adapters
 # ---------------------------------------------------------------------------
+
+def _enrich(row: Dict[str, Any]) -> Dict[str, Any]:
+    """Add ``value`` and ``recommendation`` to a base row dict.
+
+    Mutates and returns ``row`` for convenient inline use inside the
+    list-comprehension-style adapters below.
+    """
+    row['value'] = _classify_clip_value(row.get('subsystem', ''),
+                                        row.get('identifier') or '')
+    row['recommendation'] = _classify_recommendation(
+        row.get('subsystem', ''),
+        row.get('last_error'),
+        attempts=int(row.get('attempts') or 0),
+        identifier=row.get('identifier') or '',
+    )
+    return row
+
 
 def _archive_rows(limit: int) -> List[Dict[str, Any]]:
     from services import archive_queue
     rows = archive_queue.list_dead_letters(limit=limit)
     out: List[Dict[str, Any]] = []
     for r in rows:
-        out.append({
+        out.append(_enrich({
             'subsystem': 'archive',
             'id': r.get('id'),
             'identifier': r.get('source_path') or r.get('archive_path') or '',
@@ -162,7 +416,7 @@ def _archive_rows(limit: int) -> List[Dict[str, Any]]:
                 'priority': r.get('priority'),
                 'expected_size': r.get('expected_size'),
             },
-        })
+        }))
     return out
 
 
@@ -173,7 +427,7 @@ def _indexer_rows(limit: int) -> List[Dict[str, Any]]:
     rows = indexing_queue_service.list_dead_letters(MAPPING_DB_PATH, limit=limit)
     out: List[Dict[str, Any]] = []
     for r in rows:
-        out.append({
+        out.append(_enrich({
             'subsystem': 'indexer',
             'id': r.get('canonical_key'),  # natural key in this table
             'identifier': r.get('file_path') or r.get('canonical_key') or '',
@@ -185,7 +439,7 @@ def _indexer_rows(limit: int) -> List[Dict[str, Any]]:
                 'next_attempt_at': r.get('next_attempt_at'),
                 'source': r.get('source'),
             },
-        })
+        }))
     return out
 
 
@@ -196,7 +450,7 @@ def _cloud_sync_rows(limit: int) -> List[Dict[str, Any]]:
     rows = cloud_archive_service.list_dead_letters(limit=limit)
     out: List[Dict[str, Any]] = []
     for r in rows:
-        out.append({
+        out.append(_enrich({
             'subsystem': 'cloud_sync',
             'id': r.get('file_path'),  # natural key (UNIQUE)
             'identifier': r.get('file_path') or '',
@@ -208,7 +462,7 @@ def _cloud_sync_rows(limit: int) -> List[Dict[str, Any]]:
                 'file_size': r.get('file_size'),
                 'row_id': r.get('id'),
             },
-        })
+        }))
     return out
 
 
@@ -224,7 +478,7 @@ def _live_event_rows(limit: int) -> List[Dict[str, Any]]:
             continue
         if len(out) >= limit:
             break
-        out.append({
+        out.append(_enrich({
             'subsystem': 'live_event_sync',
             'id': r.get('id'),
             'identifier': r.get('event_dir') or '',
@@ -238,7 +492,7 @@ def _live_event_rows(limit: int) -> List[Dict[str, Any]]:
                 'upload_scope': r.get('upload_scope'),
                 'bytes_uploaded': r.get('bytes_uploaded'),
             },
-        })
+        }))
     return out
 
 
@@ -410,12 +664,18 @@ def failed_jobs_page():
     load — no server-side data fetch in this handler so the page
     renders fast even when one of the subsystem DBs is slow or
     unavailable.
+
+    Issue #180 — merge ``get_base_context()`` so the left sidebar /
+    mobile bottom-tab nav shows every available top-level page (Map,
+    Analytics, Media, Cloud, Settings) instead of collapsing to just
+    Settings. ``page='jobs'`` is intentional: it's not one of the
+    canonical nav targets so no nav item gets the ``active`` class
+    while the operator is on the Failed Jobs page.
     """
-    return render_template(
-        'failed_jobs.html',
-        page='settings',
-        subsystems=list(_SUBSYSTEMS),
-    )
+    ctx = get_base_context()
+    ctx['page'] = 'jobs'
+    ctx['subsystems'] = list(_SUBSYSTEMS)
+    return render_template('failed_jobs.html', **ctx)
 
 
 # ---------------------------------------------------------------------------
@@ -485,22 +745,43 @@ def api_retry():
     """Reset failed/dead-letter rows so the worker picks them up again.
 
     Request body (JSON):
-      * ``subsystem`` (required) — one of the four subsystem names.
+      * ``subsystem`` (required) — one of the four subsystem names, OR
+        the literal string ``'all'`` (issue #180) to fan the retry-
+        all out across every subsystem at once.
       * ``id`` (optional) — omit / pass ``null`` to retry **every**
         failed row in that subsystem; otherwise the natural id for
         that subsystem (int row id for archive / live_event_sync,
         canonical_key string for indexer, file_path string for
-        cloud_sync).
+        cloud_sync). Ignored when ``subsystem='all'``.
 
     Returns ``{subsystem, rows_reset}`` (HTTP 200) on success, or
-    ``{error}`` (HTTP 400) on bad input.
+    ``{error}`` (HTTP 400) on bad input. When ``subsystem='all'`` the
+    response also carries ``per_subsystem`` so the UI can show what
+    happened in each.
     """
     payload = request.get_json(silent=True) or {}
     subsystem = (payload.get('subsystem') or '').lower()
+
+    if subsystem == 'all':
+        # Fan-out across every subsystem. Each adapter is wrapped in
+        # ``_safe`` so one crashing subsystem can't deny the operator
+        # the retry-all action across the others.
+        per: Dict[str, int] = {}
+        total = 0
+        for name in _SUBSYSTEMS:
+            n = int(_safe(lambda fn=_RETRIERS[name]: fn(None), 0))
+            per[name] = n
+            total += n
+        return jsonify({
+            'subsystem': 'all',
+            'rows_reset': total,
+            'per_subsystem': per,
+        })
+
     if subsystem not in _RETRIERS:
         return jsonify({
             'error': 'unknown or missing subsystem',
-            'allowed': list(_SUBSYSTEMS),
+            'allowed': list(_SUBSYSTEMS) + ['all'],
         }), 400
 
     row_id = payload.get('id')
@@ -519,17 +800,20 @@ def api_delete():
     """Permanently delete failed/dead-letter rows.
 
     Request body (JSON):
-      * ``subsystem`` (required) — one of the four subsystem names.
+      * ``subsystem`` (required) — one of the four subsystem names, OR
+        the literal string ``'all'`` (issue #180) to fan the delete-
+        all out across every subsystem at once.
       * ``id`` (optional) — omit / pass ``null`` to delete **every**
         failed row in that subsystem; otherwise the natural id for
         that subsystem (int row id for archive / live_event_sync,
         canonical_key string for indexer, file_path string for
-        cloud_sync).
+        cloud_sync). Ignored when ``subsystem='all'``.
 
     Mirrors :func:`api_retry` exactly, but routes through ``_DELETERS``
     instead of ``_RETRIERS``. Returns ``{subsystem, rows_deleted}``
     (HTTP 200) on success, ``{error}`` (HTTP 400) on bad input,
-    ``{error, subsystem}`` (HTTP 500) on adapter crash.
+    ``{error, subsystem}`` (HTTP 500) on adapter crash. When
+    ``subsystem='all'`` the response also carries ``per_subsystem``.
 
     The delete only affects the named subsystem's queue table — it
     does NOT delete the underlying source file from disk, and it does
@@ -542,10 +826,28 @@ def api_delete():
     """
     payload = request.get_json(silent=True) or {}
     subsystem = (payload.get('subsystem') or '').lower()
+
+    if subsystem == 'all':
+        # Same fan-out semantics as retry (issue #180). Each
+        # subsystem's deleter is wrapped in ``_safe`` so a single
+        # crashing subsystem doesn't deny the operator the bulk
+        # delete across the others.
+        per: Dict[str, int] = {}
+        total = 0
+        for name in _SUBSYSTEMS:
+            n = int(_safe(lambda fn=_DELETERS[name]: fn(None), 0))
+            per[name] = n
+            total += n
+        return jsonify({
+            'subsystem': 'all',
+            'rows_deleted': total,
+            'per_subsystem': per,
+        })
+
     if subsystem not in _DELETERS:
         return jsonify({
             'error': 'unknown or missing subsystem',
-            'allowed': list(_SUBSYSTEMS),
+            'allowed': list(_SUBSYSTEMS) + ['all'],
         }), 400
 
     row_id = payload.get('id')

--- a/scripts/web/blueprints/system_health.py
+++ b/scripts/web/blueprints/system_health.py
@@ -151,8 +151,12 @@ def _indexer_block() -> Dict[str, Any]:
         sev = SEV_ERROR
         msg = 'Worker not running'
     elif dead > 0:
+        # Issue #180 — "13 dead-letter rows" is uninformative. Tell
+        # the operator what to do. The card's overall row is already
+        # clickable (jumps to /jobs) when severity != ok.
         sev = SEV_WARN
-        msg = f'{dead} dead-letter row{"s" if dead != 1 else ""}'
+        msg = (f'{dead} job{"s" if dead != 1 else ""} need attention '
+               '— open Failed Jobs')
     elif queue_depth > 100:
         sev = SEV_WARN
         msg = f'{queue_depth} queued (catch-up)'
@@ -332,22 +336,49 @@ def _archive_block() -> Dict[str, Any]:
     if wd_sev not in (SEV_OK, SEV_WARN, SEV_ERROR):
         wd_sev = SEV_UNKNOWN
 
+    # Issue #180 — keep an at-a-glance "queued, est. ETA" tail visible
+    # whenever there's pending work, regardless of which severity
+    # branch wins. Without this the message flaps between completely
+    # different topics ("13 jobs need attention" → "Worker stalled: no
+    # copy in 12 min" → "13 jobs need attention") which makes the
+    # card look chaotic. The tail anchors the message to the same two
+    # data points (queue depth, ETA) every poll so the operator can
+    # see WHAT changed across transitions, not have the whole thing
+    # rewritten.
+    queue_tail = ''
+    if pending > 0:
+        if eta_human:
+            queue_tail = f' \u00b7 {pending} queued, est. {eta_human}'
+        else:
+            queue_tail = f' \u00b7 {pending} queued'
+    # Issue #180 — when the watchdog severity (or paused / lost-files
+    # branch) wins, we still want the dead-letter count visible so the
+    # operator knows there's also failed work waiting in /jobs. The
+    # watchdog message itself already includes "(N queued)", so we
+    # don't append queue_tail to that branch — only the failed tail.
+    dead_tail = ''
+    if dead > 0:
+        dead_tail = f' \u00b7 {dead} failed'
+
     if not running:
         sev = SEV_ERROR
-        msg = 'Worker not running'
+        msg = 'Worker not running' + queue_tail + dead_tail
     elif wd_sev == SEV_ERROR:
         sev = SEV_ERROR
-        msg = (watchdog.get('message') or 'Watchdog error')[:80]
+        msg = (watchdog.get('message') or 'Watchdog error')[:160] + dead_tail
     elif lost_24h > 0:
         # Lost-files dominates dead-letters because lost footage is
         # unrecoverable, whereas a dead-letter row still has the source
         # data on the SD card and can be retried.
         sev = SEV_WARN
         msg = (f'{lost_24h} clip{"s" if lost_24h != 1 else ""} '
-               'lost in last 24h')
+               'lost in last 24h') + queue_tail + dead_tail
     elif dead > 0:
+        # Issue #180 — actionable wording instead of "N dead-letter
+        # rows" jargon. The card's overall row links to /jobs.
         sev = SEV_WARN
-        msg = f'{dead} dead-letter row{"s" if dead != 1 else ""}'
+        msg = (f'{dead} job{"s" if dead != 1 else ""} need attention '
+               '— open Failed Jobs') + queue_tail
     elif paused_effective:
         sev = SEV_WARN
         # Phase 4.5 — render the actual reason instead of an opaque
@@ -356,12 +387,12 @@ def _archive_block() -> Dict[str, Any]:
         # quick-edit), ``_format_pause_reason`` returns "background"
         # which we surface as the human-friendly fallback.
         if pause_reason == 'background':
-            msg = 'Paused (background task)'
+            msg = 'Paused (background task)' + queue_tail
         else:
-            msg = f'Paused: {pause_reason}'
+            msg = f'Paused: {pause_reason}' + queue_tail
     elif wd_sev == SEV_WARN:
         sev = SEV_WARN
-        msg = (watchdog.get('message') or 'Watchdog warn')[:80]
+        msg = (watchdog.get('message') or 'Watchdog warn')[:160] + dead_tail
     elif pending > 200:
         sev = SEV_WARN
         if eta_human:
@@ -431,8 +462,11 @@ def _cloud_block() -> Dict[str, Any]:
         pending = 0
 
     if dead > 0:
+        # Issue #180 — make the message actionable rather than just
+        # restating the row count. The card links to /jobs.
         sev = SEV_WARN
-        msg = f'{dead} dead-letter row{"s" if dead != 1 else ""}'
+        msg = (f'{dead} job{"s" if dead != 1 else ""} need attention '
+               '— open Failed Jobs')
     elif running:
         sev = SEV_OK
         msg = (f'Uploading ({pending} pending)'

--- a/scripts/web/services/archive_watchdog.py
+++ b/scripts/web/services/archive_watchdog.py
@@ -524,25 +524,38 @@ def _classify_severity(*,
             f"{int(last_copy_age_seconds)}s ago)."
         )
     elif last_copy_age_seconds < _STALE_ERROR_SECONDS:
+        # Issue #180 — informative rather than alarming. 5–10 min
+        # without a copy is the normal signature of a load-pause
+        # under heavy backlog (Pi Zero 2 W's SDIO bus contention),
+        # not a "videos may be lost" emergency. Keep the metric so
+        # the operator can correlate with system load.
         stale_sev = 'warning'
         stale_msg = (
-            f"Archive worker is slow: no copy in "
+            f"Archive worker slow: no copy in "
             f"{int(last_copy_age_seconds // 60)} min "
-            f"({pending_count} pending)."
+            f"({pending_count} queued). Often caused by SD-card load."
         )
     elif last_copy_age_seconds < _STALE_CRITICAL_SECONDS:
+        # Issue #180 — escalate the wording rather than the alarm.
+        # 10–20 min is concerning but not yet "videos are being
+        # lost" — Tesla's RecentClips circular buffer is ~60 min,
+        # so we still have time to drain.
         stale_sev = 'error'
         stale_msg = (
-            f"Archive worker may be stalled: no copy in "
+            f"Archive worker not making progress: no copy in "
             f"{int(last_copy_age_seconds // 60)} min "
-            f"({pending_count} pending) — videos may be lost!"
+            f"({pending_count} queued). Check system load and "
+            f"SD-card health."
         )
     else:
+        # 20 min+ stall with pending work IS the genuine emergency —
+        # Tesla's RecentClips ring buffer is rolling clips out faster
+        # than we can copy them. Keep the loud alarm for this case.
         stale_sev = 'critical'
         stale_msg = (
             f"Archive worker is STALLED: no copy in "
             f"{int(last_copy_age_seconds // 60)} min "
-            f"({pending_count} pending) — videos are being lost!"
+            f"({pending_count} queued) — videos are being lost!"
         )
 
     # Worker-down with pending work is critical regardless of staleness.

--- a/scripts/web/services/archive_watchdog.py
+++ b/scripts/web/services/archive_watchdog.py
@@ -634,9 +634,33 @@ def _compute_health(db_path: str, archive_root: str) -> Dict[str, Any]:
         disk_known=disk_known,
     )
 
+    # Issue #180 follow-up — only flag the snapshot as ``actionable``
+    # when the operator can actually do something to fix the problem.
+    # Most ERROR/CRITICAL severities are caused by transient backlog +
+    # SDIO contention, where the worker is doing its best and the
+    # right "action" is just to wait. Popping a banner the operator
+    # has no remedy for is pure annoyance — the system-health card
+    # surfaces the underlying numbers either way for diagnostics.
+    #
+    # Only two conditions are genuinely user-fixable:
+    #   1. Worker is not running while clips are pending  → restart
+    #      the gadget_web service / check journalctl.
+    #   2. SD-card free space is below the CRITICAL threshold → free
+    #      space or expand storage.
+    #
+    # A 20-minute+ stall on a *running* worker COULD be a real bug,
+    # but the operator still can't diagnose it from the web UI; if
+    # they can't act on it, we shouldn't yell at them about it. The
+    # underlying staleness is still visible in the System Health card
+    # message so it's not hidden — just demoted from a banner.
+    worker_down_with_work = (not worker_running) and pending_count > 0
+    disk_critical = disk_known and disk_free_mb < disk_critical_mb
+    actionable = bool(worker_down_with_work or disk_critical)
+
     snap: Dict[str, Any] = {
         'severity': severity,
         'message': message,
+        'actionable': actionable,
         'last_successful_copy_at': last_copy_iso,
         'last_successful_copy_age_seconds': int(age) if age is not None else None,
         'worker_running': bool(worker_running),

--- a/scripts/web/templates/base.html
+++ b/scripts/web/templates/base.html
@@ -260,8 +260,21 @@
                     });
                     if (!r.ok) { banner.hidden = true; return; }
                     const data = await r.json();
-                    if (data.severity === 'error'
-                        || data.severity === 'critical') {
+                    // Issue #180 follow-up — banner is gated on
+                    // BOTH severity (error/critical) AND actionable
+                    // (the user can actually fix the underlying
+                    // issue). Stale-only conditions where the
+                    // worker is doing its best under heavy backlog
+                    // are reported in the System Health card but
+                    // never popped as a banner — banners that the
+                    // operator has no remedy for are pure noise.
+                    const sevBad = data.severity === 'error'
+                        || data.severity === 'critical';
+                    // Default to true when the field is missing so
+                    // an older deployment without the actionable
+                    // flag still surfaces the banner as before.
+                    const actionable = (data.actionable !== false);
+                    if (sevBad && actionable) {
                         applySeverity(data.severity, data.message);
                         banner.hidden = false;
                     } else {

--- a/scripts/web/templates/failed_jobs.html
+++ b/scripts/web/templates/failed_jobs.html
@@ -433,7 +433,7 @@
             if (r.recommendation && r.recommendation.action) {
                 const rec = r.recommendation;
                 const recClass = 'job-recommendation job-recommendation-' + rec.action;
-                const recIcon = RECOMMENDATION_ICON[rec.action] || 'icon-help-circle';
+                const recIcon = RECOMMENDATION_ICON[rec.action] || 'icon-alert-circle';
                 const recLabel = RECOMMENDATION_LABEL[rec.action] || 'Suggested';
                 recommendation = document.createElement('div');
                 recommendation.className = recClass;

--- a/scripts/web/templates/failed_jobs.html
+++ b/scripts/web/templates/failed_jobs.html
@@ -17,6 +17,22 @@
         </div>
     </header>
 
+    <!-- Issue #180 — collapsible help section so the page is
+         self-explanatory the first time an operator lands here. -->
+    <details id="jobsHelp" style="margin-bottom: 16px; background: var(--bg-secondary); border: 1px solid var(--border-color); border-radius: 8px;">
+        <summary style="cursor: pointer; padding: 12px 14px; font-weight: 600; font-size: 0.9375rem; display: flex; align-items: center; gap: 8px;">
+            <svg class="nav-icon" aria-hidden="true" style="width: 16px; height: 16px;"><use href="{{ url_for('static', filename='icons/lucide-sprite.svg') }}#icon-info"></use></svg>
+            <span>What does this mean?</span>
+        </summary>
+        <div style="padding: 0 14px 14px; font-size: 0.875rem; color: var(--text-primary); line-height: 1.5;">
+            <p style="margin: 8px 0;">A <strong>failed job</strong> is a background task — archive copy, video index, cloud upload, or live event upload — that retried multiple times and gave up. Each card shows what failed and a recommendation for what to do.</p>
+            <p style="margin: 8px 0;"><strong>Failed</strong> vs <strong>queued</strong>: a failed job has stopped retrying and needs your decision. A "queued" or "pending" item on the Health card is just waiting in line for the worker — it isn't failed, it'll process when the worker reaches it. Big queue numbers (hundreds queued) mean the worker is catching up after a backlog, not that anything is broken.</p>
+            <p style="margin: 8px 0;"><strong>Retry</strong> resets the row so the worker picks it up again. Use this when the underlying cause is fixed (network is back, free space is restored, permissions corrected).</p>
+            <p style="margin: 8px 0;"><strong>Delete</strong> removes the queue row only — it never deletes the underlying video file from disk. Producers (file watcher, boot scan, archive worker) may legitimately re-enqueue the same file later if it still exists.</p>
+            <p style="margin: 8px 0;"><strong>Clip value</strong> badge: <span class="job-value job-value-event" style="display:inline-flex; vertical-align:middle;">Event clip</span> = Tesla recorded it because something happened (high value). <span class="job-value job-value-recent" style="display:inline-flex; vertical-align:middle;">Driving footage</span> = rolling dashcam, rotated out hourly. <span class="job-value job-value-index" style="display:inline-flex; vertical-align:middle;">Map / trip data</span> = re-derivable from the video.</p>
+        </div>
+    </details>
+
     <!-- Subsystem filter pills -->
     <nav aria-label="Filter by subsystem" style="display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 16px;">
         <button type="button" class="failed-pill" data-subsystem="all" aria-pressed="true">
@@ -45,15 +61,18 @@
         </button>
     </nav>
 
-    <!-- "Retry all" / "Delete all" bar (shown only when a single subsystem is selected) -->
-    <div id="retryAllBar" style="display: none; align-items: center; justify-content: space-between; gap: 12px; padding: 10px 14px; margin-bottom: 12px; background: var(--bg-secondary); border: 1px solid var(--border-color); border-radius: 8px;">
+    <!-- "Retry all" / "Delete all" bar. Issue #180 — always visible.
+         When the "All" pill is selected the buttons fan out across
+         every subsystem; otherwise they act on the filtered subsystem
+         only. Buttons disable when there's nothing to act on. -->
+    <div id="retryAllBar" style="display: flex; align-items: center; justify-content: space-between; gap: 12px; padding: 10px 14px; margin-bottom: 12px; background: var(--bg-secondary); border: 1px solid var(--border-color); border-radius: 8px; flex-wrap: wrap;">
         <span id="retryAllLabel" style="font-size: 0.875rem; color: var(--text-secondary);"></span>
-        <div style="display: flex; gap: 8px;">
-            <button type="button" id="retryAllBtn" class="btn btn-primary" aria-label="Retry all failed jobs in this subsystem">
+        <div style="display: flex; gap: 8px; flex-wrap: wrap;">
+            <button type="button" id="retryAllBtn" class="btn btn-primary" aria-label="Retry all failed jobs">
                 <svg class="nav-icon" aria-hidden="true"><use href="{{ url_for('static', filename='icons/lucide-sprite.svg') }}#icon-refresh-cw"></use></svg>
                 <span>Retry all</span>
             </button>
-            <button type="button" id="deleteAllBtn" class="btn btn-danger" aria-label="Permanently delete all failed jobs in this subsystem">
+            <button type="button" id="deleteAllBtn" class="btn btn-danger" aria-label="Permanently delete all failed jobs">
                 <svg class="nav-icon" aria-hidden="true"><use href="{{ url_for('static', filename='icons/lucide-sprite.svg') }}#icon-trash-2"></use></svg>
                 <span>Delete all</span>
             </button>
@@ -129,6 +148,42 @@
     color: var(--accent-danger, #EF4444);
     font-size: 0.75rem; font-weight: 600;
 }
+/* Issue #180 — clip-value badge. Color hints at the underlying
+   irreplaceability of the data (event = unique, recent = rotates,
+   archived = preserved, index = re-derivable). */
+.job-value {
+    display: inline-flex; align-items: center; gap: 4px;
+    padding: 2px 8px; border-radius: 999px;
+    font-size: 0.75rem; font-weight: 600;
+    border: 1px solid transparent;
+}
+.job-value-event,
+.job-value-live_event {
+    background: rgba(239, 68, 68, 0.10);
+    color: var(--accent-danger, #EF4444);
+    border-color: rgba(239, 68, 68, 0.30);
+}
+.job-value-recent {
+    background: rgba(245, 158, 11, 0.10);
+    color: var(--accent-warning, #F59E0B);
+    border-color: rgba(245, 158, 11, 0.30);
+}
+.job-value-archived {
+    background: rgba(34, 197, 94, 0.10);
+    color: var(--accent-success, #22C55E);
+    border-color: rgba(34, 197, 94, 0.30);
+}
+.job-value-cloud,
+.job-value-index {
+    background: rgba(59, 130, 246, 0.10);
+    color: var(--accent-primary, #3B82F6);
+    border-color: rgba(59, 130, 246, 0.30);
+}
+.job-value-unknown {
+    background: var(--bg-primary);
+    color: var(--text-secondary);
+    border-color: var(--border-color);
+}
 .job-identifier {
     font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
     font-size: 0.8125rem;
@@ -145,6 +200,39 @@
     word-break: break-word;
     max-height: 200px;
     overflow: auto;
+}
+/* Issue #180 — recommendation chip steers the operator toward the
+   right action for each failure mode. Color matches the suggested
+   action (retry = primary, delete = danger, either = neutral). */
+.job-recommendation {
+    display: flex; align-items: flex-start; gap: 8px;
+    padding: 8px 10px; border-radius: 6px;
+    font-size: 0.8125rem; line-height: 1.4;
+    border-left: 3px solid var(--border-color);
+    background: var(--bg-primary);
+    color: var(--text-primary);
+}
+.job-recommendation-retry {
+    border-left-color: var(--accent-primary, #3B82F6);
+}
+.job-recommendation-delete {
+    border-left-color: var(--accent-danger, #EF4444);
+}
+.job-recommendation .nav-icon {
+    width: 16px; height: 16px; flex-shrink: 0; margin-top: 1px;
+}
+.job-recommendation-action {
+    font-weight: 600;
+    text-transform: uppercase;
+    font-size: 0.6875rem;
+    letter-spacing: 0.04em;
+    margin-right: 6px;
+}
+.job-recommendation-retry .job-recommendation-action {
+    color: var(--accent-primary, #3B82F6);
+}
+.job-recommendation-delete .job-recommendation-action {
+    color: var(--accent-danger, #EF4444);
 }
 /* Issue #132 — multi-failure history (prior error revealed on demand) */
 .job-prev-toggle {
@@ -242,16 +330,21 @@
         document.querySelectorAll('.failed-pill').forEach(function (b) {
             b.setAttribute('aria-pressed', b.dataset.subsystem === state.subsystem ? 'true' : 'false');
         });
-        const bar = $('retryAllBar');
+        // Issue #180 — bar is always visible. When "All" is selected
+        // the buttons fan out across every subsystem; otherwise they
+        // act on just the filtered subsystem. Buttons disable when
+        // there is nothing to act on.
         if (state.subsystem === 'all') {
-            bar.style.display = 'none';
+            const total = state.counts.total || 0;
+            $('retryAllLabel').textContent = total + ' job' + (total === 1 ? '' : 's') + ' failed across all subsystems';
+            $('retryAllBtn').disabled = total === 0;
+            $('deleteAllBtn').disabled = total === 0;
         } else {
             const meta = SUBSYSTEM_META[state.subsystem];
             const n = state.counts[state.subsystem] || 0;
             $('retryAllLabel').textContent = n + ' ' + (meta ? meta.label : state.subsystem) + ' job' + (n === 1 ? '' : 's') + ' failed';
             $('retryAllBtn').disabled = n === 0;
             $('deleteAllBtn').disabled = n === 0;
-            bar.style.display = 'flex';
         }
     }
 
@@ -269,6 +362,27 @@
         return n + ' attempt' + (n === 1 ? '' : 's');
     }
 
+    // Issue #180 — Lucide icon name per recommendation action so the
+    // chip's leading glyph reinforces the suggested choice.
+    const RECOMMENDATION_ICON = {
+        retry:  'icon-refresh-cw',
+        delete: 'icon-trash-2',
+        either: 'icon-alert-circle',
+    };
+    const RECOMMENDATION_LABEL = {
+        retry:  'Try retry',
+        delete: 'Delete is OK',
+        either: 'Your call',
+    };
+
+    function escapeHtml(s) {
+        if (s == null) return '';
+        return String(s)
+            .replace(/&/g, '&amp;').replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;').replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+    }
+
     function renderRows() {
         const list = $('jobList');
         list.innerHTML = '';
@@ -283,12 +397,23 @@
             card.className = 'job-card';
             card.setAttribute('role', 'listitem');
 
+            // Issue #180 — clip-value badge (with title= tooltip
+            // describing the underlying data tier). Falls back to
+            // 'unknown' if the backend somehow omitted the value
+            // field, keeping the page renderable on a partial
+            // payload.
+            const value = r.value || { tier: 'unknown', label: 'Background task', description: '' };
+            const valueClass = 'job-value job-value-' + (value.tier || 'unknown');
+
             const header = document.createElement('div');
             header.className = 'job-card-header';
             header.innerHTML =
                 '<span class="job-subsystem-badge">' +
                   '<svg class="nav-icon" aria-hidden="true"><use href="' + SPRITE_URL + '#' + meta.icon + '"></use></svg>' +
-                  meta.label +
+                  escapeHtml(meta.label) +
+                '</span>' +
+                '<span class="' + valueClass + '" title="' + escapeHtml(value.description || '') + '">' +
+                  escapeHtml(value.label || '') +
                 '</span>' +
                 '<span class="job-attempts">' + fmtAttempts(r.attempts) + '</span>';
 
@@ -299,6 +424,27 @@
             const error = document.createElement('div');
             error.className = 'job-error';
             error.textContent = r.last_error || '(no error message)';
+
+            // Issue #180 — recommendation chip. Tells the operator
+            // which action is most likely correct for this failure
+            // pattern. Both buttons are still rendered below; this
+            // is advisory only.
+            let recommendation = null;
+            if (r.recommendation && r.recommendation.action) {
+                const rec = r.recommendation;
+                const recClass = 'job-recommendation job-recommendation-' + rec.action;
+                const recIcon = RECOMMENDATION_ICON[rec.action] || 'icon-help-circle';
+                const recLabel = RECOMMENDATION_LABEL[rec.action] || 'Suggested';
+                recommendation = document.createElement('div');
+                recommendation.className = recClass;
+                recommendation.setAttribute('role', 'note');
+                recommendation.innerHTML =
+                    '<svg class="nav-icon" aria-hidden="true"><use href="' + SPRITE_URL + '#' + recIcon + '"></use></svg>' +
+                    '<div>' +
+                      '<span class="job-recommendation-action">' + escapeHtml(recLabel) + '</span>' +
+                      '<span>' + escapeHtml(rec.reason || '') + '</span>' +
+                    '</div>';
+            }
 
             // Issue #132 — surface multi-cycle failure history on demand.
             // Hidden by default to keep the card scannable; the toggle is
@@ -357,6 +503,9 @@
             card.appendChild(header);
             card.appendChild(identifier);
             card.appendChild(error);
+            if (recommendation) {
+                card.appendChild(recommendation);
+            }
             if (prevToggle) {
                 card.appendChild(prevToggle);
                 card.appendChild(prevError);
@@ -415,8 +564,19 @@
     }
 
     function retryAll() {
-        if (state.subsystem === 'all') return;
-        retry({ subsystem: state.subsystem, id: null })
+        // Issue #180 — when "All" is selected, the backend fans out
+        // across every subsystem. Otherwise we send the filtered
+        // subsystem and let the matching adapter retry every row.
+        const sub = state.subsystem;
+        const total = sub === 'all'
+            ? (state.counts.total || 0)
+            : (state.counts[sub] || 0);
+        if (total === 0) return;
+        const label = sub === 'all'
+            ? 'every failed job across every subsystem'
+            : ((SUBSYSTEM_META[sub] ? SUBSYSTEM_META[sub].label : sub) + ' jobs');
+        if (!window.confirm('Retry all ' + total + ' ' + label + '?')) return;
+        retry({ subsystem: sub, id: null })
             .then(function (res) {
                 if (!res.ok) {
                     showError('Retry-all failed: ' + (res.body && res.body.error ? res.body.error : 'unknown'));
@@ -447,12 +607,22 @@
     }
 
     function deleteAll() {
-        if (state.subsystem === 'all') return;
-        const meta = SUBSYSTEM_META[state.subsystem];
-        const label = meta ? meta.label : state.subsystem;
-        const n = state.counts[state.subsystem] || 0;
-        if (!window.confirm('Permanently delete all ' + n + ' failed ' + label + ' job' + (n === 1 ? '' : 's') + '?\n\nThe rows will be removed from the queue. Underlying source files are NOT deleted from disk.')) return;
-        del({ subsystem: state.subsystem, id: null })
+        // Issue #180 — when "All" is selected, the backend fans out
+        // across every subsystem in one round-trip. Otherwise we
+        // send only the filtered subsystem and let the matching
+        // adapter delete every row.
+        const sub = state.subsystem;
+        const total = sub === 'all'
+            ? (state.counts.total || 0)
+            : (state.counts[sub] || 0);
+        if (total === 0) return;
+        const label = sub === 'all'
+            ? 'failed job' + (total === 1 ? '' : 's') + ' across every subsystem'
+            : 'failed ' + (SUBSYSTEM_META[sub] ? SUBSYSTEM_META[sub].label : sub) + ' job' + (total === 1 ? '' : 's');
+        const msg = 'Permanently delete all ' + total + ' ' + label + '?\n\n' +
+                    'The rows will be removed from the queue. Underlying source files are NOT deleted from disk.';
+        if (!window.confirm(msg)) return;
+        del({ subsystem: sub, id: null })
             .then(function (res) {
                 if (!res.ok) {
                     showError('Delete-all failed: ' + (res.body && res.body.error ? res.body.error : 'unknown'));

--- a/tests/test_archive_status_endpoint.py
+++ b/tests/test_archive_status_endpoint.py
@@ -118,7 +118,7 @@ class TestArchiveStatusImageGate:
 
 class TestArchiveStatusShape:
     REQUIRED_FIELDS = {
-        'severity', 'message', 'enabled', 'checked_at',
+        'severity', 'message', 'actionable', 'enabled', 'checked_at',
         'queue_depth_p1', 'queue_depth_p2', 'queue_depth_p3',
         'pending_count', 'claimed_count', 'copied_count',
         'source_gone_count', 'dead_letter_count',

--- a/tests/test_archive_watchdog.py
+++ b/tests/test_archive_watchdog.py
@@ -224,6 +224,12 @@ class TestArchiveWatchdogSeverity:
 
     def test_error_at_10_min_stale_with_pending(self):
         # Acceptance criterion 6: 10 min trigger — banner-worthy.
+        # Issue #180 — wording was toned down from the alarmist
+        # "may be stalled — videos may be lost!" to a neutral
+        # "not making progress" since 10 min without a copy is the
+        # normal signature of a load-pause under heavy backlog,
+        # not yet an emergency. CRITICAL (20 min+) keeps the loud
+        # "STALLED ... videos are being lost!" wording.
         sev, msg = archive_watchdog._classify_severity(
             worker_running=True,
             pending_count=5,
@@ -233,7 +239,9 @@ class TestArchiveWatchdogSeverity:
             disk_critical_mb=100,
         )
         assert sev == 'error'
-        assert 'stalled' in msg.lower() or 'lost' in msg.lower()
+        assert 'no copy in' in msg.lower()
+        assert 'min' in msg.lower()
+        assert '5 queued' in msg.lower()
 
     def test_critical_at_20_min_stale_with_pending(self):
         sev, msg = archive_watchdog._classify_severity(

--- a/tests/test_archive_watchdog.py
+++ b/tests/test_archive_watchdog.py
@@ -530,6 +530,203 @@ class TestArchiveWatchdogReporting:
 
 
 # ---------------------------------------------------------------------------
+# TestArchiveWatchdogActionable (#180 follow-up)
+#
+# The "footage may be lost" banner in base.html is gated on BOTH severity
+# (error/critical) AND actionable=True. The principle: don't pop a banner
+# the operator has no remedy for. Most ERROR/CRITICAL severities come from
+# transient SDIO contention where the worker is doing its best — popping
+# a banner asking "what can I do?" is pure annoyance. Only two conditions
+# are user-actionable:
+#   1. Worker not running while clips are pending → restart service.
+#   2. SD-card free space below the CRITICAL threshold → free space.
+# ---------------------------------------------------------------------------
+
+
+class TestArchiveWatchdogActionable:
+    def test_idle_worker_with_empty_queue_is_not_actionable(
+        self, db, archive_root, monkeypatch,
+    ):
+        monkeypatch.setattr(
+            archive_watchdog.shutil, 'disk_usage',
+            lambda _p: _fake_usage(free_mb=10_000),
+        )
+        snap = archive_watchdog._compute_health(db, archive_root)
+        assert snap['actionable'] is False
+
+    def test_running_worker_slow_or_stalled_is_not_actionable(
+        self, db, archive_root, monkeypatch,
+    ):
+        # Insert a "last copied" row 25 minutes ago (well into the
+        # CRITICAL stall band) plus a pending row so the watchdog
+        # severity escalates to 'critical' / "videos are being lost!".
+        # actionable MUST still be False because the worker is
+        # running and the operator can't fix it from the web UI.
+        with sqlite3.connect(db) as conn:
+            old_iso = time.strftime(
+                '%Y-%m-%dT%H:%M:%S+00:00',
+                time.gmtime(time.time() - 25 * 60),
+            )
+            conn.execute(
+                "INSERT INTO archive_queue("
+                " source_path, dest_path, expected_size, expected_mtime,"
+                " status, copied_at, priority, enqueued_at, attempts) "
+                "VALUES (?, ?, ?, ?, 'copied', ?, 1, ?, 0)",
+                (
+                    "/teslacam/RecentClips/old.mp4",
+                    os.path.join(archive_root, "RecentClips/old.mp4"),
+                    100, time.time() - 25 * 60,
+                    old_iso, old_iso,
+                ),
+            )
+            conn.execute(
+                "INSERT INTO archive_queue("
+                " source_path, dest_path, expected_size, expected_mtime,"
+                " status, priority, enqueued_at, attempts) "
+                "VALUES (?, ?, ?, ?, 'pending', 1, ?, 0)",
+                (
+                    "/teslacam/RecentClips/new.mp4",
+                    os.path.join(archive_root, "RecentClips/new.mp4"),
+                    100, time.time(),
+                    time.strftime(
+                        '%Y-%m-%dT%H:%M:%S+00:00', time.gmtime(),
+                    ),
+                ),
+            )
+        monkeypatch.setattr(
+            archive_watchdog.shutil, 'disk_usage',
+            lambda _p: _fake_usage(free_mb=10_000),
+        )
+        # archive_worker.is_running() defaults to True via the lazy
+        # import path; we don't need to start a real worker for this
+        # test — the watchdog reads the "is the worker thread alive"
+        # bool, which is False here. To exercise the running-but-
+        # stalled branch we patch is_running to True.
+        monkeypatch.setattr(
+            archive_worker, 'is_running', lambda: True,
+        )
+        snap = archive_watchdog._compute_health(db, archive_root)
+        assert snap['severity'] == 'critical'
+        # The banner gate MUST NOT fire just because the worker
+        # is slow under load — there's nothing the operator can do.
+        assert snap['actionable'] is False, (
+            "actionable must be False for stale-only conditions: a "
+            "running worker that's just slow gives the operator no "
+            "remedy and a banner would be pure noise."
+        )
+
+    def test_worker_not_running_with_pending_is_actionable(
+        self, db, archive_root, monkeypatch,
+    ):
+        # Worker thread dead + work queued = restart the service.
+        # This IS user-actionable.
+        with sqlite3.connect(db) as conn:
+            conn.execute(
+                "INSERT INTO archive_queue("
+                " source_path, dest_path, expected_size, expected_mtime,"
+                " status, priority, enqueued_at, attempts) "
+                "VALUES (?, ?, ?, ?, 'pending', 1, ?, 0)",
+                (
+                    "/teslacam/RecentClips/new.mp4",
+                    os.path.join(archive_root, "RecentClips/new.mp4"),
+                    100, time.time(),
+                    time.strftime(
+                        '%Y-%m-%dT%H:%M:%S+00:00', time.gmtime(),
+                    ),
+                ),
+            )
+        monkeypatch.setattr(
+            archive_watchdog.shutil, 'disk_usage',
+            lambda _p: _fake_usage(free_mb=10_000),
+        )
+        monkeypatch.setattr(
+            archive_worker, 'is_running', lambda: False,
+        )
+        snap = archive_watchdog._compute_health(db, archive_root)
+        assert snap['severity'] == 'critical'
+        assert snap['actionable'] is True
+
+    def test_worker_not_running_with_empty_queue_is_not_actionable(
+        self, db, archive_root, monkeypatch,
+    ):
+        # Worker dead but no work to do — there's no urgency.
+        monkeypatch.setattr(
+            archive_watchdog.shutil, 'disk_usage',
+            lambda _p: _fake_usage(free_mb=10_000),
+        )
+        monkeypatch.setattr(
+            archive_worker, 'is_running', lambda: False,
+        )
+        snap = archive_watchdog._compute_health(db, archive_root)
+        assert snap['actionable'] is False
+
+    def test_disk_critical_is_actionable(
+        self, db, archive_root, monkeypatch,
+    ):
+        # SD card below CRITICAL threshold → user can free space.
+        monkeypatch.setattr(
+            archive_watchdog.shutil, 'disk_usage',
+            lambda _p: _fake_usage(free_mb=50),  # < 100 MB threshold
+        )
+        snap = archive_watchdog._compute_health(db, archive_root)
+        assert snap['severity'] == 'critical'
+        assert snap['actionable'] is True
+
+    def test_disk_warning_alone_is_not_actionable(
+        self, db, archive_root, monkeypatch,
+    ):
+        # Below the WARNING threshold but above CRITICAL — heads-up
+        # only. The user doesn't need a banner; the System Health
+        # card will surface the % full as a yellow row.
+        monkeypatch.setattr(
+            archive_watchdog.shutil, 'disk_usage',
+            lambda _p: _fake_usage(free_mb=300),  # < 500, > 100
+        )
+        snap = archive_watchdog._compute_health(db, archive_root)
+        assert snap['actionable'] is False
+
+    def test_disk_unknown_is_not_actionable(
+        self, db, archive_root, monkeypatch,
+    ):
+        # Transient OSError on shutil.disk_usage → disk_known=False
+        # → don't claim disk-critical and definitely don't fire the
+        # banner.
+        def _boom(_p):
+            raise OSError("ENOENT (transient)")
+        monkeypatch.setattr(
+            archive_watchdog.shutil, 'disk_usage', _boom,
+        )
+        snap = archive_watchdog._compute_health(db, archive_root)
+        assert snap['actionable'] is False
+
+    def test_actionable_field_present_in_every_snapshot(
+        self, db, archive_root, monkeypatch,
+    ):
+        # Contract test: the field must always exist so the JSON
+        # endpoint (and the banner JS reading it) never trips on
+        # KeyError. Test across several severity bands.
+        for free_mb, run in [
+            (10_000, True),    # ok
+            (300, True),       # disk warn
+            (50, True),        # disk crit
+            (10_000, False),   # worker dead, queue empty
+        ]:
+            monkeypatch.setattr(
+                archive_watchdog.shutil, 'disk_usage',
+                lambda _p, _f=free_mb: _fake_usage(free_mb=_f),
+            )
+            monkeypatch.setattr(
+                archive_worker, 'is_running', lambda _r=run: _r,
+            )
+            snap = archive_watchdog._compute_health(db, archive_root)
+            assert 'actionable' in snap, (
+                f"actionable missing from snapshot "
+                f"(free_mb={free_mb}, running={run})"
+            )
+            assert isinstance(snap['actionable'], bool)
+
+
+# ---------------------------------------------------------------------------
 # TestArchiveRetention (issue spec — trip preservation contract)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_jobs_blueprint.py
+++ b/tests/test_jobs_blueprint.py
@@ -561,3 +561,477 @@ def test_html_route_registered(app):
     assert 'jobs.api_counts' in rules
     assert 'jobs.api_failed' in rules
     assert 'jobs.api_retry' in rules
+
+
+# ---------------------------------------------------------------------------
+# Issue #180 — clip-value classifier, recommendation classifier, and
+# subsystem='all' retry/delete fan-out.
+# ---------------------------------------------------------------------------
+
+class TestClipValueClassifier:
+    """``_classify_clip_value`` translates the row identifier into a
+    deterministic value-tier so the UI can show an at-a-glance "how
+    irreplaceable is this clip" badge.
+    """
+
+    def test_sentryclips_path_is_event_tier(self):
+        from blueprints.jobs import _classify_clip_value
+        v = _classify_clip_value(
+            'archive',
+            '/mnt/gadget/part1-ro/TeslaCam/SentryClips/2025-10-29_10-39-36/'
+            'front.mp4',
+        )
+        assert v['tier'] == 'event'
+        assert v['label'] == 'Event clip'
+
+    def test_savedclips_path_is_event_tier(self):
+        from blueprints.jobs import _classify_clip_value
+        v = _classify_clip_value(
+            'cloud_sync',
+            '/home/pi/ArchivedClips/SavedClips/2025-11-01_08-00-00/back.mp4',
+        )
+        # Even though it's in ArchivedClips, the SavedClips
+        # sub-folder beats the archived check (it's a saved event).
+        assert v['tier'] == 'event'
+
+    def test_recentclips_path_is_recent_tier(self):
+        from blueprints.jobs import _classify_clip_value
+        v = _classify_clip_value(
+            'archive',
+            '/mnt/gadget/part1-ro/TeslaCam/RecentClips/2025-10-29_10-39-36-'
+            'front.mp4',
+        )
+        assert v['tier'] == 'recent'
+
+    def test_archivedclips_path_is_archived_tier(self):
+        from blueprints.jobs import _classify_clip_value
+        v = _classify_clip_value(
+            'cloud_sync',
+            '/home/pi/ArchivedClips/2025-10-29/clip.mp4',
+        )
+        assert v['tier'] == 'archived'
+
+    def test_indexer_subsystem_with_unknown_path_falls_back_to_index(self):
+        from blueprints.jobs import _classify_clip_value
+        v = _classify_clip_value('indexer', '/some/other/path.mp4')
+        assert v['tier'] == 'index'
+
+    def test_cloud_sync_subsystem_with_unknown_path_falls_back_to_cloud(self):
+        from blueprints.jobs import _classify_clip_value
+        v = _classify_clip_value('cloud_sync', '/some/other/path.mp4')
+        assert v['tier'] == 'cloud'
+
+    def test_live_event_sync_is_always_event_tier(self):
+        from blueprints.jobs import _classify_clip_value
+        # LES rows are always events by construction — the subsystem
+        # only triggers on Tesla event.json arrivals. The classifier
+        # MUST short-circuit on the subsystem name even when the
+        # event_dir path doesn't contain SentryClips/SavedClips.
+        v = _classify_clip_value(
+            'live_event_sync',
+            '/some/event/dir',
+        )
+        assert v['tier'] == 'live_event'
+
+    def test_unknown_subsystem_and_path_returns_unknown_tier(self):
+        from blueprints.jobs import _classify_clip_value
+        v = _classify_clip_value('archive', 'just-some-string')
+        assert v['tier'] == 'unknown'
+
+    def test_empty_identifier_does_not_crash(self):
+        from blueprints.jobs import _classify_clip_value
+        v = _classify_clip_value('archive', '')
+        assert 'tier' in v
+        assert 'label' in v
+        assert 'description' in v
+
+    def test_case_insensitive_path_match(self):
+        from blueprints.jobs import _classify_clip_value
+        # Tesla writes mixed-case folders; the classifier lowercases
+        # before matching so /TeslaCam/SentryClips/ and
+        # /teslacam/sentryclips/ both classify the same.
+        upper = _classify_clip_value(
+            'archive', '/TeslaCam/SentryClips/x.mp4')
+        lower = _classify_clip_value(
+            'archive', '/teslacam/sentryclips/x.mp4')
+        assert upper['tier'] == lower['tier'] == 'event'
+
+
+class TestRecommendationClassifier:
+    """``_classify_recommendation`` maps a redacted ``last_error``
+    string to a Retry / Delete / Either action recommendation. The
+    operator can always override; this just steers them to the right
+    button by default.
+    """
+
+    def test_file_missing_recommends_delete(self):
+        from blueprints.jobs import _classify_recommendation
+        for err in (
+            'No such file or directory',
+            '[Errno 2] ENOENT: file not found',
+            'source_gone',
+            'File does not exist',
+            'File missing',
+        ):
+            r = _classify_recommendation('archive', err)
+            assert r['action'] == 'delete', f"failed on {err!r}"
+
+    def test_parse_error_recommends_delete(self):
+        from blueprints.jobs import _classify_recommendation
+        for err in (
+            'Invalid data found when processing input',
+            'moov atom not found',
+            'truncated',
+            'parse error',
+            'unsupported codec',
+            'corrupt header',
+        ):
+            r = _classify_recommendation('indexer', err)
+            assert r['action'] == 'delete', f"failed on {err!r}"
+
+    def test_network_error_recommends_retry(self):
+        from blueprints.jobs import _classify_recommendation
+        for err in (
+            'Connection refused',
+            'connection reset by peer',
+            'Connection timed out',
+            'Network is unreachable',
+            'temporary failure in name resolution',
+            'no route to host',
+            'TLS handshake timed out',
+            'getaddrinfo: name or service not known',
+            'dial tcp 1.2.3.4:443: i/o timeout',
+        ):
+            r = _classify_recommendation('cloud_sync', err)
+            assert r['action'] == 'retry', f"failed on {err!r}"
+
+    def test_auth_quota_recommends_retry(self):
+        from blueprints.jobs import _classify_recommendation
+        for err in (
+            'HTTP 401 Unauthorized',
+            'HTTP 403 Forbidden',
+            'access denied',
+            'Invalid credential',
+            'Quota exceeded',
+            'Out of space on device',
+            'HTTP 429 too many requests',
+        ):
+            r = _classify_recommendation('cloud_sync', err)
+            assert r['action'] == 'retry', f"failed on {err!r}"
+
+    def test_io_error_recommends_retry(self):
+        from blueprints.jobs import _classify_recommendation
+        for err in (
+            'I/O error',
+            'Input/output error',
+            'Stale file handle',
+            'Device or resource busy',
+        ):
+            r = _classify_recommendation('archive', err)
+            assert r['action'] == 'retry', f"failed on {err!r}"
+
+    def test_permission_recommends_retry(self):
+        from blueprints.jobs import _classify_recommendation
+        r = _classify_recommendation(
+            'archive', '[Errno 13] Permission denied')
+        assert r['action'] == 'retry'
+        r2 = _classify_recommendation(
+            'archive', 'Read-only file system')
+        assert r2['action'] == 'retry'
+
+    def test_lock_contention_recommends_retry(self):
+        from blueprints.jobs import _classify_recommendation
+        r = _classify_recommendation(
+            'archive', 'lock timeout while waiting for coordinator')
+        assert r['action'] == 'retry'
+
+    def test_empty_error_returns_either(self):
+        from blueprints.jobs import _classify_recommendation
+        for err in ('', None, '   '):
+            r = _classify_recommendation('archive', err)
+            assert r['action'] == 'either', f"failed on {err!r}"
+            assert r['reason']
+
+    def test_unknown_error_with_few_attempts_returns_either(self):
+        from blueprints.jobs import _classify_recommendation
+        r = _classify_recommendation(
+            'archive', 'WeirdNeverSeenBeforeError: kaboom', attempts=2)
+        assert r['action'] == 'either'
+
+    def test_unknown_error_with_many_attempts_recommends_delete(self):
+        from blueprints.jobs import _classify_recommendation
+        # Heuristic: if a row has been retried 5+ times and still
+        # doesn't match any known recoverable pattern, the failure
+        # is probably stuck — push the operator toward delete so the
+        # worker isn't hammering the same broken row forever.
+        r = _classify_recommendation(
+            'archive', 'WeirdNeverSeenBeforeError: kaboom', attempts=5)
+        assert r['action'] == 'delete'
+        assert '5' in r['reason']
+
+    def test_response_shape_is_stable(self):
+        from blueprints.jobs import _classify_recommendation
+        r = _classify_recommendation(
+            'archive', 'No such file or directory', attempts=3)
+        assert set(r.keys()) == {'action', 'reason'}
+        assert isinstance(r['action'], str)
+        assert isinstance(r['reason'], str)
+
+
+class TestRowEnrichment:
+    """Each ``_*_rows`` adapter must populate ``value`` and
+    ``recommendation`` on every row so the UI never has to handle a
+    payload missing those fields.
+    """
+
+    def test_archive_rows_include_value_and_recommendation(self,
+                                                            geo_db, tmp_path,
+                                                            monkeypatch):
+        clip = tmp_path / 'SentryClips' / 'evt' / 'front.mp4'
+        clip.parent.mkdir(parents=True)
+        clip.write_bytes(b'x' * 10)
+        _force_archive_dead_letter(geo_db, str(clip))
+
+        # ``archive_queue.list_dead_letters`` resolves the DB by lazy-
+        # importing ``config.MAPPING_DB_PATH``, so patching the config
+        # module is what redirects the read to our fixture DB.
+        import config as config_module
+        from blueprints import jobs as jobs_module
+        monkeypatch.setattr(config_module, 'MAPPING_DB_PATH', geo_db,
+                            raising=False)
+        monkeypatch.setattr(jobs_module, 'MAPPING_DB_PATH', geo_db,
+                            raising=False)
+
+        from blueprints.jobs import _archive_rows
+        rows = _archive_rows(limit=10)
+        assert rows, 'archive adapter returned no rows'
+        for r in rows:
+            assert 'value' in r
+            assert 'recommendation' in r
+            assert r['value']['tier'] in (
+                'event', 'recent', 'archived', 'index', 'cloud',
+                'live_event', 'unknown',
+            )
+            assert r['recommendation']['action'] in (
+                'retry', 'delete', 'either',
+            )
+
+    def test_classifier_used_for_indexer_with_event_path(self):
+        # Pure unit test that does not need a DB — confirms the
+        # subsystem-name + path combination flows through the
+        # classifier correctly when the indexer holds a SentryClips
+        # path (a common case for failed event-clip indexing).
+        from blueprints.jobs import (
+            _classify_clip_value, _classify_recommendation,
+        )
+        v = _classify_clip_value(
+            'indexer',
+            '/home/pi/ArchivedClips/SentryClips/2025/front.mp4',
+        )
+        assert v['tier'] == 'event'  # path beats subsystem fallback
+
+        # Indexer parse errors recommend delete (the file is corrupt;
+        # retrying won't help).
+        r = _classify_recommendation('indexer', 'moov atom not found')
+        assert r['action'] == 'delete'
+
+
+class TestFanOutAcrossAllSubsystems:
+    """Issue #180 — ``subsystem='all'`` on retry/delete must invoke
+    every per-subsystem adapter once and return a per-subsystem
+    breakdown alongside the total.
+    """
+
+    def test_retry_all_fans_out(self, client, monkeypatch):
+        calls = {}
+
+        def make(name, n):
+            def fake(row_id):
+                calls[name] = row_id
+                return n
+            return fake
+
+        _patch_retrier(monkeypatch, 'archive',         make('archive', 2))
+        _patch_retrier(monkeypatch, 'indexer',         make('indexer', 3))
+        _patch_retrier(monkeypatch, 'cloud_sync',      make('cloud_sync', 1))
+        _patch_retrier(monkeypatch, 'live_event_sync', make('live_event_sync', 4))
+
+        rv = client.post('/api/jobs/retry',
+                         data=json.dumps({'subsystem': 'all'}),
+                         content_type='application/json')
+        assert rv.status_code == 200
+        body = rv.get_json()
+        assert body['subsystem'] == 'all'
+        assert body['rows_reset'] == 2 + 3 + 1 + 4
+        assert body['per_subsystem'] == {
+            'archive': 2, 'indexer': 3, 'cloud_sync': 1, 'live_event_sync': 4,
+        }
+        # Every adapter was invoked with id=None (retry-all).
+        assert set(calls.keys()) == {
+            'archive', 'indexer', 'cloud_sync', 'live_event_sync',
+        }
+        for name, row_id in calls.items():
+            assert row_id is None, f"{name} was invoked with id={row_id!r}"
+
+    def test_retry_all_ignores_id_in_payload(self, client, monkeypatch):
+        # Even if the client sends id=42, fan-out always uses id=None.
+        captured = {}
+
+        def fake(row_id):
+            captured.setdefault('args', []).append(row_id)
+            return 1
+
+        for name in ('archive', 'indexer', 'cloud_sync', 'live_event_sync'):
+            _patch_retrier(monkeypatch, name, fake)
+
+        rv = client.post('/api/jobs/retry',
+                         data=json.dumps({'subsystem': 'all', 'id': 42}),
+                         content_type='application/json')
+        assert rv.status_code == 200
+        # All four adapter invocations got None, not 42.
+        assert captured['args'] == [None, None, None, None]
+
+    def test_retry_all_one_subsystem_crashes(self, client, monkeypatch):
+        """A crashing adapter must not block fan-out for the others."""
+        import blueprints.jobs as jobs_module
+
+        def boom(row_id):
+            raise RuntimeError('boom')
+
+        monkeypatch.setitem(jobs_module._RETRIERS, 'archive', boom)
+        _patch_retrier(monkeypatch, 'indexer',         lambda _r: 5)
+        _patch_retrier(monkeypatch, 'cloud_sync',      lambda _r: 0)
+        _patch_retrier(monkeypatch, 'live_event_sync', lambda _r: 2)
+
+        rv = client.post('/api/jobs/retry',
+                         data=json.dumps({'subsystem': 'all'}),
+                         content_type='application/json')
+        assert rv.status_code == 200
+        body = rv.get_json()
+        # Crashed adapter contributes 0 (swallowed by _safe);
+        # other adapters still produce their counts.
+        assert body['per_subsystem']['archive'] == 0
+        assert body['per_subsystem']['indexer'] == 5
+        assert body['rows_reset'] == 5 + 0 + 2
+
+    def test_delete_all_fans_out(self, client, monkeypatch):
+        calls = {}
+
+        def make(name, n):
+            def fake(row_id):
+                calls[name] = row_id
+                return n
+            return fake
+
+        import blueprints.jobs as jobs_module
+        for name, n in (('archive', 7), ('indexer', 1),
+                        ('cloud_sync', 0), ('live_event_sync', 3)):
+            monkeypatch.setitem(jobs_module._DELETERS, name, make(name, n))
+
+        rv = client.post('/api/jobs/delete',
+                         data=json.dumps({'subsystem': 'all'}),
+                         content_type='application/json')
+        assert rv.status_code == 200
+        body = rv.get_json()
+        assert body['subsystem'] == 'all'
+        assert body['rows_deleted'] == 7 + 1 + 0 + 3
+        assert body['per_subsystem'] == {
+            'archive': 7, 'indexer': 1, 'cloud_sync': 0, 'live_event_sync': 3,
+        }
+        assert all(v is None for v in calls.values())
+
+    def test_delete_all_one_subsystem_crashes(self, client, monkeypatch):
+        import blueprints.jobs as jobs_module
+
+        def boom(row_id):
+            raise RuntimeError('boom')
+
+        monkeypatch.setitem(jobs_module._DELETERS, 'cloud_sync', boom)
+        monkeypatch.setitem(jobs_module._DELETERS, 'archive',
+                            lambda _r: 4)
+        monkeypatch.setitem(jobs_module._DELETERS, 'indexer',
+                            lambda _r: 0)
+        monkeypatch.setitem(jobs_module._DELETERS, 'live_event_sync',
+                            lambda _r: 2)
+
+        rv = client.post('/api/jobs/delete',
+                         data=json.dumps({'subsystem': 'all'}),
+                         content_type='application/json')
+        assert rv.status_code == 200
+        body = rv.get_json()
+        assert body['per_subsystem']['cloud_sync'] == 0  # crash swallowed
+        assert body['rows_deleted'] == 4 + 0 + 0 + 2
+
+    def test_unknown_subsystem_lists_all_in_allowed(self, client):
+        rv = client.post('/api/jobs/retry',
+                         data=json.dumps({'subsystem': 'bogus', 'id': None}),
+                         content_type='application/json')
+        assert rv.status_code == 400
+        body = rv.get_json()
+        # The "allowed" array must include 'all' so the client knows
+        # the bulk fan-out option exists.
+        assert 'all' in body['allowed']
+
+
+class TestFailedJobsPageContext:
+    """Issue #180 — the /jobs HTML route must merge
+    ``get_base_context()`` so the left sidebar / mobile bottom-tab
+    nav renders with all top-level pages instead of collapsing to
+    just Settings.
+    """
+
+    def test_render_template_receives_base_context(self, app, monkeypatch):
+        # Capture the kwargs render_template is called with so we can
+        # assert that get_base_context's flags flow into the template.
+        # Patching get_base_context to a known dict is simpler than
+        # patching render_template (the latter would require taking
+        # over the template loading machinery).
+        captured = {}
+
+        import blueprints.jobs as jobs_module
+
+        fake_ctx = {
+            'mode_token': 'present',
+            'mode_label': 'Present',
+            'mode_class': 'ok',
+            'share_paths': [],
+            'hostname': 'cybertruckusb',
+            'map_available': True,
+            'analytics_available': True,
+            'cloud_archive_available': True,
+            'chimes_available': True,
+            'shows_available': False,
+            'wraps_available': False,
+            'music_available': False,
+            'boombox_available': False,
+            'license_plates_available': False,
+            'videos_available': True,
+        }
+        monkeypatch.setattr(jobs_module, 'get_base_context',
+                            lambda: dict(fake_ctx))
+
+        # Stub render_template so the test doesn't need the entire
+        # base.html chain (with its url_for calls into every other
+        # blueprint). We just verify the template name and the kwargs
+        # it would have been called with.
+        def fake_render(template, **kwargs):
+            captured['template'] = template
+            captured['kwargs'] = kwargs
+            return 'ok'
+
+        monkeypatch.setattr(jobs_module, 'render_template', fake_render)
+
+        with app.test_client() as client:
+            rv = client.get('/jobs')
+            assert rv.status_code == 200
+
+        assert captured['template'] == 'failed_jobs.html'
+        # Every flag that was in the base context must reach the template.
+        for key, value in fake_ctx.items():
+            assert captured['kwargs'].get(key) == value, \
+                f"base-context flag {key!r} missing from /jobs render"
+        # And the page identifier must NOT collapse the nav by
+        # falsely highlighting Settings (issue #180 root cause).
+        assert captured['kwargs'].get('page') == 'jobs'
+        # The subsystem list still flows through.
+        assert 'subsystems' in captured['kwargs']

--- a/tests/test_system_health_blueprint.py
+++ b/tests/test_system_health_blueprint.py
@@ -404,7 +404,11 @@ def test_indexer_block_dead_letter(monkeypatch):
     })
     block = sh._indexer_block()
     assert block['severity'] == 'warn'
-    assert '3 dead-letter' in block['message']
+    # Issue #180 — actionable wording: "N jobs need attention — open
+    # Failed Jobs" instead of the old "N dead-letter rows" jargon.
+    assert '3 jobs need attention' in block['message']
+    assert 'Failed Jobs' in block['message']
+    assert block['dead_letter_count'] == 3
 
 
 def test_indexer_block_not_running(monkeypatch):
@@ -538,7 +542,10 @@ def test_archive_block_files_lost_takes_precedence_over_dead_letters(
 
     block = sh._archive_block()
     assert 'lost' in block['message'].lower()
-    assert 'dead-letter' not in block['message'].lower()
+    # Issue #180 — message now says "N jobs need attention" instead of
+    # "N dead-letter rows", so check for absence of the "need attention"
+    # phrase to confirm lost-files dominates.
+    assert 'need attention' not in block['message'].lower()
 
 
 def test_archive_block_lost_24h_zero_means_ok(monkeypatch):
@@ -866,7 +873,12 @@ def test_archive_block_paused_load_message(monkeypatch):
     })
     block = sh._archive_block()
     assert block['severity'] == 'warn'
-    assert block['message'] == 'Paused: load 4.2 > 3.5'
+    # Issue #180 — message now appends a queue-depth tail "· N queued"
+    # whenever there's pending work, so the operator sees consistent
+    # info even as the headline severity branch swaps. Pause-reason
+    # is the canonical prefix.
+    assert block['message'].startswith('Paused: load 4.2 > 3.5')
+    assert '10 queued' in block['message']
     assert block['pause_reason'] == 'load 4.2 > 3.5'
 
 
@@ -903,7 +915,8 @@ def test_archive_block_load_auto_paused_without_manual_flag(monkeypatch):
     # auto-pause, not the narrower manual flag.
     assert block['paused'] is True
     assert block['severity'] == 'warn'
-    assert block['message'] == 'Paused: load 3.9 > 3.5'
+    assert block['message'].startswith('Paused: load 3.9 > 3.5')
+    assert '442 queued' in block['message']
     assert block['pause_reason'] == 'load 3.9 > 3.5'
 
 
@@ -933,7 +946,8 @@ def test_archive_block_disk_auto_paused_without_manual_flag(monkeypatch):
     block = sh._archive_block()
     assert block['paused'] is True
     assert block['severity'] == 'warn'
-    assert block['message'] == 'Paused: SD card 96% full'
+    assert block['message'].startswith('Paused: SD card 96% full')
+    assert '5 queued' in block['message']
     assert block['pause_reason'] == 'SD card 96% full'
 
 
@@ -959,6 +973,7 @@ def test_archive_block_paused_disk_message(monkeypatch):
     })
     block = sh._archive_block()
     assert block['severity'] == 'warn'
+    # pending=0 → no queue tail; message stays clean.
     assert block['message'] == 'Paused: SD card 96% full'
     assert block['pause_reason'] == 'SD card 96% full'
 
@@ -983,7 +998,8 @@ def test_archive_block_paused_background_message(monkeypatch):
     })
     block = sh._archive_block()
     assert block['severity'] == 'warn'
-    assert block['message'] == 'Paused (background task)'
+    assert block['message'].startswith('Paused (background task)')
+    assert '5 queued' in block['message']
     assert block['pause_reason'] == 'background'
 
 
@@ -1051,7 +1067,11 @@ def test_cloud_block_dead_letters(monkeypatch):
     })
     block = sh._cloud_block()
     assert block['severity'] == 'warn'
-    assert 'dead-letter' in block['message']
+    # Issue #180 — actionable wording: "N jobs need attention — open
+    # Failed Jobs" instead of "N dead-letter rows".
+    assert '4 jobs need attention' in block['message']
+    assert 'Failed Jobs' in block['message']
+    assert block['dead_letter_count'] == 4
 
 
 def test_cloud_block_uploading(monkeypatch):


### PR DESCRIPTION
Closes #180.

Bundles the four explicit /jobs page issues from #180 plus a fifth follow-up the user observed during testing — the System Health archive row was flapping between dramatically different messages as severity transitioned (yellow "13 dead-letter rows" → red "hundreds of videos to be moved!" → back to yellow), giving no stable picture of what was happening.

## /jobs page (issues 1-4)

| # | Concern | Fix |
|---|---------|-----|
| 1 | Page only showed Settings in the nav | `failed_jobs_page` now calls `get_base_context()` (was missing) and sets `page='jobs'` (was `'settings'`). Without `get_base_context()`, every `*_available` flag was undefined → `base.html`'s `{% if %}` guards collapsed every conditional nav item. |
| 2 | No "Delete All" on the All tab | `Retry all` / `Delete all` bar is now always visible. On the All tab the buttons fan out across every subsystem with per-subsystem crash isolation (one failing adapter doesn't block the bulk action). |
| 3 | No per-row guidance on retry vs delete | Each row now shows a deterministic Retry/Delete recommendation chip driven by regex classification of `last_error`. Many-attempts (≥5) fallback recommends delete on unknown errors so the operator isn't told to retry a stuck row forever. |
| 4 | No clip-value indication | Each row shows a clip-value badge: **Event clip** (red — Tesla recorded it because something happened), **Driving footage** (amber — rolling dashcam, rotated hourly), **Map / trip data** (blue — re-derivable from the video), **Cloud upload** / **Background task** / etc. Plus a collapsible "What does this mean?" help section at the top of the page. |

## System Health (issue 5 — flapping)

The user reported: _"the Local Archive is yellow with some dead letter items and then suddenly it shows red and there are hundreds of videos that need to be moved, then back to just some dead letter rows"_.

Root cause: `_archive_block` is a **winner-takes-all** ladder. As the watchdog's staleness counter crosses 5 / 10 / 20 minute thresholds the headline message gets completely rewritten — the dead-letter context disappears, the queue context disappears, and the wording goes from neutral to alarmist. Each poll of `/api/system/health` could hit a different branch.

**Fixes:**
* `_archive_block` now appends a stable **"· N queued, est. <ETA>"** tail whenever there's pending work, regardless of which severity branch wins. The operator sees consistent numbers across transitions.
* When the watchdog branch wins, append **"· N failed"** so the dead-letter count stays visible alongside the staleness alert.
* Watchdog message truncation bumped 80 → 160 chars so the new actionable hints aren't cut off mid-sentence.
* `archive_watchdog` WARN (5–10 min) and ERROR (10–20 min) messages **toned down** from alarmist (`"videos may be lost!"`) to informative (`"Worker slow / not making progress — often caused by SD-card load"`). 5–20 min without a copy is the normal signature of a load-pause under heavy backlog, not a "videos may be lost" emergency.
* CRITICAL (20 min+ stall) **keeps** the loud `"STALLED — videos are being lost!"` wording since that IS the genuine emergency (Tesla's RecentClips ring buffer rolls over faster than we can copy).
* Replaced `"N dead-letter rows"` jargon with `"N jobs need attention — open Failed Jobs"` in indexer / archive / cloud blocks.

## Before / after

**Before** (yellow → red → yellow flap):
```
13 dead-letter rows
Archive worker may be stalled: no copy in 12 min (543 pending) — videos may be lost!
13 dead-letter rows
```

**After** (stable, layered):
```
13 jobs need attention — open Failed Jobs · 543 queued, est. 2h
Archive worker not making progress: no copy in 12 min (543 queued). Check system load and SD-card health. · 13 failed
13 jobs need attention — open Failed Jobs · 543 queued, est. 2h
```

Both numbers (queued + failed) are visible across all three transitions; the operator can correlate.

## Tests

* **1598 passed, 4 skipped** — full suite green.
* Added ~30 new tests (`TestClipValueClassifier`, `TestRecommendationClassifier`, `TestRowEnrichment`, `TestFanOutAcrossAllSubsystems`, `TestFailedJobsPageContext`).
* Updated 6 existing tests to allow the new queue-depth tail and the new watchdog wording.

## Pi safety
* No service file changes
* No mount / gadget / image-binding changes
* No new dependencies
* Pure Python + template + CSS changes, plus opinionated wording changes in two existing functions
* Deployable via `git pull && systemctl restart gadget_web.service` — no setup_usb.sh re-run needed
