### PR TITLE
Docs: Wave 1 — Foundation + flagship video lifecycle

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,457 @@
+# Architecture
+
+A bird's-eye view of TeslaUSB. After this doc you should be able to
+name every major component, sketch the data flow between them, and
+know which document to read for the deeper details.
+
+For "what happens to a video?" — that's the
+[`VIDEO_LIFECYCLE.md`](VIDEO_LIFECYCLE.md) flagship doc, and you
+should read it next.
+
+---
+
+## What TeslaUSB is
+
+A Raspberry Pi (Zero 2 W) that:
+
+1. **Pretends to be a USB drive** that Tesla writes dashcam, Sentry,
+   and Saved-event clips to.
+2. **Captures those clips** to its own SD card before Tesla rotates
+   them out.
+3. **Indexes** each clip's H.264 SEI metadata to extract GPS, speed,
+   and telemetry.
+4. **Maps** the trips on a web UI with event markers.
+5. **Uploads** the important clips to a cloud provider (Google Drive,
+   S3, etc.) via rclone.
+6. **Manages** lock chimes, light shows, custom wraps, license plates,
+   and boombox sounds — everything Tesla reads from the LightShow
+   and Music drives.
+7. **Falls back** to its own WiFi access point when no home network
+   is reachable, so the in-car browser can still drive the UI.
+
+All of this runs on a Pi with **512 MB of RAM** and a **single SDIO
+bus** shared between the SD card and the WiFi chip. The architecture
+is shaped around those two constraints.
+
+---
+
+## Layered view
+
+```mermaid
+flowchart TB
+    subgraph Tesla["Tesla vehicle"]
+        TC[Tesla cameras]
+    end
+
+    subgraph Hardware["Pi hardware"]
+        UDC[USB Device Controller]
+        SD[SD card]
+        WIFI[WiFi chip]
+    end
+
+    subgraph Kernel["Linux kernel"]
+        GADGET[USB gadget driver]
+        FS[exFAT / FAT32 filesystems]
+        INOTIFY[inotify]
+        NM[NetworkManager]
+    end
+
+    subgraph SystemServices["systemd services"]
+        PRESENT[present_usb_on_boot.service]
+        WEB[gadget_web.service]
+        CHIMES[chime_scheduler.timer]
+        WIFIMON[wifi-monitor.service]
+        WATCHDOG[watchdog.service]
+        DEFERRED[teslausb-deferred-tasks.service]
+    end
+
+    subgraph FlaskApp["Flask application (gadget_web)"]
+        BLUEPRINTS[Blueprints<br/>HTTP routes]
+        WORKERS[Background workers<br/>archive / indexer / cloud / LES]
+        WATCHER[file_watcher_service<br/>inotify]
+        COORDINATOR[task_coordinator<br/>fairness lock]
+    end
+
+    subgraph DataStores["Persistent state"]
+        IMG_CAM[(usb_cam.img<br/>TeslaCam LUN)]
+        IMG_LS[(usb_lightshow.img<br/>LightShow LUN)]
+        IMG_M[(usb_music.img<br/>Music LUN, optional)]
+        ARCHIVE[(~/ArchivedClips<br/>SD card)]
+        GEO[(geodata.db)]
+        CLOUDDB[(cloud_sync.db)]
+        CONFIG[(config.yaml)]
+    end
+
+    TC -->|USB writes| UDC
+    UDC --> GADGET
+    GADGET <-->|backing files| IMG_CAM
+    GADGET <-->|backing files| IMG_LS
+    GADGET <-.optional.-> IMG_M
+
+    PRESENT --> GADGET
+    WEB --> FlaskApp
+    CHIMES --> WEB
+    WIFIMON --> NM
+    WATCHDOG --> Hardware
+    DEFERRED --> WEB
+
+    INOTIFY --> WATCHER
+    WATCHER --> WORKERS
+    WORKERS --> ARCHIVE
+    WORKERS --> GEO
+    WORKERS --> CLOUDDB
+    WORKERS -->|rclone via WiFi| WIFI
+
+    BLUEPRINTS --> ARCHIVE
+    BLUEPRINTS --> GEO
+    BLUEPRINTS --> CLOUDDB
+    BLUEPRINTS -.read.-> CONFIG
+    WORKERS -.read.-> CONFIG
+    COORDINATOR -.coordinates.-> WORKERS
+```
+
+---
+
+## The major components
+
+### Hardware
+
+- **Raspberry Pi Zero 2 W** (4 ARM cores, 512 MB RAM)
+- **USB Device Controller (UDC)** — kernel interface to the gadget
+- **SD card** — OS, runtime data, all `.img` files, all SQLite DBs
+- **Broadcom WiFi chip** — shares SDIO bus with the SD card
+
+### USB gadget
+
+The Pi presents 2 or 3 LUNs to Tesla:
+
+| LUN | Drive       | Filesystem | Backing file        |
+|-----|-------------|------------|---------------------|
+| 0   | TeslaCam    | exFAT      | `usb_cam.img`       |
+| 1   | LightShow   | FAT32      | `usb_lightshow.img` |
+| 2   | Music *(opt)*| FAT32     | `usb_music.img`     |
+
+The gadget binds the `.img` files **directly** — not via loop devices.
+Loop devices are used only for **local mount access** so the web UI
+can read or write the contents.
+
+The gadget is bound at boot by `present_usb.sh` writing the UDC name
+to `/sys/kernel/config/usb_gadget/g1/UDC`. Unbind happens (rarely)
+during edit-mode switches and during chime-change USB rebinds. **Any
+unbind during normal operation loses Tesla footage**, so background
+subsystems are forbidden from triggering one.
+
+### Modes
+
+- **Present mode** (default) — gadget bound, partitions mounted RO,
+  Samba off
+- **Edit mode** (rare) — gadget unbound, partitions mounted RW,
+  Samba on
+
+The UI does not expose mode terminology to the user; write
+operations transparently use `quick_edit_part2` to open a brief RW
+window on LUN 1 without leaving present mode. See
+[`GLOSSARY.md`](GLOSSARY.md) for the full definition.
+
+### systemd services
+
+The Pi-side services that drive everything:
+
+| Service                              | Owns                                                              |
+|--------------------------------------|-------------------------------------------------------------------|
+| `present_usb_on_boot.service`        | Bind the USB gadget at boot (~3 s after power-on)                  |
+| `gadget_web.service`                 | The Flask web app + ALL background workers                         |
+| `chime_scheduler.timer` + `.service` | Periodic chime schedule check (every 60 s)                         |
+| `wifi-monitor.service`               | STA-loss detection + AP fallback                                   |
+| `watchdog.service`                   | Userspace ping for the hardware watchdog (90 s timeout)            |
+| `network-optimizations.service`      | Power-save off for WiFi (roaming responsiveness)                   |
+| `teslausb-deferred-tasks.service`    | Post-boot cleanup + random chime selection (runs after gadget bind) |
+| `teslausb-safe-mode.service`         | Detects 3+ reboots in 10 minutes; skips TeslaUSB services if so    |
+
+Notice that **`gadget_web.service` owns every background worker**.
+The archive worker, indexing worker, cloud-archive worker, LES
+worker, file watcher, and chime scheduler ticker are all threads
+inside the Flask process. There is no separate worker daemon.
+
+### The Flask application (`gadget_web`)
+
+`scripts/web/web_control.py` is the app factory. It:
+
+1. Loads `config.yaml` via `scripts/web/config.py`.
+2. Initializes `geodata.db` and `cloud_sync.db` (running migrations
+   in `mapping_migrations.py`).
+3. Registers every blueprint under `scripts/web/blueprints/`.
+4. Starts the background workers as daemon threads.
+5. Starts the file watcher.
+6. Binds Flask on port **80** (required for captive portal).
+
+The blueprints are organized by page or API surface
+(`mapping.py`, `videos.py`, `cloud_archive.py`, `jobs.py`, etc.).
+Service modules under `scripts/web/services/` hold the actual
+business logic so blueprints stay thin.
+
+---
+
+## The big four background workers
+
+All four run in the `gadget_web` process. All four use the
+`task_coordinator` to take a fairness-aware mutex before doing
+heavy work.
+
+### 1. File watcher
+
+`file_watcher_service.py`. Single thread using Linux `inotify`
+plus a 5-minute polling fallback. Watches the **read-only USB
+mount** and the **`~/ArchivedClips` SD-card folder**. Routes
+events:
+
+- New `.mp4` on RO mount → archive callback (after 60 s age gate)
+- New `.mp4` in ArchivedClips → indexing callback
+- New `event.json` (anywhere) → Live Event Sync callback (no age gate)
+
+### 2. Archive worker
+
+`archive_worker.py`. Single thread that drains the
+`archive_queue` table (in `cloud_sync.db`):
+
+```
+producer enqueues → claim → atomic_copy → mark copied → enqueue indexing
+```
+
+Copies clips from the read-only USB mount to `~/ArchivedClips/<date>/`
+on the SD card, **before** Tesla rotates RecentClips (~60 minute
+buffer). Heavily throttled — `nice` priority, inter-file sleep,
+load-pause guard, chunk pause, per-file time budget.
+
+### 3. Indexing worker
+
+`indexing_worker.py`. Single thread that drains the
+`indexing_queue` table (in `geodata.db`):
+
+```
+producer enqueues → claim → index_single_file → terminal/retry outcome
+```
+
+Parses each clip's H.264 SEI for GPS, telemetry, and event
+detection. Writes `indexed_files`, `waypoints`, `detected_events`
+rows. Updates / merges `trips`. Returns a typed `IndexResult` with
+an `IndexOutcome` enum value.
+
+### 4. Cloud upload (two cooperating workers)
+
+- **`cloud_archive_service.py`** — bulk catch-up uploader. Drains
+  `cloud_synced_files` (status `pending`). Priority order: events
+  first → geolocated → non-event (opt-in). One rclone subprocess
+  at a time.
+- **`live_event_sync_service.py`** (LES) — opt-in real-time
+  uploader. Triggered by `event.json` arrival. Drains
+  `live_event_queue`. Has its own thread, idle on
+  `threading.Event.wait()`. **Disabled by default.**
+
+The two cloud subsystems coordinate via `task_coordinator`. When
+LES has work, `cloud_archive` yields between files. The NM WiFi
+dispatcher (`refresh_cloud_token.py`) wakes LES first, waits up
+to 10 minutes for it to drain, then triggers `cloud_archive`.
+
+---
+
+## Data flow at a glance
+
+```mermaid
+flowchart LR
+    Tesla -->|writes mp4 + event.json| GadgetIMG[usb_cam.img]
+    GadgetIMG -->|inotify on RO mount| Watcher
+    Watcher -->|new mp4| ArchiveProducer
+    Watcher -->|event.json| LES
+    ArchiveProducer --> ArchiveQueue[(archive_queue)]
+    ArchiveQueue --> ArchiveWorker
+    ArchiveWorker -->|copy| ArchivedClips[(~/ArchivedClips)]
+    ArchivedClips -->|inotify on SD| Watcher2[Watcher]
+    Watcher2 -->|new mp4| IndexQueue[(indexing_queue)]
+    IndexQueue --> Indexer
+    Indexer --> GeoDB[(geodata.db<br/>trips/waypoints/events)]
+    ArchivedClips --> CloudArchive
+    CloudArchive --> CloudDB[(cloud_synced_files)]
+    CloudArchive -->|rclone| CloudProvider[Cloud provider]
+    LES --> LESQueue[(live_event_queue)]
+    LES -->|rclone| CloudProvider
+```
+
+That diagram is the **video lifecycle** in 14 nodes. Every node has
+its own dedicated subsystem doc. The full narrative — including
+every branch, decision point, retry, and failure mode — is in
+[`VIDEO_LIFECYCLE.md`](VIDEO_LIFECYCLE.md).
+
+---
+
+## Persistent state
+
+Three categories of persistent state live on the SD card:
+
+### USB-gadget backing files
+
+- `usb_cam.img` — TeslaCam drive
+- `usb_lightshow.img` — LightShow drive
+- `usb_music.img` *(if `disk_images.music_enabled`)* — Music drive
+
+These are owned by `installation.target_user`, live in
+`installation.mount_dir`, and are **protected** from every UI
+delete code path.
+
+### SD-card archive
+
+- `~/ArchivedClips/<YYYY-MM-DD>/<event-folder-or-flat>/` — copies of
+  Tesla's recordings, retained per `cleanup.default_retention_days`
+  (default inherited; current default 30 days).
+
+### SQLite databases
+
+| File             | Owns                                                                          |
+|------------------|-------------------------------------------------------------------------------|
+| `geodata.db`     | Trips, waypoints, detected events, indexed file records, the indexing queue   |
+| `cloud_sync.db`  | Cloud-upload state, the archive queue, the LES queue, sync sessions           |
+
+Schemas are documented in
+[`contributor/core/DATABASES.md`](contributor/core/DATABASES.md).
+
+### One-line state files
+
+- `state.txt` — current mode (`present` or `edit`)
+- `~/.quick_edit_part2.lock` — quick-edit in-flight marker (120 s
+  stale timeout)
+- `/run/teslausb-ap/force.mode` — runtime AP force mode (lost on reboot)
+
+---
+
+## Configuration
+
+A single `config.yaml` at the repo root holds **everything**:
+paths, credentials, network settings, archive thresholds, indexing
+params, cloud sync behavior, retention, AP behavior, mapping event
+detection thresholds.
+
+Two thin wrappers expose values to runtime code:
+
+- **Bash** reads via `scripts/config.sh` (uses `yq`).
+- **Python** reads via `scripts/web/config.py` (uses PyYAML).
+
+Both wrappers cache the parsed YAML once at startup. **Never
+hardcode values** in source — always read from the wrappers. After
+editing `config.yaml`, restart `gadget_web.service` (and
+`wifi-monitor.service` if AP/STA settings changed).
+
+For a comprehensive reference of every configuration key,
+see [`contributor/core/CONFIGURATION_SYSTEM.md`](contributor/core/CONFIGURATION_SYSTEM.md).
+
+---
+
+## Networking
+
+Two interfaces, both managed by NetworkManager:
+
+- **`wlan0`** — STA mode, connects to a home / mesh / extender SSID
+- **`uap0`** — virtual AP interface, broadcasts `offline_ap.ssid`
+
+The two run **concurrently** (not exclusively). When STA loses
+the configured network, `wifi-monitor.sh` brings the AP up after
+`offline_ap.disconnect_grace` seconds. STA reconnect attempts
+continue with **exponential backoff** (2.5 → 5 → 15 → 30 min cap)
+so a flapping STA can't take the AP down repeatedly. When STA
+reconnects with stable RSSI, the AP tears down.
+
+The web UI uses port **80** so the OS captive-portal detection
+fires automatically when a device joins the AP.
+
+---
+
+## Mutual exclusion: the task coordinator
+
+The Pi Zero 2 W's single SDIO bus means heavy concurrent I/O
+trashes throughput and can starve the watchdog. The
+`task_coordinator` is the single mutex point.
+
+Tasks are named: `'indexer'`, `'archive'`, `'cloud_sync'`,
+`'live_event_sync'`, `'retention'`. Workers call
+`acquire_task('<name>', wait_seconds=N, yield_to_waiters=True)` to
+get exclusive access. The fairness model lets a tight cyclic
+worker (the indexer) yield to a less-frequent priority task
+(archive) without the priority task starving.
+
+`WATCHDOG_NEAR_MISS_THRESHOLD_SECONDS = 60.0`. Any worker that
+holds the lock longer than that logs a WARNING with the message
+"NEAR-MISS hardware watchdog threshold". This is a forensic hint
+that the system was close to a watchdog-triggered reset.
+
+The full coordinator contract is the subject of a future
+`core/TASK_COORDINATOR.md` doc.
+
+---
+
+## Failure modes the architecture is designed against
+
+These shaped the architecture and are worth knowing:
+
+1. **Power loss at any time.** Tesla cuts USB power when the car
+   sleeps. All file writes use atomic `temp + fsync + rename`. Boot
+   `fsck` (`disk_images.boot_fsck_enabled`) auto-repairs the FATs.
+   Stale claims in queues are reset to `pending` on startup.
+2. **SDIO bus saturation.** Heavy archive copies + concurrent rclone
+   uploads + Tesla writes can starve the kernel `mmc1` driver and
+   the userspace watchdog. Mitigations: `_atomic_copy` chunk-pause,
+   per-file time budget, load-pause guard, single-rclone constraint,
+   watchdog priority drop-in.
+3. **Tesla onboard-clock drift.** Tesla can write a clip with a
+   wildly wrong filename timestamp when GPS time-sync is lost. The
+   indexer reads the MP4 `mvhd` atom (GPS-derived UTC) instead of
+   the filename for absolute time.
+4. **Tesla cache.** Tesla caches USB file contents and won't notice
+   a chime change without a USB re-enumeration. After replacing
+   `LockChime.wav`, the gadget is unbound and rebound to force a
+   re-scan.
+5. **Watchdog reset during heavy load.** The hardware watchdog
+   resets the Pi if the userspace daemon stops pinging. The
+   `watchdog.service` systemd drop-in (`teslausb-priority.conf`)
+   gives the daemon `Nice=-5 IOSchedulingClass=realtime` so it
+   keeps its tick under load.
+6. **STA reconnect storms.** Repeated rapid STA reconnect attempts
+   while the AP is up issue heavy `brcmf_cfg80211_stop_ap` SDIO
+   writes that can lock the WiFi chip. Mitigated by exponential
+   backoff in `wifi-monitor.sh`.
+
+---
+
+## Where to read next
+
+- [`VIDEO_LIFECYCLE.md`](VIDEO_LIFECYCLE.md) — the flagship
+  narrative; follows a single clip end-to-end with every branch
+  and decision point. **This is the single most important doc.**
+- [`GLOSSARY.md`](GLOSSARY.md) — every term defined.
+- [`contributor/REPO_LAYOUT.md`](contributor/REPO_LAYOUT.md) — where
+  things live in the source tree.
+- [`contributor/core/CONFIGURATION_SYSTEM.md`](contributor/core/CONFIGURATION_SYSTEM.md)
+  — how the config system works under the hood.
+- [`contributor/core/DATABASES.md`](contributor/core/DATABASES.md) —
+  schema overview for `geodata.db` and `cloud_sync.db`.
+
+---
+
+## Source files
+
+The architecture description above maps to the following modules.
+When any of these change in a way that affects the high-level
+behavior, update this doc.
+
+- `scripts/web/web_control.py` — Flask app factory, worker startup
+- `scripts/web/services/file_watcher_service.py` — inotify + polling
+- `scripts/web/services/archive_*.py` — archive subsystem
+- `scripts/web/services/indexing_*.py`, `mapping_*.py` — indexing
+- `scripts/web/services/cloud_archive_service.py` — bulk cloud sync
+- `scripts/web/services/live_event_sync_service.py` — LES
+- `scripts/web/services/task_coordinator.py` — fairness lock
+- `scripts/web/services/partition_*.py`, `mode_service.py` — modes/mounts
+- `scripts/web/helpers/refresh_cloud_token.py` — NM dispatcher entry point
+- `scripts/present_usb.sh`, `scripts/edit_usb.sh` — gadget bind/unbind
+- `scripts/wifi-monitor.sh`, `scripts/ap_control.sh` — STA/AP control
+- `templates/*.service`, `templates/*.timer` — systemd units
+- `templates/99-teslausb-cloud-refresh` — NM dispatcher
+- `config.yaml` — the single source of configuration truth

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -1,0 +1,321 @@
+# Glossary
+
+Every recurring term used in the TeslaUSB codebase, docs, and UI,
+with the precise meaning the project gives it. If a term is used in
+the docs and isn't defined here, that's a bug — please file an issue
+or open a PR.
+
+Terms are grouped by topic. Within a group, alphabetical order.
+
+---
+
+## Hardware and OS
+
+### Pi Zero 2 W
+The Raspberry Pi model TeslaUSB is built and tested on. 4 ARM cores,
+512 MB RAM, single SDIO bus shared between the SD card and the
+on-board Broadcom WiFi chip. The 512 MB ceiling and the shared SDIO
+bus drive most of the codebase's "be gentle" engineering — load-pause
+guards, chunked copies, swap configuration, and the watchdog priority
+drop-in.
+
+### SDIO bus
+The single hardware bus the Pi Zero 2 W uses for both SD-card I/O
+and WiFi. Heavy SD-card reads (catch-up archive runs) and heavy WiFi
+writes (rclone uploads, AP teardown/restart) compete for the bus.
+Saturating it can starve the userspace `watchdog` daemon and trigger
+a hardware reset.
+
+### Hardware watchdog
+The Broadcom-side hardware timer that resets the Pi if the userspace
+`watchdog` daemon stops pinging it. Configured with a 90-second
+timeout (raised from 60 s to give SDIO contention some headroom).
+
+### UDC (USB Device Controller)
+The kernel interface that binds or unbinds the USB gadget from the
+host (Tesla). Writing the UDC name to
+`/sys/kernel/config/usb_gadget/g1/UDC` activates the gadget; writing
+empty unbinds it. **Unbind is destructive — Tesla loses the drive
+instantly.**
+
+---
+
+## USB gadget and storage
+
+### Gadget
+The USB device personality the Pi presents to Tesla. TeslaUSB's
+gadget exposes 2 or 3 LUNs depending on `disk_images.music_enabled`.
+
+### LUN (Logical Unit Number)
+One "drive" inside the USB gadget. TeslaUSB always exposes:
+
+- **LUN 0** — TeslaCam drive (exFAT, dashcam recordings)
+- **LUN 1** — LightShow drive (FAT32, lock chimes / wraps / shows)
+- **LUN 2** *(optional)* — Music drive (FAT32)
+
+Each LUN is backed by an `.img` file in `installation.mount_dir`
+(default `/mnt/gadget`).
+
+### `.img` file
+A raw filesystem image stored on the SD card and exposed to Tesla
+via the USB gadget. **`*.img` files are protected** — `is_protected_file()`
+in `partition_service` refuses every delete request that targets one.
+
+### Loop device (`/dev/loopN`)
+A kernel construct that lets the Pi mount an `.img` file locally so
+the web UI can read or write its contents. **The gadget itself does
+not use loop devices** — it serves the `.img` file directly. Loop
+devices are only used for local mount access. Multiple loop devices
+on the same image are normal and harmless.
+
+### Mount namespace (`nsenter`)
+Mounts performed inside a subprocess vanish when that subprocess
+exits, because each subprocess runs in its own mount namespace.
+Every mount/umount/mountpoint command in TeslaUSB is therefore
+prefixed with `sudo nsenter --mount=/proc/1/ns/mnt …` so the mount
+lands in PID 1's namespace and survives.
+
+### Quick edit (`quick_edit_part2`)
+A coordinated short-lived RW window on LUN 1, used while still in
+present mode. The flow: clear LUN 1's backing file → unmount RO → detach
+read-only loops → create RW loop → mount RW → do work → sync → unmount
+→ reattach RO loop → restore LUN 1's backing file. Guarded by
+`~/.quick_edit_part2.lock` (120 s stale timeout). Used for chime
+upload, light-show upload, license plate upload, etc.
+
+---
+
+## Modes
+
+### Present mode
+The "default" mode: USB gadget is bound to Tesla, partitions mount
+**read-only** at `/mnt/gadget/part*-ro`, Samba is off. State token in
+`state.txt`. Tesla is actively recording.
+
+### Edit mode
+Maintenance mode: USB gadget is unbound, partitions mount
+**read-write** at `/mnt/gadget/part*`, Samba is on. Used for bulk
+manual edits via SMB. The UI does not expose "Edit Mode" / "Present
+Mode" terminology — instead it shows a status dot:
+"Network Sharing Active" (amber) vs normal (green).
+
+---
+
+## Files Tesla writes
+
+### TeslaCam
+The top-level folder Tesla creates on LUN 0. Contains:
+
+- `RecentClips/` — rolling 1-hour buffer (continuous recording)
+- `SentryClips/<event-dir>/` — one folder per Sentry-triggered event
+- `SavedClips/<event-dir>/` — one folder per user-triggered save
+- `boot/` — Tesla boot diagnostics
+
+### RecentClips
+Tesla's rolling buffer. Written continuously while the car is
+powered (driving **or** Sentry standby) and rotated automatically
+every ~60 minutes. **Most RecentClips on a parked car are not
+"driving footage" — they're idle dashcam.** UI labels them
+**"Rolling buffer"**, not "Driving footage", to keep that honest.
+
+### SentryClips / SavedClips
+Per-event folders, each containing 6 camera files (`front`, `back`,
+`left_repeater`, `right_repeater`, `left_pillar`, `right_pillar`)
+plus an `event.json` describing what triggered the recording.
+
+### `event.json`
+Tesla writes this file **last** in an event folder, after the 6
+camera mp4s. So `event.json` arriving via inotify means the event
+recording is fully written and safe to upload. This is why the
+file_watcher's event.json callback path **does not apply the
+60-second age gate** that mp4 callbacks use.
+
+### ArchivedClips
+The Pi-managed archive on the SD card, not the USB gadget. The
+archive subsystem copies `RecentClips` (and event clips) here before
+Tesla rotates them out. Path: `~/ArchivedClips/<YYYY-MM-DD>/…`.
+Source of truth for the indexer and cloud sync — they never index
+or upload directly from the live RO mount.
+
+---
+
+## Background workers
+
+### File watcher
+`file_watcher_service.py`. Single process using `inotify` (Linux
+kernel filesystem-event API) plus a 5-minute polling fallback.
+Routes new mp4s on the RO mount to the **archive** producer, new
+mp4s in `ArchivedClips` to the **indexing** queue, and `event.json`
+arrivals to **Live Event Sync**.
+
+### Archive producer / queue / worker / watchdog
+Four cooperating components in `archive_*.py`:
+
+- **Producer** scans Tesla's folders and enqueues new mp4s
+- **Queue** is a SQLite table (`archive_queue` in `cloud_sync.db`)
+- **Worker** is one thread that copies one file at a time from RO mount
+  to `ArchivedClips`, then enqueues the destination for indexing
+- **Watchdog** classifies severity, triggers retention prune, and
+  surfaces health to the `/api/archive/status` endpoint
+
+### Indexing queue / worker
+`indexing_queue` table in `geodata.db` plus a single
+`indexing_worker.py` thread. Parses each video's H.264 SEI metadata
+to extract GPS waypoints, telemetry, and detect events. Outcomes are
+typed via the `IndexOutcome` enum.
+
+### Cloud archive
+`cloud_archive_service.py`. Bulk catch-up cloud uploader. Uses
+`rclone` under `nice -n 19` and `ionice -c 3`. Priority order:
+events first, then geolocated, then non-event clips (opt-in).
+
+### Live Event Sync (LES)
+`live_event_sync_service.py`. Opt-in real-time uploader that fires
+on `event.json` arrivals. Has its own queue (`live_event_queue` in
+`cloud_sync.db`), its own worker thread, and a strict 25 MB
+steady-state RSS budget. **Disabled by default.**
+
+### Task coordinator
+`task_coordinator.py`. The single mutual-exclusion point for the
+heavy background workers (`indexer`, `archive`, `cloud_sync`,
+`live_event_sync`, `retention`). Provides fairness so a tight cyclic
+worker (the indexer) cannot starve a less-frequent priority task
+(archive). `WATCHDOG_NEAR_MISS_THRESHOLD_SECONDS = 60.0` seconds —
+any worker holding the lock longer logs a WARNING.
+
+---
+
+## Indexing and mapping
+
+### Canonical key
+`mapping_service.canonical_key(path)`. Resolves both the SD-card
+view (`~/ArchivedClips/.../front.mp4`) and the USB-RO view
+(`/mnt/gadget/part1-ro/TeslaCam/RecentClips/front.mp4`) of the same
+file to the **same string**, so the indexing queue can dedupe them.
+
+### IndexOutcome
+The enum in `mapping_service` that names every possible result of
+parsing a single video. Values include `INDEXED`,
+`ALREADY_INDEXED`, `DUPLICATE_UPGRADED`, `NO_GPS_RECORDED`,
+`NOT_FRONT_CAMERA`, `TOO_NEW`, `FILE_MISSING`, `PARSE_ERROR`,
+`DB_BUSY`. Each is either **terminal** (deletes the queue row) or
+**retry** (with exponential backoff).
+
+### `mvhd` time
+The MP4 `mvhd` (Movie Header) atom carries the GPS-derived UTC
+start-of-recording time. **Authoritative** for absolute time —
+unaffected by Tesla's onboard-clock drift. The indexer's
+`_resolve_recording_time()` reads `mvhd` first and only falls back
+to the filename when the atom is unreadable. A divergence of ≥ 5
+minutes between `mvhd` and the filename logs a WARNING.
+
+### Trip
+A contiguous drive, defined by waypoints separated by less than
+`mapping.trip_gap_minutes` (default 5). Trips are **sacred**: they
+are real records of where the user drove, and the only thing that
+may delete them is an explicit user "Delete Trip" action. Losing
+the underlying clip does not unhappen the drive.
+
+### Waypoint
+A single GPS point with telemetry (speed, heading, gear, autopilot
+state, steering, pedals, blinkers) extracted from one frame of one
+clip.
+
+### Detected event
+A waypoint that crossed an event threshold — harsh brake, emergency
+brake, hard accel, sharp turn, speeding, FSD engage, FSD disengage —
+recorded in the `detected_events` table. Thresholds are configurable
+under `mapping.event_detection`.
+
+### RDP simplification
+Ramer–Douglas–Peucker polyline simplification, used by
+`mapping_queries._simplify_polyline_rdp()` to thin out the route
+polylines drawn on the map. Default `epsilon_m = 8.0`. Run once per
+trip; trips are split at gaps before simplification so the gap line
+stays straight rather than getting "shortcut" through.
+
+---
+
+## Cloud and networking
+
+### `rclone`
+Third-party multi-cloud sync tool TeslaUSB invokes for every cloud
+upload. Run with `nice -n 19`, `ionice -c 3`, and a `--bwlimit`
+matching `cloud_archive.max_upload_mbps`. **Only one rclone
+subprocess runs at a time**, ever, across both `cloud_archive` and
+LES — coordinated via `task_coordinator`.
+
+### NM dispatcher (`refresh_cloud_token.py`)
+The single WiFi-connect entry point. NetworkManager runs
+`/etc/NetworkManager/dispatcher.d/99-teslausb-cloud-refresh` on
+every link-up event, which runs this script. The script: refresh
+RO mount → wake LES → wait for archive (5 min cap) → wait for
+indexing (2 min cap) → wait for LES drain (10 min cap) →
+trigger cloud sync.
+
+### AP / STA / `uap0`
+- **STA** = WiFi client mode (the Pi connects to a home network).
+- **AP** = WiFi access point mode (the Pi broadcasts its own
+  network for in-car use when STA is unavailable).
+- **`uap0`** is the virtual AP interface; STA stays on `wlan0`.
+  TeslaUSB runs **concurrent AP+STA** (not exclusive switching)
+  so STA reconnect attempts don't take the AP down.
+
+### Captive portal
+The OS feature that pops a splash screen automatically when a device
+joins a WiFi network. TeslaUSB triggers it via dnsmasq DNS spoofing
+(`address=/#/<gateway-ip>`) plus a Flask blueprint
+(`captive_portal.py`) that intercepts every OS's connectivity-check
+URL on port 80. The web service must run on port 80 for this to
+work.
+
+### AP force mode
+One of `auto`, `force_on`, `force_off`. Persisted in
+`config.yaml`'s `offline_ap.force_mode`; runtime changes are
+written to `/run/teslausb-ap/force.mode` and lost on reboot.
+
+---
+
+## UI and operations
+
+### Quick-edit lock
+The file `~/.quick_edit_part2.lock` whose presence indicates an
+in-flight `quick_edit_part2` operation. 120-second stale timeout —
+any process holding the lock for longer is assumed dead and the
+lock is forcibly broken.
+
+### `state.txt`
+A one-line file containing the mode token (`present` or `edit`).
+`mode_service.current_mode()` reads this and falls back to live
+detection if the file is absent or stale.
+
+### Failed jobs
+The `/jobs` page surfaces every queue row across `archive_queue`,
+`indexing_queue`, `cloud_synced_files` (with status `failed` or
+`dead_letter`), and `live_event_queue`. Each row is enriched with a
+**clip value** badge ("Event clip" / "Rolling buffer" / "Already on
+SD card" / etc.) and a **recommendation chip** ("Retry" / "Delete" /
+"Either is safe") classified from the error message.
+
+### System Health
+The `/api/system/health` endpoint and the matching UI card. Reports
+disk free, RAM, queue depths, worker liveness, retention summary,
+and the archive watchdog snapshot.
+
+### Severity vs actionable
+The archive watchdog's status payload carries both. **Severity** is
+about diagnostics: `ok` / `warning` / `error` / `critical`.
+**Actionable** is about whether the user can fix it: `true` only
+when the worker is **not** running with pending work, or disk free
+is below the critical threshold. The in-page banner only fires
+when both `severity ∈ {error, critical}` AND `actionable == true`,
+so users are never alerted about something they cannot act on.
+
+---
+
+## Source files
+
+This glossary is a navigational reference; it has no single source
+of truth. Each defined term cites the function or module that
+implements it. When you change one of those source files in a way
+that affects the term's definition, please update this glossary.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,147 @@
+# TeslaUSB Documentation
+
+This directory holds the in-depth documentation for the TeslaUSB
+project. It is organized around **what the device does** and the
+**decisions** it makes — not around where the source files happen to
+live. If you want a quick install or feature overview, the project
+[`readme.md`](../readme.md) at the repo root is the right starting
+point.
+
+---
+
+## Who is this for?
+
+The docs are written for two audiences. Pick the column that matches
+why you're here.
+
+| Audience      | Goal                                                  | Start here                                           |
+|---------------|-------------------------------------------------------|------------------------------------------------------|
+| **Operator**  | Install, configure, monitor, recover a TeslaUSB device | [`operator/README.md`](operator/README.md)           |
+| **Contributor** | Modify the code with full understanding of subsystem contracts | [`contributor/README.md`](contributor/README.md)     |
+
+If you're not sure, you're probably an operator first — the operator
+docs cross-link into the contributor docs when a deeper explanation
+is helpful.
+
+---
+
+## Reading order — the 30-minute tour
+
+If you have 30 minutes and want to understand the device, read these
+five documents in order:
+
+1. **[`ARCHITECTURE.md`](ARCHITECTURE.md)** — what the major
+   components are and how they hand off work to each other.
+2. **[`VIDEO_LIFECYCLE.md`](VIDEO_LIFECYCLE.md)** — the flagship
+   narrative. Follows a single dashcam clip from the moment Tesla
+   writes it to the moment it's deleted, with every branch
+   enumerated. **This is the most important doc in the repo.**
+3. **[`GLOSSARY.md`](GLOSSARY.md)** — every recurring term with a
+   one-paragraph explanation.
+4. **[`UI_UX_DESIGN_SYSTEM.md`](UI_UX_DESIGN_SYSTEM.md)** — design
+   tokens and rules for any UI work.
+5. **[`contributor/REPO_LAYOUT.md`](contributor/REPO_LAYOUT.md)** —
+   where things live in the source tree.
+
+After that, navigate by interest from `operator/` or `contributor/`.
+
+---
+
+## Top-level documents
+
+| Document                                          | What it covers                                                              |
+|---------------------------------------------------|-----------------------------------------------------------------------------|
+| [`ARCHITECTURE.md`](ARCHITECTURE.md)              | System overview, components, data flow, processes and threads              |
+| [`VIDEO_LIFECYCLE.md`](VIDEO_LIFECYCLE.md)        | Full lifetime of a clip with every decision point — the **flagship doc**    |
+| [`GLOSSARY.md`](GLOSSARY.md)                      | Definitions of every recurring TeslaUSB term                                |
+| [`UI_UX_DESIGN_SYSTEM.md`](UI_UX_DESIGN_SYSTEM.md) | Design tokens, colors, typography, components, accessibility rules          |
+
+---
+
+## Operator docs (`operator/`)
+
+Runbooks and reference for people deploying and managing devices.
+
+| Document                                                    | When to read                                                  |
+|-------------------------------------------------------------|---------------------------------------------------------------|
+| [`operator/README.md`](operator/README.md)                  | Entry point — points you at the right runbook                  |
+
+> Additional operator runbooks (installation walkthrough, configuration
+> reference, services and timers, web interface tour, storage and
+> retention, cloud providers setup, WiFi and AP, failed jobs and health,
+> backup and recovery, upgrading, troubleshooting) are being filled in
+> across the documentation waves. See **Documentation status** below.
+
+---
+
+## Contributor docs (`contributor/`)
+
+Internals, contracts, and decision points for people modifying the
+source.
+
+| Document                                                                                  | When to read                                              |
+|-------------------------------------------------------------------------------------------|-----------------------------------------------------------|
+| [`contributor/README.md`](contributor/README.md)                                          | Entry point — points you at core / subsystems / flows      |
+| [`contributor/REPO_LAYOUT.md`](contributor/REPO_LAYOUT.md)                                | Where everything lives in the source tree                  |
+| [`contributor/DEV_WORKFLOW.md`](contributor/DEV_WORKFLOW.md)                              | Branching, testing, deploying, security review skill       |
+| [`contributor/core/CONFIGURATION_SYSTEM.md`](contributor/core/CONFIGURATION_SYSTEM.md)    | `config.yaml` + Bash and Python wrappers + templating      |
+| [`contributor/core/DATABASES.md`](contributor/core/DATABASES.md)                          | `geodata.db` and `cloud_sync.db` schemas, migrations       |
+
+> Core internals (boot sequence, USB gadget and modes, mount safety,
+> task coordinator, file safety), subsystems (every worker / service),
+> end-to-end flows, and the reference catalog (IndexOutcome enum,
+> archive priorities, event types, error catalog, API endpoints, etc.)
+> are being filled in across the documentation waves below.
+
+---
+
+## Documentation status
+
+Documentation is built in **waves**. Each wave is a coherent slice
+landed as its own pull request. Status as of writing:
+
+| Wave   | Theme                                                   | Status        |
+|--------|---------------------------------------------------------|---------------|
+| 1      | Foundation + flagship video lifecycle                   | **landed**    |
+| 2      | Core internals (boot, gadget, mounts, coordinator)      | planned       |
+| 3      | Video pipeline subsystems + flows + decision references | planned       |
+| 4      | Cloud + sync (LES vs cloud_archive arbitration)         | planned       |
+| 5      | Video playback / deletion / retention flows             | planned       |
+| 6      | Networking + safety                                     | planned       |
+| 7      | Mode + boot flows                                       | planned       |
+| 8      | Asset-management subsystems + flows                     | planned       |
+| 9      | Operator runbooks                                       | planned       |
+| 10     | Reference completion + polish                           | planned       |
+
+Until a planned wave lands, the most authoritative source for that
+material is the source code itself (and, as a quick-reference index,
+[`.github/copilot-instructions.md`](../.github/copilot-instructions.md),
+which gives a dense overview of every subsystem).
+
+---
+
+## Conventions used throughout these docs
+
+- **Mermaid diagrams.** Sequence flows, state machines, and decision
+  trees use Mermaid blocks. GitHub renders them natively in the web UI;
+  in plain-text viewers the source is still readable.
+- **Code citations on every claim.** When a doc states "the worker
+  does X", it cites the function and the source file (e.g.
+  `mapping_service.index_single_file()`). Line numbers are deliberately
+  avoided because they drift; function names and module paths stay
+  stable.
+- **Decision tables.** Every branch the code takes is rendered as a
+  table or flowchart so a reader can answer "what happens if…?"
+  without reading code.
+- **No timelines or roadmap.** These docs describe **current**
+  behavior. Plans for the future live in
+  [GitHub Issues](https://github.com/mphacker/TeslaUSB/issues).
+- **Stale-prevention footer.** Every doc ends with a `## Source files`
+  list, so a reviewer touching one of those files knows exactly which
+  docs to update.
+
+---
+
+## Source files
+
+This document is purely navigational; it has no source-code dependency.

--- a/docs/VIDEO_LIFECYCLE.md
+++ b/docs/VIDEO_LIFECYCLE.md
@@ -1,0 +1,762 @@
+# Video Lifecycle
+
+> The flagship narrative. Follow one Tesla-recorded clip from the
+> moment the camera starts capturing it through every decision the
+> device makes — archive, index, map, cloud, retention, deletion.
+> If you read only one document, read this one.
+
+This doc describes the **complete journey of a single video clip**:
+
+1. **Tesla writes the file** to the USB gadget
+2. **The file watcher detects it**
+3. **The archive worker copies it** to the SD card
+4. **The indexer parses it** — extracts GPS, telemetry, and detects events
+5. **Mapping merges it into a trip** (or doesn't)
+6. **The cloud uploader queues it** (bulk catch-up vs real-time)
+7. **Retention eventually prunes it**
+8. **Or the user deletes it manually**
+
+Every branch the device can take at every stage is enumerated. Each
+section ends with a decision-point table you can scan for
+"what if?" answers.
+
+For a description of the components themselves (without the
+narrative), see [`ARCHITECTURE.md`](ARCHITECTURE.md). For
+definitions of recurring terms (LUN, mvhd, LES, quick_edit, …) see
+[`GLOSSARY.md`](GLOSSARY.md).
+
+---
+
+## At a glance
+
+```mermaid
+flowchart LR
+    T["Tesla camera"] -->|1. write| IMG["usb_cam.img<br/>via USB gadget"]
+    IMG -->|2. inotify on RO mount| FW["File watcher"]
+    FW -->|3a. mp4| AQ[("archive_queue")]
+    FW -->|3b. event.json| LESQ[("live_event_queue<br/>LES only")]
+    AQ --> AW["Archive worker"]
+    AW -->|4. copy| AC["~/ArchivedClips<br/>SD card"]
+    AC -->|5. inotify on SD| FW
+    FW -->|6. enqueue| IQ[("indexing_queue")]
+    IQ --> IW["Indexing worker"]
+    IW -->|7. waypoints, events| GEO[("geodata.db")]
+    AC -->|8. periodic scan| CA["cloud_archive worker"]
+    CA -->|9. rclone| CLOUD["Cloud provider"]
+    LESQ -->|10. real-time| LES["LES worker"]
+    LES -->|rclone| CLOUD
+    AC -->|11. retention| PRUNE["archive_watchdog"]
+    PRUNE -->|delete file| RIP["disk freed"]
+    PRUNE -->|orphan row| GEO
+    USER["User UI"] -->|12. delete event| DELETE["videos.delete_event"]
+    DELETE --> AC
+    DELETE --> GEO
+```
+
+The top-level data flow is **strictly producer-queue-consumer**.
+There are exactly four queues (`archive_queue`, `indexing_queue`,
+`live_event_queue`, `cloud_synced_files`); each has exactly one
+worker thread that drains it. Producers never bypass the queue;
+workers never spawn more workers. This is what keeps the Pi Zero
+2 W from melting under load.
+
+---
+
+## Stage 1 — Tesla writes the file
+
+### What Tesla does
+
+Tesla mounts `usb_cam.img` (LUN 0) as a normal USB mass-storage
+device. While driving or in Sentry standby, it writes:
+
+| Folder         | When                                                     | Files per minute     |
+|----------------|----------------------------------------------------------|----------------------|
+| `RecentClips/` | Continuously, rolling buffer (~60 minutes retained)      | 6 (one per camera)   |
+| `SavedClips/<event-dir>/` | User taps the dashcam-save button             | 6 + `event.json`     |
+| `SentryClips/<event-dir>/` | Sentry alarm triggers                        | 6 + `event.json`     |
+
+`event.json` is small (< 1 KB) and is **always written last** in
+an event folder, atomically — Tesla finalizes the .mp4s first,
+then writes event.json as the closing marker. We rely on this
+ordering: the file watcher uses `event.json` arrival as the signal
+that the event folder is fully populated.
+
+### What's happening underneath
+
+Tesla writes via the **gadget block layer**: byte-level writes go
+to the kernel's USB Mass Storage gadget driver (`f_mass_storage`),
+which serves them out of the `usb_cam.img` file directly. The
+filesystem on the image is exFAT.
+
+The Pi reads the same image file via VFS (the local mount of the
+loop device on top of `usb_cam.img`). Tesla and the Pi can
+read/write the same image file concurrently — there is no lock
+contention between the two paths because they hit the file
+through different I/O paths.
+
+### Tesla onboard-clock caveat
+
+Tesla derives the `YYYY-MM-DD_HH-MM-SS-camera.mp4` filename prefix
+from the **car's onboard local clock**, not GPS time. When the car
+loses GPS time-sync (long underground parking, GPS antenna fault),
+the clock drifts. We have observed clips written under the wrong
+date by 19+ hours.
+
+The MP4 `mvhd` atom (Movie Header) carries the **GPS-derived UTC
+start-of-recording time** and is immune to onboard-clock drift.
+The indexer reads `mvhd` first and falls back to the filename
+only when the atom is unreadable. **Never write code that uses
+the filename for absolute time decisions.**
+
+### Decisions at this stage
+
+| Question                              | Outcome / Rule                                                  |
+|---------------------------------------|-----------------------------------------------------------------|
+| Can Tesla write while we're reading?  | Yes — gadget block layer and VFS don't contend                  |
+| Are filenames trustworthy?            | No — use `mvhd` for absolute time                                |
+| Is `event.json` written last?         | Yes — rely on it as the "folder ready" marker                    |
+| Is RecentClips persistent?            | No — Tesla overwrites at ~60 min unless we copy it first         |
+
+---
+
+## Stage 2 — The file watcher detects it
+
+`scripts/web/services/file_watcher_service.py` runs a single
+thread using Linux inotify, with a 5-minute polling fallback for
+filesystems where inotify isn't reliable.
+
+### What's watched
+
+- `/mnt/gadget/part1-ro/TeslaCam/` (recursive) — the read-only
+  USB mount
+- `~/ArchivedClips/` (recursive) — the SD-card archive folder
+
+### Callback types
+
+The watcher exposes **four** distinct callback subscriptions; each
+has its own producer concern:
+
+| Callback                              | Fires on                                          | Subscribes to                  | Age gate                   |
+|---------------------------------------|---------------------------------------------------|--------------------------------|----------------------------|
+| `register_callback(cb)`               | New `.mp4` arrivals                               | Archive producer / indexer     | **60 s** (`_MIN_FILE_AGE_SECONDS`) |
+| `register_event_json_callback(cb)`    | New `event.json` arrivals                         | Live Event Sync                | None — fires immediately   |
+| `register_delete_callback(cb)`        | File deletes (rotation, manual)                   | Indexer (orphan cleanup)       | N/A                        |
+| `register_archive_callback(cb)`       | New file in `~/ArchivedClips/`                    | Indexer (post-archive enqueue) | 60 s                       |
+
+The 60-second age gate on `.mp4` files is the **"not still being
+written"** check: Tesla finalizes a clip in seconds, but the gate
+absorbs jitter and accidental early-trigger calls from inotify.
+
+The **no age gate on event.json** is deliberate — Tesla writes
+event.json atomically as the last step of finalizing an event
+folder, so by the time inotify reports it the file is complete.
+LES therefore wakes immediately (no 60-second delay between Tesla
+finishing the event and the cloud upload starting).
+
+### Polling fallback
+
+inotify can miss events when the underlying filesystem is mounted
+or remounted (which we do during quick_edit). To recover, the
+watcher polls `_POLL_INTERVAL_SECONDS` (300 — every 5 minutes)
+and re-fires callbacks for files it didn't see during inotify
+downtime. **Both callback types fire from the polling path, too.**
+
+### Decisions at this stage
+
+| Condition                                         | Action                                                           |
+|---------------------------------------------------|------------------------------------------------------------------|
+| New `.mp4` mtime > 60 s old                        | Fire archive callback + (after archive) indexing callback        |
+| New `.mp4` mtime ≤ 60 s old                        | Skip; will re-check next poll                                    |
+| New `event.json`                                  | Fire LES callback **immediately**, no age gate                    |
+| inotify silent for 5 minutes                      | Run polling sweep                                                 |
+| Watched mount unmounted (mode switch)             | Watcher pauses; resumes on remount                                |
+
+---
+
+## Stage 3 — The archive worker copies it
+
+`scripts/web/services/archive_worker.py`. Single-thread consumer
+of `archive_queue` (in `cloud_sync.db`).
+
+### Why we copy
+
+Tesla's RecentClips folder rotates at ~60 minutes — once Tesla
+overwrites a clip, it's gone forever. Sentry / Saved events live
+on the USB drive longer but still take Tesla USB space. By copying
+to the SD card we:
+
+1. Preserve clips past Tesla's rotation
+2. Free Tesla's USB space (Tesla's own retention removes copied
+   clips on its next pass)
+3. Give the indexer a stable path to parse from (the RO USB mount
+   is volatile during Tesla writes)
+
+**Critical rule**: the indexer **never** parses files directly
+from the RO USB mount. Tesla can rotate or rewrite a clip mid-parse,
+which causes `FILE_MISSING` errors and broken DB rows. Indexing
+runs only against files in `~/ArchivedClips/`.
+
+### Producer side
+
+`archive_producer.py` enqueues files into `archive_queue`:
+
+| Trigger                         | When                                               |
+|----------------------------------|---------------------------------------------------|
+| Boot catch-up scan              | Once at gadget_web start                           |
+| File watcher callback            | Every new `.mp4` on the RO USB mount               |
+| Manual trigger                   | UI "Archive Now" button                            |
+
+### Worker side: the loop
+
+```mermaid
+sequenceDiagram
+    participant Q as archive_queue
+    participant W as Archive worker
+    participant TC as task_coordinator
+    participant FS as ~/ArchivedClips
+    participant IDX as indexing_queue
+
+    loop Every cycle
+        W->>TC: acquire_task('archive', wait=60)
+        TC-->>W: lock acquired
+        W->>Q: SELECT next pending row (lowest priority)
+        W->>Q: UPDATE status='claimed'
+        W->>FS: _atomic_copy(src, dest.tmp)
+        W->>FS: fsync, rename to dest
+        W->>Q: UPDATE status='copied'
+        W->>IDX: enqueue_for_indexing(dest)
+        W->>TC: release
+        W->>W: sleep(inter_file_sleep_seconds)
+    end
+```
+
+### Priority ordering
+
+`archive_queue.PRIORITY_*` constants (lower number = higher):
+
+| Constant                   | Value | Folders matched                             |
+|----------------------------|-------|---------------------------------------------|
+| `PRIORITY_EVENTS`          | 1     | `SentryClips/`, `SavedClips/`               |
+| `PRIORITY_RECENT_CLIPS`    | 2     | `RecentClips/`                              |
+| `PRIORITY_OTHER`           | 3     | Anything else                               |
+
+Events drain before RecentClips because event clips are
+irreplaceable (a Sentry trigger is a one-time signal); RecentClips
+have continuous coverage so a small prioritization delay is fine.
+
+### `_atomic_copy` guards
+
+The copy itself is **heavily throttled** to keep the SDIO bus
+from saturating and starving the watchdog daemon:
+
+| Guard                                | Default | Purpose                                                                  |
+|--------------------------------------|---------|--------------------------------------------------------------------------|
+| `inter_file_sleep_seconds`           | 1.0 s   | Pause between files                                                      |
+| `chunk_pause_seconds`                | 0.25 s  | Pause every chunk **inside** a single copy                                |
+| `per_file_time_budget_seconds`       | 60.0 s  | Hard ceiling on a single copy; raises `_CopyTimeBudgetExceeded`          |
+| `load_pause_threshold`               | 3.5     | If `loadavg[0] >= 3.5` between files, sleep `load_pause_seconds`         |
+| `load_pause_seconds`                 | 30 s    | How long to sleep when load is high                                       |
+| `boot_scan_defer_seconds`            | 30 s    | Don't run boot catch-up scan for the first 30 s after gadget_web start    |
+| `nice` priority                      | -19 (low) | Process scheduled at lowest CPU priority                                |
+| `ionice` class                       | idle    | Block-I/O priority is "idle" — only runs when nothing else needs the disk |
+
+The **mid-copy guards** (`chunk_pause_seconds`, `per_file_time_budget_seconds`)
+fire **inside** `_atomic_copy`. If a single copy takes longer than
+60 seconds, `_CopyTimeBudgetExceeded` releases the claim back to
+`pending` *without* bumping `attempts` — the file is fine, the
+system is overloaded, so a row can never reach `dead_letter`
+purely from load.
+
+### Status transitions
+
+```
+                  ┌────────────┐
+                  │  pending   │
+                  └─────┬──────┘
+                        ▼
+                  ┌────────────┐
+                  │  claimed   │
+                  └─────┬──────┘
+            ┌─────────┬─┴───┬──────────┐
+            ▼         ▼     ▼          ▼
+     ┌──────────┐ ┌────┐ ┌──────┐ ┌─────────────┐
+     │  copied  │ │err │ │source│ │skipped_     │
+     │(terminal)│ │    │ │_gone │ │stationary   │
+     └──────────┘ └─┬──┘ └──────┘ └─────────────┘
+                   │
+                   ▼
+               ┌─────┐
+               │retry│ → pending (with backoff)
+               └─────┘
+                   ↓ attempts >= max
+               ┌──────────┐
+               │dead_letter│
+               └──────────┘
+```
+
+### Decisions at this stage
+
+| Condition                                          | Outcome                                                              |
+|----------------------------------------------------|----------------------------------------------------------------------|
+| Source file no longer exists when claimed          | `source_gone` (terminal) — Tesla rotated it out before we got to it |
+| Source file is older than retention horizon        | `skipped_stationary` (terminal) — too old to be worth copying        |
+| Copy completes successfully                        | `copied` (terminal) — enqueue for indexing                           |
+| Copy raises `_CopyTimeBudgetExceeded` (≥60 s)      | Release claim back to `pending`, don't increment `attempts`           |
+| Copy raises any other exception                    | `error` → retry with backoff                                          |
+| `attempts >= retry_max_attempts`                   | `dead_letter`                                                         |
+| `loadavg[0] >= 3.5` between files                  | Sleep 30 s, then retry from queue                                     |
+| LES has a pending row                              | Yield: release lock, sleep briefly, re-acquire                        |
+
+---
+
+## Stage 4 — The indexer parses it
+
+`scripts/web/services/indexing_worker.py`. Single-thread consumer
+of `indexing_queue` (in `geodata.db`).
+
+### What "indexing" means
+
+For each archived `.mp4`:
+
+1. Parse the H.264 stream's SEI (Supplemental Enhancement
+   Information) NAL units to extract Tesla's per-frame telemetry
+   payload (GPS, speed, accelerations, gear, autopilot state,
+   blinkers, brake, steering).
+2. Read the `mvhd` atom for the absolute UTC start time.
+3. Insert one `waypoints` row per parsed frame.
+4. Run event detection over the waypoint sequence.
+5. Insert any triggered events into `detected_events`.
+6. Update or merge a `trips` row.
+7. Insert a booking row in `indexed_files`.
+
+### `index_single_file` returns a typed `IndexResult`
+
+The result carries an `IndexOutcome` enum value plus details:
+
+| `IndexOutcome`            | What it means                                                  | Next action                                           |
+|---------------------------|----------------------------------------------------------------|-------------------------------------------------------|
+| `INDEXED`                 | Successfully parsed and stored                                 | Delete queue row (terminal)                           |
+| `ALREADY_INDEXED`         | `indexed_files` already has a matching row                     | Delete queue row (terminal)                           |
+| `DUPLICATE_UPGRADED`      | New file is a higher-quality dup of an existing row            | Replace existing, delete queue row (terminal)         |
+| `NO_GPS_RECORDED`         | Frames had no GPS telemetry (parking-lot recording)            | Insert `indexed_files`, no waypoints, terminal        |
+| `NOT_FRONT_CAMERA`        | File is `*-back.mp4` / `*-left_repeater.mp4` etc.              | Skip (only the front cam carries the canonical SEI)   |
+| `TOO_NEW`                 | mtime within `mapping.index_too_new_seconds` (default 120 s)   | Defer with backoff                                    |
+| `FILE_MISSING`            | File deleted between enqueue and parse                         | Delete queue row (terminal)                           |
+| `PARSE_ERROR`             | SEI/mvhd parse raised                                          | Retry with backoff                                    |
+| `DB_BUSY`                 | SQLite returned BUSY                                           | Retry with backoff                                    |
+
+The retry set is **`{TOO_NEW, PARSE_ERROR, DB_BUSY}`**. All other
+outcomes are terminal — successful or not, the queue row is
+deleted. After enough retries, the row moves to a separate
+dead-letter state (visible on `/jobs`).
+
+### Front camera only
+
+Tesla writes 6 cameras per minute (`-front`, `-back`,
+`-left_repeater`, `-right_repeater`, `-left_pillar`,
+`-right_pillar`). Only the **front camera** carries the canonical
+SEI telemetry — the other five mirror it but it's redundant. We
+parse only `*-front.mp4`. The other five rows still get archived
+(for playback) but they never enter the indexing queue.
+
+### Trip merge
+
+After waypoints are inserted, the indexer decides whether they
+belong to an existing trip:
+
+```
+Take the new clip's first waypoint.
+Find the most recent existing waypoint with timestamp before this one.
+If gap_seconds < trip_gap_minutes (default 5 min):
+    merge into the existing trip
+    extend its end_time / end_lat / end_lon
+Else:
+    create a new trip row
+```
+
+**The gap math uses `strftime('%s', x)` for exact integer-second
+arithmetic**, never `(julianday(a) - julianday(b)) * 86400` —
+the latter has float precision issues that misclassify boundary
+gaps. (See PR #78 for the bug history.)
+
+### Event detection
+
+`mapping_service.detect_events()` scans the waypoints and may
+insert rows for:
+
+- `harsh_brake`, `emergency_brake` — based on negative
+  acceleration thresholds
+- `hard_acceleration` — positive acceleration threshold
+- `sharp_turn` — steering-angle + speed combination
+- `speeding` — over a configured limit
+- `fsd_engage`, `fsd_disengage` — autopilot state transitions
+
+All thresholds live under `mapping.event_detection` in
+`config.yaml`.
+
+### Decisions at this stage
+
+| Condition                                              | `IndexOutcome`             |
+|--------------------------------------------------------|----------------------------|
+| Filename is not `*-front.mp4`                           | `NOT_FRONT_CAMERA`         |
+| File mtime within last 120 s                            | `TOO_NEW`                  |
+| `indexed_files` has matching row already                 | `ALREADY_INDEXED`          |
+| New file is a larger / longer dup of existing            | `DUPLICATE_UPGRADED`       |
+| No GPS in any parsed frame                               | `NO_GPS_RECORDED`          |
+| Parse raises                                             | `PARSE_ERROR`              |
+| SQLite BUSY                                              | `DB_BUSY`                  |
+| File missing at parse start                              | `FILE_MISSING`             |
+| Everything succeeded                                     | `INDEXED`                  |
+| New waypoints' first ts within 5 min of an existing trip | Merge into that trip       |
+| Otherwise                                                | Create new trip            |
+
+---
+
+## Stage 5 — Cloud upload
+
+There are **two cooperating cloud uploaders**, both producing into
+the same provider via shared rclone helpers but with distinct
+queues, distinct triggers, and distinct cadences. They never run
+rclone concurrently — `task_coordinator` serializes them.
+
+### Path A: bulk catch-up (`cloud_archive_service`)
+
+Drains `cloud_synced_files` (status `pending`) one file at a time.
+
+- **Triggers**: WiFi reconnect (NM dispatcher), file-watcher new
+  file (after archive), periodic timer
+- **Priority order**: events first → geolocated next → non-event
+  last (and non-event is **opt-in**, off by default via
+  `cloud_archive.sync_non_event_videos: false`)
+- **Coordination**: holds `task_coordinator('cloud_sync')` for one
+  file, then releases. Between files, checks
+  `live_event_sync_service.has_ready_live_event_work()` — if LES
+  has a pending row, yields the lock.
+
+### Path B: real-time per-event (`live_event_sync_service`, "LES")
+
+Drains `live_event_queue`. Triggered by `event.json` arrival via
+the file watcher's dedicated callback (no polling, no second
+inotify watcher).
+
+- **Default**: `live_event_sync.enabled: false`. When disabled, no
+  callback is registered, no thread starts, the queue table is
+  unused.
+- **Worker**: a single dedicated thread that **idles on
+  `threading.Event.wait()`** when the queue is empty (< 0.1% CPU).
+  Wakes when (a) `enqueue_event_json` is called or (b) the NM
+  dispatcher hits `/api/live_events/wake`.
+- **File selection**: `live_event_sync.upload_scope` — `event_minute`
+  (default; event.json + the 6 cameras matching the
+  `YYYY-MM-DD_HH-MM` prefix) or `event_folder` (every `.mp4` in
+  the dir).
+- **Retry**: 5 attempts with exponential backoff `[30 s, 120 s,
+  300 s, 900 s, 3600 s]`. After the last attempt, the row is
+  `failed` and stays there until manual retry via
+  `/api/live_events/retry/<id>`.
+- **WiFi-aware**: when WiFi is down, queue grows but worker idles;
+  on reconnect, drains immediately.
+- **Daily cap**: `live_event_sync.daily_data_cap_mb` (0 =
+  unlimited). When hit, worker idles until midnight local.
+- **Webhook**: `live_event_sync.notify_webhook_url` fired via
+  stdlib `urllib.request` after a successful upload (no
+  `requests` import — keeps RSS budget intact).
+
+### The arbitration contract
+
+When WiFi reconnects, the NM dispatcher
+(`refresh_cloud_token.py`) does this in order:
+
+```mermaid
+sequenceDiagram
+    participant NM as NetworkManager
+    participant D as refresh_cloud_token.py
+    participant LES as live_event_sync
+    participant CA as cloud_archive
+    participant W as Web app
+
+    NM->>D: dispatch up event
+    D->>W: refresh RO mount
+    D->>W: POST /api/live_events/wake
+    W->>LES: wake() — start draining live_event_queue
+    D->>D: poll /api/live_events/status<br/>(timeout 10 min)
+    LES-->>D: pending+uploading == 0
+    D->>D: wait for archive worker (timeout 5 min)
+    D->>D: wait for indexing queue drain (timeout 2 min)
+    D->>CA: trigger cloud_archive
+```
+
+**LES gets to drain before cloud_archive starts.** The cap is 10
+minutes (`_LIVE_EVENT_TIMEOUT_SECONDS`); after that cloud_archive
+runs anyway and they coexist with mid-file yielding.
+
+### Power-loss safety on the cloud side
+
+A file is marked `synced` only **after** rclone confirms upload AND
+the DB commit completes AND fsync returns. If power dies mid-upload:
+
+- The partially uploaded file's row is still `uploading`.
+- On startup, `_startup_recovery()` resets every `uploading` row
+  back to `pending`.
+- The next sync cycle re-uploads. rclone's chunked uploads are
+  resumable for providers that support it.
+
+### Decisions at this stage
+
+| Condition                                                | Outcome                                                  |
+|----------------------------------------------------------|----------------------------------------------------------|
+| LES enabled + new event.json                              | Enqueue into `live_event_queue`; wake LES worker         |
+| LES disabled                                              | Event clip goes through the normal cloud_archive path    |
+| WiFi down                                                 | Worker idles; queue grows                                 |
+| WiFi reconnects                                           | LES drains first; cloud_archive waits up to 10 min        |
+| LES has pending work + cloud_archive is running           | cloud_archive yields between files                        |
+| `cloud_archive.sync_non_event_videos: false` + non-event  | Skip — only events + geolocated clips uploaded           |
+| Daily cap exceeded                                        | LES idles until local midnight                            |
+| Upload fails 5 times                                      | LES row → `failed`, requires manual retry                 |
+
+---
+
+## Stage 6 — Retention prune
+
+The clip is now on the SD card, indexed, possibly cloud-uploaded.
+Sooner or later retention will reclaim its disk space.
+
+### `archive_watchdog` — the periodic guard
+
+Runs from `gadget_web`. Walks `~/ArchivedClips/` and asks per-file:
+
+1. How old is this clip?
+2. Does it have GPS? Is it part of an indexed trip?
+3. Has it been cloud-synced (`cloud_synced_files.status = synced`)?
+4. Is the SD card running out of space?
+
+Then it picks a **bucket** and acts:
+
+| Bucket           | Criterion                                             | Action                                                    |
+|------------------|-------------------------------------------------------|-----------------------------------------------------------|
+| `kept_has_gps`   | Has GPS, indexed, part of a trip                      | Keep — these are the irreplaceable trip recordings        |
+| `kept_event`     | Sentry / Saved event, recently captured               | Keep                                                       |
+| `kept_synced`    | Recently synced to cloud, within retention horizon    | Keep                                                       |
+| `prune_synced_old` | Synced + older than `default_retention_days`        | Delete file                                                |
+| `prune_unsynced_old` | Unsynced + older + `delete_unsynced` allows it    | Delete file                                                |
+
+### The "delete_unsynced" three-state config
+
+`cloud_archive.delete_unsynced` is **tri-state** (`null` / `false` / `true`):
+
+| Value     | Behavior                                                                  |
+|-----------|---------------------------------------------------------------------------|
+| `null`    | Auto: delete unsynced only when free space drops below the target         |
+| `false`   | Never delete an unsynced clip — keep them forever, even at disk-full risk |
+| `true`    | Delete unsynced clips at the same age as synced ones                      |
+
+The default is `null` (the auto behavior). `false` is for users
+who want a guaranteed local-only retention; `true` is for users
+who treat the cloud as canonical.
+
+### Sacred trips rule
+
+When retention deletes a clip, `mapping_service.purge_deleted_videos()`
+is called. This function:
+
+1. Removes the matching `indexed_files` row.
+2. **Sets `waypoints.video_path = NULL`** for every waypoint that
+   referenced the deleted file.
+3. **Sets `detected_events.video_path = NULL`** for every event
+   that referenced it.
+4. **Does NOT touch the `trips` row**. The trip happened — losing
+   the dashcam clip doesn't unhappen the drive.
+
+This rule was hardened after the May 7 2026 regression where a
+naive cleanup cascade-deleted an entire McDonald's trip's data
+when the source clip rotated out. The contract now is:
+
+> **Trips are sacred. Only an explicit user "Delete Trip" action
+> may remove them.**
+
+This is enforced in code (`purge_deleted_videos` doesn't take a
+trip-deletion path) and in the design system (no UI button
+deletes trips silently — only a deliberate user action).
+
+### Watchdog actionability
+
+Retention can also raise a banner in the UI when free space gets
+critical. The banner has two flags:
+
+- `severity` — `info` / `warning` / `error` / `critical`
+- `actionable` — `true` only when there's something the user can
+  *do* (worker stalled with pending work, or disk critically full)
+
+The UI shows the "footage may be lost" banner only when both
+`severity ∈ {error, critical}` AND `actionable === true`. The
+distinction matters because non-actionable critical states (e.g.,
+"the cleanup is in progress and disk is briefly low") shouldn't
+spam users with banners they can't dismiss with action.
+
+### Decisions at this stage
+
+| Condition                                                | Bucket / Action                                                |
+|----------------------------------------------------------|----------------------------------------------------------------|
+| Has GPS + part of a trip                                  | `kept_has_gps` — never deleted by retention                    |
+| Sentry / Saved event, within event retention             | `kept_event`                                                    |
+| Synced, within `default_retention_days`                   | `kept_synced`                                                   |
+| Synced + older than retention                             | `prune_synced_old` — delete file, NULL `video_path` references |
+| Unsynced + `delete_unsynced=null` + free space ok        | Keep                                                             |
+| Unsynced + `delete_unsynced=null` + free space low       | `prune_unsynced_old` — delete                                   |
+| Unsynced + `delete_unsynced=false`                       | Keep regardless                                                  |
+| Unsynced + `delete_unsynced=true` + age past retention   | `prune_unsynced_old` — delete                                   |
+| Free space critical + worker idle                        | `actionable=true` → banner shown                                |
+| Free space critical + worker actively pruning            | `actionable=false` → banner suppressed                          |
+
+---
+
+## Stage 7 — User deletion
+
+Users can also delete clips manually from the UI. Two entry
+points:
+
+### Delete a single event
+
+`scripts/web/blueprints/videos.py::delete_event(folder, event_name)`
+
+- Validates `folder` against the allowed set (`SentryClips`,
+  `SavedClips`, `RecentClips`, `ArchivedClips`).
+- Validates `event_name` doesn't contain path traversal.
+- Removes the file/dir from `~/ArchivedClips/`.
+- Calls `purge_deleted_videos()` so DB references go to NULL.
+- Returns JSON success/failure.
+
+### Delete a trip (rare; the only way to remove a `trips` row)
+
+A separate explicit user action — **the only code path that
+deletes a `trips` row.** Deletes the trip and its waypoints / events
+in a single transaction. This is the explicit "I don't want this
+drive in my history" action.
+
+### Decisions at this stage
+
+| Condition                          | Outcome                                                 |
+|------------------------------------|---------------------------------------------------------|
+| User clicks "Delete event"          | File removed; `video_path` references NULLed; trip kept |
+| User clicks "Delete trip" (rare)    | Trip + its waypoints + events all removed               |
+| Filename contains `..` or `/`       | 400 — rejected                                           |
+| Folder not in allowed set           | 400 — rejected                                           |
+
+---
+
+## Tying it together: the full clip-lifetime decision tree
+
+```mermaid
+flowchart TD
+    A["Tesla writes clip"] --> B{"file age > 60 s?"}
+    B -- no --> B
+    B -- yes --> C["Archive enqueue"]
+    C --> D{"copy succeeds?"}
+    D -- no, retry --> D
+    D -- timeout 60s --> C
+    D -- yes --> E["Indexing enqueue"]
+    E --> F{"front camera?"}
+    F -- no --> Z1["NOT_FRONT_CAMERA<br/>terminal"]
+    F -- yes --> G{"mtime fresh?"}
+    G -- yes --> E
+    G -- no --> H{"parse OK?"}
+    H -- no --> E
+    H -- yes --> I{"GPS in any frame?"}
+    I -- no --> Z2["NO_GPS_RECORDED<br/>terminal"]
+    I -- yes --> J["INDEXED<br/>insert waypoints/events/trip"]
+    J --> K{"event.json arrived?"}
+    K -- yes & LES on --> L["LES enqueue"]
+    K -- no --> M["cloud_archive enqueue"]
+    L --> N["upload via rclone"]
+    M --> N
+    N --> O{"sync ok?"}
+    O -- no, retry --> N
+    O -- yes --> P["mark synced"]
+    P --> Q{"retention check"}
+    Q -- has GPS, in trip --> R["kept_has_gps<br/>never delete"]
+    Q -- synced + old --> S["prune_synced_old<br/>file deleted, trip kept"]
+    Q -- unsynced + delete_unsynced=null + low space --> S
+    Q -- user clicks delete --> S
+```
+
+---
+
+## Cross-cutting safety rules
+
+These apply at every stage. Violating any of them has caused
+real production incidents (cited in the relevant
+copilot-instructions sections).
+
+1. **Background subsystems never unmount or rebind the USB
+   gadget.** Tesla may be recording at any moment. Any UDC
+   unbind / LUN clear / RO→RW remount of part1 loses footage.
+   The only USB-disrupting operations are user-initiated
+   (`quick_edit_part2`, mode switch, gadget rebind after lock
+   chime change). Background workers (archive, indexer, file
+   watcher, cloud_archive, LES) are read-only consumers.
+2. **Tesla writes via the gadget block layer; we read via VFS.**
+   No lock contention. Concurrent reads/writes of the same image
+   file are fine.
+3. **VFS cache invalidation on the RO mount uses
+   `echo 2 > /proc/sys/vm/drop_caches` (slabs only).** Never
+   `umount -l + remount` — that breaks the gadget's view.
+4. **mvhd over filename for absolute time.** Always.
+5. **Trips are sacred.** Only an explicit user delete may remove
+   a `trips` row. `purge_deleted_videos` only NULLs `video_path`.
+6. **Index from `~/ArchivedClips/` only.** Never from the RO USB
+   mount. Tesla may rotate a clip mid-parse.
+7. **One rclone subprocess at a time.** Coordinated via
+   `task_coordinator` keys `'cloud_sync'` and `'live_event_sync'`.
+8. **No new dependencies in `live_event_sync_service.py`.** The
+   25 MB RSS steady-state ceiling on Pi Zero 2 W is enforced by
+   code review. `urllib.request` for webhooks; never `requests`.
+9. **Atomic copy + fsync + rename for every file write.** Power
+   cuts at any time.
+
+---
+
+## Where to read next
+
+- [`ARCHITECTURE.md`](ARCHITECTURE.md) — the component-level view
+  of everything described above.
+- [`GLOSSARY.md`](GLOSSARY.md) — every term defined.
+- [`contributor/core/DATABASES.md`](contributor/core/DATABASES.md)
+  — the database tables this doc references.
+- [`contributor/core/CONFIGURATION_SYSTEM.md`](contributor/core/CONFIGURATION_SYSTEM.md)
+  — every config key cited above.
+- *(planned, Wave 3)* `contributor/subsystems/VIDEO_ARCHIVE.md`,
+  `VIDEO_INDEXING.md`, `MAPPING_AND_TRIPS.md`, `EVENT_DETECTION.md`,
+  `TELEMETRY_AND_SEI.md`, `FILE_WATCHER.md`.
+- *(planned, Wave 4)* `contributor/subsystems/CLOUD_ARCHIVE.md`,
+  `LIVE_EVENT_SYNC.md`.
+- *(planned, Wave 7)*
+  `contributor/flows/POWER_LOSS_RECOVERY.md`,
+  `MODE_SWITCH_PRESENT_TO_EDIT.md`,
+  `MODE_SWITCH_EDIT_TO_PRESENT.md`.
+
+---
+
+## Source files
+
+The lifecycle described above touches these modules. When any of
+them changes in a way that affects the per-stage decisions, update
+this doc.
+
+- `scripts/web/services/file_watcher_service.py` — Stage 2
+- `scripts/web/services/archive_producer.py` — Stage 3 producer
+- `scripts/web/services/archive_worker.py` — Stage 3 worker
+- `scripts/web/services/archive_queue.py` — Stage 3 status enum,
+  priority constants
+- `scripts/web/services/archive_watchdog.py` — Stage 6 retention
+- `scripts/web/services/indexing_worker.py` — Stage 4 worker
+- `scripts/web/services/indexing_queue_service.py` — Stage 4 queue API
+- `scripts/web/services/mapping_service.py` — Stage 4
+  (`index_single_file`, `IndexResult`, `IndexOutcome`,
+  trip merge, `purge_deleted_videos`)
+- `scripts/web/services/mapping_queries.py` — read-only map queries
+- `scripts/web/services/cloud_archive_service.py` — Stage 5 path A
+- `scripts/web/services/live_event_sync_service.py` — Stage 5 path B
+- `scripts/web/services/task_coordinator.py` — fairness lock
+  contract
+- `scripts/web/helpers/refresh_cloud_token.py` — NM dispatcher
+- `scripts/web/blueprints/videos.py::delete_event()` — Stage 7

--- a/docs/contributor/DEV_WORKFLOW.md
+++ b/docs/contributor/DEV_WORKFLOW.md
@@ -1,0 +1,304 @@
+# Development Workflow
+
+The full cycle for any change to TeslaUSB: branch, test, commit, PR,
+review, deploy. Following this consistently is what keeps the device
+stable in production.
+
+---
+
+## At a glance
+
+```mermaid
+flowchart LR
+  A[Pick an issue] --> B[Branch from main]
+  B --> C[Implement + add tests]
+  C --> D[Run pytest locally]
+  D -->|fail| C
+  D -->|pass| E[Commit with Co-authored-by trailer]
+  E --> F[Push branch]
+  F --> G[Open PR]
+  G --> H[review-pr skill]
+  H --> I[security-review skill]
+  I -->|findings| C
+  I -->|clean| J[Merge - squash + delete branch]
+  J --> K[Deploy to cybertruckusb.local]
+  K --> L[Smoke test on device]
+```
+
+---
+
+## 1. Pick an issue
+
+Work is tracked in [GitHub Issues](https://github.com/mphacker/TeslaUSB/issues).
+The two most common entry points:
+
+- The `resolve-issue` skill (`.github/skills/resolve-issue/SKILL.md`)
+  takes an issue number and runs the full investigation → branch →
+  fix → test → PR cycle.
+- For ad-hoc work, branch and code as described below.
+
+Either way, **never push to `main` directly** — every change goes
+through a PR.
+
+---
+
+## 2. Branch from `main`
+
+```bash
+git checkout main
+git pull --ff-only origin main
+git checkout -b <type>/<issue>-<short-slug>
+```
+
+Branch naming convention:
+
+| Prefix     | Use for                                          | Example                        |
+|------------|--------------------------------------------------|--------------------------------|
+| `fix/`     | Bug fixes (closes a specific issue)              | `fix/180-failed-jobs-ux`       |
+| `feat/`    | New features                                      | `feat/65-wraps-preview`        |
+| `docs/`    | Documentation-only changes                        | `docs/wave-1-foundation`       |
+| `refactor/`| Internal restructuring (no behavior change)       | `refactor/issue-72-io-storm`   |
+
+Always branch from a freshly pulled `main` so your diff is minimal.
+
+---
+
+## 3. Implement + add tests
+
+For any code change, **add or update pytest coverage** for the new
+behavior. The repo currently has ~1600 tests and that's the bar — a
+PR that adds new behavior without tests should expect "missing test"
+findings in review.
+
+Per-subsystem test conventions live in the dedicated subsystem docs;
+for now, follow the patterns in the existing `tests/test_*.py` file
+that matches your area.
+
+For docs-only changes, no tests are required.
+
+---
+
+## 4. Run the test suite
+
+```bash
+python -m pytest --tb=short -q
+```
+
+The full suite runs in ~70 seconds on a developer machine. Always
+run it before pushing.
+
+For faster iteration on a single area:
+
+```bash
+python -m pytest tests/test_<module>.py --tb=short -q
+```
+
+There is **no automated CI**; the test run is your responsibility.
+Reviewers will re-run if a finding is uncertain.
+
+---
+
+## 5. Commit
+
+Always sign commits with the Copilot Co-authored-by trailer
+(required by the project's `git_commit_trailer` policy):
+
+```
+Fix #180 — gate archive watchdog banner on actionability
+
+<body explaining what changed and why>
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
+```
+
+Commit message conventions:
+
+- **Subject line** starts with `Fix #N`, `Feat #N`, `Docs:`, or
+  `Refactor:` and is **≤ 72 characters**.
+- **Body** explains *what* and *why*, not *how* (the diff shows how).
+- For multi-paragraph bodies, leading bullets are fine.
+- **Reference the issue** in the subject line so GitHub auto-links.
+
+---
+
+## 6. Push and open the PR
+
+```bash
+git push -u origin <branch-name>
+gh pr create --repo mphacker/TeslaUSB --base main --head <branch-name> \
+  --title "<short subject>" --body-file <prepared-body>.md
+```
+
+**PR description requirements:**
+
+- One-paragraph summary of *what changed* and *why*.
+- A test summary (`Tests: 1606 passed, 4 skipped` or similar).
+- For multi-commit PRs, a bullet list of the commits.
+
+The body should be **specific enough that a reviewer can decide
+whether to merge without reading the diff first**.
+
+---
+
+## 7. Code review via the `review-pr` skill
+
+For non-trivial PRs, run the project's review skill against your own
+PR before requesting human review:
+
+```
+review-pr <PR number>
+```
+
+The skill (`.github/skills/review-pr/SKILL.md`) checks the diff
+against project conventions: configuration compliance, mount safety,
+path traversal, subprocess security, image gating, Flask blueprint
+patterns, template deployment correctness, resource efficiency,
+power-loss safety, and security. It posts the review directly to
+the PR.
+
+You **cannot self-approve your own PR** via the skill — the skill
+posts a review comment instead.
+
+---
+
+## 8. Security review
+
+Every PR that touches code (not just docs) gets a security review
+via the `security-review` skill, which runs in `changed` mode against
+the PR diff. It's invoked automatically inside `review-pr` and covers:
+
+- Subprocess injection (no `f-string + shell=True`)
+- Path traversal (filename sanitization, `os.path.commonpath` checks)
+- Configuration security (no hardcoded secrets)
+- Mount and gadget safety
+- Network exposure (port-80 captive portal is intentional; nothing
+  else listens publicly)
+- WiFi AP security
+- File upload validation (extension, size, content)
+- Root privilege usage (only services that need it)
+- Dependency security (no new heavyweight imports without
+  justification on Pi Zero 2 W)
+- Data protection (no PII in logs, no credentials in commits)
+
+A clean security review is required before merge.
+
+---
+
+## 9. Merge
+
+After review approval (or for low-risk changes the user merges
+directly), squash-merge and delete the branch:
+
+```bash
+gh pr merge <number> --repo mphacker/TeslaUSB --squash --delete-branch
+```
+
+**Squash merge is the project default.** Each merged PR maps to a
+single commit on `main`, making `git log` and bisect easy.
+
+---
+
+## 10. Deploy to the device
+
+The reference device is `cybertruckusb.local` (SSH access). Deploy
+flow:
+
+```bash
+ssh pi@cybertruckusb.local
+cd ~/TeslaUSB
+git pull --ff-only origin main
+sudo systemctl restart gadget_web.service
+```
+
+For most code changes (Python services, Flask blueprints, Jinja
+templates, static assets), `git pull` + `systemctl restart
+gadget_web.service` is enough.
+
+**You only need to re-run `setup_usb.sh` if** any of the following
+changed:
+
+- A file under `templates/` (systemd unit, NM dispatcher, sshd
+  drop-in)
+- A shell script under `scripts/` that gets installed somewhere
+- The web service's *deployment* path (rare)
+- A package dependency (rare)
+
+After `git pull`, **always**:
+
+1. Verify the service is up: `systemctl is-active gadget_web.service`
+2. Smoke-test the area you changed in the browser.
+
+---
+
+## 11. Smoke test
+
+Browser tests on the device are run via the live URL:
+
+- `http://cybertruckusb.local`
+
+Verify:
+
+- The page you changed renders without errors.
+- The action you changed (button, form, API call) succeeds.
+- The system health card on `/` (or `/api/system/health`) reports
+  no new failures.
+
+For interactive flows (camera-switch, mode change, chime upload),
+walk through the user steps once.
+
+If the smoke test reveals a regression, **revert your change on the
+device immediately** (`git reset --hard HEAD~1 && systemctl restart
+gadget_web.service`) and reopen the PR.
+
+---
+
+## Common tooling
+
+| Tool                | Purpose                                                        |
+|---------------------|----------------------------------------------------------------|
+| `gh` CLI            | All GitHub operations (PR, issue, review, comment, merge)      |
+| `pytest`            | Test runner; configured via `pytest.ini`                       |
+| `git`               | Version control; never `git stash -u` near runtime data files  |
+| `journalctl`        | Logs (`-u gadget_web.service -f`)                              |
+| `systemctl`         | Service management on the device                                |
+| `ssh`               | Connect to `cybertruckusb.local`                                |
+
+---
+
+## Things to never do
+
+These are the workflow-level repeats of the rules in
+`.github/copilot-instructions.md`. Internalize them.
+
+1. **Never `git stash -u`** anywhere near runtime data files
+   (`*.db`, `state.txt`, `*.bak.*`, `tesla_salt.bin`). The
+   `.gitignore` is hardened against committing them, but a stash
+   captures untracked files.
+2. **Never push directly to `main`.** Every change goes through a PR.
+3. **Never install dependencies inside the repo** (no `node_modules/`,
+   no scratch `package.json`). Test tooling lives outside the
+   working tree.
+4. **Never commit secrets.** Cloud creds are encrypted at rest by
+   `crypto_utils.py`; OAuth tokens never touch the repo.
+5. **Never run `setup_usb.sh` to deploy a one-file template change**
+   if you can avoid it — `setup_usb.sh` has interactive prompts that
+   hang on closed stdin and re-runs many setup steps. For one-off
+   template tweaks, sed-substitute the placeholders manually and
+   `systemctl daemon-reload`.
+6. **Never deploy without smoke testing.** A passing local pytest
+   does not guarantee the device behaves correctly — the device runs
+   on a Pi Zero 2 W with real SDIO bus contention and real Tesla
+   recordings.
+
+---
+
+## Source files
+
+- `.github/copilot-instructions.md` — the dense rule-set every PR
+  is reviewed against
+- `.github/skills/review-pr/SKILL.md` — the PR review skill
+- `.github/skills/security-review/SKILL.md` — the security review skill
+- `.github/skills/resolve-issue/SKILL.md` — the end-to-end issue
+  resolution skill
+- `pytest.ini` — pytest configuration
+- `tests/conftest.py` — shared test fixtures

--- a/docs/contributor/README.md
+++ b/docs/contributor/README.md
@@ -1,0 +1,154 @@
+# Contributor Documentation
+
+Welcome — this section is for **contributors**, the people who modify
+the TeslaUSB source code. Read this first; it points you at the
+right deeper docs.
+
+If you're here to **operate** a device (deploy, configure, monitor,
+recover), you want [`../operator/README.md`](../operator/README.md)
+instead.
+
+---
+
+## Before you write a single line of code
+
+Read these in order, even if you've contributed before:
+
+1. **[`../README.md`](../README.md)** — the docs hub, including the
+   conventions used in every document (Mermaid diagrams, code
+   citations, decision tables, source-file footers).
+2. **[`../ARCHITECTURE.md`](../ARCHITECTURE.md)** — what the major
+   components are and how they interact.
+3. **[`../VIDEO_LIFECYCLE.md`](../VIDEO_LIFECYCLE.md)** — the flagship
+   narrative. Even if you're touching something unrelated to video,
+   the lifecycle doc shows the **decision-density and citation
+   style** every contributor doc aims for.
+4. **[`REPO_LAYOUT.md`](REPO_LAYOUT.md)** — where things live in
+   the source tree, plus naming conventions.
+5. **[`DEV_WORKFLOW.md`](DEV_WORKFLOW.md)** — branching, testing,
+   deploying, and the security-review skill.
+6. **[`../../.github/copilot-instructions.md`](../../.github/copilot-instructions.md)**
+   — the dense, opinionated rule-set every PR is reviewed against.
+   The contributor docs in this folder are the **narrative**
+   counterpart to that file. The two should never disagree; if they
+   do, the source code is the tiebreaker.
+
+---
+
+## Folder layout
+
+```
+docs/contributor/
+├── README.md            ← you are here
+├── REPO_LAYOUT.md       ← source-tree map
+├── DEV_WORKFLOW.md      ← test/branch/PR/deploy/security-review
+│
+├── core/                ← cross-cutting infrastructure
+│   ├── CONFIGURATION_SYSTEM.md
+│   └── DATABASES.md
+│
+├── subsystems/          ← one doc per worker / service (Waves 3-8)
+├── flows/               ← end-to-end traces with sequence diagrams (Waves 3-8)
+└── reference/           ← lookup tables and API surface (Waves 3-10)
+```
+
+`subsystems/`, `flows/`, and `reference/` are populated across
+documentation waves — see the
+[status table](../README.md#documentation-status). The two `core/`
+docs that exist now (Configuration system, Databases) are the ones
+every other doc cites.
+
+---
+
+## Where to look first by topic
+
+These cross-references will be filled out wave-by-wave. Until then,
+this table is also a map of where each topic **will** be documented.
+
+| Topic                          | Doc to read (planned wave)                                           |
+|--------------------------------|----------------------------------------------------------------------|
+| Boot sequence                  | `core/BOOT_SEQUENCE.md` *(Wave 2)*                                   |
+| USB gadget, modes, LUNs        | `core/USB_GADGET_AND_MODES.md` *(Wave 2)*                            |
+| Mount safety, `nsenter`        | `core/MOUNT_SAFETY.md` *(Wave 2)*                                    |
+| Configuration system           | [`core/CONFIGURATION_SYSTEM.md`](core/CONFIGURATION_SYSTEM.md)        |
+| Task coordinator               | `core/TASK_COORDINATOR.md` *(Wave 2)*                                |
+| Databases                      | [`core/DATABASES.md`](core/DATABASES.md)                              |
+| File safety, atomic writes     | `core/FILE_SAFETY.md` *(Wave 2)*                                     |
+| File watcher (`inotify`)       | `subsystems/FILE_WATCHER.md` *(Wave 3)*                              |
+| Archive subsystem              | `subsystems/VIDEO_ARCHIVE.md` *(Wave 3)*                             |
+| Indexing subsystem             | `subsystems/VIDEO_INDEXING.md` *(Wave 3)*                            |
+| Mapping and trips              | `subsystems/MAPPING_AND_TRIPS.md` *(Wave 3)*                         |
+| Event detection thresholds     | `subsystems/EVENT_DETECTION.md` *(Wave 3)*                           |
+| Cloud archive                  | `subsystems/CLOUD_ARCHIVE.md` *(Wave 4)*                             |
+| Live Event Sync (LES)          | `subsystems/LIVE_EVENT_SYNC.md` *(Wave 4)*                           |
+| Failed Jobs internals          | `subsystems/FAILED_JOBS_INTERNALS.md` *(Wave 4)*                     |
+| WiFi / AP internals            | `subsystems/WIFI_AND_AP_INTERNALS.md` *(Wave 6)*                     |
+| Captive portal                 | `subsystems/CAPTIVE_PORTAL.md` *(Wave 6)*                            |
+| Memory and watchdog            | `subsystems/MEMORY_AND_WATCHDOG.md` *(Wave 6)*                       |
+| Lock chimes                    | `subsystems/LOCK_CHIMES.md` *(Wave 8)*                               |
+| Light shows and wraps          | `subsystems/LIGHT_SHOWS_AND_WRAPS.md` *(Wave 8)*                     |
+| Telemetry / SEI parsing        | `subsystems/TELEMETRY_AND_SEI.md` *(Wave 3)*                         |
+
+---
+
+## Writing new documentation
+
+If you're contributing a new doc (or modifying one), follow the
+**per-doc template** the existing docs use — at minimum:
+
+1. **One-sentence summary** at the top.
+2. **At a glance** — 30-second overview.
+3. **Sequence diagram** in Mermaid.
+4. **Step-by-step walkthrough** with code citations (function +
+   module, no line numbers).
+5. **Decision points** as a table or `flowchart` Mermaid block.
+6. **Configuration** — which `config.yaml` keys affect this and how.
+7. **Failure modes & recovery** — power loss, lock contention,
+   missing files.
+8. **Source files** footer — list every module the doc covers.
+
+Every claim in the doc should either be obviously true from the
+prose or cite a function. **Don't speculate** — if you're not sure
+how the code branches, read the code or grep for the constant
+before writing.
+
+---
+
+## A few non-obvious rules
+
+These come from `.github/copilot-instructions.md` and are worth
+internalizing before you make your first change:
+
+1. **Background subsystems must NEVER unmount or rebind the USB
+   gadget.** Tesla may be recording. The only USB-disrupting
+   operations are user-initiated (`quick_edit_part2`, mode switch,
+   gadget rebind after lock chime change).
+2. **Loop devices serve local mounts only.** The gadget binds the
+   `.img` file directly. Unmounting/detaching loop devices does not
+   affect Tesla's view of the drive.
+3. **Trips are sacred.** `purge_deleted_videos` only deletes the
+   `indexed_files` row and NULLs the `video_path` on waypoints and
+   detected events. It never deletes trips, waypoints, or events.
+   That rule prevented (and prevents) a class of data-loss
+   regressions.
+4. **Tesla's onboard clock can drift hours.** The MP4 `mvhd` atom
+   is the authoritative absolute time. Use `_resolve_recording_time`,
+   never the filename, for anything time-sensitive.
+5. **The `task_coordinator` lock must never be held across sleeps.**
+   Cyclic workers do `acquire → work → release → sleep`, never
+   `acquire → work → sleep → release`. That rule prevented production
+   data loss in PR #78.
+6. **The Pi Zero 2 W has 512 MB of RAM and a single SDIO bus.**
+   Every new dependency, thread, and in-memory cache needs a
+   justification. Saturating SDIO can starve the watchdog daemon
+   and trigger a hardware reset.
+7. **Never install dependencies, scratch files, or test artifacts
+   inside the git working tree.** Test tooling (Playwright, npm
+   packages, debug scripts) lives **outside** the repo.
+
+---
+
+## Source files
+
+This document is purely navigational; it has no source-code
+dependency.

--- a/docs/contributor/REPO_LAYOUT.md
+++ b/docs/contributor/REPO_LAYOUT.md
@@ -1,0 +1,289 @@
+# Repository Layout
+
+Where everything lives in the TeslaUSB source tree, plus the naming
+and structural conventions every contributor should know. Use this
+as a map when you're hunting for a specific piece of functionality.
+
+---
+
+## Top-level layout
+
+```
+TeslaUSB/
+├── readme.md                      ← user-facing project overview / install
+├── config.yaml                    ← the single source of truth for ALL config
+├── setup_usb.sh                   ← one-shot deploy / re-deploy script
+├── upgrade.sh                     ← upgrade helper (reapplies setup, restarts)
+├── cleanup.sh                     ← optional standalone cleanup invocation
+├── pytest.ini                     ← pytest configuration
+│
+├── docs/                          ← these documents
+│   ├── README.md                  ← docs hub
+│   ├── ARCHITECTURE.md
+│   ├── VIDEO_LIFECYCLE.md         ← the flagship narrative
+│   ├── GLOSSARY.md
+│   ├── UI_UX_DESIGN_SYSTEM.md
+│   ├── operator/                  ← runbooks for deploying / managing devices
+│   ├── contributor/               ← internals + contracts (this folder)
+│   │   ├── core/                  ← cross-cutting infrastructure
+│   │   ├── subsystems/            ← one doc per worker / service
+│   │   ├── flows/                 ← end-to-end sequence-diagram traces
+│   │   └── reference/             ← lookup tables and API surface
+│   └── screenshots/               ← marketing / readme screenshots
+│
+├── scripts/                       ← runtime code (everything Pi-side)
+│   ├── present_usb.sh             ← bring USB gadget UP (present mode)
+│   ├── edit_usb.sh                ← bring USB gadget DOWN (edit mode)
+│   ├── boot_present_with_cleanup.sh
+│   ├── boot_deferred_tasks.sh
+│   ├── ap_control.sh              ← offline AP enable/disable wrapper
+│   ├── wifi-monitor.sh            ← STA loss → AP fallback service
+│   ├── fsck_with_swap.sh          ← boot-time fsck (uses swap on low RAM)
+│   ├── optimize_network.sh
+│   ├── check_chime_schedule.py    ← periodic chime scheduler tick
+│   ├── select_random_chime.py     ← boot-time random chime selection
+│   ├── run_boot_cleanup.py        ← deferred post-boot cleanup
+│   ├── config.sh                  ← Bash wrapper around config.yaml (uses yq)
+│   └── web/                       ← the Flask application
+│       ├── web_control.py         ← the Flask `app` factory + entry point
+│       ├── config.py              ← Python wrapper around config.yaml
+│       ├── utils.py               ← shared template context, helpers
+│       ├── blueprints/            ← Flask blueprint modules
+│       ├── services/              ← business logic (workers, queues, helpers)
+│       ├── helpers/               ← scripts run by external triggers
+│       ├── templates/             ← Jinja2 HTML templates
+│       └── static/                ← CSS, JS, fonts, icon sprite, images
+│
+├── templates/                     ← source templates with placeholders
+│   ├── 99-teslausb-cloud-refresh  ← NM dispatcher
+│   ├── *.service                  ← systemd unit templates
+│   ├── *.timer                    ← systemd timer templates
+│   ├── sshd-protect.conf          ← sshd hardening drop-in
+│   └── teslausb-safe-mode.service ← safe-mode boot detector
+│
+├── tests/                         ← pytest suite (~1600 tests)
+│   ├── conftest.py                ← shared fixtures
+│   └── test_*.py                  ← one file per service / blueprint
+│
+└── .github/
+    ├── copilot-instructions.md    ← dense rule-set every PR reviewed against
+    ├── workflows/                 ← (none today — TeslaUSB has no CI)
+    └── skills/                    ← agent skills (resolve-issue, review-pr, …)
+```
+
+---
+
+## `scripts/` (runtime code)
+
+Code that runs on the Pi. Split into shell scripts at the top level and
+the Flask application under `web/`.
+
+### Shell entry points
+
+| Script                              | Purpose                                               |
+|-------------------------------------|-------------------------------------------------------|
+| `present_usb.sh`                    | Mount partitions RO, bind UDC, present gadget         |
+| `edit_usb.sh`                       | Unbind UDC, unmount partitions, mount RW, start Samba |
+| `boot_present_with_cleanup.sh`      | Wrapper that runs `present_usb.sh` then deferred work |
+| `boot_deferred_tasks.sh`            | Post-boot cleanup + random chime selection            |
+| `ap_control.sh`                     | Wrapper around hostapd / dnsmasq for AP control       |
+| `wifi-monitor.sh`                   | STA-loss detector with exponential AP-retry backoff   |
+| `fsck_with_swap.sh`                 | Boot-time `fsck -p` against `usb_cam.img` and `usb_lightshow.img` |
+| `config.sh`                         | Bash wrapper around `config.yaml` (uses `yq`)          |
+
+### Python utilities at `scripts/`
+
+| Script                              | Purpose                                               |
+|-------------------------------------|-------------------------------------------------------|
+| `check_chime_schedule.py`           | Tick called by `chime_scheduler.timer`                |
+| `select_random_chime.py`            | Boot-time random chime picker                         |
+| `run_boot_cleanup.py`               | Deferred cleanup runner                               |
+
+### `scripts/web/` — the Flask application
+
+```
+scripts/web/
+├── web_control.py     ← Flask app factory + main entrypoint
+├── config.py          ← Python wrapper around config.yaml (uses PyYAML)
+├── utils.py           ← shared utilities (context processors, escapers)
+├── blueprints/        ← one blueprint per page or API surface
+├── services/          ← business logic, workers, queues, parsers
+├── helpers/           ← scripts run by external triggers (NM dispatcher)
+├── templates/         ← Jinja2 HTML templates
+└── static/            ← CSS / JS / fonts / icon sprite / images
+```
+
+#### `blueprints/` (HTTP routes)
+
+| File                          | Owns                                                       |
+|-------------------------------|------------------------------------------------------------|
+| `mapping.py`                  | `/` map dashboard + `/api/index/*` indexer endpoints        |
+| `videos.py`                   | Video file serving + delete-event endpoint                  |
+| `media.py`                    | Cross-cutting media listing / range-request serving         |
+| `analytics.py`                | `/analytics` page                                           |
+| `lock_chimes.py`              | Chime upload / preview / set-active / scheduler             |
+| `light_shows.py`              | Light show upload / delete                                  |
+| `wraps.py`                    | Custom wrap upload / delete                                 |
+| `license_plates.py`           | License plate upload / auto-crop                            |
+| `boombox.py`                  | Boombox sound upload (Music LUN)                            |
+| `music.py`                    | Music drive listing                                         |
+| `cleanup.py`                  | Cleanup policies UI and execution                           |
+| `cloud_archive.py`            | Cloud sync UI + `/api/cloud/*`                              |
+| `live_events.py`              | LES JSON API at `/api/live_events/*`                        |
+| `archive_queue.py`            | `/api/archive/*` (status, queue, watchdog)                  |
+| `jobs.py`                     | `/jobs` failed-jobs page across all subsystems              |
+| `system_health.py`            | `/api/system/health`                                        |
+| `mode_control.py`             | Mode-switch endpoints                                       |
+| `settings_advanced.py`        | Advanced settings UI                                        |
+| `storage_retention.py`        | Storage / retention settings                                |
+| `fsck.py`                     | Manual fsck endpoint                                        |
+| `captive_portal.py`           | Captive-portal interception URLs                            |
+| `api.py`                      | Misc API endpoints not big enough for their own blueprint   |
+
+#### `services/` (business logic)
+
+Grouped by subsystem:
+
+**Configuration / shared infra**
+
+- `config.py` *(see also `scripts/web/config.py`)*
+- `task_coordinator.py` — fairness lock for heavy workers
+- `crypto_utils.py` — encryption for cloud-provider creds
+- `file_safety.py` — atomic-write helpers, IMG-file guard
+- `partition_service.py`, `partition_mount_service.py`,
+  `mode_service.py`, `samba_service.py` — mount and mode plumbing
+
+**Video pipeline**
+
+- `file_watcher_service.py` — inotify + polling fallback
+- `archive_producer.py`, `archive_queue.py`, `archive_worker.py`,
+  `archive_watchdog.py`, `video_archive_service.py`
+- `indexing_queue_service.py`, `indexing_worker.py`
+- `mapping_service.py`, `mapping_queries.py`, `mapping_migrations.py`
+- `sei_parser.py` — H.264 SEI extraction (uses `mmap`)
+- `dashcam_pb2.py` — protobuf bindings for Tesla's SEI payload
+- `video_service.py` — file-listing for the UI
+- `analytics_service.py` — aggregate stats from the trip DB
+
+**Cloud**
+
+- `cloud_archive_service.py` — bulk catch-up uploader
+- `cloud_oauth_service.py` — OAuth flow for Drive / OneDrive / etc.
+- `cloud_rclone_service.py` — rclone subprocess management
+- `live_event_sync_service.py` — opt-in real-time uploader
+- `bandwidth_test_service.py` — speed test for cloud throughput planning
+
+**Asset management**
+
+- `lock_chime_service.py`, `chime_group_service.py`,
+  `chime_scheduler_service.py`
+- `light_show_service.py`, `wrap_service.py`,
+  `license_plate_service.py`, `boombox_service.py`,
+  `music_service.py`
+
+**Networking**
+
+- `wifi_service.py`, `ap_service.py`
+
+**Maintenance**
+
+- `cleanup_service.py`, `fsck_service.py`,
+  `clock_skew_repair.py` *(one-shot CLI)*
+
+#### `helpers/` (scripts run by external triggers)
+
+- `refresh_cloud_token.py` — invoked by the NetworkManager
+  dispatcher on every WiFi `up` event. Refreshes RO mount, wakes
+  LES, waits (bounded) for archive + indexer + LES drain, then
+  triggers cloud sync.
+
+#### `templates/` and `static/`
+
+Jinja2 templates and static assets (CSS, JS, fonts, Lucide icon
+sprite, images). The UI follows the rules in
+[`UI_UX_DESIGN_SYSTEM.md`](../UI_UX_DESIGN_SYSTEM.md).
+
+---
+
+## `templates/` (source templates with placeholders)
+
+These files contain `__GADGET_DIR__`, `__MNT_DIR__`, `__TARGET_USER__`,
+`__IMG_NAME__`, `__SECRET_KEY__` placeholders that `setup_usb.sh`
+substitutes during installation. **Never hardcode the deployed paths
+in source — always use placeholders.**
+
+| File                              | Where it gets installed                                 |
+|-----------------------------------|---------------------------------------------------------|
+| `gadget_web.service`              | `/etc/systemd/system/`                                  |
+| `present_usb_on_boot.service`     | `/etc/systemd/system/`                                  |
+| `chime_scheduler.service`         | `/etc/systemd/system/`                                  |
+| `chime_scheduler.timer`           | `/etc/systemd/system/`                                  |
+| `wifi-monitor.service`            | `/etc/systemd/system/`                                  |
+| `network-optimizations.service`   | `/etc/systemd/system/`                                  |
+| `teslausb-deferred-tasks.service` | `/etc/systemd/system/`                                  |
+| `teslausb-safe-mode.service`      | `/etc/systemd/system/`                                  |
+| `99-teslausb-cloud-refresh`       | `/etc/NetworkManager/dispatcher.d/`                     |
+| `sshd-protect.conf`               | `/etc/systemd/system/ssh.service.d/`                    |
+
+After editing **any** template or any script under `scripts/` or
+`templates/`, run `sudo ./setup_usb.sh` to substitute and deploy,
+then restart any affected services.
+
+---
+
+## `tests/`
+
+Approximately 1600 pytest tests covering services and blueprints.
+Run the full suite with:
+
+```bash
+python -m pytest --tb=short -q
+```
+
+Naming convention: one test file per service / blueprint
+(`test_<module_name>.py`). Shared fixtures live in `conftest.py`.
+
+The repo has **no automated CI pipeline**; tests are run by
+contributors and reviewers locally and through the `review-pr` /
+`security-review` skills.
+
+---
+
+## Naming conventions
+
+- **Snake-case** for Python modules and functions, **kebab-case**
+  for shell scripts and systemd unit files.
+- **`_underscore_prefix`** marks "module-private" — by convention,
+  not enforced. Tests freely import these when necessary.
+- **`__double-underscore-bracketed__`** placeholders are
+  template-substitution targets. Never appear in deployed files.
+- **Constants in UPPER_SNAKE_CASE.** Exposed to tests by importing
+  the module.
+- **Service files end in `_service.py`**, blueprint files do not
+  (e.g., `lock_chime_service.py` vs `lock_chimes.py` blueprint).
+- **Database file names** end in `.db` (`geodata.db`,
+  `cloud_sync.db`).
+- **Image files** are protected (`*.img` in `installation.mount_dir`).
+
+---
+
+## What lives where for common tasks
+
+| You want to…                                    | Look in                                                    |
+|-------------------------------------------------|------------------------------------------------------------|
+| Add a new web page                              | New blueprint in `scripts/web/blueprints/` + template       |
+| Add a new background worker                     | New service in `scripts/web/services/`, register in app factory |
+| Add a new config key                            | `config.yaml` (with default) + `scripts/config.sh` if used in Bash |
+| Add a new database table                        | `mapping_migrations.py` (new schema version + migration)   |
+| Add a new SEI-extracted field                   | `sei_parser.py` + `dashcam_pb2.py` regen if proto changes  |
+| Change a deployed systemd unit                  | Source template under `templates/`, then `setup_usb.sh`    |
+| Change which dirs the file watcher watches      | `file_watcher_service.py::_classify_paths()`               |
+| Change how a video is classified for /jobs      | `jobs.py::_classify_clip_value()`                          |
+| Add a new failure pattern recommendation        | `jobs.py::_RECOMMENDATION_RULES`                           |
+
+---
+
+## Source files
+
+This document is a navigational reference only. Update it whenever
+you add a new top-level folder, blueprint, or service module.

--- a/docs/contributor/core/CONFIGURATION_SYSTEM.md
+++ b/docs/contributor/core/CONFIGURATION_SYSTEM.md
@@ -1,0 +1,314 @@
+# Configuration System
+
+How TeslaUSB loads, exposes, and reloads configuration. After this
+doc you should understand exactly where every value comes from at
+runtime, why we use two thin wrappers (one Bash, one Python), and
+how the template-substitution layer turns `config.yaml` values into
+deployed paths.
+
+---
+
+## At a glance
+
+- **Single source of truth**: `config.yaml` at the repo root. Holds
+  paths, credentials, network settings, retention thresholds,
+  indexing parameters — everything.
+- **Two thin wrappers**: `scripts/config.sh` for Bash,
+  `scripts/web/config.py` for Python. Both load and cache the YAML
+  once.
+- **Templates**: source files under `scripts/` and `templates/`
+  contain `__GADGET_DIR__`-style placeholders. `setup_usb.sh`
+  substitutes them and writes the result into systemd / sshd / NM
+  dispatcher locations.
+- **Reload model**: most changes take effect on `systemctl restart
+  gadget_web.service`. AP/STA changes also need
+  `systemctl restart wifi-monitor.service`.
+
+---
+
+## File: `config.yaml`
+
+Lives at the **repo root**, not inside `scripts/`. Edited in place
+on the device. Annotated with comments explaining each key.
+
+The top-level structure (see the file for everything):
+
+```yaml
+installation:        # target user, mount dir
+disk_images:         # cam_name, lightshow_name, music_*, boot_fsck_enabled
+setup:               # partition sizes, archive_reserve_size (used by setup_usb.sh)
+network:             # samba_password, web_port (80 for captive portal)
+offline_ap:          # SSID, passphrase, channel, force_mode, etc.
+system:              # config.txt path, smb.conf path
+web:                 # secret_key, lock-chime constraints, upload limits
+mapping:             # indexing on/off, sample_rate, trip_gap_minutes,
+                     # event_detection thresholds, index_too_new_seconds
+cloud_archive:       # provider, remote_path, bandwidth limit, retention,
+                     # delete_unsynced, sync_non_event_videos, dead-letter
+cleanup:             # default_retention_days, free_space_target_pct,
+                     # max_archive_size_gb, per-folder policies
+archive:             # rescan interval, worker tuning, _atomic_copy guards,
+                     # boot_scan_defer_seconds, retention_days fallback
+live_event_sync:     # enabled, upload_scope, retry backoff, daily cap, webhook
+```
+
+A handful of keys are **deprecated** — they're still accepted but
+have no effect. The yaml comments label them explicitly:
+
+- `mapping.index_on_startup` — superseded by the persistent indexing
+  queue
+- `mapping.index_on_mode_switch` — same
+
+Do not remove deprecated keys silently; surface them as a one-line
+deprecation note in the YAML so existing installs don't break on
+upgrade.
+
+---
+
+## Wrapper: `scripts/config.sh` (Bash)
+
+Sourced by every Bash script that needs a config value. Single
+optimized `yq` call evaluated as Bash assignments — saves about
+1.2 s per invocation versus calling `yq` per key.
+
+Typical use inside a Bash script:
+
+```bash
+# At the top of the script:
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/config.sh"
+
+# Now config values are exported as Bash variables:
+echo "$GADGET_DIR"           # e.g. /mnt/gadget
+echo "$TARGET_USER"          # e.g. pi
+echo "$IMG_CAM_NAME"         # e.g. usb_cam.img
+```
+
+Important: **all values in the eval are double-quoted** so a value
+containing special characters can never inject Bash. This is a
+deliberate security control — `yq | eval` without quoting was a
+known injection path.
+
+When you add a new config key that Bash needs, add it to
+`config.sh`'s eval line in the same quoted form.
+
+---
+
+## Wrapper: `scripts/web/config.py` (Python)
+
+Imported by every Python module that needs a config value. Single
+PyYAML load at module-import time, cached as module-level constants.
+
+Typical use:
+
+```python
+from scripts.web import config
+
+print(config.GADGET_DIR)         # str
+print(config.IMG_CAM_PATH)       # computed: GADGET_DIR + IMG_CAM_NAME
+print(config.MUSIC_ENABLED)      # bool
+print(config.LIVE_EVENT_SYNC_ENABLED)
+```
+
+Computed values (paths assembled from multiple keys) are exported as
+top-level constants too, so callers don't have to assemble them by
+hand. Examples:
+
+- `IMG_CAM_PATH = os.path.join(GADGET_DIR, IMG_CAM_NAME)`
+- `IMG_LIGHTSHOW_PATH = …`
+- `IMG_MUSIC_PATH = …`
+- `ARCHIVE_DIR = os.path.expanduser("~/ArchivedClips")`
+
+These are **the strings you should pass around**, not raw config
+keys. `os.path.isfile(IMG_CAM_PATH)` is the canonical "is the
+TeslaCam drive present?" check used by the image-gating layer.
+
+When you add a new config key that Python needs, add it to
+`config.py` as a module-level constant alongside the others. Stay
+typed — booleans as `bool`, paths as fully-resolved `str`, lists
+as actual `list`.
+
+---
+
+## Image gating
+
+A pattern the docs cite repeatedly: each blueprint that depends on
+a particular `.img` file checks at request-time whether the file
+exists, and gates routes / nav links accordingly.
+
+```python
+# In a blueprint:
+@bp.before_request
+def _gate_on_cam_image():
+    if not os.path.isfile(config.IMG_CAM_PATH):
+        if request.headers.get("X-Requested-With") == "XMLHttpRequest":
+            return jsonify(error="cam image missing"), 503
+        flash("TeslaCam drive not configured")
+        return redirect(url_for("settings_advanced.index"))
+```
+
+The matching nav-link guard is in the base template:
+
+```jinja
+{% if videos_available %}
+<a href="{{ url_for('mapping.index') }}">Map</a>
+{% endif %}
+```
+
+The `videos_available` / `analytics_available` / `chimes_available`
+booleans are populated by `partition_service.get_feature_availability()`
+(merged into every template context by `utils.get_base_context()`).
+That function does the `os.path.isfile()` checks per request — it
+doesn't cache, because the user may add or remove `.img` files at
+any time without restarting.
+
+When you add a new feature gated on a new `.img` file:
+
+1. Add the path constant in `config.py`.
+2. Add the feature-availability flag in
+   `partition_service.get_feature_availability()`.
+3. Wrap the nav link in `base.html` (both desktop and mobile menus).
+4. Add a `@bp.before_request` guard in the blueprint.
+
+---
+
+## Template substitution
+
+Source files under `scripts/` and `templates/` contain placeholders
+that `setup_usb.sh` rewrites during installation. The placeholders:
+
+| Placeholder           | Substituted with                                                |
+|-----------------------|-----------------------------------------------------------------|
+| `__GADGET_DIR__`      | `installation.mount_dir` (default `/mnt/gadget`)                 |
+| `__MNT_DIR__`         | Same — alias                                                     |
+| `__TARGET_USER__`     | `installation.target_user` (auto-overridden by `SUDO_USER`)      |
+| `__IMG_NAME__`        | `disk_images.cam_name` etc., depending on context                |
+| `__SECRET_KEY__`      | `web.secret_key` (auto-generated on first install if default)    |
+
+Examples of substituted files:
+
+- `templates/gadget_web.service` → `/etc/systemd/system/gadget_web.service`
+- `templates/99-teslausb-cloud-refresh` →
+  `/etc/NetworkManager/dispatcher.d/99-teslausb-cloud-refresh`
+- `scripts/present_usb.sh` → executed in place after substitution
+- `scripts/edit_usb.sh` → same
+
+After substitution, the deployed file has **fully resolved paths**.
+The repo source has **only placeholders**. The rule is:
+
+> **Never hardcode `/home/pi/...` or `/mnt/gadget/...` in source.**
+> Always use placeholders so the same source works on any device.
+
+---
+
+## Reload model
+
+### When `systemctl restart gadget_web.service` is enough
+
+- Any change to `mapping.*`, `cloud_archive.*`, `cleanup.*`,
+  `live_event_sync.*`, `archive.*`, `web.*`
+- Any change to a Python service or blueprint
+- Any change to a Jinja template
+- Any change to a static asset
+
+### When `wifi-monitor.service` also needs a restart
+
+- Any change to `offline_ap.*`
+
+### When `setup_usb.sh` re-run is required
+
+- Any change to a file under `templates/` (systemd unit, NM
+  dispatcher, sshd drop-in)
+- Any change to `installation.target_user` (re-substitutes
+  everything)
+- Any change to a placeholder-using shell script
+
+The setup script is interactive and re-runs many steps; for a
+one-line template change, `sed`-substituting the placeholders by
+hand and `systemctl daemon-reload` is faster.
+
+### When a reboot is required
+
+- Any change to `disk_images.boot_fsck_enabled`
+- Any change to `installation.mount_dir`
+- Any change to `disk_images.music_enabled` from `true` to `false`
+  (the gadget config has to be regenerated and the kernel module
+  reloaded)
+
+---
+
+## Versioning and migrations
+
+`config.yaml` does not carry a version number. Backward-compatible
+key additions ship without ceremony — the wrappers default-init
+missing keys to sensible values and log a warning at startup when
+they do.
+
+For breaking changes (key renames, removals), the procedure is:
+
+1. Keep the old key as a backward-compat fallback in the wrapper for
+   one release.
+2. Ship a deprecation comment in the YAML.
+3. Flag it in the readme's "CHANGES FOR EXISTING USERS" callout.
+4. Remove the fallback in a later release.
+
+A precedent for this is the `cleanup.default_retention_days` →
+old-`cloud_archive.archived_clips_retention_days` →
+old-`archive.retention_days` fallback chain in
+`archive_watchdog._resolve_retention_days()`. Follow that pattern
+when introducing new fallbacks.
+
+---
+
+## Decision points
+
+| Question                                              | Where the decision lives                              | Outcome                                                       |
+|-------------------------------------------------------|-------------------------------------------------------|---------------------------------------------------------------|
+| Where do `.img` files live?                            | `installation.mount_dir`                              | All `.img` files placed there                                  |
+| Should the third (Music) LUN be presented?            | `disk_images.music_enabled`                           | `True` → 3 LUNs at boot; `False` → 2                           |
+| Should boot-time fsck run?                            | `disk_images.boot_fsck_enabled`                       | `True` → `fsck -p` on each `.img` before UDC bind              |
+| Which port does Flask bind to?                        | `network.web_port`                                    | Should always be `80` for captive portal                       |
+| Should LES be active?                                 | `live_event_sync.enabled`                             | `False` (default) → no thread, no callback, no DB writes       |
+| Should non-event clips be cloud-uploaded?             | `cloud_archive.sync_non_event_videos`                 | `False` (default) → only events + geolocated clips             |
+| When should retention delete an unsynced clip?        | `cloud_archive.delete_unsynced` (`null`/`false`/`true`) | See [`GLOSSARY.md`](../../GLOSSARY.md) under "delete_unsynced" |
+
+---
+
+## Failure modes & recovery
+
+### `config.yaml` is missing or malformed
+
+Both wrappers fail loudly on startup. `gadget_web.service` won't
+start; `journalctl -u gadget_web.service` shows the YAML error. Fix
+the file and restart.
+
+### Wrapper imports a key that doesn't exist
+
+The Python wrapper logs a WARNING and uses the documented default.
+The Bash wrapper uses a `||` default in the eval expression.
+
+### A placeholder reaches the deployed file
+
+A bug in `setup_usb.sh`'s substitution. Symptom: a literal
+`__GADGET_DIR__` string appears somewhere. Re-run setup; if it
+recurs, file an issue.
+
+### Deprecated key still present
+
+Logged as INFO at startup. No functional impact. Remove the key
+from `config.yaml` at the next maintenance window.
+
+---
+
+## Source files
+
+- `config.yaml` — the source of truth
+- `scripts/config.sh` — Bash wrapper (single optimized `yq` eval)
+- `scripts/web/config.py` — Python wrapper (PyYAML, cached at
+  import-time)
+- `scripts/web/services/partition_service.py::get_feature_availability()`
+  — image-gating booleans
+- `scripts/web/utils.py::get_base_context()` — merges availability
+  flags into every template context
+- `setup_usb.sh` — template substitution + deployment
+- `templates/*` — placeholder-bearing source templates

--- a/docs/contributor/core/DATABASES.md
+++ b/docs/contributor/core/DATABASES.md
@@ -1,0 +1,327 @@
+# Databases
+
+TeslaUSB has two SQLite databases on the SD card. This doc gives
+the high-level structure of each, lists the tables and their roles,
+and points you at the schema definitions and migrations.
+
+For column-by-column documentation, see
+`reference/DB_SCHEMAS.md` *(planned, Wave 10)*. For the rules
+around the protected "trips are sacred" contract, see
+`subsystems/MAPPING_AND_TRIPS.md` *(planned, Wave 3)*.
+
+---
+
+## At a glance
+
+| Database         | Owns                                                                          |
+|------------------|-------------------------------------------------------------------------------|
+| `geodata.db`     | Trips, waypoints, detected events, indexed file records, the indexing queue   |
+| `cloud_sync.db`  | Cloud-upload state, the archive queue, the LES queue, sync sessions           |
+
+Both files live next to the repo at runtime (the gadget_web service
+runs from the repo directory, so `geodata.db` and `cloud_sync.db`
+sit alongside `config.yaml`). They are **gitignored**; under no
+circumstance should they be committed.
+
+Both use SQLite's WAL mode for concurrent reader / single-writer
+access from the Flask app's worker threads.
+
+Both are **migrated automatically** on `gadget_web` startup. The
+schema versions are tracked in `mapping_migrations.py` (which
+defines schemas for **both** databases despite the name — see
+"Module split" below).
+
+---
+
+## `geodata.db`
+
+Holds everything the map page needs.
+
+### Tables
+
+| Table              | Purpose                                                                 |
+|--------------------|-------------------------------------------------------------------------|
+| `trips`            | One row per drive, defined as a continuous waypoint sequence            |
+| `waypoints`        | One row per indexed video frame: lat, lon, telemetry                    |
+| `detected_events`  | Events detected from waypoints (harsh brake, FSD disengage, etc.)       |
+| `indexed_files`    | One row per video file the indexer has processed                        |
+| `indexing_queue`   | Files waiting to be indexed; consumed by the indexing worker            |
+
+### `trips`
+
+A trip is a contiguous drive — waypoints separated by less than
+`mapping.trip_gap_minutes` minutes (default 5) belong to the same
+trip. Trips are **sacred**: only an explicit user "Delete Trip"
+action may remove them. Cleanup paths that find an orphaned
+`indexed_files` row only NULL the `video_path` references on
+related waypoints and events; they never touch the `trips` row.
+
+Approximate columns (see `mapping_migrations.py::_SCHEMA_SQL` for
+exact definitions): `id, start_time, end_time, start_lat,
+start_lon, end_lat, end_lon, distance_km, duration_seconds,
+source_folder, indexed_at`.
+
+### `waypoints`
+
+One row per indexed video frame. Carries the GPS point plus the
+full telemetry payload extracted from the H.264 SEI: speed,
+heading, accelerations, gear, autopilot state, steering, brake
+status, blinker positions. The `video_path` and `frame_offset`
+columns let the UI seek back to the source clip when the user
+clicks a point on the map.
+
+Approximate columns: `id, trip_id, timestamp, lat, lon, heading,
+speed_mps, acceleration_x, acceleration_y, acceleration_z, gear,
+autopilot_state, steering_angle, brake_applied, blinker_on_left,
+blinker_on_right, video_path, frame_offset`.
+
+### `detected_events`
+
+Events triggered by waypoint analysis: harsh brake, emergency
+brake, hard accel, sharp turn, speeding, FSD engage, FSD disengage.
+Thresholds are configurable under `mapping.event_detection` in
+`config.yaml`.
+
+Approximate columns: `id, trip_id, timestamp, lat, lon, event_type,
+severity, description, video_path, frame_offset, metadata`.
+
+### `indexed_files`
+
+Booking record for which video files have been processed. Keyed
+by `file_path` (the canonical path on disk). Used to dedupe and to
+drive the daily stale-scan that orphans rows whose underlying file
+has been deleted.
+
+Approximate columns: `file_path, file_size, file_mtime, indexed_at,
+waypoint_count, event_count`.
+
+### `indexing_queue`
+
+Inputs to the indexing worker. **Single producer / single consumer
+pattern** — multiple producers (file watcher, archive worker, boot
+catch-up scan, manual trigger) call `enqueue_for_indexing()` /
+`enqueue_many_for_indexing()`; the indexing worker thread is the
+only consumer.
+
+Approximate columns: `canonical_key, file_path, priority,
+enqueued_at, next_attempt_at, attempts, last_error,
+previous_last_error, claimed_by, claimed_at, source`.
+
+`canonical_key` is `mapping_service.canonical_key(path)`, which
+maps both the SD-card view and the USB-RO view of the same file
+to the same string so duplicate enqueues from different producers
+no-op.
+
+`status` is implicit in the column shape: `claimed_by IS NOT NULL`
+means a worker has the row; otherwise it's `pending`. Outcomes
+("indexed", "deferred", "errored") are terminal — successful and
+permanent-fail rows are deleted, retry rows have `attempts`
+incremented and `next_attempt_at` set.
+
+---
+
+## `cloud_sync.db`
+
+Holds everything related to cloud uploads and to the archive copy
+queue. Despite "cloud" in the name, the **archive queue** lives
+here too — both subsystems share the DB so a single backup file
+captures the entire transient queue state.
+
+### Tables
+
+| Table                | Purpose                                                              |
+|----------------------|----------------------------------------------------------------------|
+| `archive_queue`      | Files queued for copy from RO USB mount → `~/ArchivedClips/`          |
+| `cloud_synced_files` | Per-file cloud-upload state                                           |
+| `cloud_sync_sessions`| Audit log of sync runs                                                |
+| `live_event_queue`   | Per-event LES upload queue (only used when LES is enabled)            |
+
+### `archive_queue`
+
+The archive worker drains this. Producers: archive_producer (boot
+catch-up + watcher-driven), and the `archive_producer.enqueue_*`
+helpers called manually from triggered re-scans.
+
+Approximate columns: `id, source_path, dest_path, priority, status,
+attempts, last_error, previous_last_error, enqueued_at, claimed_at,
+claimed_by, copied_at, expected_size, expected_mtime`.
+
+`status` is an explicit enum:
+`pending`, `claimed`, `copied`, `source_gone`, `skipped_stationary`,
+`error`, `dead_letter`. Terminal: `copied`, `source_gone`,
+`skipped_stationary`, `dead_letter`. Retry: `error` (with backoff).
+
+`priority`:
+
+| Constant            | Value | Folders matched                        |
+|---------------------|-------|----------------------------------------|
+| `PRIORITY_EVENTS`   | 1     | `SentryClips/`, `SavedClips/`          |
+| `PRIORITY_RECENT_CLIPS` | 2 | `RecentClips/`                          |
+| `PRIORITY_OTHER`    | 3     | Anything else (boot/, root, …)         |
+
+(Constants in `archive_queue.py`. Lower number = higher priority.
+After PR #178 / #179 the priority order is "events first, then
+RecentClips, then other"; this overrode an earlier ordering.)
+
+### `cloud_synced_files`
+
+Per-file cloud upload state. Status enum: `pending`, `uploading`,
+`synced`, `failed`, `dead_letter`.
+
+A row is marked `synced` only **after rclone confirms upload AND
+the DB commit completes AND fsync returns**. Partials detected at
+restart (status `uploading` with no recent rclone process) are
+reset to `pending`.
+
+Approximate columns: `id, file_path, file_size, file_mtime,
+remote_path, status, synced_at, retry_count, last_error,
+previous_last_error`.
+
+### `cloud_sync_sessions`
+
+Audit-log table tracking each sync session: when it started, what
+triggered it, how many files moved, total bytes, errors. Used by
+the cloud sync UI to show "last sync" history.
+
+### `live_event_queue`
+
+LES-only. Populated by the file watcher's `event.json` callback
+firing `live_event_sync_service.enqueue_event_json()`.
+
+Approximate columns: `id, event_dir, event_json_path,
+event_timestamp, event_reason, upload_scope, status, enqueued_at,
+uploaded_at, next_retry_at, attempts, last_error,
+previous_last_error, bytes_uploaded`. **Unique on `event_dir`** —
+duplicate enqueues of the same event are no-ops.
+
+`status` enum: `pending`, `uploading`, `uploaded`, `failed`.
+`upload_scope` is one of `event_minute` (default — event.json plus
+the 6 cameras matching the timestamp's `YYYY-MM-DD_HH-MM` prefix)
+or `event_folder` (every `.mp4` in the event dir).
+
+Retry backoff is the constant
+`LIVE_EVENT_RETRY_BACKOFF_SECONDS = [30, 120, 300, 900, 3600]` —
+five attempts, growing from 30 seconds to 1 hour. After the last
+attempt, the row moves to `failed` and stays there until a manual
+retry via `/api/live_events/retry/<id>`.
+
+---
+
+## Module split
+
+The schema and queue API are intentionally split across modules:
+
+| Module                                                | Owns                                                                 |
+|-------------------------------------------------------|----------------------------------------------------------------------|
+| `services/mapping_migrations.py`                      | DDL for **both** databases, schema version constants, migrations      |
+| `services/indexing_queue_service.py`                  | Indexing-queue API (enqueue / claim / complete / defer / release)     |
+| `services/mapping_service.py`                         | Indexing core (`index_single_file`, `IndexResult`, trip merge, …)     |
+| `services/mapping_queries.py`                         | Read-only query helpers for the map UI (route polylines, RDP, …)     |
+| `services/archive_queue.py`                           | Archive-queue API + status enum                                       |
+| `services/cloud_archive_service.py`                   | Cloud upload state mutations                                          |
+| `services/live_event_sync_service.py`                 | LES queue mutations                                                   |
+
+Backward compatibility: `mapping_service` re-exports many of the
+schema/migration symbols so existing imports keep working. **New
+code should import from the dedicated module** (`indexing_queue_service`,
+`mapping_migrations`, `mapping_queries`) directly — the re-exports
+exist only to avoid breaking older callers.
+
+---
+
+## Migrations
+
+Schema versioning lives in `mapping_migrations.py`:
+
+```python
+_SCHEMA_VERSION = N        # current target version
+_BACKUP_RETENTION = M      # number of backups to keep
+_SCHEMA_SQL = "..."        # canonical CREATE TABLE / CREATE INDEX
+```
+
+On each `gadget_web` startup:
+
+1. Open both DBs in WAL mode.
+2. Read `PRAGMA user_version`.
+3. If less than `_SCHEMA_VERSION`, run the version-specific
+   migration helpers in order (`_migrate_to_v2`, `_migrate_to_v3`, …).
+4. Each migration helper is **idempotent** — safe to re-run after a
+   crashed migration.
+5. Take a backup snapshot before each migration; rotate per
+   `_BACKUP_RETENTION`.
+
+When you change the schema:
+
+1. Bump `_SCHEMA_VERSION`.
+2. Append the new DDL to `_SCHEMA_SQL`.
+3. Add a `_migrate_to_vN` helper that performs the upgrade against
+   an older live DB.
+4. Add a test that builds a vN-1 DB, runs the migration, and
+   asserts the expected vN shape.
+5. Document the change in
+   `reference/DB_SCHEMAS.md` *(planned, Wave 10)*.
+
+**Never delete a column without a deprecation cycle**. Always
+write the migration to leave old columns in place; remove them in
+a later release once you're sure no rollback is needed.
+
+---
+
+## Decision points
+
+| Question                                                  | Where decided                                            |
+|-----------------------------------------------------------|----------------------------------------------------------|
+| Should this enqueue be skipped as a duplicate?            | `mapping_service.canonical_key()` + UNIQUE index         |
+| Should this row become `dead_letter`?                     | `attempts >= retry_max_attempts` (per-subsystem config)  |
+| Should retention delete this orphaned `indexed_files`?    | `mapping_service.purge_deleted_videos()` (yes, but **never** the trip row) |
+| Should the migration take a backup first?                 | Always — every migration call snapshots the live DB      |
+
+---
+
+## Failure modes & recovery
+
+### Database file missing on startup
+
+`gadget_web` recreates it from the canonical schema, then runs all
+migrations. No error to the user. The new DB is empty — boot
+catch-up scan repopulates `indexing_queue`, the archive worker
+catches up, and the indexer fills `trips` / `waypoints` /
+`detected_events` over the next several hours.
+
+### Database file corrupt
+
+SQLite returns `SQLITE_CORRUPT` on the first read. `gadget_web`
+logs a critical error and refuses to start. Recovery:
+
+1. Restore the most recent migration backup from `*.db.bak.*`.
+2. Failing that, delete the corrupt file and let `gadget_web`
+   recreate it. Trip history is lost but Tesla footage on the SD
+   card is unaffected.
+
+### Stale claims from a crashed worker
+
+Boot recovery resets every claim with `claimed_at` older than the
+stale threshold. `archive_queue.recover_stale_claims()` and
+`indexing_queue_service.recover_stale_claims()` run automatically
+at worker startup. No data loss.
+
+### Mid-write power loss
+
+WAL mode plus the atomic-write contract (temp file → fsync →
+rename) means a partially written DB page is rolled back at next
+open. Workers' transactions are short and committed before
+acknowledging completion to producers.
+
+---
+
+## Source files
+
+- `scripts/web/services/mapping_migrations.py` — schemas + migrations
+- `scripts/web/services/indexing_queue_service.py` — indexing queue
+- `scripts/web/services/mapping_service.py` — indexing core, trip merge,
+  `purge_deleted_videos`
+- `scripts/web/services/mapping_queries.py` — read-only query helpers
+  for the map UI
+- `scripts/web/services/archive_queue.py` — archive queue + status enum
+- `scripts/web/services/cloud_archive_service.py` — cloud upload state
+- `scripts/web/services/live_event_sync_service.py` — LES queue

--- a/docs/operator/README.md
+++ b/docs/operator/README.md
@@ -1,0 +1,103 @@
+# Operator Documentation
+
+Welcome — this section is for **operators**, the people who deploy,
+configure, and run TeslaUSB devices. Whether you have one device
+plugged into your own car or you're managing a fleet, you should be
+able to answer every "what does this thing do, and how do I make it
+do what I want?" question by reading documents in this folder.
+
+If you're here to **modify the source code**, you want
+[`../contributor/README.md`](../contributor/README.md) instead.
+
+If you just installed your device for the first time, the
+[main project readme](../../readme.md) is the most up-to-date
+quickstart — come back here once the web interface is up and you
+want to know what each page does and how to keep things healthy.
+
+---
+
+## How to use this section
+
+Read the [top-level documentation README](../README.md) first if you
+haven't — it explains the conventions used throughout (Mermaid
+diagrams, source-file citations, etc.).
+
+Then dip in based on what you need:
+
+| If you want to…                                              | Start with                                                            |
+|--------------------------------------------------------------|-----------------------------------------------------------------------|
+| Understand what the device does end-to-end                   | [`../VIDEO_LIFECYCLE.md`](../VIDEO_LIFECYCLE.md)                       |
+| Understand how the parts fit together                        | [`../ARCHITECTURE.md`](../ARCHITECTURE.md)                             |
+| Look up an unfamiliar term                                   | [`../GLOSSARY.md`](../GLOSSARY.md)                                     |
+| Adjust a configuration value safely                          | `operator/CONFIGURATION_REFERENCE.md` *(planned, Wave 9)*              |
+| Find which systemd service does what                         | `operator/SERVICES_AND_TIMERS.md` *(planned, Wave 9)*                  |
+| Set up a cloud provider for backup                           | `operator/CLOUD_PROVIDERS_SETUP.md` *(planned, Wave 9)*                |
+| Diagnose a Failed Jobs entry                                 | `operator/FAILED_JOBS_AND_HEALTH.md` *(planned, Wave 9)*               |
+| Recover after a power loss / crash                           | `operator/BACKUP_AND_RECOVERY.md` *(planned, Wave 6)*                  |
+| Troubleshoot a non-obvious failure                           | `operator/TROUBLESHOOTING.md` *(planned, Wave 10)*                     |
+
+Documents marked *planned* are scheduled for an upcoming
+documentation wave (see the
+[status table](../README.md#documentation-status)). Until they land,
+the most authoritative source is the source code itself plus
+[`.github/copilot-instructions.md`](../../.github/copilot-instructions.md).
+
+---
+
+## What you should know up front
+
+A few facts that every operator hits on day one:
+
+1. **The web interface runs on port 80**, not 5000. URLs are simply
+   `http://<pi-ip>` or `http://<hostname>.local`. Port 80 is required
+   for the captive-portal splash screen to fire automatically when you
+   join the device's WiFi.
+
+2. **There is no "Edit Mode" / "Present Mode" toggle in the UI.**
+   The device handles RO/RW transitions transparently via
+   `quick_edit_part2`. The status dot in the header tells you the
+   visible state: green = normal, amber = "Network Sharing Active"
+   (Samba is up). All write operations work from the UI without you
+   needing to switch modes manually.
+
+3. **`*.img` files are protected.** Every delete code path refuses
+   to delete an `.img` file in `installation.mount_dir`. If you really
+   need to remove one, do it from a shell.
+
+4. **Tesla recording is sacred.** The device's #1 priority is to
+   present the USB drive within ~3 seconds of boot so Tesla never
+   misses a frame. Every background subsystem (archive, indexer,
+   cloud sync, LES) is read-only and yields to Tesla writes.
+
+5. **Reboots that look like crashes might be normal vehicle sleep.**
+   Tesla cuts USB power when the car sleeps. Unclean-shutdown journal
+   files (`*.journal~`) accumulate from both real watchdog resets and
+   normal vehicle sleep. The
+   [`MEMORY_AND_WATCHDOG.md`](../contributor/subsystems/MEMORY_AND_WATCHDOG.md)
+   *(planned, Wave 6)* doc explains how to tell them apart.
+
+---
+
+## Where to look when something is wrong
+
+Until the dedicated `TROUBLESHOOTING.md` lands, here is the
+short version:
+
+- **Check `/jobs`** — the Failed Jobs page surfaces every stuck
+  queue row across all subsystems with a recommendation
+  (Retry / Delete / Either) and a clip-value badge so you know
+  what's at stake.
+- **Check `/api/system/health`** — JSON dump of disk, memory,
+  worker liveness, queue depths, retention summary, archive
+  watchdog severity.
+- **Check `journalctl -u gadget_web.service -f`** for live logs.
+- **Check the `.github/copilot-instructions.md` file** for the
+  "Pitfalls to avoid" section, which lists known failure-mode
+  signatures.
+
+---
+
+## Source files
+
+This document is purely navigational; it has no source-code
+dependency.


### PR DESCRIPTION
## Wave 1 of the docs build-out

This is the first of 10 planned documentation waves. It lands the
**skeleton structure** (operator/ vs contributor/ split, the
flow-first authoring convention, the per-doc template) plus the
**flagship narrative** that ties every video-handling subsystem
together.

After this PR a reader can:

1. Open `docs/README.md` and navigate the tree.
2. Read `docs/ARCHITECTURE.md` for the system-level view.
3. Read `docs/VIDEO_LIFECYCLE.md` and understand exactly what
   happens to a Tesla-recorded clip from the moment the camera
   captures it through every decision the device makes.
4. Find every recurring term in `docs/GLOSSARY.md`.
5. Use the contributor docs (`REPO_LAYOUT.md`, `DEV_WORKFLOW.md`,
   `core/CONFIGURATION_SYSTEM.md`, `core/DATABASES.md`) to start
   making changes safely.

### What's in this PR

10 new docs (3,178 insertions, 0 deletions, no code touched):

**Top level**
- `docs/README.md` — TOC, audience map, doc-status table, conventions
- `docs/ARCHITECTURE.md` — system overview with Mermaid component
  diagram, layered view of hardware → kernel → systemd → Flask
- `docs/VIDEO_LIFECYCLE.md` — **flagship**, 762 lines, traces a
  clip end-to-end: Tesla writes → file watcher → archive → indexing
  → mapping → cloud (cloud_archive vs LES) → retention → user
  delete. Every branch, every IndexOutcome, every retry path
  enumerated.
- `docs/GLOSSARY.md` — every recurring term (LUN, mvhd, LES,
  quick_edit, present mode, sacred trips, etc.) defined and
  grouped by topic.

**Operator entry**
- `docs/operator/README.md` — entry point with planned-doc
  table mapped to wave numbers.

**Contributor**
- `docs/contributor/README.md` — entry point + topic→doc table +
  non-obvious rules.
- `docs/contributor/REPO_LAYOUT.md` — full source tree, blueprints
  table, services table, "where to look for common tasks" table.
- `docs/contributor/DEV_WORKFLOW.md` — 11-step issue→deploy
  workflow with Mermaid flowchart, plus "things to never do".
- `docs/contributor/core/CONFIGURATION_SYSTEM.md` — `config.yaml`
  + `scripts/config.sh` (Bash, `yq`) + `scripts/web/config.py`
  (Python, PyYAML) + template-substitution layer.
- `docs/contributor/core/DATABASES.md` — `geodata.db` and
  `cloud_sync.db` table-by-table overview, migration model, the
  sacred-trips contract.

### Conventions established by this wave

- **Markdown + Mermaid** — sequence diagrams + flowcharts +
  decision tables. GitHub renders Mermaid natively.
- **Citations by function name + module path** — never line
  numbers (they drift). Every doc ends with a `## Source files`
  footer listing the modules it covers, so reviewers touching
  those modules know which docs to update.
- **Decision-points front and center** — every subsystem doc must
  have at least one truth table or Mermaid decision tree
  enumerating the branches the code takes.
- **Flow-first authoring** — `flows/` is a first-class directory
  (Wave 3+), not an appendix. The `VIDEO_LIFECYCLE.md` flagship
  is the prototype for that convention at the docs root.
- **Per-doc template**: At a glance → Sequence diagram →
  Step-by-step walkthrough → Decision points → Configuration →
  Failure modes & recovery → Source files.

### What's NOT in this PR

- No code changes.
- No tests changed (TeslaUSB has no docs-lint pipeline).
- No `readme.md` changes — the user-facing install quickstart
  stays as-is until Wave 10 adds a "Full Documentation" pointer.
- No `UI_UX_DESIGN_SYSTEM.md` changes — it stays exactly as is.
- No subsystem deep-dives yet — those land in Waves 2–8 (one wave
  per coherent subsystem cluster).

### Validation

All 10 docs:
- ✅ Have `## Source files` footers
- ✅ Have balanced code fences (verified via PowerShell scan)
- ✅ Use only relative cross-links
- ✅ Cite functions and modules, never line numbers
- ✅ Reference real symbols / config keys verified against the
  current source

The Mermaid blocks all parse — they were checked for matching
fence count and bracket balance before commit.

### Plan for the remaining waves

Per the approved plan in the session workspace:

- **Wave 2** — Core internals (5 docs: BOOT_SEQUENCE,
  USB_GADGET_AND_MODES, MOUNT_SAFETY, TASK_COORDINATOR,
  FILE_SAFETY)
- **Wave 3** — Video pipeline subsystems + flows + decision
  references (12 docs)
- **Wave 4** — Cloud + sync (6 docs)
- **Wave 5** — Video playback / deletion / retention (4 docs)
- **Wave 6** — Networking + safety (5 docs)
- **Wave 7** — Mode + boot flows (5 docs)
- **Wave 8** — Asset-management subsystems + flows (8 docs)
- **Wave 9** — Operator runbooks (8 docs)
- **Wave 10** — Reference completion + polish (5 docs)

Each wave ships as its own PR.

---

🤖 Generated with the GitHub Copilot CLI.
