### PR TITLE
refactor(#184): I/O reduction (Wave 2 — Phases B+C+E+F)

### DIFF
--- a/scripts/web/blueprints/storage_retention.py
+++ b/scripts/web/blueprints/storage_retention.py
@@ -440,6 +440,42 @@ def api_cleanup_run_now():
     }), 200
 
 
+@storage_retention_bp.route('/api/cleanup/reconcile_index', methods=['POST'])
+def api_reconcile_index():
+    """Trigger an immediate stale-scan reconciliation pass.
+
+    Issue #184 Wave 2 — Phase F: the periodic stale scan that used to
+    run daily now runs monthly (real-time deletes still fire via the
+    watcher's ``register_delete_callback`` so this is a safety-net
+    cadence change). This endpoint exposes a manual "Reconcile" button
+    so an operator who suspects orphans (e.g., after a manual ``rm``
+    over SSH, or after an SD-card image swap) can request a one-shot
+    scan without waiting up to ~30 days.
+
+    Wraps :func:`mapping_service.trigger_stale_scan_now` with the
+    standard 10-minute debounce so a click-spam doesn't queue multiple
+    scans. Returns immediately; the scan runs on a daemon thread.
+    """
+    try:
+        from services.mapping_service import trigger_stale_scan_now
+        from services.video_service import get_teslacam_path
+        from config import MAPPING_DB_PATH
+        result = trigger_stale_scan_now(
+            MAPPING_DB_PATH, get_teslacam_path, source='manual_reconcile',
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("storage_retention: trigger_stale_scan_now raised")
+        return jsonify({
+            'success': False,
+            'message': f"Reconcile failed: {exc}",
+        }), 500
+
+    return jsonify({
+        'success': True,
+        'result': result if isinstance(result, dict) else {},
+    }), 200
+
+
 @storage_retention_bp.route('/api/cleanup/reclaim_stationary_recent',
                              methods=['POST'])
 def api_reclaim_stationary_recent():
@@ -535,18 +571,37 @@ def api_get_skipped_stationary_tally():
     endpoint exists purely to power the badge so operators can see how
     many overnight Sentry-mode RecentClips were skipped at source in
     the last 24 hours.
+
+    Issue #184 Wave 2 — Phase B: skips now happen at the producer
+    (no DB row written) so the count is the SUM of:
+
+      * the in-memory deque managed by ``archive_producer`` for
+        post-Wave-2 skips, and
+      * the legacy ``count_skipped_stationary_recent`` for any
+        rows already in ``archive_queue`` from before the upgrade
+        (worker-side fallback path also writes here as
+        defense-in-depth).
     """
     skipped_24h = 0
     try:
         from services import archive_queue
-        skipped_24h = int(
+        skipped_24h += int(
             archive_queue.count_skipped_stationary_recent(24)
         )
     except Exception:  # noqa: BLE001
         logger.exception(
-            "skipped_stationary status: count helper failed"
+            "skipped_stationary status: legacy DB count helper failed"
         )
-        skipped_24h = 0
+
+    try:
+        from services import archive_producer
+        skipped_24h += int(
+            archive_producer.get_skipped_stationary_count(24)
+        )
+    except Exception:  # noqa: BLE001
+        logger.exception(
+            "skipped_stationary status: producer tally helper failed"
+        )
 
     return jsonify({
         'success': True,
@@ -563,6 +618,10 @@ def api_clear_skipped_stationary_tally():
     files-lost banner (issue #163) — the operator has acknowledged
     the running tally and wants the badge zeroed without waiting
     24 h for it to age out. Returns the number of rows deleted.
+
+    Issue #184 Wave 2 — Phase B: also clears the in-memory deque the
+    producer maintains for post-Wave-2 skips so the badge truly
+    zeroes out across both legacy and current code paths.
     """
     try:
         from services import archive_queue
@@ -573,6 +632,13 @@ def api_clear_skipped_stationary_tally():
             'success': False,
             'message': f"Clear failed: {exc}",
         }), 500
+    try:
+        from services import archive_producer
+        archive_producer.reset_skipped_stationary_tally()
+    except Exception:  # noqa: BLE001
+        logger.exception(
+            "skipped_stationary: producer tally reset failed (non-fatal)"
+        )
     return jsonify({
         'success': True,
         'deleted': n,

--- a/scripts/web/services/archive_producer.py
+++ b/scripts/web/services/archive_producer.py
@@ -185,10 +185,17 @@ def _peek_clip_for_gps(source_path: str) -> Optional[bool]:
     """Producer-side wrapper around the worker's SEI peek.
 
     Mirrors :func:`archive_worker._clip_has_gps_signal` so the producer
-    doesn't have to import the worker module (one-way dependency:
-    worker imports producer-side helpers, never the reverse).
-    Returns the same tri-state: True (has GPS), False (no GPS / skip),
-    None (parse error / fall through).
+    doesn't have to import the worker module at load time (one-way
+    dependency: the worker may import producer-side helpers, never
+    the reverse). Returns the same tri-state: True (has GPS), False
+    (no GPS / skip), None (parse error / fall through).
+
+    The peek tunables (``MAX_MESSAGES``, ``SAMPLE_RATE``,
+    ``MAX_WALK_BYTES``) are pulled from the worker module at call time
+    so a tuning change in one place takes effect in both. Lazy import
+    keeps the producer's load-time footprint light and avoids a
+    circular dependency (worker imports producer, never the other way
+    at module load).
     """
     try:
         from services import sei_parser
@@ -199,12 +206,19 @@ def _peek_clip_for_gps(source_path: str) -> Optional[bool]:
         )
         return None
 
-    # Mirror archive_worker constants exactly. They live there for the
-    # worker-side defense-in-depth peek; we don't import them to keep
-    # the producer module's load profile light.
-    _MAX_MESSAGES = 90
-    _SAMPLE_RATE = 30
-    _MAX_WALK_BYTES = 2 * 1024 * 1024
+    try:
+        from services.archive_worker import (
+            _SKIP_GPS_PEEK_MAX_MESSAGES as _MAX_MESSAGES,
+            _SKIP_GPS_PEEK_SAMPLE_RATE as _SAMPLE_RATE,
+            _SKIP_GPS_PEEK_MAX_WALK_BYTES as _MAX_WALK_BYTES,
+        )
+    except Exception:  # noqa: BLE001
+        # Worker not importable in this context (e.g., a focused
+        # producer-only test); fall back to the same defaults the
+        # worker uses today. Keep these in sync with archive_worker.py.
+        _MAX_MESSAGES = 90
+        _SAMPLE_RATE = 30
+        _MAX_WALK_BYTES = 2 * 1024 * 1024
 
     scanned = 0
     try:
@@ -258,7 +272,7 @@ def enqueue_with_peek(paths: Iterable[str],
         if not raw:
             continue
         considered += 1
-        priority = archive_queue._infer_priority(raw)
+        priority = archive_queue.infer_priority(raw)
         if priority != archive_queue.PRIORITY_RECENT_CLIPS:
             pending_enqueue.append(raw)
             continue

--- a/scripts/web/services/archive_producer.py
+++ b/scripts/web/services/archive_producer.py
@@ -27,6 +27,17 @@ no worker drains them until Phase 2b. The producer thread therefore
 performs zero copy work, no network I/O, and never touches the gadget
 or any mount — pure read-side observer.
 
+**Issue #184 Wave 2 — Phase B**: the SEI peek that decides whether a
+RecentClips clip is stationary now runs **before** the row is enqueued
+(via :func:`enqueue_with_peek`). Stationary clips never become a
+queue row, so the worker's pick-claim-stat-skip-mark-row cycle (~6 SD
+writes per row) collapses to zero SD writes for the parked-overnight
+common case. The skipped count is tallied in an in-memory deque
+(:func:`get_skipped_stationary_count`) so the Settings badge still has
+a number to show without hitting the DB. The worker-side peek stays as
+defense-in-depth for legacy rows already in the queue at upgrade time
+and for tests that bypass the producer.
+
 Public API:
 
 * :func:`start_producer(teslacam_root, db_path, *, rescan_interval_seconds, boot_catchup_enabled)` — start the thread (idempotent).
@@ -34,10 +45,17 @@ Public API:
 * :func:`get_producer_status()` — small dict for the observability stub.
 * :func:`run_boot_catchup_once(teslacam_root, db_path)` — synchronous
   helper exposed for tests; never call from the request thread.
+* :func:`enqueue_with_peek(paths, db_path)` — enqueue a batch with the
+  Phase B SEI peek applied to RecentClips candidates.
+* :func:`get_skipped_stationary_count(hours)` — return the in-memory
+  count of clips skipped at the producer in the last N hours.
+* :func:`reset_skipped_stationary_tally()` — clear the in-memory deque
+  (for tests and the "clear badge" admin action).
 """
 
 from __future__ import annotations
 
+import collections
 import logging
 import os
 import threading
@@ -63,6 +81,27 @@ _WATCH_SUBDIRS = ('RecentClips', 'SentryClips', 'SavedClips')
 # Flask app pulls from ``config.yaml``).
 _DEFAULT_RESCAN_INTERVAL = 60.0
 
+# Issue #184 Wave 2 — Phase B: minimum file age before the producer
+# will run an SEI peek on a RecentClips candidate. Mirrors the
+# worker's stable-write gate so we never peek at a half-written file
+# and misclassify it as stationary because GPS lock hasn't been
+# written yet. Reads the same config value at call time so tests can
+# monkeypatch.
+_STABLE_WRITE_AGE_FALLBACK = 5.0
+
+
+def _stable_write_age_seconds() -> float:
+    """Return ``ARCHIVE_QUEUE_STABLE_WRITE_AGE_SECONDS`` from config.
+
+    Falls back to ``_STABLE_WRITE_AGE_FALLBACK`` (5 s) if config isn't
+    importable (unit-test environments without the full app).
+    """
+    try:
+        from config import ARCHIVE_QUEUE_STABLE_WRITE_AGE_SECONDS
+        return float(ARCHIVE_QUEUE_STABLE_WRITE_AGE_SECONDS)
+    except Exception:  # noqa: BLE001
+        return _STABLE_WRITE_AGE_FALLBACK
+
 
 # ---------------------------------------------------------------------------
 # Module state — every read/write through ``_state_lock``
@@ -81,15 +120,188 @@ _state: Dict = {
     'last_scan_at': None,
     'last_enqueued': 0,
     'last_seen': 0,
+    'last_skipped_stationary': 0,
     'last_error': None,
     'started_at': None,
 }
+
+
+# Issue #184 Wave 2 — Phase B: in-memory rolling tally of skip-at-source
+# decisions. Deque of monotonic timestamps (``time.time()``). We bound
+# the maxlen at 10 000 so a runaway condition can't grow this without
+# limit; in practice a parked Pi sees ~144 stationary clips per day
+# (RecentClips writes one per minute), so 10 000 is ~70 days of headroom
+# at full saturation. Resets on service restart — that's acceptable for
+# a 24-hour badge and avoids the SD writes the legacy DB-backed counter
+# was incurring.
+_SKIPPED_TALLY_MAX = 10000
+_skipped_tally_lock = threading.Lock()
+_skipped_tally: 'collections.deque[float]' = collections.deque(
+    maxlen=_SKIPPED_TALLY_MAX,
+)
 
 
 def _is_running() -> bool:
     with _state_lock:
         t = _thread
     return t is not None and t.is_alive()
+
+
+def reset_skipped_stationary_tally() -> None:
+    """Clear the in-memory skip tally. Test / admin helper."""
+    with _skipped_tally_lock:
+        _skipped_tally.clear()
+
+
+def get_skipped_stationary_count(hours: int = 24) -> int:
+    """Return how many clips were skipped at the producer in the last N hours.
+
+    Issue #184 Wave 2 — Phase B: replaces the DB-backed
+    ``count_skipped_stationary_recent`` for the post-Phase-B steady
+    state. The Settings badge reads this PLUS the legacy DB count so
+    historical rows from before the upgrade still show.
+
+    Walks the deque from oldest, evicts anything older than the
+    horizon, and returns the remaining size. O(N) in evicted entries
+    but those entries are dropped permanently so amortized O(1) per
+    skip.
+    """
+    if hours <= 0:
+        return 0
+    horizon = time.time() - (int(hours) * 3600)
+    with _skipped_tally_lock:
+        while _skipped_tally and _skipped_tally[0] < horizon:
+            _skipped_tally.popleft()
+        return len(_skipped_tally)
+
+
+def _record_skip() -> None:
+    """Append a skip timestamp to the in-memory tally."""
+    with _skipped_tally_lock:
+        _skipped_tally.append(time.time())
+
+
+def _peek_clip_for_gps(source_path: str) -> Optional[bool]:
+    """Producer-side wrapper around the worker's SEI peek.
+
+    Mirrors :func:`archive_worker._clip_has_gps_signal` so the producer
+    doesn't have to import the worker module (one-way dependency:
+    worker imports producer-side helpers, never the reverse).
+    Returns the same tri-state: True (has GPS), False (no GPS / skip),
+    None (parse error / fall through).
+    """
+    try:
+        from services import sei_parser
+    except Exception as e:  # noqa: BLE001
+        logger.debug(
+            "archive_producer._peek_clip_for_gps: sei_parser unavailable "
+            "(%s); deferring to worker", e,
+        )
+        return None
+
+    # Mirror archive_worker constants exactly. They live there for the
+    # worker-side defense-in-depth peek; we don't import them to keep
+    # the producer module's load profile light.
+    _MAX_MESSAGES = 90
+    _SAMPLE_RATE = 30
+    _MAX_WALK_BYTES = 2 * 1024 * 1024
+
+    scanned = 0
+    try:
+        for msg in sei_parser.extract_sei_messages(
+                source_path,
+                sample_rate=_SAMPLE_RATE,
+                max_walk_bytes=_MAX_WALK_BYTES):
+            scanned += 1
+            if msg.has_gps:
+                return True
+            if scanned >= _MAX_MESSAGES:
+                break
+        return False
+    except FileNotFoundError:
+        return None
+    except Exception as e:  # noqa: BLE001
+        logger.debug(
+            "archive_producer._peek_clip_for_gps: peek failed for %s "
+            "(%s); deferring to worker", source_path, e,
+        )
+        return None
+
+
+def enqueue_with_peek(paths: Iterable[str],
+                      db_path: Optional[str] = None) -> Dict[str, int]:
+    """Enqueue ``paths`` into ``archive_queue`` with the Phase B SEI peek.
+
+    For each path:
+
+    * If the path is **not** a RecentClips candidate (i.e., it's a
+      Sentry/Saved event clip), enqueue it immediately. Event clips
+      bypass the SEI peek.
+    * If the path **is** a RecentClips candidate, ``stat()`` it. If
+      the file is younger than ``_stable_write_age_seconds()`` (Tesla
+      may still be writing it), enqueue immediately and let the
+      worker's stable-write gate handle freshness — a fresh file
+      could legitimately be missing GPS just because Tesla hasn't
+      written the lock-acquired SEI yet. If the file is old enough,
+      run the SEI peek. ``False`` means stationary → record the skip
+      in the in-memory tally and DO NOT enqueue. ``True`` or ``None``
+      → enqueue normally.
+
+    Returns ``{enqueued, skipped_stationary, considered}`` so callers
+    can update their own counters.
+    """
+    pending_enqueue: List[str] = []
+    skipped = 0
+    considered = 0
+    stable_age = _stable_write_age_seconds()
+    for raw in paths:
+        if not raw:
+            continue
+        considered += 1
+        priority = archive_queue._infer_priority(raw)
+        if priority != archive_queue.PRIORITY_RECENT_CLIPS:
+            pending_enqueue.append(raw)
+            continue
+        # RecentClips — apply the freshness gate, then peek.
+        try:
+            mtime = os.path.getmtime(raw)
+        except OSError:
+            # Source vanished between watcher fire and our stat;
+            # silently drop — next scan will not see it either.
+            continue
+        if (time.time() - mtime) < stable_age:
+            # Too fresh — defer to the worker so we never misclassify
+            # a half-written clip as stationary.
+            pending_enqueue.append(raw)
+            continue
+        verdict = _peek_clip_for_gps(raw)
+        if verdict is False:
+            _record_skip()
+            skipped += 1
+            logger.debug(
+                "archive_producer: skipped stationary RecentClips at "
+                "source: %s", raw,
+            )
+            continue
+        # True or None — enqueue.
+        pending_enqueue.append(raw)
+
+    enqueued = 0
+    if pending_enqueue:
+        try:
+            enqueued = archive_queue.enqueue_many_for_archive(
+                pending_enqueue, db_path=db_path,
+            )
+        except Exception as e:  # noqa: BLE001
+            logger.warning(
+                "archive_producer.enqueue_with_peek: "
+                "enqueue_many_for_archive failed: %s", e,
+            )
+    return {
+        'enqueued': enqueued,
+        'skipped_stationary': skipped,
+        'considered': considered,
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -145,21 +357,31 @@ def _iter_archive_candidates(teslacam_root: str) -> List[str]:
 
 
 def _scan_once(teslacam_root: str, db_path: str) -> Dict[str, int]:
-    """Run one scan iteration. Returns ``{seen, enqueued}``.
+    """Run one scan iteration. Returns ``{seen, enqueued, skipped_stationary}``.
 
-    Logs only when something was newly enqueued (avoid log spam from
-    the steady-state every-60-s rescan).
+    Logs only when something was newly enqueued or skipped (avoid log
+    spam from the steady-state every-60-s rescan).
+
+    Issue #184 Wave 2 — Phase B: routes the batch through
+    :func:`enqueue_with_peek` so RecentClips clips with no GPS-bearing
+    SEI never become a queue row.
     """
     seen = _iter_archive_candidates(teslacam_root)
     if not seen:
-        return {'seen': 0, 'enqueued': 0}
-    enqueued = archive_queue.enqueue_many_for_archive(seen, db_path=db_path)
-    if enqueued > 0:
+        return {'seen': 0, 'enqueued': 0, 'skipped_stationary': 0}
+    result = enqueue_with_peek(seen, db_path=db_path)
+    enqueued = int(result.get('enqueued', 0))
+    skipped = int(result.get('skipped_stationary', 0))
+    if enqueued > 0 or skipped > 0:
         logger.info(
-            "archive_producer: scan enqueued %d new clip(s) (saw %d total)",
-            enqueued, len(seen),
+            "archive_producer: scan enqueued=%d, skipped_stationary=%d "
+            "(saw %d total)", enqueued, skipped, len(seen),
         )
-    return {'seen': len(seen), 'enqueued': enqueued}
+    return {
+        'seen': len(seen),
+        'enqueued': enqueued,
+        'skipped_stationary': skipped,
+    }
 
 
 def run_boot_catchup_once(teslacam_root: str,
@@ -320,6 +542,9 @@ def _run_loop(teslacam_root: str, db_path: Optional[str],
                 _state['last_scan_at'] = time.time()
                 _state['last_seen'] = int(result.get('seen', 0))
                 _state['last_enqueued'] = int(result.get('enqueued', 0))
+                _state['last_skipped_stationary'] = int(
+                    result.get('skipped_stationary', 0)
+                )
                 _state['last_error'] = None
         except Exception as e:  # noqa: BLE001  -- never let producer die
             logger.exception("archive_producer scan iteration failed")

--- a/scripts/web/services/archive_queue.py
+++ b/scripts/web/services/archive_queue.py
@@ -156,6 +156,16 @@ def _infer_priority(path: str) -> int:
     return PRIORITY_OTHER
 
 
+# Public alias for callers outside the archive_queue module that need
+# to compute the priority for a path before enqueueing (e.g.
+# ``archive_producer.enqueue_with_peek`` decides whether to apply the
+# SEI peek based on whether a candidate is a RecentClips clip). Kept
+# as an alias rather than a renamed function so the original
+# underscore-prefixed name remains valid for in-module callers and
+# downstream tests that monkeypatch it.
+infer_priority = _infer_priority
+
+
 # ---------------------------------------------------------------------------
 # Connection helpers
 # ---------------------------------------------------------------------------

--- a/scripts/web/services/archive_worker.py
+++ b/scripts/web/services/archive_worker.py
@@ -281,6 +281,26 @@ def _maybe_trigger_critical_cleanup(archive_root: str) -> bool:
                 "archive_worker: disk-critical cleanup raised: %s", e,
             )
 
+        # Issue #184 Wave 2 — Phase F: also trigger an out-of-cycle
+        # stale scan so any indexed_files rows whose underlying clip
+        # was just rotated/pruned are reaped immediately, not in
+        # ~30 days when the periodic sweep would otherwise run.
+        # ``trigger_stale_scan_now`` is itself debounced (10 min) so
+        # repeated disk-critical signals collapse into a single scan.
+        try:
+            from services.mapping_service import trigger_stale_scan_now
+            from services.video_service import get_teslacam_path
+            from config import MAPPING_DB_PATH
+            trigger_stale_scan_now(
+                MAPPING_DB_PATH, get_teslacam_path,
+                source='disk_critical',
+            )
+        except Exception as e:  # noqa: BLE001
+            logger.debug(
+                "archive_worker: disk-critical stale-scan trigger "
+                "skipped: %s", e,
+            )
+
     logger.info(
         "archive_worker: disk-critical at %s — triggering immediate "
         "retention cleanup (debounced, daemon thread)", archive_root,

--- a/scripts/web/services/mapping_migrations.py
+++ b/scripts/web/services/mapping_migrations.py
@@ -46,7 +46,7 @@ logger = logging.getLogger(__name__)
 # Database Schema & Management
 # ---------------------------------------------------------------------------
 
-_SCHEMA_VERSION = 13
+_SCHEMA_VERSION = 14
 _BACKUP_RETENTION = 3  # Keep this many migration backups before pruning oldest
 
 _SCHEMA_SQL = """
@@ -228,6 +228,20 @@ CREATE INDEX IF NOT EXISTS archive_queue_ready
 CREATE INDEX IF NOT EXISTS archive_queue_source_gone_claimed
     ON archive_queue(claimed_at)
     WHERE status = 'source_gone';
+
+-- v14 (issue #184 Wave 2 — Phase E): generic key/value table for
+-- service-level scalars that don't merit their own table. First
+-- consumer is the boot catch-up scan watermark
+-- (``boot_catchup_archived_max_mtime``): the highest mtime seen by
+-- ``boot_catchup_scan`` in any prior run, so the next run can short-
+-- circuit the dir-walk + canonical_key + DB-lookup work for the
+-- unchanged majority of files. Stored as TEXT so future scalars
+-- (versions, last-run timestamps, feature flags) don't need new
+-- migrations. Lookup key is unique; values are opaque to the schema.
+CREATE TABLE IF NOT EXISTS kv_meta (
+    key TEXT PRIMARY KEY,
+    value TEXT
+);
 """
 
 
@@ -481,6 +495,13 @@ def _init_db(db_path: str) -> sqlite3.Connection:
                 )
                 conn.commit()
                 return conn
+        # v14 (issue #184 Wave 2 — Phase E): ``kv_meta`` table for
+        # service-level scalars (boot catch-up watermark, etc.).
+        # Created by the executescript above (CREATE TABLE IF NOT
+        # EXISTS is idempotent); no data migration required — the
+        # first ``boot_catchup_scan`` after the upgrade will take the
+        # full O(N) hit, then write the watermark, and every
+        # subsequent boot will short-circuit on the watermark.
         conn.execute("DELETE FROM schema_version")
         conn.execute(
             "INSERT INTO schema_version (version) VALUES (?)",

--- a/scripts/web/services/mapping_service.py
+++ b/scripts/web/services/mapping_service.py
@@ -1894,11 +1894,106 @@ def purge_deleted_videos(db_path: str, teslacam_path: Optional[str] = None,
     }
 
 
+def _kv_get(conn: sqlite3.Connection, key: str) -> Optional[str]:
+    """Read a value from the ``kv_meta`` table. Returns None if absent."""
+    try:
+        row = conn.execute(
+            "SELECT value FROM kv_meta WHERE key = ?", (key,),
+        ).fetchone()
+        return row[0] if row else None
+    except sqlite3.Error:
+        return None
+
+
+def _kv_set(conn: sqlite3.Connection, key: str, value: str) -> None:
+    """Upsert a value into the ``kv_meta`` table. Best-effort; logs on failure."""
+    try:
+        conn.execute(
+            "INSERT INTO kv_meta (key, value) VALUES (?, ?) "
+            "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+            (key, value),
+        )
+        conn.commit()
+    except sqlite3.Error as e:
+        logger.warning("kv_meta upsert failed for %r: %s", key, e)
+
+
+# Persistent key for the boot catch-up watermark (Phase E).
+_BOOT_CATCHUP_WATERMARK_KEY = 'boot_catchup_archived_max_mtime'
+
+
+def _iter_archived_with_mtime() -> Generator[Tuple[str, float], None, None]:
+    """Yield ``(path, mtime)`` for every front-camera mp4 under ARCHIVE_DIR.
+
+    Sister generator to ``_find_archived_videos`` that also returns the
+    file's mtime so the boot catch-up scan (Phase E) can apply its
+    watermark gate without an extra ``os.stat`` round-trip per file.
+    Yields nothing if archiving is disabled or the directory is absent.
+    """
+    try:
+        from config import ARCHIVE_DIR, ARCHIVE_ENABLED
+    except ImportError:
+        return
+    if not ARCHIVE_ENABLED or not ARCHIVE_DIR or not os.path.isdir(ARCHIVE_DIR):
+        return
+
+    def _stat_mtime(p: str) -> Optional[float]:
+        try:
+            return os.path.getmtime(p)
+        except OSError:
+            return None
+
+    # Top-level mp4s (legacy archive layout — flat directory).
+    try:
+        for f in sorted(os.listdir(ARCHIVE_DIR)):
+            full = os.path.join(ARCHIVE_DIR, f)
+            if (
+                os.path.isfile(full)
+                and f.lower().endswith('.mp4')
+                and '-front' in f.lower()
+            ):
+                m = _stat_mtime(full)
+                if m is not None:
+                    yield full, m
+    except OSError:
+        return
+
+    for sub in ('RecentClips', 'SavedClips', 'SentryClips'):
+        sub_path = os.path.join(ARCHIVE_DIR, sub)
+        if not os.path.isdir(sub_path):
+            continue
+        try:
+            for entry in sorted(os.listdir(sub_path)):
+                entry_path = os.path.join(sub_path, entry)
+                if os.path.isfile(entry_path):
+                    if (
+                        entry.lower().endswith('.mp4')
+                        and '-front' in entry.lower()
+                    ):
+                        m = _stat_mtime(entry_path)
+                        if m is not None:
+                            yield entry_path, m
+                    continue
+                if not os.path.isdir(entry_path):
+                    continue
+                try:
+                    for f in sorted(os.listdir(entry_path)):
+                        if f.lower().endswith('.mp4') and '-front' in f.lower():
+                            ev_path = os.path.join(entry_path, f)
+                            m = _stat_mtime(ev_path)
+                            if m is not None:
+                                yield ev_path, m
+                except OSError:
+                    continue
+        except OSError:
+            continue
+
+
 def boot_catchup_scan(db_path: str, teslacam_path: str = '',
                       *, source: str = 'catchup') -> Dict[str, int]:
     """Diff filesystem vs ``indexed_files`` and enqueue any orphans.
 
-    **Phase 2b (issue #76)**: This now walks ONLY ``ARCHIVE_DIR``
+    **Phase 2b (issue #76)**: This walks ONLY ``ARCHIVE_DIR``
     (``~/ArchivedClips``). The ``archive_producer`` thread handles
     USB-side catch-up by enqueueing into ``archive_queue``; the
     ``archive_worker`` then copies clips into ArchivedClips, where
@@ -1906,22 +2001,87 @@ def boot_catchup_scan(db_path: str, teslacam_path: str = '',
     moment of the worker's enqueue (e.g. a manual scp landed a clip
     while ``gadget_web`` was restarting).
 
+    **Phase E (issue #184 Wave 2)**: A persistent watermark
+    (``kv_meta.boot_catchup_archived_max_mtime``) records the highest
+    file mtime seen by any prior run. The walker stat()s every file
+    (a cheap inode read) but only does the canonical_key + DB-lookup
+    + enqueue work for files newer than the watermark. The first run
+    after upgrade still pays the full cost, but every subsequent boot
+    drops to O(new files) — typically zero work because the file
+    watcher already handled real-time arrivals.
+
     The ``teslacam_path`` parameter is accepted for backward
     compatibility but is **ignored** — there is intentionally no path
     from this function to the RO USB mount any more.
 
-    Returns ``{scanned, already_indexed, enqueued}``. The
-    ``active_file`` banner stays off during this call (no parsing); the
-    banner only lights up when the worker actually picks up an orphan.
+    Returns ``{scanned, already_indexed, enqueued, skipped_by_watermark}``.
+    The ``active_file`` banner stays off during this call (no
+    parsing); the banner only lights up when the worker actually
+    picks up an orphan.
     """
     # ``teslacam_path`` is intentionally ignored — see docstring.
     del teslacam_path
-    result = {'scanned': 0, 'already_indexed': 0, 'enqueued': 0}
+    result = {
+        'scanned': 0, 'already_indexed': 0, 'enqueued': 0,
+        'skipped_by_watermark': 0,
+    }
 
-    # Build the set of canonical_keys already represented in
-    # indexed_files. We diff against canonical keys (not raw paths) so a
-    # clip that exists in both Recent and Archived doesn't get
-    # re-enqueued.
+    # First pass: collect new (path, mtime) tuples; everything below the
+    # watermark is dropped without any string slicing or DB work.
+    try:
+        conn = _init_db(db_path)
+        try:
+            wm_raw = _kv_get(conn, _BOOT_CATCHUP_WATERMARK_KEY)
+        finally:
+            conn.close()
+    except sqlite3.Error as e:
+        logger.warning(
+            "boot_catchup_scan: watermark read failed (%s) — full scan",
+            e,
+        )
+        wm_raw = None
+
+    try:
+        watermark = float(wm_raw) if wm_raw is not None else 0.0
+    except (TypeError, ValueError):
+        watermark = 0.0
+
+    new_files: List[Tuple[str, float]] = []
+    new_max_mtime = watermark
+    for fpath, mtime in _iter_archived_with_mtime():
+        result['scanned'] += 1
+        if mtime > new_max_mtime:
+            new_max_mtime = mtime
+        if mtime <= watermark:
+            result['skipped_by_watermark'] += 1
+            continue
+        new_files.append((fpath, mtime))
+
+    # Fast path: nothing new since last boot — skip the DB read entirely.
+    if not new_files:
+        if new_max_mtime > watermark:
+            try:
+                conn = _init_db(db_path)
+                try:
+                    _kv_set(
+                        conn, _BOOT_CATCHUP_WATERMARK_KEY,
+                        repr(new_max_mtime),
+                    )
+                finally:
+                    conn.close()
+            except sqlite3.Error as e:
+                logger.warning(
+                    "boot_catchup_scan: watermark write failed: %s", e,
+                )
+        logger.info(
+            "boot_catchup_scan: scanned=%d, already_indexed=0, "
+            "enqueued=0, skipped_by_watermark=%d (watermark=%.3f, "
+            "no new files)",
+            result['scanned'], result['skipped_by_watermark'], watermark,
+        )
+        return result
+
+    # Slow path: load the existing canonical-key sets and dedup.
     try:
         conn = _init_db(db_path)
         try:
@@ -1947,8 +2107,7 @@ def boot_catchup_scan(db_path: str, teslacam_path: str = '',
     indexed_keys.discard('')
 
     to_enqueue: List[Tuple[str, Optional[int]]] = []
-    for fpath in _find_archived_videos():
-        result['scanned'] += 1
+    for fpath, _mtime in new_files:
         key = canonical_key(fpath)
         if not key:
             continue
@@ -1970,15 +2129,35 @@ def boot_catchup_scan(db_path: str, teslacam_path: str = '',
         from services.indexing_queue_service import enqueue_many_for_indexing
         n = enqueue_many_for_indexing(db_path, to_enqueue, source=source)
         result['enqueued'] = n
+
+    # Persist new watermark — even if nothing was enqueued (the files
+    # might already have been indexed via the realtime watcher path).
+    if new_max_mtime > watermark:
+        try:
+            conn = _init_db(db_path)
+            try:
+                _kv_set(
+                    conn, _BOOT_CATCHUP_WATERMARK_KEY,
+                    repr(new_max_mtime),
+                )
+            finally:
+                conn.close()
+        except sqlite3.Error as e:
+            logger.warning(
+                "boot_catchup_scan: watermark write failed: %s", e,
+            )
+
     logger.info(
-        "boot_catchup_scan: scanned=%d, already_indexed=%d, enqueued=%d",
+        "boot_catchup_scan: scanned=%d, already_indexed=%d, enqueued=%d, "
+        "skipped_by_watermark=%d (watermark=%.3f → %.3f)",
         result['scanned'], result['already_indexed'], result['enqueued'],
+        result['skipped_by_watermark'], watermark, new_max_mtime,
     )
     return result
 
 
 # ---------------------------------------------------------------------------
-# Daily stale-data sweep
+# Periodic stale-data sweep (issue #184 Wave 2 — Phase F)
 # ---------------------------------------------------------------------------
 
 # Independent safety net for the case where ``purge_deleted_videos`` calls
@@ -1991,18 +2170,27 @@ def boot_catchup_scan(db_path: str, teslacam_path: str = '',
 # (e.g. files Tesla rotated out of RecentClips while the Pi was off)
 # get cleaned up before the user opens the map page, but long enough
 # that boot-time IO doesn't compete with USB gadget presentation.
-# Subsequent fires happen ~daily with jitter so multiple Pis don't
-# hammer the same minute.
 #
-# Out-of-cycle scans can be triggered with :func:`trigger_stale_scan_now`
-# from high-signal events (after each archive cycle, on the first map
-# page load after a restart). The trigger is debounced so concurrent
-# triggers from different services collapse into a single scan.
-_DAILY_STALE_SCAN_INTERVAL = 24 * 60 * 60  # 24 hours
-_DAILY_STALE_SCAN_JITTER = 60 * 60         # +/- 1 hour
-_INITIAL_STALE_SCAN_BASE = 5 * 60          # 5 minutes after boot
-_INITIAL_STALE_SCAN_JITTER = 5 * 60        # +0..5 min spread
-_TRIGGER_DEBOUNCE_SECONDS = 10 * 60        # 10 minutes between fires
+# **Cadence (issue #184 Wave 2 — Phase F):** Subsequent fires happen
+# ~monthly (was: daily) with jitter so multiple Pis don't hammer the
+# same minute. The watcher's per-delete callback is the real-time
+# cleanup path — it stat()s nothing, just deletes the row whose
+# canonical_key was just removed. The periodic sweep is the safety
+# net for the rare case where a delete happened while gadget_web
+# was down (e.g., the user copied an SD-card image off the Pi or a
+# manual ``rm`` happened over SSH); for a 10k-clip install this
+# cuts ``os.path.isfile`` syscalls from 10,000/day → 10,000/month
+# (~30× reduction). Out-of-cycle scans can be triggered with
+# :func:`trigger_stale_scan_now` from high-signal events (after each
+# archive cycle, on the first map page load after a restart, when
+# disk-space drops to ``critical``, or when the user clicks a
+# Reconcile button). The trigger is debounced so concurrent triggers
+# from different services collapse into a single scan.
+_DAILY_STALE_SCAN_INTERVAL = 30 * 24 * 60 * 60  # 30 days (was: 24 h)
+_DAILY_STALE_SCAN_JITTER = 24 * 60 * 60         # +/- 1 day (was: +/- 1 h)
+_INITIAL_STALE_SCAN_BASE = 5 * 60               # 5 minutes after boot
+_INITIAL_STALE_SCAN_JITTER = 5 * 60             # +0..5 min spread
+_TRIGGER_DEBOUNCE_SECONDS = 10 * 60             # 10 minutes between fires
 _daily_stale_scan_thread: Optional[threading.Thread] = None
 _daily_stale_scan_stop: Optional[threading.Event] = None
 _stale_scan_state_lock = threading.Lock()

--- a/scripts/web/web_control.py
+++ b/scripts/web/web_control.py
@@ -173,16 +173,15 @@ if __name__ == "__main__":
             try:
                 from config import MAPPING_ENABLED, MAPPING_DB_PATH
                 if MAPPING_ENABLED:
-                    def _on_new_videos(file_paths):
-                        from services.indexing_queue_service import (
-                            enqueue_many_for_indexing,
-                        )
-                        items = [(p, None) for p in file_paths if p]
-                        if items:
-                            enqueue_many_for_indexing(
-                                MAPPING_DB_PATH, items, source='watcher',
-                            )
-
+                    # Issue #184 Wave 2 — Phase C: the inotify→indexing
+                    # callback that used to live here was a duplicate
+                    # enqueue path. The archive worker (which is the
+                    # only writer to ``ArchivedClips``) calls
+                    # ``_enqueue_indexed`` directly after each
+                    # successful copy, and ``boot_catchup_scan``
+                    # handles anything an operator might rsync into
+                    # ArchivedClips outside the worker. Per-clip
+                    # ``indexing_queue`` INSERTs drop from 2→1.
                     def _on_deleted_videos(file_paths):
                         # Mirror deletes immediately so the map page
                         # doesn't keep showing trips/events for clips
@@ -198,9 +197,8 @@ if __name__ == "__main__":
                         except Exception as e:
                             print(f"Warning: purge_deleted_videos failed: {e}")
 
-                    register_callback(_on_new_videos)
                     register_delete_callback(_on_deleted_videos)
-                    print("File watcher → indexing queue producer registered")
+                    print("File watcher → delete callback registered")
             except Exception as e:
                 print(f"Warning: Failed to register watcher callbacks: {e}")
 
@@ -229,13 +227,17 @@ if __name__ == "__main__":
             # mp4 callback into the archive_queue table. Issue #184 Wave 1
             # made the queue subsystem unconditional — there is no longer
             # an enable flag.
+            #
+            # Issue #184 Wave 2 — Phase B: the inotify path now calls
+            # ``archive_producer.enqueue_with_peek`` instead of the raw
+            # ``archive_queue.enqueue_many_for_archive`` so RecentClips
+            # candidates with no GPS-bearing SEI are dropped at the
+            # producer (no queue row, no worker pick, no SD writes).
             try:
                 def _on_new_videos_for_archive(file_paths):
-                    from services.archive_queue import (
-                        enqueue_many_for_archive,
-                    )
+                    from services.archive_producer import enqueue_with_peek
                     try:
-                        enqueue_many_for_archive(list(file_paths))
+                        enqueue_with_peek(list(file_paths))
                     except Exception as e:
                         print(
                             "Warning: archive_queue enqueue failed: "

--- a/tests/test_archive_producer.py
+++ b/tests/test_archive_producer.py
@@ -137,13 +137,13 @@ class TestIterArchiveCandidates:
 class TestRunBootCatchupOnce:
     def test_enqueues_all_clips_first_run(self, db, teslacam):
         result = archive_producer.run_boot_catchup_once(teslacam, db_path=db)
-        assert result == {'seen': 5, 'enqueued': 5}
+        assert result == {'seen': 5, 'enqueued': 5, 'skipped_stationary': 0}
         assert archive_queue.get_queue_status(db_path=db)['pending'] == 5
 
     def test_second_run_enqueues_zero_due_to_dedup(self, db, teslacam):
         archive_producer.run_boot_catchup_once(teslacam, db_path=db)
         result = archive_producer.run_boot_catchup_once(teslacam, db_path=db)
-        assert result == {'seen': 5, 'enqueued': 0}
+        assert result == {'seen': 5, 'enqueued': 0, 'skipped_stationary': 0}
         assert archive_queue.get_queue_status(db_path=db)['pending'] == 5
 
     def test_picks_up_new_clip_between_runs(self, db, teslacam):
@@ -154,7 +154,7 @@ class TestRunBootCatchupOnce:
         with open(new_clip, 'wb') as f:
             f.write(b"new")
         result = archive_producer.run_boot_catchup_once(teslacam, db_path=db)
-        assert result == {'seen': 6, 'enqueued': 1}
+        assert result == {'seen': 6, 'enqueued': 1, 'skipped_stationary': 0}
 
     def test_priorities_are_inferred(self, db, teslacam):
         archive_producer.run_boot_catchup_once(teslacam, db_path=db)
@@ -351,3 +351,151 @@ class TestProducerStatus:
         assert status['rescan_interval_seconds'] == 42.0
         assert status['boot_catchup_enabled'] is False
         archive_producer.stop_producer(timeout=5.0)
+
+
+# ---------------------------------------------------------------------------
+# Issue #184 Wave 2 — Phase B: SEI peek at the producer
+# ---------------------------------------------------------------------------
+
+
+class TestEnqueueWithPeek:
+    """Phase B moves the stationary-clip skip from the worker to the
+    producer. Tests cover the three peek outcomes (True / False / None)
+    and the freshness gate that defers fresh files to the worker."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_tally(self):
+        archive_producer.reset_skipped_stationary_tally()
+        yield
+        archive_producer.reset_skipped_stationary_tally()
+
+    def test_event_clips_skip_peek_and_enqueue_directly(self, db, tmp_path,
+                                                         monkeypatch):
+        # Sentry/Saved event clips bypass the SEI peek entirely.
+        # Force the peek function to assert it's NOT called for these.
+        called = {'count': 0}
+
+        def _fail_peek(_path):
+            called['count'] += 1
+            return False  # if we wrongly called it, force a skip
+
+        monkeypatch.setattr(
+            archive_producer, '_peek_clip_for_gps', _fail_peek,
+        )
+        sentry_clip = tmp_path / "TeslaCam" / "SentryClips" / "evt"
+        sentry_clip.mkdir(parents=True)
+        path = str(sentry_clip / "2026-05-11_09-00-00-front.mp4")
+        with open(path, 'wb') as f:
+            f.write(b"x")
+        result = archive_producer.enqueue_with_peek([path], db_path=db)
+        assert result['enqueued'] == 1
+        assert result['skipped_stationary'] == 0
+        assert called['count'] == 0
+
+    def test_recentclips_with_no_gps_is_skipped(self, db, tmp_path,
+                                                  monkeypatch):
+        # SEI peek returns False → producer drops the clip and bumps
+        # the in-memory tally.
+        recent = tmp_path / "TeslaCam" / "RecentClips"
+        recent.mkdir(parents=True)
+        path = str(recent / "2026-05-11_09-00-00-front.mp4")
+        with open(path, 'wb') as f:
+            f.write(b"x")
+        # Backdate the file so the freshness gate doesn't bypass the peek.
+        old = time.time() - 60
+        os.utime(path, (old, old))
+        monkeypatch.setattr(
+            archive_producer, '_peek_clip_for_gps', lambda _p: False,
+        )
+        result = archive_producer.enqueue_with_peek([path], db_path=db)
+        assert result['enqueued'] == 0
+        assert result['skipped_stationary'] == 1
+        assert archive_producer.get_skipped_stationary_count(24) == 1
+        # Confirm no row was written.
+        from services import archive_queue
+        assert archive_queue.get_queue_status(db_path=db)['pending'] == 0
+
+    def test_recentclips_with_gps_is_enqueued(self, db, tmp_path,
+                                                monkeypatch):
+        recent = tmp_path / "TeslaCam" / "RecentClips"
+        recent.mkdir(parents=True)
+        path = str(recent / "2026-05-11_09-00-00-front.mp4")
+        with open(path, 'wb') as f:
+            f.write(b"x")
+        old = time.time() - 60
+        os.utime(path, (old, old))
+        monkeypatch.setattr(
+            archive_producer, '_peek_clip_for_gps', lambda _p: True,
+        )
+        result = archive_producer.enqueue_with_peek([path], db_path=db)
+        assert result['enqueued'] == 1
+        assert result['skipped_stationary'] == 0
+
+    def test_recentclips_with_unknown_verdict_is_enqueued(self, db, tmp_path,
+                                                            monkeypatch):
+        # Peek returns None (parse error) — must fall through to enqueue
+        # so a parser bug never silently drops a clip.
+        recent = tmp_path / "TeslaCam" / "RecentClips"
+        recent.mkdir(parents=True)
+        path = str(recent / "2026-05-11_09-00-00-front.mp4")
+        with open(path, 'wb') as f:
+            f.write(b"x")
+        old = time.time() - 60
+        os.utime(path, (old, old))
+        monkeypatch.setattr(
+            archive_producer, '_peek_clip_for_gps', lambda _p: None,
+        )
+        result = archive_producer.enqueue_with_peek([path], db_path=db)
+        assert result['enqueued'] == 1
+        assert result['skipped_stationary'] == 0
+
+    def test_fresh_recentclips_bypass_peek(self, db, tmp_path, monkeypatch):
+        # File mtime is now() — younger than stable_write_age. Producer
+        # must enqueue without calling the peek so the worker's stable-
+        # write gate can handle freshness.
+        recent = tmp_path / "TeslaCam" / "RecentClips"
+        recent.mkdir(parents=True)
+        path = str(recent / "2026-05-11_09-00-00-front.mp4")
+        with open(path, 'wb') as f:
+            f.write(b"x")
+        called = {'count': 0}
+
+        def _peek_should_not_run(_path):
+            called['count'] += 1
+            return False
+
+        monkeypatch.setattr(
+            archive_producer, '_peek_clip_for_gps', _peek_should_not_run,
+        )
+        result = archive_producer.enqueue_with_peek([path], db_path=db)
+        assert called['count'] == 0
+        assert result['enqueued'] == 1
+        assert result['skipped_stationary'] == 0
+
+    def test_skipped_stationary_count_horizon_evicts_old_entries(self):
+        # Manually push timestamps from 25 hours ago into the deque.
+        from services.archive_producer import (
+            _skipped_tally, _skipped_tally_lock,
+        )
+        ancient = time.time() - 25 * 3600
+        with _skipped_tally_lock:
+            _skipped_tally.append(ancient)
+        # 24-hour horizon must drop the ancient entry.
+        assert archive_producer.get_skipped_stationary_count(24) == 0
+
+    def test_reset_skipped_stationary_tally_clears(self, db, tmp_path,
+                                                     monkeypatch):
+        recent = tmp_path / "TeslaCam" / "RecentClips"
+        recent.mkdir(parents=True)
+        path = str(recent / "2026-05-11_09-00-00-front.mp4")
+        with open(path, 'wb') as f:
+            f.write(b"x")
+        old = time.time() - 60
+        os.utime(path, (old, old))
+        monkeypatch.setattr(
+            archive_producer, '_peek_clip_for_gps', lambda _p: False,
+        )
+        archive_producer.enqueue_with_peek([path], db_path=db)
+        assert archive_producer.get_skipped_stationary_count(24) == 1
+        archive_producer.reset_skipped_stationary_tally()
+        assert archive_producer.get_skipped_stationary_count(24) == 0

--- a/tests/test_archive_queue.py
+++ b/tests/test_archive_queue.py
@@ -2553,12 +2553,16 @@ class TestPriorityMigrationV12ToV13:
         conn.commit()
         conn.close()
 
-        # Should not raise.
+        # Should not raise. Re-initializing must bump us to whatever
+        # the current schema version is (Phase E added v14, so this
+        # passes through both the v12→v13 priority migration and the
+        # v13→v14 kv_meta table creation in one shot).
         conn = _init_db(db_path)
         try:
+            from services.mapping_migrations import _SCHEMA_VERSION
             row = conn.execute(
                 "SELECT MAX(version) AS v FROM schema_version"
             ).fetchone()
-            assert row['v'] == 13
+            assert row['v'] == _SCHEMA_VERSION
         finally:
             conn.close()

--- a/tests/test_mapping_service.py
+++ b/tests/test_mapping_service.py
@@ -3226,7 +3226,10 @@ class TestBootCatchupScan:
         db = str(tmp_path / "g.db")
         _init_db(db)
         result = boot_catchup_scan(db, '')
-        assert result == {'scanned': 0, 'already_indexed': 0, 'enqueued': 0}
+        assert result == {
+            'scanned': 0, 'already_indexed': 0, 'enqueued': 0,
+            'skipped_by_watermark': 0,
+        }
 
     def test_enqueues_orphan_clips(self, tmp_path):
         db = str(tmp_path / "g.db")
@@ -3328,12 +3331,99 @@ class TestBootCatchupScan:
         result = boot_catchup_scan(db, legacy_tc)
         assert result == {
             'scanned': 0, 'already_indexed': 0, 'enqueued': 0,
+            'skipped_by_watermark': 0,
         }
         with sqlite3.connect(db) as c:
             count = c.execute(
                 "SELECT COUNT(*) FROM indexing_queue"
             ).fetchone()[0]
         assert count == 0
+
+
+# ---------------------------------------------------------------------------
+# Issue #184 Wave 2 — Phase E: boot catch-up watermark
+# ---------------------------------------------------------------------------
+
+
+class TestBootCatchupWatermark:
+    """The boot catch-up scan persists a high-water mark of the highest
+    file mtime it has ever seen and uses it on subsequent boots to
+    skip files older than the watermark — turning the steady-state
+    boot scan from O(N) into O(new files)."""
+
+    def _make_archive(self, root, files):
+        for rel in files:
+            full = root / rel
+            full.parent.mkdir(parents=True, exist_ok=True)
+            full.write_bytes(b'')
+        return str(root)
+
+    @pytest.fixture(autouse=True)
+    def _patch_archive_dir(self, tmp_path, monkeypatch):
+        archive_root = tmp_path / "ArchivedClips"
+        archive_root.mkdir()
+        import config as _cfg
+        monkeypatch.setattr(_cfg, 'ARCHIVE_DIR', str(archive_root))
+        monkeypatch.setattr(_cfg, 'ARCHIVE_ENABLED', True)
+        self._archive_root = archive_root
+
+    def test_first_run_writes_watermark(self, tmp_path):
+        from services.mapping_service import (
+            _kv_get, _BOOT_CATCHUP_WATERMARK_KEY,
+        )
+        db = str(tmp_path / "g.db")
+        _init_db(db)
+        self._make_archive(self._archive_root, [
+            "RecentClips/2026-05-11_09-00-00-front.mp4",
+        ])
+        result = boot_catchup_scan(db, '')
+        assert result['scanned'] == 1
+        assert result['enqueued'] == 1
+        assert result['skipped_by_watermark'] == 0
+        # Watermark must be set to the file's mtime.
+        with sqlite3.connect(db) as conn:
+            stored = _kv_get(conn, _BOOT_CATCHUP_WATERMARK_KEY)
+        assert stored is not None
+        assert float(stored) > 0.0
+
+    def test_second_run_skips_unchanged_files(self, tmp_path):
+        db = str(tmp_path / "g.db")
+        _init_db(db)
+        self._make_archive(self._archive_root, [
+            "RecentClips/2026-05-11_09-00-00-front.mp4",
+            "RecentClips/2026-05-11_09-01-00-front.mp4",
+        ])
+        # First run — full scan.
+        first = boot_catchup_scan(db, '')
+        assert first['scanned'] == 2
+        # Second run — watermark covers both files.
+        second = boot_catchup_scan(db, '')
+        assert second['scanned'] == 2
+        assert second['skipped_by_watermark'] == 2
+        assert second['enqueued'] == 0
+        assert second['already_indexed'] == 0
+
+    def test_new_file_after_watermark_is_processed(self, tmp_path):
+        db = str(tmp_path / "g.db")
+        _init_db(db)
+        self._make_archive(self._archive_root, [
+            "RecentClips/2026-05-11_09-00-00-front.mp4",
+        ])
+        boot_catchup_scan(db, '')
+        # Add a new file with a strictly newer mtime.
+        new_path = (
+            self._archive_root / "RecentClips" /
+            "2026-05-11_09-05-00-front.mp4"
+        )
+        new_path.write_bytes(b'')
+        # Bump its mtime explicitly so the test isn't sensitive to
+        # filesystem timestamp granularity (FAT32 has 2-s resolution).
+        future = time.time() + 60
+        os.utime(str(new_path), (future, future))
+        result = boot_catchup_scan(db, '')
+        assert result['scanned'] == 2
+        assert result['skipped_by_watermark'] == 1
+        assert result['enqueued'] == 1
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Wave 2 — I/O reduction (Phases B + C + E + F)

Second wave of the issue #184 architecture remediation. All four phases here cut steady-state I/O and SD writes without changing user-visible behavior. Wave 1 (Phase A toggle cleanup) is already merged in #185.

Ref #184 (Wave 2)

### What changes

**Phase B — SEI peek hoisted from worker to producer**
- New `archive_producer.enqueue_with_peek()` runs the GPS-bearing-SEI peek **before** a queue row is written.
- RecentClips clips with no GPS (overnight Sentry-while-parked footage) are dropped at the producer: 0 SD writes, 0 worker pick cycle, 0 `mark_skipped_stationary` row update.
- In-memory deque tally (`get_skipped_stationary_count`) replaces the per-clip DB write the worker was incurring. Bounded at 10 000 entries (~70 days at full saturation), resets on service restart — acceptable for a 24-hour badge.
- Worker-side `_clip_has_gps_signal` stays as **defense-in-depth** for legacy queue rows from before this PR and for tests that bypass the producer.
- `/api/archive/skipped_stationary` now returns the **sum** of the legacy DB count and the new in-memory tally so the Settings badge stays continuous across the upgrade.
- Freshness gate (5 s mtime age) before peek so a half-written clip is never misclassified as stationary because Tesla hasn't written the GPS-locked SEI yet.

**Phase C — drop duplicate inotify→indexing enqueue**
- Removed `register_callback(_on_new_videos)` in `web_control.py`. The archive worker's `_enqueue_indexed` call after each successful copy is the **single** source of truth.
- The boot catch-up scan covers the rare manual-`scp`-into-ArchivedClips case.
- Per-clip `indexing_queue` INSERTs drop **2 → 1**.
- Delete callback (`register_delete_callback`) preserved for real-time orphan cleanup.

**Phase E — boot catch-up watermark**
- New `kv_meta` table (schema **v14**) stores the highest mtime seen by `boot_catchup_scan` in any prior run.
- The walker still `stat()`s every file (cheap inode read), but only does the `canonical_key` + DB-lookup + enqueue work for files newer than the watermark.
- When **no** files have changed since last boot, the slow-path DB read is **skipped entirely** — typical post-Wave-2 boot scan drops from O(N indexed files) to O(0).
- Migration is purely additive (`CREATE TABLE IF NOT EXISTS`); the first scan after upgrade still pays the full O(N) cost, then writes the watermark, and every subsequent boot short-circuits.

**Phase F — stale scan: daily → monthly + on-demand triggers**
- `_DAILY_STALE_SCAN_INTERVAL`: 24 h → 30 days
- `_DAILY_STALE_SCAN_JITTER`: ±1 h → ±1 day (proportional)
- Real-time deletes still fire via the watcher's `register_delete_callback` so the cadence change only affects the safety-net periodic sweep.
- Disk-critical cleanup in `archive_worker` now also calls `trigger_stale_scan_now` so any `indexed_files` rows whose clip was just rotated get reaped immediately.
- New `POST /api/cleanup/reconcile_index` endpoint exposes a manual Reconcile trigger for operators who suspect orphans (e.g., after a manual `rm` over SSH or an SD-card image swap).
- For a 10k-clip install, daily `os.path.isfile()` syscalls drop **~30×** (10 000/day → 10 000/month).

### Acceptance criteria from the issue body

| Criterion | Status |
|---|---|
| Per-stationary-clip I/O drops to 0 SD writes (Phase B) | ✅ producer drops the row before any DB write |
| Boot-time `boot_catchup_scan` runtime drops from O(N) to O(new) (Phase E) | ✅ watermark short-circuit + fast-path skips DB read entirely when no new files |
| Daily `stat()` syscalls drop ~30× (Phase F) | ✅ 24 h → 30-day cadence |
| Per-clip `indexing_queue` INSERT count drops 2 → 1 (Phase C) | ✅ duplicate `register_callback(_on_new_videos)` removed |

### Tests

Full suite: **1 600 passed, 4 skipped**. Key additions:

- `TestBootCatchupWatermark` — Phase E behavior: watermark write on first run, skip on second run, new file pickup after watermark.
- `TestEnqueueWithPeek` — Phase B behavior: event clips bypass peek, RecentClips with False/True/None verdicts, freshness gate bypass, deque horizon eviction, reset.

Existing tests updated for the new dict shapes (`skipped_stationary` and `skipped_by_watermark` keys) and for the bumped `_SCHEMA_VERSION` (13 → 14).

### Safety

- Schema migration is forward-only and additive — no data is touched.
- The `_clip_has_gps_signal` worker-side fallback stays in place, so any in-flight queue rows from before this deploy still get the same skip decision they would have gotten under the old code.
- Real-time delete handling (`register_delete_callback`) is unchanged.
- The freshness gate in `enqueue_with_peek` matches `archive_worker._stable_write_age_seconds()` so half-written clips behave identically across both paths.
- Daily stale scan downgrade is safe because real-time delete callbacks already handle the common case; the periodic sweep was the safety net for missed deletes (e.g., `gadget_web` was down when a delete happened over SSH).
- Per the project's safety doctrine: this PR does NOT touch the USB gadget, mount/unmount logic, or the `quick_edit_part2` path.

### What remains

- **Wave 3** — Phase D (hot/cold waypoints), Phase H (atomic-copy staging dir), Phase G (idle WAL checkpoints).
- **Wave 4** — Phases I.1–I.5 (pipeline_queue unification), J (batched rclone), K (drop LES poll).
