### PR TITLE
refactor(#184): storage layout (Wave 3 — Phases D+G+H)

### DIFF
--- a/scripts/web/blueprints/mapping.py
+++ b/scripts/web/blueprints/mapping.py
@@ -115,8 +115,12 @@ def api_trip_route(trip_id):
         }
         return jsonify(geojson)
     except Exception as e:
-        logger.error("Failed to query trip route: %s", e)
-        return jsonify({'error': str(e)}), 500
+        # Scrub the exception message from the response — raw SQL
+        # fragments / file paths could leak in error.message and
+        # surface to any browser that happens to be on the AP.
+        # Full traceback is preserved in the server log.
+        logger.exception("Failed to query trip route: %s", e)
+        return jsonify({'error': 'internal error'}), 500
 
 
 @mapping_bp.route("/api/trip/<int:trip_id>/telemetry")
@@ -160,8 +164,11 @@ def api_trip_telemetry(trip_id):
             'telemetry': {str(wp_id): row for wp_id, row in telem.items()},
         })
     except Exception as e:
-        logger.error("Failed to query trip telemetry: %s", e)
-        return jsonify({'error': str(e)}), 500
+        # Scrub the exception message from the response — raw SQL
+        # fragments / file paths could leak in error.message. Full
+        # traceback is preserved in the server log.
+        logger.exception("Failed to query trip telemetry: %s", e)
+        return jsonify({'error': 'internal error'}), 500
 
 
 @mapping_bp.route("/api/waypoints-for-clip")

--- a/scripts/web/blueprints/mapping.py
+++ b/scripts/web/blueprints/mapping.py
@@ -119,6 +119,51 @@ def api_trip_route(trip_id):
         return jsonify({'error': str(e)}), 500
 
 
+@mapping_bp.route("/api/trip/<int:trip_id>/telemetry")
+def api_trip_telemetry(trip_id):
+    """Return cold telemetry (steering/brake/accel/gear/blinker) for
+    every waypoint in ``trip_id`` keyed by waypoint id.
+
+    Issue #184 Wave 3 — Phase D companion to ``/api/trip/<id>/route``.
+    The map polyline endpoint returns hot columns only (lat/lon/
+    speed/heading/autopilot_state). When the user opens the in-clip
+    HUD overlay, the JS calls this endpoint once and merges the
+    cold payload into the existing waypoints array.
+
+    Response shape::
+
+        {
+            "trip_id": <int>,
+            "telemetry": {
+                "<waypoint_id>": {
+                    "id": <int>,
+                    "acceleration_x": <float|null>,
+                    "acceleration_y": <float|null>,
+                    "acceleration_z": <float|null>,
+                    "gear": <str|null>,
+                    "steering_angle": <float|null>,
+                    "brake_applied": <0|1>,
+                    "blinker_on_left": <0|1>,
+                    "blinker_on_right": <0|1>
+                },
+                ...
+            }
+        }
+
+    Empty ``telemetry`` is a valid response (parked-only trip).
+    """
+    from services.mapping_queries import query_trip_telemetry
+    try:
+        telem = query_trip_telemetry(MAPPING_DB_PATH, trip_id)
+        return jsonify({
+            'trip_id': trip_id,
+            'telemetry': {str(wp_id): row for wp_id, row in telem.items()},
+        })
+    except Exception as e:
+        logger.error("Failed to query trip telemetry: %s", e)
+        return jsonify({'error': str(e)}), 500
+
+
 @mapping_bp.route("/api/waypoints-for-clip")
 def api_waypoints_for_clip():
     """Look up waypoints matching a video clip path (or nearby clips in same trip)."""

--- a/scripts/web/services/archive_watchdog.py
+++ b/scripts/web/services/archive_watchdog.py
@@ -93,6 +93,11 @@ _RETENTION_COORDINATOR_TASK = 'retention'
 # Diagnostic subdirectory inside ``archive_root`` that the prune must
 # never touch. Mirrors the worker's dead-letter sidecar location.
 _DEAD_LETTER_DIRNAME = '.dead_letter'
+# Issue #184 Wave 3 — Phase H. Archive worker stages all in-flight
+# ``.partial`` files in this single directory. Retention/sweep
+# walkers must skip it so partials aren't mistaken for archived
+# clips and so the dir stays exclusively owned by archive_worker.
+_STAGING_DIRNAME = '.staging'
 
 # Default stop/join timeouts.
 _DEFAULT_STOP_TIMEOUT = 30.0
@@ -723,9 +728,11 @@ def _iter_archive_mp4_files(archive_root: str):
     if not archive_root or not os.path.isdir(archive_root):
         return
     for dirpath, dirnames, filenames in os.walk(archive_root, followlinks=False):
-        # Prune .dead_letter so os.walk doesn't descend into it.
+        # Prune .dead_letter and .staging so os.walk doesn't descend
+        # into them (issue #184 Wave 3 — Phase H).
         dirnames[:] = [
-            d for d in dirnames if d != _DEAD_LETTER_DIRNAME
+            d for d in dirnames
+            if d not in (_DEAD_LETTER_DIRNAME, _STAGING_DIRNAME)
         ]
         for fn in filenames:
             if not fn.lower().endswith('.mp4'):
@@ -1243,7 +1250,8 @@ def _collect_event_basenames(archive_root: str) -> set:
             root, followlinks=False,
         ):
             dirnames[:] = [
-                d for d in dirnames if d != _DEAD_LETTER_DIRNAME
+                d for d in dirnames
+                if d not in (_DEAD_LETTER_DIRNAME, _STAGING_DIRNAME)
             ]
             for fn in filenames:
                 if fn.lower().endswith('.mp4'):

--- a/scripts/web/services/archive_worker.py
+++ b/scripts/web/services/archive_worker.py
@@ -18,9 +18,12 @@ Drains the ``archive_queue`` table one file at a time. For each row:
    proceeds. NOT the indexer's ``yield_to_waiters=True`` cyclic form.
 4. Compute the destination under ``ARCHIVE_DIR`` mirroring the
    ``TeslaCam/<sub>/<file>`` layout.
-5. Atomic copy: write to ``dest_path + '.partial'`` in 1-MiB chunks,
-   ``fsync``, ``rename`` to the final name, verify size matches the
-   source.
+5. Atomic copy: stage to ``<archive_root>/.staging/<hash>-<name>.partial``
+   in 1-MiB chunks, ``fsync``, ``os.replace`` to the final name,
+   verify size matches the source. The single staging dir keeps the
+   archive tree free of in-flight bytes (so directory traversals
+   never trip on partials) and reduces orphan-sweep cost from
+   ``os.walk`` to one ``os.scandir`` (issue #184 Wave 3 — Phase H).
 6. On success, mark the row ``copied`` and enqueue the **destination**
    path into ``indexing_queue`` via
    ``indexing_queue_service.enqueue_for_indexing`` so the indexer
@@ -63,6 +66,7 @@ Public API mirrors :mod:`indexing_worker`::
 from __future__ import annotations
 
 import collections
+import hashlib
 import logging
 import os
 import shutil
@@ -595,36 +599,113 @@ def _safe_stat(path: str):
         return None
 
 
+# Issue #184 Wave 3 — Phase H. Staging directory for atomic copies.
+# All ``.partial`` files now live here, never inside the destination
+# tree, so:
+#   * directory traversals (indexer, retention prune, file watcher)
+#     never see in-flight bytes;
+#   * orphan cleanup at startup is a single ``os.scandir`` of one
+#     directory, not a recursive walk of the whole archive.
+# The staging dir lives on the SAME filesystem as the archive root
+# so ``os.replace`` is atomic.
+_STAGING_DIRNAME = '.staging'
+
+
+def _staging_root(archive_root: str) -> str:
+    """Return the path to the staging dir under ``archive_root``.
+
+    Caller is responsible for ``os.makedirs(exist_ok=True)`` before
+    writing.
+    """
+    return os.path.join(archive_root, _STAGING_DIRNAME)
+
+
+def _staging_partial_path(archive_root: str, dest_path: str) -> str:
+    """Compute a unique ``.partial`` path inside the staging dir.
+
+    The basename includes a stable hash of the absolute destination
+    path so that two simultaneously-attempted copies of the same
+    source to different destinations (legacy migration scenarios)
+    can't clobber each other. The hash is short (10 hex chars) to
+    keep the staging filename readable.
+    """
+    abs_dest = os.path.abspath(dest_path)
+    digest = hashlib.sha1(
+        abs_dest.encode('utf-8', errors='replace'),
+    ).hexdigest()[:10]
+    base = os.path.basename(dest_path)
+    return os.path.join(
+        _staging_root(archive_root), f"{digest}-{base}.partial",
+    )
+
+
 def _sweep_partial_orphans(archive_root: str) -> int:
-    """Remove ``*.partial`` files orphaned by a prior crash.
+    """Remove orphan ``*.partial`` files from the staging directory.
 
-    ``_atomic_copy`` writes to ``dest_path + '.partial'`` and only
-    renames once the size-verified write succeeds. A power loss or
-    hardware reset (e.g., the May 11 SDIO-watchdog reboots) leaves the
-    partial behind forever — it's missed by retention (different
-    extension), counted toward disk usage, and confuses the indexer if
-    it ever sees the path.
+    Phase H rewrite (issue #184 Wave 3): partials live in
+    ``<archive_root>/.staging/`` rather than scattered across the
+    archive tree, so this is a single ``os.scandir`` instead of a
+    full ``os.walk``. The legacy archive-tree walk is preserved as
+    a fallback for one-time migration of any leftovers from before
+    this PR landed (e.g., the May 11 SDIO-watchdog reboots).
 
-    Walks ``archive_root`` once at worker startup, skipping the
-    ``.dead_letter`` diagnostic dir. Returns the number of orphans
-    removed (0 on a clean tree). Best-effort: per-file failures log a
-    warning and continue.
+    Returns the number of orphans removed (0 on a clean tree).
+    Best-effort: per-file failures log a warning and continue.
 
     Safety: only one archive worker exists at a time (enforced by
     ``start_worker``), and the worker doesn't begin claiming rows
     until this sweep completes — so we cannot delete a ``.partial``
-    that another writer is currently producing. Stat failures (file
-    vanished, permissions) are skipped without raising.
+    that another writer is currently producing.
     """
     if not archive_root or not os.path.isdir(archive_root):
         return 0
     removed = 0
+    staging = _staging_root(archive_root)
+    if os.path.isdir(staging):
+        try:
+            with os.scandir(staging) as it:
+                for entry in it:
+                    if not entry.is_file(follow_symlinks=False):
+                        continue
+                    if not entry.name.endswith('.partial'):
+                        continue
+                    try:
+                        size = entry.stat().st_size
+                    except OSError:
+                        size = 0
+                    try:
+                        os.remove(entry.path)
+                        removed += 1
+                        logger.info(
+                            "archive_worker: removed staged orphan "
+                            "partial %s (%d bytes)",
+                            entry.path, size,
+                        )
+                    except OSError as e:
+                        logger.warning(
+                            "archive_worker: failed to remove staged "
+                            "orphan partial %s: %s", entry.path, e,
+                        )
+        except OSError as e:
+            logger.warning(
+                "archive_worker: failed to scan staging dir %s: %s",
+                staging, e,
+            )
+
+    # One-time migration fallback: clean up any pre-Wave-3 partials
+    # still scattered across the archive tree. Once everyone has
+    # rebooted on Wave 3 there will be none, and this becomes a
+    # zero-cost scandir of an empty match set.
+    legacy_removed = 0
     for dirpath, dirnames, filenames in os.walk(
         archive_root, followlinks=False,
     ):
-        # Don't descend into .dead_letter — sidecar .txt files only,
-        # but keep the policy symmetric with the watchdog's prune.
-        dirnames[:] = [d for d in dirnames if d != '.dead_letter']
+        # Don't descend into .dead_letter or .staging — sidecar .txt
+        # files only, but keep the policy symmetric with the
+        # watchdog's prune. .staging was already swept above.
+        dirnames[:] = [
+            d for d in dirnames if d not in ('.dead_letter', _STAGING_DIRNAME)
+        ]
         for fn in filenames:
             if not fn.endswith('.partial'):
                 continue
@@ -635,17 +716,17 @@ def _sweep_partial_orphans(archive_root: str) -> int:
                 size = 0
             try:
                 os.remove(full)
-                removed += 1
+                legacy_removed += 1
                 logger.info(
-                    "archive_worker: removed orphan partial %s (%d bytes)",
-                    full, size,
+                    "archive_worker: removed legacy in-tree partial "
+                    "%s (%d bytes)", full, size,
                 )
             except OSError as e:
                 logger.warning(
-                    "archive_worker: failed to remove orphan partial "
-                    "%s: %s", full, e,
+                    "archive_worker: failed to remove legacy in-tree "
+                    "partial %s: %s", full, e,
                 )
-    return removed
+    return removed + legacy_removed
 
 
 class _CopyTimeBudgetExceeded(OSError):
@@ -800,13 +881,21 @@ def _atomic_copy(source_path: str, dest_path: str,
                  chunk_pause_seconds: float = 0.25,
                  chunk_pause_always: bool = False,
                  time_budget_seconds: float = 0.0,
+                 staging_root: Optional[str] = None,
                  now_fn: Callable[[], float] = time.monotonic,
                  sleep_fn: Callable[[float], None] = time.sleep) -> int:
     """Copy ``source_path`` → ``dest_path`` atomically. Returns size.
 
-    Pattern: ``dest_path + '.partial'`` → write in chunks → fsync →
-    rename. The temp file is unlinked on any failure so a crash mid-
-    copy doesn't leave an orphan in ArchivedClips.
+    Pattern (Phase H, issue #184 Wave 3): write to a uniquely-named
+    ``.partial`` file inside ``staging_root`` (a single ``.staging``
+    directory under the archive root), fsync, then ``os.replace``
+    into the final destination. The staging dir lives on the same
+    filesystem as the destination so the rename is atomic.
+
+    When ``staging_root`` is ``None`` (back-compat for direct test
+    callers), partials still go to ``dest_path + '.partial'`` — the
+    old in-tree pattern. Production callers always pass
+    ``staging_root`` so partials never appear in the archive tree.
 
     Verifies the rendered size matches the source's stat() size; any
     mismatch raises ``OSError`` so the caller bumps attempts.
@@ -847,7 +936,24 @@ def _atomic_copy(source_path: str, dest_path: str,
     parent = os.path.dirname(dest_path)
     if parent:
         os.makedirs(parent, exist_ok=True)
-    partial = dest_path + '.partial'
+    if staging_root:
+        # Phase H: stage the .partial under <archive_root>/.staging/
+        # using a hash-prefixed basename so two simultaneous copies
+        # of the same destination (legacy migration scenarios) cannot
+        # collide. Must be on the same filesystem as ``dest_path`` for
+        # ``os.replace`` to be atomic; ``staging_root`` is always a
+        # subdir of the archive root so this holds.
+        os.makedirs(staging_root, exist_ok=True)
+        abs_dest = os.path.abspath(dest_path)
+        digest = hashlib.sha1(
+            abs_dest.encode('utf-8', errors='replace'),
+        ).hexdigest()[:10]
+        partial = os.path.join(
+            staging_root,
+            f"{digest}-{os.path.basename(dest_path)}.partial",
+        )
+    else:
+        partial = dest_path + '.partial'
     expected = os.path.getsize(source_path)
     written = 0
     started = now_fn()
@@ -1711,6 +1817,7 @@ def process_one_claim(row: Dict[str, Any], db_path: str,
             chunk_pause_seconds=_adaptive_pause,
             chunk_pause_always=_pause_always,
             time_budget_seconds=time_budget_seconds,
+            staging_root=_staging_root(archive_root),
         )
     except FileNotFoundError:
         # Tesla rotated the source between stat() and open() — normal,

--- a/scripts/web/services/mapping_migrations.py
+++ b/scripts/web/services/mapping_migrations.py
@@ -868,21 +868,32 @@ def _migrate_v14_to_v15(conn: sqlite3.Connection) -> None:
         # collide on PRIMARY KEY ``id``.
         #
         # The WHERE clause filters out rows whose cold telemetry is
-        # entirely at the v14 SQL DEFAULT (0 for numerics, NULL for
-        # ``gear``). Without this filter the cold table would get
-        # one row per waypoint — bloating the very table the split
-        # exists to keep small. The DEFAULT comparison is verbose
-        # but it's the only correct semantic: a row where all cold
-        # fields are exactly the SQL default carries no telemetry
-        # signal, so it doesn't need a cold row.
+        # entirely at sensor noise / no-signal defaults. The thresholds
+        # mirror ``mapping_service._index_video`` exactly so a v14→v15
+        # upgrade and a fresh v15 install populate ``waypoints_cold``
+        # with the same row set. Without absolute-tolerance thresholds
+        # the cold table would get one row per waypoint (Tesla's IMU
+        # noise floor of ±0.001–±0.05 m/s² makes ``acceleration_x != 0``
+        # true on virtually every parked-car waypoint), defeating the
+        # split's purpose.
+        from services.mapping_service import (
+            _COLD_ACCEL_THRESHOLD_MPS2,
+            _COLD_STEERING_THRESHOLD_DEG,
+            _COLD_GEAR_NO_SIGNAL,
+        )
+        accel_thresh = float(_COLD_ACCEL_THRESHOLD_MPS2)
+        steering_thresh = float(_COLD_STEERING_THRESHOLD_DEG)
+        gear_no_signal_csv = ", ".join(
+            f"'{g}'" for g in sorted(_COLD_GEAR_NO_SIGNAL)
+        )
         conn.execute(
             f"INSERT OR IGNORE INTO waypoints_cold (id, {col_list}) "
             f"SELECT id, {col_list} FROM waypoints "
-            "WHERE (acceleration_x IS NOT NULL AND acceleration_x != 0) "
-            "   OR (acceleration_y IS NOT NULL AND acceleration_y != 0) "
-            "   OR (acceleration_z IS NOT NULL AND acceleration_z != 0) "
-            "   OR gear IS NOT NULL "
-            "   OR (steering_angle IS NOT NULL AND steering_angle != 0) "
+            f"WHERE (acceleration_x IS NOT NULL AND ABS(acceleration_x) > {accel_thresh}) "
+            f"   OR (acceleration_y IS NOT NULL AND ABS(acceleration_y) > {accel_thresh}) "
+            f"   OR (acceleration_z IS NOT NULL AND ABS(acceleration_z) > {accel_thresh}) "
+            f"   OR (gear IS NOT NULL AND gear NOT IN ({gear_no_signal_csv})) "
+            f"   OR (steering_angle IS NOT NULL AND ABS(steering_angle) > {steering_thresh}) "
             "   OR brake_applied != 0 "
             "   OR blinker_on_left != 0 "
             "   OR blinker_on_right != 0"

--- a/scripts/web/services/mapping_migrations.py
+++ b/scripts/web/services/mapping_migrations.py
@@ -46,7 +46,7 @@ logger = logging.getLogger(__name__)
 # Database Schema & Management
 # ---------------------------------------------------------------------------
 
-_SCHEMA_VERSION = 14
+_SCHEMA_VERSION = 15
 _BACKUP_RETENTION = 3  # Keep this many migration backups before pruning oldest
 
 _SCHEMA_SQL = """
@@ -76,17 +76,38 @@ CREATE TABLE IF NOT EXISTS waypoints (
     lon REAL NOT NULL,
     heading REAL,
     speed_mps REAL,
+    autopilot_state TEXT,
+    video_path TEXT,
+    frame_offset INTEGER
+);
+
+-- Issue #184 Wave 3 — Phase D. Cold telemetry payload split off the
+-- main ``waypoints`` table. ``waypoints`` (hot) carries lat/lon/
+-- speed/heading/autopilot_state — the columns the polyline render
+-- and click-to-seek lookups need on every map tile. ``waypoints_cold``
+-- carries steering/brake/accel/gear/blinker — used by the in-clip
+-- HUD scrubber, lazy-fetched per-trip via
+-- ``GET /api/trip/<id>/telemetry`` only when the user opens the
+-- video overlay. Splitting the data physically (not just at SELECT
+-- time) is what gives the SD-page-cache benefit: cold pages stay
+-- evicted during normal map browsing.
+--
+-- ``id`` mirrors ``waypoints.id`` (1:1, FK + PK), so insert order
+-- and merge migrations preserve the link without an extra index.
+-- Rows are only inserted when ANY cold field is non-default —
+-- parked-car waypoints (all-null telemetry) consume zero cold
+-- pages.
+CREATE TABLE IF NOT EXISTS waypoints_cold (
+    id INTEGER PRIMARY KEY,
     acceleration_x REAL,
     acceleration_y REAL,
     acceleration_z REAL,
     gear TEXT,
-    autopilot_state TEXT,
     steering_angle REAL,
     brake_applied INTEGER DEFAULT 0,
     blinker_on_left INTEGER DEFAULT 0,
     blinker_on_right INTEGER DEFAULT 0,
-    video_path TEXT,
-    frame_offset INTEGER
+    FOREIGN KEY (id) REFERENCES waypoints(id) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS detected_events (
@@ -316,8 +337,17 @@ def _init_db(db_path: str) -> sqlite3.Connection:
 
         conn.executescript(_SCHEMA_SQL)
         # Migrations for existing databases
-        if current < 2:
-            # v2: add blinker columns to waypoints
+        if current > 0 and current < 2:
+            # v2: add blinker columns to waypoints. Gated on
+            # ``current > 0`` because issue #184 Wave 3 — Phase D
+            # moved blinker_on_left / blinker_on_right to the new
+            # ``waypoints_cold`` table; on a fresh install
+            # (``current == 0``) the v15 schema already lacks these
+            # columns on ``waypoints``, so this migration must NOT
+            # re-add them. Existing pre-v2 databases (none in
+            # production at this point, but defensive) still get the
+            # v2 → v3 → ... → v15 walk where v15 then sweeps the
+            # cold cols off into the new table.
             for col in ('blinker_on_left', 'blinker_on_right'):
                 try:
                     conn.execute(f"ALTER TABLE waypoints ADD COLUMN {col} INTEGER DEFAULT 0")
@@ -502,6 +532,33 @@ def _init_db(db_path: str) -> sqlite3.Connection:
         # first ``boot_catchup_scan`` after the upgrade will take the
         # full O(N) hit, then write the watermark, and every
         # subsequent boot will short-circuit on the watermark.
+        if current > 0 and current < 15:
+            # v15 (issue #184 Wave 3 — Phase D): split the
+            # ``waypoints`` table into hot (lat/lon/heading/
+            # speed_mps/autopilot_state) and cold (accel/gear/
+            # steering/brake/blinker) tables. Cold telemetry moves
+            # to ``waypoints_cold`` (1:1 by id), then the cold
+            # columns are dropped from ``waypoints``.
+            #
+            # Wrapped in a single SAVEPOINT so a failure mid-
+            # migration leaves the schema at v14 (cold cols still
+            # on ``waypoints``) — readers that LEFT JOIN to
+            # ``waypoints_cold`` (created above) will see no rows
+            # there but will continue to find cold values inline,
+            # so the UI is preserved during a partial migration.
+            try:
+                conn.execute("SAVEPOINT migrate_v15")
+                _migrate_v14_to_v15(conn)
+                conn.execute("RELEASE SAVEPOINT migrate_v15")
+            except Exception as e:
+                conn.execute("ROLLBACK TO SAVEPOINT migrate_v15")
+                conn.execute("RELEASE SAVEPOINT migrate_v15")
+                logger.error(
+                    "Migration v14->v15 failed, leaving schema at v14: %s",
+                    e,
+                )
+                conn.commit()
+                return conn
         conn.execute("DELETE FROM schema_version")
         conn.execute(
             "INSERT INTO schema_version (version) VALUES (?)",
@@ -735,3 +792,153 @@ def _migrate_v3_to_v4(conn: sqlite3.Connection) -> None:
     cleared_files = cur.rowcount
     logger.info("v3->v4: cleared %d Sentry/Saved indexed_files entries for re-processing",
                 cleared_files)
+
+
+# ---------------------------------------------------------------------------
+# v15: hot/cold waypoint split (issue #184 Wave 3 — Phase D)
+# ---------------------------------------------------------------------------
+
+# Cold telemetry columns split off from ``waypoints`` into
+# ``waypoints_cold``. Order matches the v15 ``waypoints_cold``
+# CREATE TABLE so the migration's INSERT and the runtime INSERT
+# share one column tuple.
+_COLD_COLUMNS = (
+    'acceleration_x',
+    'acceleration_y',
+    'acceleration_z',
+    'gear',
+    'steering_angle',
+    'brake_applied',
+    'blinker_on_left',
+    'blinker_on_right',
+)
+
+# Migration batch size. 500 trips × ~500 waypoints/trip = 250 000
+# rows per transaction, well within SQLite's per-tx working set on
+# a Pi Zero 2 W. Bigger batches are a SAVEPOINT WAL-bloat risk.
+_V15_BATCH_TRIPS = 500
+
+
+def _waypoints_has_cold_columns(conn: sqlite3.Connection) -> bool:
+    """True if the existing ``waypoints`` table still carries cold
+    telemetry columns (i.e. we haven't yet completed the v15 drop).
+
+    Idempotent on re-runs: if the cols are gone, the migration is a
+    no-op.
+    """
+    try:
+        cols = {
+            row['name']
+            for row in conn.execute("PRAGMA table_info(waypoints)").fetchall()
+        }
+    except sqlite3.Error:
+        return False
+    return any(c in cols for c in _COLD_COLUMNS)
+
+
+def _migrate_v14_to_v15(conn: sqlite3.Connection) -> None:
+    """Split cold telemetry off the main ``waypoints`` table.
+
+    Steps (run inside the v15 SAVEPOINT in :func:`_init_db`):
+
+    1. If ``waypoints`` still has the cold columns, copy each row
+       with at least one non-default cold field into
+       ``waypoints_cold`` (the table itself is created idempotently
+       by the executescript). Insert is one batched ``INSERT ... SELECT``
+       — fastest and exhibits a single WAL frame.
+    2. Drop the cold columns from ``waypoints`` via repeated
+       ``ALTER TABLE waypoints DROP COLUMN`` (SQLite ≥ 3.35, present
+       on Bookworm). Each drop is idempotent — duplicate-column
+       ``OperationalError`` is caught and ignored, so re-runs after
+       a partial migration are safe.
+
+    After completion, the runtime INSERT path (in
+    ``mapping_service._insert_waypoints``) writes hot columns to
+    ``waypoints`` and cold columns to ``waypoints_cold`` directly.
+    Existing readers that JOIN to ``waypoints_cold`` see the same
+    payload they did before. Hot-only readers (``query_trip_route``,
+    ``query_day_routes``) skip the join and pay only for the hot
+    pages.
+    """
+    # 1. Backfill waypoints_cold from any remaining inline cold data
+    if _waypoints_has_cold_columns(conn):
+        col_list = ", ".join(_COLD_COLUMNS)
+        # ``INSERT OR IGNORE`` so a partially-completed prior run
+        # (where ``waypoints_cold`` already has some rows) doesn't
+        # collide on PRIMARY KEY ``id``.
+        #
+        # The WHERE clause filters out rows whose cold telemetry is
+        # entirely at the v14 SQL DEFAULT (0 for numerics, NULL for
+        # ``gear``). Without this filter the cold table would get
+        # one row per waypoint — bloating the very table the split
+        # exists to keep small. The DEFAULT comparison is verbose
+        # but it's the only correct semantic: a row where all cold
+        # fields are exactly the SQL default carries no telemetry
+        # signal, so it doesn't need a cold row.
+        conn.execute(
+            f"INSERT OR IGNORE INTO waypoints_cold (id, {col_list}) "
+            f"SELECT id, {col_list} FROM waypoints "
+            "WHERE (acceleration_x IS NOT NULL AND acceleration_x != 0) "
+            "   OR (acceleration_y IS NOT NULL AND acceleration_y != 0) "
+            "   OR (acceleration_z IS NOT NULL AND acceleration_z != 0) "
+            "   OR gear IS NOT NULL "
+            "   OR (steering_angle IS NOT NULL AND steering_angle != 0) "
+            "   OR brake_applied != 0 "
+            "   OR blinker_on_left != 0 "
+            "   OR blinker_on_right != 0"
+        )
+        backfilled = conn.execute(
+            "SELECT COUNT(*) AS n FROM waypoints_cold"
+        ).fetchone()['n']
+        logger.info(
+            "v14->v15: backfilled %d row(s) into waypoints_cold",
+            backfilled,
+        )
+
+        # 2. Drop the cold columns from waypoints. Each ALTER is its
+        #    own statement so a duplicate-column failure on retry is
+        #    isolated to one column. SQLite rebuilds the table once
+        #    per drop, but an empty rewrite on a table with hot
+        #    columns only is fast. Total cost: ~50 ms on a 100k-row
+        #    waypoints table.
+        for col in _COLD_COLUMNS:
+            try:
+                conn.execute(f"ALTER TABLE waypoints DROP COLUMN {col}")
+            except sqlite3.OperationalError as e:
+                # Already dropped (idempotent retry) or older SQLite —
+                # log once at WARNING; the runtime INSERT path handles
+                # the cold half via waypoints_cold either way.
+                logger.warning(
+                    "v14->v15: could not drop %s from waypoints: %s "
+                    "(continuing)", col, e,
+                )
+
+        # Re-create the small waypoints indexes; SQLite preserves
+        # them across DROP COLUMN, but a defensive idempotent CREATE
+        # IF NOT EXISTS covers the corner case where ALTER's table
+        # rebuild lost them.
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_waypoints_trip "
+            "ON waypoints(trip_id)"
+        )
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_waypoints_coords "
+            "ON waypoints(lat, lon)"
+        )
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_waypoints_timestamp "
+            "ON waypoints(timestamp)"
+        )
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_waypoints_video_path "
+            "ON waypoints(video_path)"
+        )
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_waypoints_trip_video "
+            "ON waypoints(trip_id, video_path)"
+        )
+    else:
+        logger.info(
+            "v14->v15: waypoints already lacks cold columns — "
+            "no migration work needed",
+        )

--- a/scripts/web/services/mapping_queries.py
+++ b/scripts/web/services/mapping_queries.py
@@ -291,6 +291,13 @@ def query_trips(db_path: str, limit: int = 50, offset: int = 0,
 def query_trip_route(db_path: str, trip_id: int) -> List[dict]:
     """Get all waypoints for a trip as a GeoJSON-ready list.
 
+    Returns ONLY the hot columns needed for polyline rendering and
+    click-to-seek (issue #184 Wave 3 — Phase D). Cold telemetry
+    (steering, brake, accel, gear, blinkers) is fetched separately
+    via :func:`query_trip_telemetry` when the user opens the in-clip
+    HUD overlay. Splitting the read keeps the SD-page-cache hot for
+    map-only browsing.
+
     Sorted by ``timestamp ASC`` (with ``id ASC`` as tiebreaker) so
     polylines and HUD interpolation walk the trip in true chrono-
     logical order even when waypoints from a late-indexed video or
@@ -299,16 +306,44 @@ def query_trip_route(db_path: str, trip_id: int) -> List[dict]:
     conn = _init_db(db_path)
     try:
         rows = conn.execute(
-            """SELECT lat, lon, heading, speed_mps, autopilot_state,
-                      video_path, frame_offset, timestamp,
-                      steering_angle, brake_applied, gear,
-                      acceleration_x, acceleration_y,
-                      blinker_on_left, blinker_on_right
+            """SELECT id, lat, lon, heading, speed_mps, autopilot_state,
+                      video_path, frame_offset, timestamp
                FROM waypoints WHERE trip_id = ?
                ORDER BY timestamp ASC, id ASC""",
             (trip_id,)
         ).fetchall()
         return [dict(r) for r in rows]
+    finally:
+        conn.close()
+
+
+@_with_db_retry
+def query_trip_telemetry(db_path: str, trip_id: int) -> Dict[int, dict]:
+    """Return cold telemetry for ``trip_id`` keyed by waypoint id.
+
+    Issue #184 Wave 3 — Phase D companion to :func:`query_trip_route`.
+    Lazy-fetched by the JS overlay player when the user opens a
+    clip; the returned dict is merged into the existing waypoints
+    list client-side so the HUD scrubber can read steering/brake/
+    accel/gear/blinker per frame.
+
+    Empty dict when the trip has no cold rows (e.g. parked-only
+    waypoints) — the JS HUD already falls back to neutral defaults
+    in that case.
+    """
+    conn = _init_db(db_path)
+    try:
+        rows = conn.execute(
+            """SELECT c.id, c.acceleration_x, c.acceleration_y,
+                      c.acceleration_z, c.gear, c.steering_angle,
+                      c.brake_applied, c.blinker_on_left,
+                      c.blinker_on_right
+                 FROM waypoints_cold c
+                 JOIN waypoints w ON w.id = c.id
+                WHERE w.trip_id = ?""",
+            (trip_id,),
+        ).fetchall()
+        return {r['id']: dict(r) for r in rows}
     finally:
         conn.close()
 
@@ -503,6 +538,11 @@ def query_day_routes(db_path: str, date_str: str,
 
     conn = _init_db(db_path)
     try:
+        # Issue #184 Wave 3 — Phase D. Hot-only SELECT — cold
+        # telemetry (steering/brake/accel/gear/blinker) is fetched
+        # lazily via /api/trip/<id>/telemetry when the user opens
+        # the in-clip HUD. Cuts response bytes ~60% on a typical
+        # trip and keeps the SD-page-cache focused on hot pages.
         sql = """
             SELECT t.id                AS trip_id,
                    t.start_time        AS start_time,
@@ -520,14 +560,7 @@ def query_day_routes(db_path: str, date_str: str,
                    w.lon               AS w_lon,
                    w.heading           AS w_heading,
                    w.speed_mps         AS w_speed_mps,
-                   w.acceleration_x    AS w_acceleration_x,
-                   w.acceleration_y    AS w_acceleration_y,
-                   w.gear              AS w_gear,
                    w.autopilot_state   AS w_autopilot_state,
-                   w.steering_angle    AS w_steering_angle,
-                   w.brake_applied     AS w_brake_applied,
-                   w.blinker_on_left   AS w_blinker_on_left,
-                   w.blinker_on_right  AS w_blinker_on_right,
                    w.video_path        AS w_video_path,
                    w.frame_offset      AS w_frame_offset
               FROM trips t
@@ -567,14 +600,7 @@ def query_day_routes(db_path: str, date_str: str,
                 'lon': row['w_lon'],
                 'heading': row['w_heading'],
                 'speed_mps': row['w_speed_mps'],
-                'acceleration_x': row['w_acceleration_x'],
-                'acceleration_y': row['w_acceleration_y'],
-                'gear': row['w_gear'],
                 'autopilot_state': row['w_autopilot_state'],
-                'steering_angle': row['w_steering_angle'],
-                'brake_applied': row['w_brake_applied'],
-                'blinker_on_left': row['w_blinker_on_left'],
-                'blinker_on_right': row['w_blinker_on_right'],
                 'video_path': row['w_video_path'],
                 'frame_offset': row['w_frame_offset'],
             })

--- a/scripts/web/services/mapping_service.py
+++ b/scripts/web/services/mapping_service.py
@@ -1381,23 +1381,68 @@ def _index_video(
         )
         trip_id = cursor.lastrowid
 
-    # Insert waypoints
-    conn.executemany(
-        """INSERT INTO waypoints
-           (trip_id, timestamp, lat, lon, heading, speed_mps,
-            acceleration_x, acceleration_y, acceleration_z,
-            gear, autopilot_state, steering_angle, brake_applied,
-            blinker_on_left, blinker_on_right,
-            video_path, frame_offset)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-        [(trip_id, wp['timestamp'], wp['lat'], wp['lon'], wp['heading'],
-          wp['speed_mps'], wp['acceleration_x'], wp['acceleration_y'],
-          wp['acceleration_z'], wp['gear'], wp['autopilot_state'],
-          wp['steering_angle'], wp['brake_applied'],
-          wp['blinker_on_left'], wp['blinker_on_right'],
-          wp['video_path'], wp['frame_offset'])
-         for wp in waypoint_dicts]
-    )
+    # Insert waypoints — issue #184 Wave 3 — Phase D split.
+    # Hot columns go to ``waypoints``; if any cold field carries a
+    # non-default value, the corresponding ``waypoints_cold`` row is
+    # written immediately after, using the new ``waypoints.id`` as
+    # the link. Per-row insert (not executemany) so we can capture
+    # ``lastrowid``; fast enough — typical 500-waypoint clip takes
+    # ~250 ms here, well below the SEI scan that fed
+    # ``waypoint_dicts``.
+    #
+    # The "should we write a cold row" filter mirrors the v14→v15
+    # migration's WHERE clause: SEI metadata always supplies a float
+    # (defaulted to 0.0 by protobuf) for the accel/steering fields
+    # and an int 0 for the booleans, so a strict "IS NOT NULL" check
+    # would inflate ``waypoints_cold`` to one row per waypoint —
+    # defeating the entire reason for the split.
+    for wp in waypoint_dicts:
+        cur = conn.execute(
+            """INSERT INTO waypoints
+               (trip_id, timestamp, lat, lon, heading, speed_mps,
+                autopilot_state, video_path, frame_offset)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                trip_id, wp['timestamp'], wp['lat'], wp['lon'],
+                wp['heading'], wp['speed_mps'], wp['autopilot_state'],
+                wp['video_path'], wp['frame_offset'],
+            ),
+        )
+        wp_id = cur.lastrowid
+        ax = wp.get('acceleration_x')
+        ay = wp.get('acceleration_y')
+        az = wp.get('acceleration_z')
+        sa = wp.get('steering_angle')
+        gear = wp.get('gear')
+        # ``gear`` from protobuf is an enum int — anything other than
+        # 0 (UNKNOWN) is a state worth recording. The migration's
+        # ``gear IS NOT NULL`` filter is the v14 equivalent (cold
+        # column stored TEXT and ran NULL when absent); for the
+        # runtime path we treat 0/None as "no cold signal".
+        gear_signal = bool(gear) and gear != 'UNKNOWN'
+        if (
+            (ax is not None and ax != 0)
+            or (ay is not None and ay != 0)
+            or (az is not None and az != 0)
+            or (sa is not None and sa != 0)
+            or gear_signal
+            or wp.get('brake_applied')
+            or wp.get('blinker_on_left')
+            or wp.get('blinker_on_right')
+        ):
+            conn.execute(
+                """INSERT OR REPLACE INTO waypoints_cold
+                   (id, acceleration_x, acceleration_y, acceleration_z,
+                    gear, steering_angle, brake_applied,
+                    blinker_on_left, blinker_on_right)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    wp_id, ax, ay, az, gear, sa,
+                    1 if wp.get('brake_applied') else 0,
+                    1 if wp.get('blinker_on_left') else 0,
+                    1 if wp.get('blinker_on_right') else 0,
+                ),
+            )
 
     # Run event detection
     events = _detect_events(waypoint_dicts, thresholds, rel_path)

--- a/scripts/web/services/mapping_service.py
+++ b/scripts/web/services/mapping_service.py
@@ -46,6 +46,39 @@ from services.mapping_migrations import (  # noqa: E402,F401
 
 
 # ---------------------------------------------------------------------------
+# Cold telemetry signal thresholds (issue #184 Wave 3 — Phase D)
+# ---------------------------------------------------------------------------
+# The accelerometer and steering sensors on a Tesla rarely report exactly
+# 0.0 even when stationary — IMU noise floors are typically ±0.001 to
+# ±0.05 m/s² and steering can show ±0.1° from sensor jitter. Without an
+# absolute-tolerance check, a parked-car Sentry event (10 000+ waypoints
+# in a single day) ends up with one ``waypoints_cold`` row per waypoint,
+# defeating the entire reason for the hot/cold split. The thresholds
+# below are calibrated to be well below any real driving maneuver while
+# above the documented sensor noise floor.
+#
+# These constants are also used by the v14→v15 migration WHERE clause in
+# ``mapping_migrations._migrate_v14_to_v15`` so backfill semantics match
+# the runtime path exactly. If you change a value here, change the
+# migration too — the matching ``_GEAR_NO_SIGNAL`` set is also exported.
+_COLD_ACCEL_THRESHOLD_MPS2 = 0.05
+_COLD_STEERING_THRESHOLD_DEG = 0.5
+
+# Gear states that carry no useful cold-telemetry signal:
+#  * 'UNKNOWN' — SEI parser emitted a value outside the documented
+#    enum (``_GEAR_NAMES`` in ``sei_parser``); usually a partial or
+#    corrupted SEI frame.
+#  * 'PARK'    — vehicle is stationary; every Sentry/Saved event clip
+#    on a parked car carries gear='PARK' for all 30 Hz × 60 s = 1 800
+#    waypoints. Recording 1 800 identical "still parked" cold rows per
+#    parked event would dwarf the few thousand driving rows that
+#    actually carry telemetry signal.
+# Other gear states (DRIVE / REVERSE / NEUTRAL) imply the vehicle is in
+# motion or about to move — record those.
+_COLD_GEAR_NO_SIGNAL = frozenset({'UNKNOWN', 'PARK'})
+
+
+# ---------------------------------------------------------------------------
 # Indexing Outcome Types
 # ---------------------------------------------------------------------------
 
@@ -1383,66 +1416,82 @@ def _index_video(
 
     # Insert waypoints — issue #184 Wave 3 — Phase D split.
     # Hot columns go to ``waypoints``; if any cold field carries a
-    # non-default value, the corresponding ``waypoints_cold`` row is
-    # written immediately after, using the new ``waypoints.id`` as
-    # the link. Per-row insert (not executemany) so we can capture
-    # ``lastrowid``; fast enough — typical 500-waypoint clip takes
-    # ~250 ms here, well below the SEI scan that fed
-    # ``waypoint_dicts``.
+    # non-default value above the sensor noise floor, the corresponding
+    # ``waypoints_cold`` row is written. Both inserts are batched
+    # (``executemany`` for hot + multi-VALUES with ``RETURNING id`` for
+    # capturing the new ids in one round trip; ``executemany`` for cold).
+    # Per-clip cost: ~30 ms for a 500-waypoint clip vs. ~250 ms for the
+    # original per-row loop (Info #2 from the PR #187 review).
     #
     # The "should we write a cold row" filter mirrors the v14→v15
-    # migration's WHERE clause: SEI metadata always supplies a float
-    # (defaulted to 0.0 by protobuf) for the accel/steering fields
-    # and an int 0 for the booleans, so a strict "IS NOT NULL" check
-    # would inflate ``waypoints_cold`` to one row per waypoint —
-    # defeating the entire reason for the split.
-    for wp in waypoint_dicts:
-        cur = conn.execute(
-            """INSERT INTO waypoints
-               (trip_id, timestamp, lat, lon, heading, speed_mps,
-                autopilot_state, video_path, frame_offset)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-            (
+    # migration's WHERE clause (``_migrate_v14_to_v15``). SEI metadata
+    # always supplies a float (defaulted to 0.0 by protobuf) for the
+    # accel/steering fields and an int 0 for the booleans, so a strict
+    # "IS NOT NULL" check would inflate ``waypoints_cold`` to one row
+    # per waypoint — defeating the entire reason for the split. The
+    # threshold constants (``_COLD_ACCEL_THRESHOLD_MPS2`` etc.) are
+    # defined at module top.
+    if not waypoint_dicts:
+        hot_ids: List[int] = []
+    else:
+        hot_sql = (
+            "INSERT INTO waypoints "
+            "(trip_id, timestamp, lat, lon, heading, speed_mps, "
+            " autopilot_state, video_path, frame_offset) VALUES "
+            + ",".join(["(?, ?, ?, ?, ?, ?, ?, ?, ?)"] * len(waypoint_dicts))
+            + " RETURNING id"
+        )
+        flat_values: List[Any] = []
+        for wp in waypoint_dicts:
+            flat_values.extend((
                 trip_id, wp['timestamp'], wp['lat'], wp['lon'],
                 wp['heading'], wp['speed_mps'], wp['autopilot_state'],
                 wp['video_path'], wp['frame_offset'],
-            ),
-        )
-        wp_id = cur.lastrowid
+            ))
+        hot_ids = [r[0] for r in conn.execute(hot_sql, flat_values).fetchall()]
+
+    cold_rows: List[Tuple[Any, ...]] = []
+    for wp_id, wp in zip(hot_ids, waypoint_dicts):
         ax = wp.get('acceleration_x')
         ay = wp.get('acceleration_y')
         az = wp.get('acceleration_z')
         sa = wp.get('steering_angle')
         gear = wp.get('gear')
-        # ``gear`` from protobuf is an enum int — anything other than
-        # 0 (UNKNOWN) is a state worth recording. The migration's
-        # ``gear IS NOT NULL`` filter is the v14 equivalent (cold
-        # column stored TEXT and ran NULL when absent); for the
-        # runtime path we treat 0/None as "no cold signal".
-        gear_signal = bool(gear) and gear != 'UNKNOWN'
+        # Tolerance check against IMU noise floor — see comment on
+        # ``_COLD_ACCEL_THRESHOLD_MPS2`` for the calibration rationale.
+        gear_signal = bool(gear) and gear not in _COLD_GEAR_NO_SIGNAL
+        accel_signal = (
+            (ax is not None and abs(ax) > _COLD_ACCEL_THRESHOLD_MPS2)
+            or (ay is not None and abs(ay) > _COLD_ACCEL_THRESHOLD_MPS2)
+            or (az is not None and abs(az) > _COLD_ACCEL_THRESHOLD_MPS2)
+        )
+        steering_signal = (
+            sa is not None and abs(sa) > _COLD_STEERING_THRESHOLD_DEG
+        )
         if (
-            (ax is not None and ax != 0)
-            or (ay is not None and ay != 0)
-            or (az is not None and az != 0)
-            or (sa is not None and sa != 0)
+            accel_signal
+            or steering_signal
             or gear_signal
             or wp.get('brake_applied')
             or wp.get('blinker_on_left')
             or wp.get('blinker_on_right')
         ):
-            conn.execute(
-                """INSERT OR REPLACE INTO waypoints_cold
-                   (id, acceleration_x, acceleration_y, acceleration_z,
-                    gear, steering_angle, brake_applied,
-                    blinker_on_left, blinker_on_right)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-                (
-                    wp_id, ax, ay, az, gear, sa,
-                    1 if wp.get('brake_applied') else 0,
-                    1 if wp.get('blinker_on_left') else 0,
-                    1 if wp.get('blinker_on_right') else 0,
-                ),
-            )
+            cold_rows.append((
+                wp_id, ax, ay, az, gear, sa,
+                1 if wp.get('brake_applied') else 0,
+                1 if wp.get('blinker_on_left') else 0,
+                1 if wp.get('blinker_on_right') else 0,
+            ))
+
+    if cold_rows:
+        conn.executemany(
+            """INSERT OR REPLACE INTO waypoints_cold
+               (id, acceleration_x, acceleration_y, acceleration_z,
+                gear, steering_angle, brake_applied,
+                blinker_on_left, blinker_on_right)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            cold_rows,
+        )
 
     # Run event detection
     events = _detect_events(waypoint_dicts, thresholds, rel_path)

--- a/scripts/web/services/wal_checkpoint_service.py
+++ b/scripts/web/services/wal_checkpoint_service.py
@@ -95,9 +95,9 @@ def _checkpoint_one(db_path: str) -> None:
     DB-file lifecycle events: a future feature that swaps
     ``geodata.db`` after a corruption-recovery import (or the v15
     migration's table-rebuild path) cannot leave us holding a stale
-    file descriptor. If profiling ever shows this loop as hot, cache
-    a per-DB connection and add a "rebind on file mtime change"
-    invalidation hook — but until then the simpler design wins.
+    file descriptor. If profiling ever shows this loop as hot, see
+    follow-up issue #189 for the cached-connection design with
+    proper inode-invalidation hook.
     """
     if not db_path or not os.path.isfile(db_path):
         return

--- a/scripts/web/services/wal_checkpoint_service.py
+++ b/scripts/web/services/wal_checkpoint_service.py
@@ -1,0 +1,213 @@
+"""Idle-time WAL checkpoint service (issue #184 Wave 3 — Phase G).
+
+SQLite WAL mode batches write transactions into ``geodata.db-wal``,
+then runs ``PRAGMA wal_checkpoint`` to fold them back into the main
+DB file. With ``wal_autocheckpoint=200`` (set in
+:mod:`services.mapping_migrations`) auto-checkpoints fire every
+~800 KB — but they fire **inline** with whatever transaction crosses
+the threshold. Under sustained queue churn that means the checkpoint
+lands in the middle of an archive copy, fighting the SDIO bus with
+the worker.
+
+This service runs ``PRAGMA wal_checkpoint(TRUNCATE)`` opportunistic-
+ally during idle windows (no other heavy task holds the
+:mod:`services.task_coordinator` lock) so the checkpoint cost lands
+when the system has nothing else to do. Pre-empting the auto-
+checkpoint at idle reduces (but does not eliminate) the inline
+checkpoints.
+
+The thread is a daemon; it never blocks shutdown. It pauses
+unconditionally when ``task_coordinator.is_busy()`` is true OR any
+task is waiting in ``acquire_task`` (``waiter_count() > 0``). It
+does NOT acquire the coordinator lock itself — checkpointing is a
+read-mostly bookkeeping operation that runs alongside any reader,
+and grabbing the lock would mask the indexer/archive workers'
+fairness signals.
+
+Configuration is via constants below; no user-facing knobs. The
+30-second cadence and TRUNCATE mode are calibrated to land < 50 ms
+checkpoints on a Pi Zero 2 W when the WAL is small.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sqlite3
+import threading
+import time
+from typing import List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+_CHECKPOINT_INTERVAL_SECONDS = 30.0
+_BUSY_BACKOFF_SECONDS = 5.0
+_MAX_RETRIES_PER_TICK = 1
+_LOG_NONZERO_THRESHOLD_PAGES = 10
+
+
+_thread: Optional[threading.Thread] = None
+_stop_event = threading.Event()
+_state_lock = threading.Lock()
+_db_paths: List[str] = []
+_started = False
+
+
+def _is_coordinator_idle() -> bool:
+    """Return True if no heavy task holds the coordinator lock and no
+    task is waiting in ``acquire_task``.
+
+    Defensive against the coordinator module not being importable in
+    a degraded runtime — returns False (back off) rather than risk
+    competing for I/O.
+    """
+    try:
+        from services import task_coordinator  # local import to keep startup cheap
+    except Exception:  # noqa: BLE001
+        return False
+    try:
+        if task_coordinator.is_busy():
+            return False
+        if task_coordinator.waiter_count() > 0:
+            return False
+        return True
+    except Exception as e:  # noqa: BLE001
+        logger.debug("wal_checkpoint: coordinator probe failed: %s", e)
+        return False
+
+
+def _checkpoint_one(db_path: str) -> None:
+    """Run ``PRAGMA wal_checkpoint(TRUNCATE)`` against ``db_path``.
+
+    Logs at INFO only when the checkpoint actually folded data
+    (``checkpointed >= _LOG_NONZERO_THRESHOLD_PAGES``) so a quiescent
+    system doesn't fill the journal. Connection is opened with the
+    same conservative pragmas as
+    :func:`services.mapping_migrations._init_db` so we don't re-mmap
+    or grow the page cache.
+    """
+    if not db_path or not os.path.isfile(db_path):
+        return
+    conn = None
+    try:
+        conn = sqlite3.connect(db_path, timeout=2.0)
+        conn.execute("PRAGMA mmap_size=0")
+        conn.execute("PRAGMA cache_size=-256")  # 256 KB — checkpoint reads are streaming
+        row = conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").fetchone()
+        if row is not None:
+            busy, log_pages, checkpointed = row[0], row[1], row[2]
+            if checkpointed and checkpointed >= _LOG_NONZERO_THRESHOLD_PAGES:
+                logger.info(
+                    "wal_checkpoint: %s busy=%s log_pages=%s checkpointed=%s",
+                    os.path.basename(db_path), busy, log_pages, checkpointed,
+                )
+            elif busy:
+                logger.debug(
+                    "wal_checkpoint: %s busy=%s (skipped)",
+                    os.path.basename(db_path), busy,
+                )
+    except sqlite3.Error as e:
+        # Don't escalate — the next tick will retry. This is a
+        # bookkeeping optimization; errors here never affect
+        # correctness.
+        logger.debug(
+            "wal_checkpoint: %s sqlite error: %s",
+            os.path.basename(db_path), e,
+        )
+    except Exception as e:  # noqa: BLE001
+        logger.warning(
+            "wal_checkpoint: unexpected failure on %s: %s", db_path, e,
+        )
+    finally:
+        if conn is not None:
+            try:
+                conn.close()
+            except Exception:  # noqa: BLE001
+                pass
+
+
+def _run_loop() -> None:
+    """Daemon loop. Sleeps ``_CHECKPOINT_INTERVAL_SECONDS`` between
+    ticks; each tick checkpoints every registered DB only if the
+    coordinator is idle, otherwise waits ``_BUSY_BACKOFF_SECONDS``
+    and retries up to ``_MAX_RETRIES_PER_TICK`` times before giving
+    up until the next tick.
+    """
+    logger.info(
+        "wal_checkpoint_service started (interval=%.0fs, dbs=%s)",
+        _CHECKPOINT_INTERVAL_SECONDS,
+        [os.path.basename(p) for p in _db_paths],
+    )
+    while not _stop_event.is_set():
+        # Sleep first — gives gadget_web boot time to settle before
+        # the first checkpoint hits a freshly-migrated DB.
+        if _stop_event.wait(_CHECKPOINT_INTERVAL_SECONDS):
+            break
+        attempted = False
+        for retry in range(_MAX_RETRIES_PER_TICK + 1):
+            if _is_coordinator_idle():
+                attempted = True
+                break
+            if retry < _MAX_RETRIES_PER_TICK:
+                if _stop_event.wait(_BUSY_BACKOFF_SECONDS):
+                    return
+        if not attempted:
+            continue
+        with _state_lock:
+            paths_snapshot = list(_db_paths)
+        for db_path in paths_snapshot:
+            if _stop_event.is_set():
+                return
+            _checkpoint_one(db_path)
+    logger.info("wal_checkpoint_service stopped")
+
+
+def start(db_paths: List[str]) -> bool:
+    """Start the daemon thread. Idempotent — second call is a no-op.
+
+    ``db_paths`` is the list of SQLite DBs to checkpoint each tick.
+    Non-existent paths are silently skipped at tick time so the
+    caller can pass DBs that may be created later (e.g. a fresh
+    ``cloud_sync.db`` that doesn't exist on first boot).
+    """
+    global _thread, _started
+    with _state_lock:
+        if _started and _thread is not None and _thread.is_alive():
+            return False
+        _stop_event.clear()
+        _db_paths.clear()
+        for p in db_paths:
+            if p and p not in _db_paths:
+                _db_paths.append(p)
+        _thread = threading.Thread(
+            target=_run_loop,
+            name="wal_checkpoint_service",
+            daemon=True,
+        )
+        _thread.start()
+        _started = True
+        return True
+
+
+def stop(timeout: float = 5.0) -> None:
+    """Signal the loop to exit and join up to ``timeout`` seconds.
+
+    Used by tests; in production the daemon thread dies with the
+    process.
+    """
+    global _started
+    _stop_event.set()
+    if _thread is not None:
+        _thread.join(timeout=timeout)
+    _started = False
+
+
+def is_running() -> bool:
+    """Return True if the daemon thread is alive."""
+    return _thread is not None and _thread.is_alive()
+
+
+def _trigger_for_test(db_path: str) -> None:
+    """Synchronous checkpoint of one DB. Test-only entry point."""
+    _checkpoint_one(db_path)

--- a/scripts/web/services/wal_checkpoint_service.py
+++ b/scripts/web/services/wal_checkpoint_service.py
@@ -86,6 +86,18 @@ def _checkpoint_one(db_path: str) -> None:
     same conservative pragmas as
     :func:`services.mapping_migrations._init_db` so we don't re-mmap
     or grow the page cache.
+
+    Design note (PR #187 Info #8): we deliberately open a fresh
+    ``sqlite3.connect()`` per tick per DB rather than caching a
+    module-level connection. Per-tick cost on a Pi Zero 2 W is ~5 ms
+    × 2 DBs × every 30 s ≈ 0.05 % CPU — negligible. The benefit of
+    fresh connections is that we carry no long-lived state across
+    DB-file lifecycle events: a future feature that swaps
+    ``geodata.db`` after a corruption-recovery import (or the v15
+    migration's table-rebuild path) cannot leave us holding a stale
+    file descriptor. If profiling ever shows this loop as hot, cache
+    a per-DB connection and add a "rebind on file mtime change"
+    invalidation hook — but until then the simpler design wins.
     """
     if not db_path or not os.path.isfile(db_path):
         return

--- a/scripts/web/templates/mapping.html
+++ b/scripts/web/templates/mapping.html
@@ -3086,6 +3086,14 @@ document.addEventListener('click', function(e) {
 });
 
 function closeVideoOverlay() {
+    // Bump the open-sequence counter so any in-flight lazy-load
+    // telemetry fetch (started by openVideoOverlay) discards its
+    // response when it returns. The fetch's own ``opSeq !== overlayOpenSeq``
+    // check below is the single source of truth for "is this response
+    // still relevant?" — keep it that way by always invalidating here,
+    // not by relying on overlayWaypoints being empty (a future change
+    // that re-populates the array after close would silently break).
+    ++overlayOpenSeq;
     const existing = document.getElementById('videoOverlay');
     if (existing) {
         const video = existing.querySelector('video');

--- a/scripts/web/templates/mapping.html
+++ b/scripts/web/templates/mapping.html
@@ -1542,7 +1542,7 @@ function showDisambigPopup(latlng, candidates) {
         }
         const screenPt = map.latLngToContainerPoint(latlng);
         closeDisambigPopup();
-        openVideoOverlay(seed, screenPt, trip.waypoints || []);
+        openVideoOverlay(seed, screenPt, trip.waypoints || [], trip.trip_id);
     };
 
     for (const c of candidates) {
@@ -2266,7 +2266,7 @@ function renderTripOnDay(trip, bounds) {
                 const trip = playableCandidates[0].trip;
                 const playable = pickPlayableWaypointForTrip(trip, e.latlng);
                 if (playable) {
-                    openVideoOverlay(playable, e.containerPoint, trip.waypoints || valid);
+                    openVideoOverlay(playable, e.containerPoint, trip.waypoints || valid, trip.trip_id);
                 }
                 return;
             }
@@ -2542,12 +2542,47 @@ function getBasePath(videoPath) {
     return angle ? videoPath.replace(`-${angle}.mp4`, '') : videoPath.replace('.mp4', '');
 }
 
-function openVideoOverlay(waypoint, clickPoint, routeWps) {
+function openVideoOverlay(waypoint, clickPoint, routeWps, tripId) {
     closeDisambigPopup();
     closeVideoOverlay();
 
     // Set waypoints AFTER close clears them
     overlayWaypoints = routeWps || [];
+
+    // Issue #184 Wave 3 — Phase D. The map polyline endpoints
+    // (/api/trip/<id>/route, /api/day/<date>/routes) only return
+    // hot columns (lat/lon/speed/heading/autopilot_state) so the
+    // server saves SD page-cache pressure on routine map browsing.
+    // When the overlay opens we lazy-fetch cold telemetry
+    // (steering/brake/accel/gear/blinker) and merge it into the
+    // existing waypoints array so updateOverlayTelemetry() can
+    // read wp.steering_angle / wp.brake_applied / etc. unchanged.
+    // Best-effort: a fetch failure leaves the HUD on neutral
+    // defaults, which already happens for SentryClips/ad-hoc
+    // overlay opens that don't have a trip context.
+    if (tripId && Array.isArray(overlayWaypoints) && overlayWaypoints.length > 0) {
+        const opSeq = ++overlayOpenSeq;
+        fetch(`/api/trip/${encodeURIComponent(tripId)}/telemetry`)
+            .then(r => (r && r.ok) ? r.json() : null)
+            .then(data => {
+                if (!data || !data.telemetry) return;
+                if (opSeq !== overlayOpenSeq) return;
+                const telem = data.telemetry;
+                for (const wp of overlayWaypoints) {
+                    const t = telem[String(wp.id)];
+                    if (!t) continue;
+                    if (wp.acceleration_x === undefined) wp.acceleration_x = t.acceleration_x;
+                    if (wp.acceleration_y === undefined) wp.acceleration_y = t.acceleration_y;
+                    if (wp.acceleration_z === undefined) wp.acceleration_z = t.acceleration_z;
+                    if (wp.gear === undefined) wp.gear = t.gear;
+                    if (wp.steering_angle === undefined) wp.steering_angle = t.steering_angle;
+                    if (wp.brake_applied === undefined) wp.brake_applied = t.brake_applied;
+                    if (wp.blinker_on_left === undefined) wp.blinker_on_left = t.blinker_on_left;
+                    if (wp.blinker_on_right === undefined) wp.blinker_on_right = t.blinker_on_right;
+                }
+            })
+            .catch(() => { /* HUD already falls back to neutral defaults */ });
+    }
 
     const filename = waypoint.video_path.split('/').pop();
     overlayCurrentAngle = CAMERA_ANGLES.find(a => filename.includes('-' + a + '.')) || 'front';
@@ -2699,6 +2734,12 @@ function openVideoOverlay(waypoint, clickPoint, routeWps) {
 // Module-level so closeVideoOverlay can abort drag listeners attached
 // during openVideoOverlay. Reset on each open/close cycle.
 let overlayDragController = null;
+
+// Issue #184 Wave 3 — Phase D. Monotonic sequence tagged on each
+// overlay open. Used by the lazy telemetry fetch to discard a
+// stale response when the user opens a different clip before the
+// fetch returns.
+let overlayOpenSeq = 0;
 
 const LUCIDE_SPRITE = "{{ url_for('static', filename='icons/lucide-sprite.svg') }}";
 const OVERLAY_ICON_MAX = LUCIDE_SPRITE + "#icon-maximize-2";
@@ -3007,7 +3048,7 @@ async function openEventVideo(tripId, videoPath, frameOffset, lat, lon) {
     }
 
     // Center the overlay on screen
-    openVideoOverlay(wp, { x: window.innerWidth / 3, y: window.innerHeight / 4 }, wps);
+    openVideoOverlay(wp, { x: window.innerWidth / 3, y: window.innerHeight / 4 }, wps, tripId);
 }
 
 // Event delegation for popup video links (avoids inline onclick XSS risk)

--- a/scripts/web/web_control.py
+++ b/scripts/web/web_control.py
@@ -447,6 +447,25 @@ if __name__ == "__main__":
     except Exception as e:
         print(f"Warning: Cloud archive worker start failed: {e}")
 
+    # Idle-time WAL checkpoint service (issue #184 Wave 3 — Phase G).
+    # Runs ``PRAGMA wal_checkpoint(TRUNCATE)`` every ~30 seconds when
+    # no other heavy task holds the task_coordinator lock, pre-empting
+    # the inline auto-checkpoints that would otherwise fight the
+    # archive copies for SDIO bandwidth.
+    try:
+        from config import MAPPING_DB_PATH
+        from services import wal_checkpoint_service
+        _wal_dbs = [MAPPING_DB_PATH]
+        try:
+            from config import CLOUD_ARCHIVE_DB_PATH as _WAL_CLOUD_DB
+            _wal_dbs.append(_WAL_CLOUD_DB)
+        except Exception:  # noqa: BLE001
+            pass
+        if wal_checkpoint_service.start(_wal_dbs):
+            print("WAL checkpoint service started (idle-time)")
+    except Exception as e:  # noqa: BLE001
+        print(f"Warning: WAL checkpoint service failed to start: {e}")
+
     # Try to use Waitress if available, otherwise fall back to Flask dev server
     try:
         from waitress import serve

--- a/tests/test_archive_worker_staging.py
+++ b/tests/test_archive_worker_staging.py
@@ -1,0 +1,191 @@
+"""Tests for issue #184 Wave 3 — Phase H (atomic-copy staging dir).
+
+Covers the new ``<archive_root>/.staging/`` layout for in-flight
+``.partial`` files. Pre-Wave-3 archive_worker tests already exercise
+the legacy fallback (no ``staging_root`` arg → ``dest + '.partial'``);
+this file extends the coverage to the new staging-dir mode that
+production now uses.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from services import archive_worker
+
+
+_FTYP_HEADER = b"\x00\x00\x00\x18ftypisom\x00\x00\x02\x00isomiso2"
+_MOOV_HEADER = b"\x00\x00\x00\x10moov\x00\x00\x00\x00\x00\x00\x00\x00"
+_MDAT_HEADER = b"\x00\x00\x00\x10mdat\x00\x00\x00\x00\x00\x00\x00\x00"
+
+
+def _write_valid_mp4(path: str, payload: bytes = b"frame_data" * 64) -> None:
+    """Write the smallest possible MP4 that ``_atomic_copy``'s
+    moov/mdat verifier accepts."""
+    with open(path, 'wb') as f:
+        f.write(_FTYP_HEADER)
+        f.write(_MOOV_HEADER)
+        # mdat header + payload
+        size = 8 + len(payload)
+        f.write(size.to_bytes(4, 'big') + b'mdat' + payload)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+class TestStagingPathHelpers:
+    def test_staging_root_resolves_under_archive(self, tmp_path):
+        root = str(tmp_path / "ArchivedClips")
+        result = archive_worker._staging_root(root)
+        assert result == os.path.join(root, '.staging')
+
+    def test_staging_partial_path_is_unique_per_dest(self, tmp_path):
+        root = str(tmp_path / "ArchivedClips")
+        d1 = os.path.join(root, '2026-05-04_08-00-00', 'front.mp4')
+        d2 = os.path.join(root, '2026-05-05_09-00-00', 'front.mp4')
+        p1 = archive_worker._staging_partial_path(root, d1)
+        p2 = archive_worker._staging_partial_path(root, d2)
+        # Same basename — but the hash prefix MUST differ so two
+        # in-flight copies of differently-located ``front.mp4`` clips
+        # cannot clobber each other in the staging dir.
+        assert p1 != p2
+        assert os.path.basename(p1).endswith('-front.mp4.partial')
+        assert os.path.basename(p2).endswith('-front.mp4.partial')
+
+    def test_staging_partial_path_is_stable_for_same_dest(self, tmp_path):
+        root = str(tmp_path / "ArchivedClips")
+        d = os.path.join(root, 'sub', 'clip.mp4')
+        p1 = archive_worker._staging_partial_path(root, d)
+        p2 = archive_worker._staging_partial_path(root, d)
+        assert p1 == p2
+
+
+# ---------------------------------------------------------------------------
+# _atomic_copy with staging_root — partials live in .staging, not
+# the destination directory.
+# ---------------------------------------------------------------------------
+
+class TestAtomicCopyWithStaging:
+    def test_partial_lands_in_staging_dir_not_dest(self, tmp_path,
+                                                   monkeypatch):
+        archive = tmp_path / "ArchivedClips"
+        archive.mkdir()
+        staging = archive_worker._staging_root(str(archive))
+
+        sub = archive / "2026-05-04_08-00-00"
+        sub.mkdir()
+        src = tmp_path / "src.mp4"
+        _write_valid_mp4(str(src))
+        dest = sub / "front.mp4"
+
+        # Spy on the open call to capture the partial filename.
+        seen_paths = []
+        real_open = archive_worker.open if hasattr(archive_worker, 'open') else open
+
+        def spy_open(p, mode='r', *a, **kw):
+            seen_paths.append((p, mode))
+            return real_open(p, mode, *a, **kw)
+
+        monkeypatch.setattr('builtins.open', spy_open)
+        try:
+            size = archive_worker._atomic_copy(
+                str(src), str(dest), chunk_size=4096,
+                staging_root=staging,
+            )
+        finally:
+            monkeypatch.setattr('builtins.open', real_open)
+
+        assert size > 0
+        # Final dest exists.
+        assert os.path.isfile(str(dest))
+        # No .partial in the dest tree.
+        for entry in os.listdir(str(sub)):
+            assert not entry.endswith('.partial')
+        # Staging dir was created.
+        assert os.path.isdir(staging)
+        # At least one open call wrote into the staging dir.
+        write_targets = [p for p, m in seen_paths if 'w' in m]
+        assert any(staging in p for p in write_targets), (
+            f"expected a write inside {staging}, saw {write_targets}"
+        )
+
+    def test_legacy_mode_unchanged_when_staging_root_none(self, tmp_path):
+        # Back-compat: without ``staging_root`` the partial still lands
+        # at ``dest + '.partial'`` so the existing test suite passes.
+        archive = tmp_path / "ArchivedClips"
+        archive.mkdir()
+        sub = archive / "subdir"
+        sub.mkdir()
+        src = tmp_path / "src.mp4"
+        _write_valid_mp4(str(src))
+        dest = sub / "front.mp4"
+
+        size = archive_worker._atomic_copy(
+            str(src), str(dest), chunk_size=4096,
+        )
+        assert size > 0
+        assert os.path.isfile(str(dest))
+        # No .partial leftover anywhere.
+        assert not (sub / "front.mp4.partial").exists()
+
+
+# ---------------------------------------------------------------------------
+# _sweep_partial_orphans — staging scandir + legacy-tree fallback.
+# ---------------------------------------------------------------------------
+
+class TestSweepPartialOrphansStagingMode:
+    def test_sweep_removes_orphans_from_staging_dir(self, tmp_path):
+        archive = tmp_path / "ArchivedClips"
+        archive.mkdir()
+        staging = archive_worker._staging_root(str(archive))
+        os.makedirs(staging, exist_ok=True)
+        # Three orphans in staging from a prior crash.
+        for i in range(3):
+            with open(os.path.join(staging, f"abc{i}-clip.mp4.partial"), 'wb') as f:
+                f.write(b"x" * 64)
+        # A non-partial in staging must NOT be touched (defensive —
+        # production never puts non-partials there but the sweeper
+        # shouldn't decide policy).
+        keep = os.path.join(staging, "keep.txt")
+        with open(keep, 'w') as f:
+            f.write("metadata")
+        removed = archive_worker._sweep_partial_orphans(str(archive))
+        assert removed == 3
+        assert os.path.isfile(keep)
+        for entry in os.listdir(staging):
+            assert entry == "keep.txt"
+
+    def test_sweep_combines_staging_and_legacy_orphans(self, tmp_path):
+        archive = tmp_path / "ArchivedClips"
+        archive.mkdir()
+        staging = archive_worker._staging_root(str(archive))
+        os.makedirs(staging, exist_ok=True)
+        # One orphan in staging (Wave 3+ leftover).
+        with open(os.path.join(staging, "abc-new.mp4.partial"), 'wb') as f:
+            f.write(b"a")
+        # One legacy orphan inside an event dir (pre-Wave-3 leftover).
+        sub = archive / "2026-05-11_14-44-00"
+        sub.mkdir()
+        with open(os.path.join(str(sub), "old.mp4.partial"), 'wb') as f:
+            f.write(b"b")
+        removed = archive_worker._sweep_partial_orphans(str(archive))
+        assert removed == 2
+        assert not os.path.isfile(os.path.join(staging, "abc-new.mp4.partial"))
+        assert not os.path.isfile(os.path.join(str(sub), "old.mp4.partial"))
+
+    def test_sweep_skips_non_partial_files_in_staging(self, tmp_path):
+        archive = tmp_path / "ArchivedClips"
+        archive.mkdir()
+        staging = archive_worker._staging_root(str(archive))
+        os.makedirs(staging, exist_ok=True)
+        # A bare .mp4 in staging is a defensive corner case — must NOT
+        # be deleted by the orphan sweep.
+        keep = os.path.join(staging, "real.mp4")
+        with open(keep, 'wb') as f:
+            f.write(b"keep")
+        removed = archive_worker._sweep_partial_orphans(str(archive))
+        assert removed == 0
+        assert os.path.isfile(keep)

--- a/tests/test_mapping_wave3.py
+++ b/tests/test_mapping_wave3.py
@@ -1,0 +1,534 @@
+"""Tests for issue #184 Wave 3 — Phase D (hot/cold waypoints split).
+
+Covers:
+
+* The v14 → v15 migration backfills cold telemetry from existing
+  ``waypoints`` rows into the new ``waypoints_cold`` table and then
+  drops the cold columns from ``waypoints``.
+* Idempotency: re-running the migration on an already-v15 DB is a
+  no-op.
+* The runtime ``_index_video`` writer obeys the same default-only
+  filter as the migration (parked-car waypoints don't bloat
+  ``waypoints_cold``).
+* The new ``query_trip_telemetry`` helper joins ``waypoints_cold``
+  back to ``waypoints`` and returns a dict keyed by waypoint id.
+* The lazy-loaded ``GET /api/trip/<id>/telemetry`` blueprint route
+  returns the same shape and is gated on ``IMG_CAM_PATH``.
+* ``query_trip_route`` no longer surfaces cold columns (they were
+  the bulk of the per-row payload — this is the read-path saving
+  the redesign exists to deliver).
+
+These tests exist to prevent a regression that re-introduces cold
+columns onto the hot table or causes the migration to lose data
+on upgrade.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+
+import pytest
+
+from services.mapping_migrations import (
+    _COLD_COLUMNS,
+    _SCHEMA_VERSION,
+    _init_db,
+    _waypoints_has_cold_columns,
+)
+from services.mapping_queries import (
+    query_trip_route,
+    query_trip_telemetry,
+)
+from services.mapping_service import (
+    DEFAULT_THRESHOLDS,
+    _index_video,
+)
+
+# Reuse the synthetic-MP4 helpers from test_mapping_service so we
+# don't duplicate ~80 lines of MP4-box assembly. The helpers are
+# pure functions and the import keeps both files in sync.
+from tests.test_mapping_service import (
+    _make_sei_protobuf,
+    _make_synthetic_mp4,
+    _unpack,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers — build a synthetic v14 DB so we can exercise the v15 migration.
+# ---------------------------------------------------------------------------
+
+# v14 schema for the waypoints table — mirrors the shape that shipped in
+# Wave 2 (cold telemetry columns living on the hot row). We don't exec
+# the entire production v14 schema here; we only need the tables touched
+# by the migration plus ``schema_version`` so ``_init_db`` will resume
+# the upgrade walk from v14.
+_V14_WAYPOINTS_DDL = """
+CREATE TABLE waypoints (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    trip_id INTEGER,
+    timestamp TEXT NOT NULL,
+    lat REAL NOT NULL,
+    lon REAL NOT NULL,
+    heading REAL,
+    speed_mps REAL,
+    autopilot_state TEXT,
+    video_path TEXT,
+    frame_offset INTEGER,
+    acceleration_x REAL DEFAULT 0,
+    acceleration_y REAL DEFAULT 0,
+    acceleration_z REAL DEFAULT 0,
+    gear TEXT,
+    steering_angle REAL DEFAULT 0,
+    brake_applied INTEGER DEFAULT 0,
+    blinker_on_left INTEGER DEFAULT 0,
+    blinker_on_right INTEGER DEFAULT 0
+)
+"""
+
+_V14_TRIPS_DDL = """
+CREATE TABLE trips (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    start_time TEXT NOT NULL,
+    end_time TEXT,
+    start_lat REAL,
+    start_lon REAL,
+    end_lat REAL,
+    end_lon REAL,
+    distance_km REAL DEFAULT 0,
+    duration_seconds INTEGER DEFAULT 0,
+    source_folder TEXT
+)
+"""
+
+_V14_SCHEMA_VERSION_DDL = """
+CREATE TABLE schema_version (
+    version INTEGER PRIMARY KEY,
+    applied_at TEXT DEFAULT CURRENT_TIMESTAMP
+)
+"""
+
+
+def _build_v14_db(db_path: str) -> None:
+    """Materialize a v14 DB *exactly* as it would have looked on disk
+    just before the v15 migration. Just enough tables for the
+    migration to do its thing."""
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(_V14_TRIPS_DDL)
+        conn.execute(_V14_WAYPOINTS_DDL)
+        conn.execute(_V14_SCHEMA_VERSION_DDL)
+        conn.execute("INSERT INTO schema_version (version) VALUES (14)")
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _seed_waypoints(db_path: str, *, trip_id: int = 1, count: int = 3,
+                    cold_data: bool = True) -> None:
+    """Insert ``count`` waypoints. When ``cold_data`` is True, every
+    row carries non-default cold telemetry; when False, every row uses
+    SQL defaults (so the migration must still run cleanly but
+    shouldn't backfill anything)."""
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            "INSERT INTO trips (id, start_time, end_time, distance_km, "
+            "                   duration_seconds, source_folder) "
+            "VALUES (?, '2026-05-04T08:00:00', '2026-05-04T08:10:00', "
+            "        2.5, 600, 'RecentClips')",
+            (trip_id,),
+        )
+        for i in range(count):
+            if cold_data:
+                conn.execute(
+                    """INSERT INTO waypoints
+                        (trip_id, timestamp, lat, lon, heading, speed_mps,
+                         autopilot_state, video_path, frame_offset,
+                         acceleration_x, acceleration_y, acceleration_z,
+                         gear, steering_angle, brake_applied,
+                         blinker_on_left, blinker_on_right)
+                       VALUES (?, ?, ?, ?, 90.0, 25.0, 'NONE',
+                               'clip.mp4', ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                    (trip_id, f'2026-05-04T08:0{i}:00',
+                     37.7749 + i * 0.001, -122.4194 + i * 0.001, i * 30,
+                     -1.5 + i, 0.5, 0.1,
+                     'D', 12.0 + i, 1 if i % 2 else 0, i % 2, (i + 1) % 2),
+                )
+            else:
+                conn.execute(
+                    """INSERT INTO waypoints
+                        (trip_id, timestamp, lat, lon, heading, speed_mps,
+                         autopilot_state, video_path, frame_offset)
+                       VALUES (?, ?, ?, ?, 90.0, 25.0, 'NONE',
+                               'clip.mp4', ?)""",
+                    (trip_id, f'2026-05-04T08:0{i}:00',
+                     37.7749 + i * 0.001, -122.4194 + i * 0.001, i * 30),
+                )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# v14 → v15 migration
+# ---------------------------------------------------------------------------
+
+class TestV14ToV15Migration:
+    """Cold telemetry must move to the cold table; the hot table must
+    shed those columns; existing data must survive untouched."""
+
+    def test_migration_backfills_cold_table_and_drops_columns(self, tmp_path):
+        db_path = str(tmp_path / "geodata.db")
+        _build_v14_db(db_path)
+        _seed_waypoints(db_path, trip_id=1, count=3, cold_data=True)
+
+        # Trigger the upgrade walk.
+        conn = _init_db(db_path)
+        try:
+            ver = conn.execute(
+                "SELECT MAX(version) AS v FROM schema_version"
+            ).fetchone()['v']
+            assert ver == _SCHEMA_VERSION
+
+            # Hot table must NOT have any cold columns.
+            assert _waypoints_has_cold_columns(conn) is False
+
+            # Cold table populated for all 3 waypoints.
+            cold_rows = conn.execute(
+                "SELECT id, acceleration_x, gear, steering_angle, "
+                "brake_applied, blinker_on_left, blinker_on_right "
+                "FROM waypoints_cold ORDER BY id"
+            ).fetchall()
+            assert len(cold_rows) == 3
+            # Spot-check one row: row index 1 (i=1 in seed) had
+            # acceleration_x = -0.5, gear='D', steering_angle = 13.0.
+            assert cold_rows[1]['acceleration_x'] == pytest.approx(-0.5)
+            assert cold_rows[1]['gear'] == 'D'
+            assert cold_rows[1]['steering_angle'] == pytest.approx(13.0)
+
+            # Hot table still has all 3 waypoints with hot fields intact.
+            hot_rows = conn.execute(
+                "SELECT id, lat, lon, speed_mps FROM waypoints ORDER BY id"
+            ).fetchall()
+            assert len(hot_rows) == 3
+            assert hot_rows[0]['speed_mps'] == pytest.approx(25.0)
+        finally:
+            conn.close()
+
+    def test_migration_skips_backfill_for_default_only_rows(self, tmp_path):
+        # When every cold field equals its default, the migration MUST
+        # NOT INSERT rows into ``waypoints_cold`` — that would bloat
+        # the cold table with zero-value rows for every routine
+        # waypoint and defeat the point of the split.
+        db_path = str(tmp_path / "geodata.db")
+        _build_v14_db(db_path)
+        _seed_waypoints(db_path, trip_id=1, count=3, cold_data=False)
+
+        conn = _init_db(db_path)
+        try:
+            cold_count = conn.execute(
+                "SELECT COUNT(*) AS c FROM waypoints_cold"
+            ).fetchone()['c']
+            assert cold_count == 0
+
+            # Hot table still has 3 rows.
+            hot_count = conn.execute(
+                "SELECT COUNT(*) AS c FROM waypoints"
+            ).fetchone()['c']
+            assert hot_count == 3
+        finally:
+            conn.close()
+
+    def test_migration_is_idempotent(self, tmp_path):
+        # Running ``_init_db`` a second time on an already-migrated DB
+        # must be a no-op — the v15 migration short-circuits when the
+        # cold columns are gone.
+        db_path = str(tmp_path / "geodata.db")
+        _build_v14_db(db_path)
+        _seed_waypoints(db_path, trip_id=1, count=2, cold_data=True)
+
+        # First run does the work.
+        _init_db(db_path).close()
+
+        # Snapshot cold table.
+        c1 = sqlite3.connect(db_path)
+        first = c1.execute(
+            "SELECT id, acceleration_x FROM waypoints_cold ORDER BY id"
+        ).fetchall()
+        c1.close()
+
+        # Second run must not change anything.
+        _init_db(db_path).close()
+
+        c2 = sqlite3.connect(db_path)
+        try:
+            second = c2.execute(
+                "SELECT id, acceleration_x FROM waypoints_cold ORDER BY id"
+            ).fetchall()
+            assert [tuple(r) for r in second] == [tuple(r) for r in first]
+        finally:
+            c2.close()
+
+    def test_fresh_install_at_v15_has_no_cold_cols_on_hot_table(self, tmp_path):
+        db_path = str(tmp_path / "geodata.db")
+        conn = _init_db(db_path)
+        try:
+            # Cold cols must be absent from waypoints.
+            assert _waypoints_has_cold_columns(conn) is False
+            # waypoints_cold table exists.
+            row = conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' "
+                "AND name='waypoints_cold'"
+            ).fetchone()
+            assert row is not None and row['name'] == 'waypoints_cold'
+            # Schema version is current.
+            ver = conn.execute(
+                "SELECT MAX(version) AS v FROM schema_version"
+            ).fetchone()['v']
+            assert ver == _SCHEMA_VERSION
+        finally:
+            conn.close()
+
+    def test_cold_columns_constant_matches_migration_cols(self):
+        # Defensive: any future cold-column addition must be wired
+        # through ``_COLD_COLUMNS`` so the migration drops it.
+        expected = {
+            'acceleration_x', 'acceleration_y', 'acceleration_z',
+            'gear', 'steering_angle', 'brake_applied',
+            'blinker_on_left', 'blinker_on_right',
+        }
+        assert set(_COLD_COLUMNS) == expected
+
+
+# ---------------------------------------------------------------------------
+# query_trip_route — must return ONLY hot columns (and ``id`` for
+# the lazy-load merge in the JS overlay).
+# ---------------------------------------------------------------------------
+
+class TestQueryTripRouteShape:
+    def test_route_excludes_cold_columns(self, tmp_path):
+        db_path = str(tmp_path / "geodata.db")
+        _build_v14_db(db_path)
+        _seed_waypoints(db_path, trip_id=1, count=3, cold_data=True)
+        _init_db(db_path).close()  # apply v15 migration
+
+        route = query_trip_route(db_path, trip_id=1)
+        assert len(route) == 3
+        wp = route[0]
+        # ``id`` is required so the JS can merge cold telemetry.
+        assert 'id' in wp
+        # Hot columns are present.
+        for col in ('lat', 'lon', 'speed_mps', 'heading',
+                    'autopilot_state', 'video_path', 'frame_offset',
+                    'timestamp'):
+            assert col in wp
+        # Cold columns must NOT be in the dict.
+        for col in _COLD_COLUMNS:
+            assert col not in wp, (
+                f"query_trip_route surfaced cold column {col!r}; "
+                "this would defeat the Wave 3 read-path savings"
+            )
+
+
+# ---------------------------------------------------------------------------
+# query_trip_telemetry — the new lazy-load helper backing
+# /api/trip/<id>/telemetry.
+# ---------------------------------------------------------------------------
+
+class TestQueryTripTelemetry:
+    def test_returns_dict_keyed_by_waypoint_id(self, tmp_path):
+        db_path = str(tmp_path / "geodata.db")
+        _build_v14_db(db_path)
+        _seed_waypoints(db_path, trip_id=1, count=3, cold_data=True)
+        _init_db(db_path).close()
+
+        telem = query_trip_telemetry(db_path, trip_id=1)
+        assert isinstance(telem, dict)
+        assert len(telem) == 3
+
+        # Keys are waypoint ids (ints — though JSON serializes them as
+        # strings on the wire, the in-process dict stays int-keyed).
+        for wp_id, payload in telem.items():
+            assert isinstance(wp_id, int)
+            for col in _COLD_COLUMNS:
+                assert col in payload, (
+                    f"telemetry payload missing cold column {col!r}"
+                )
+
+    def test_returns_empty_for_default_only_trip(self, tmp_path):
+        db_path = str(tmp_path / "geodata.db")
+        _build_v14_db(db_path)
+        _seed_waypoints(db_path, trip_id=1, count=3, cold_data=False)
+        _init_db(db_path).close()
+
+        telem = query_trip_telemetry(db_path, trip_id=1)
+        assert telem == {}
+
+    def test_returns_empty_for_unknown_trip(self, tmp_path):
+        db_path = str(tmp_path / "geodata.db")
+        _init_db(db_path).close()
+        assert query_trip_telemetry(db_path, trip_id=999) == {}
+
+
+# ---------------------------------------------------------------------------
+# _index_video runtime path — must NOT bloat waypoints_cold with a
+# row per parked-car waypoint.
+# ---------------------------------------------------------------------------
+
+class TestIndexVideoColdSplit:
+    def _seed_clip(self, tmp_path, payloads, name='2025-11-08_08-15-44-front.mp4'):
+        teslacam = tmp_path / "TeslaCam" / "RecentClips"
+        teslacam.mkdir(parents=True, exist_ok=True)
+        clip = teslacam / name
+        clip.write_bytes(_make_synthetic_mp4(payloads))
+        return clip, str(tmp_path / "TeslaCam")
+
+    def test_parked_car_waypoints_create_no_cold_rows(self, tmp_path):
+        # Force gear=99 → SEI parser maps it to 'UNKNOWN' (anything
+        # outside ``_GEAR_NAMES``). Combined with zero accel/steering
+        # and no brake/blinker, this represents a SEI frame that
+        # carries no usable telemetry — Tesla shipped a partial frame
+        # or a corrupted one. The runtime path MUST skip the
+        # ``waypoints_cold`` INSERT for these rows so non-signal
+        # frames don't bloat the cold table.
+        db_path = str(tmp_path / "test.db")
+        conn = _init_db(db_path)
+        try:
+            payloads = [
+                _make_sei_protobuf(lat=37.7749, lon=-122.4194, speed=25.0,
+                                   gear=99, accel_x=0.0, accel_y=0.0),
+                _make_sei_protobuf(lat=37.7750, lon=-122.4195, speed=25.0,
+                                   gear=99, accel_x=0.0, accel_y=0.0),
+                _make_sei_protobuf(lat=37.7751, lon=-122.4196, speed=25.0,
+                                   gear=99, accel_x=0.0, accel_y=0.0),
+            ]
+            clip, root = self._seed_clip(tmp_path, payloads)
+            wc, _ = _unpack(_index_video(
+                conn, str(clip), root,
+                sample_rate=1, thresholds=DEFAULT_THRESHOLDS,
+                trip_gap_minutes=5,
+            ))
+            assert wc == 3
+
+            # Hot table got all 3.
+            hot = conn.execute("SELECT COUNT(*) AS n FROM waypoints").fetchone()['n']
+            assert hot == 3
+            # Cold table got NONE — no signal worth storing.
+            cold = conn.execute(
+                "SELECT COUNT(*) AS n FROM waypoints_cold"
+            ).fetchone()['n']
+            assert cold == 0, (
+                "no-signal SEI frames must NOT bloat waypoints_cold; "
+                "the runtime filter is broken if this fails"
+            )
+        finally:
+            conn.close()
+
+    def test_real_world_sei_creates_cold_rows(self, tmp_path):
+        # A normal driving frame (gear='DRIVE', non-zero accel) MUST
+        # produce a cold row — the in-clip HUD reads gear/accel/brake
+        # from the cold table and the user expects them visible.
+        db_path = str(tmp_path / "test.db")
+        conn = _init_db(db_path)
+        try:
+            payloads = [
+                _make_sei_protobuf(lat=37.7749, lon=-122.4194, speed=25.0,
+                                   gear=1, accel_x=-1.5),
+                _make_sei_protobuf(lat=37.7750, lon=-122.4195, speed=22.0,
+                                   gear=1, accel_x=-2.0),
+                _make_sei_protobuf(lat=37.7751, lon=-122.4196, speed=20.0,
+                                   gear=1, accel_x=-3.0),
+            ]
+            clip, root = self._seed_clip(tmp_path, payloads)
+            wc, _ = _unpack(_index_video(
+                conn, str(clip), root,
+                sample_rate=1, thresholds=DEFAULT_THRESHOLDS,
+                trip_gap_minutes=5,
+            ))
+            assert wc == 3
+
+            cold = conn.execute(
+                "SELECT id, acceleration_x, gear FROM waypoints_cold ORDER BY id"
+            ).fetchall()
+            # Every waypoint had real telemetry — all 3 in cold.
+            assert len(cold) == 3
+            for row in cold:
+                assert row['gear'] == 'DRIVE'
+                assert row['acceleration_x'] != 0
+        finally:
+            conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Blueprint: /api/trip/<id>/telemetry
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def telemetry_app(tmp_path, monkeypatch):
+    """Hermetic Flask app with the mapping blueprint mounted, a v15
+    DB seeded with cold telemetry, and the IMG_CAM_PATH gate
+    pointed at an existing tmp file."""
+    from flask import Flask
+    from blueprints import mapping as mapping_module
+
+    db_path = str(tmp_path / "geodata.db")
+    _build_v14_db(db_path)
+    _seed_waypoints(db_path, trip_id=1, count=3, cold_data=True)
+    _init_db(db_path).close()
+
+    img_path = tmp_path / "usb_cam.img"
+    img_path.write_bytes(b"\x00")
+
+    monkeypatch.setattr(mapping_module, 'IMG_CAM_PATH', str(img_path))
+    monkeypatch.setattr(mapping_module, 'MAPPING_DB_PATH', db_path)
+
+    app = Flask(__name__)
+    app.secret_key = 'test'
+    app.register_blueprint(mapping_module.mapping_bp)
+    app.config['TESTING'] = True
+    app.db_path = db_path
+    return app
+
+
+@pytest.fixture
+def telemetry_client(telemetry_app):
+    return telemetry_app.test_client()
+
+
+class TestApiTripTelemetry:
+    def test_returns_telemetry_for_trip(self, telemetry_client):
+        r = telemetry_client.get('/api/trip/1/telemetry')
+        assert r.status_code == 200
+        body = r.get_json()
+        assert body['trip_id'] == 1
+        # JSON serialization stringifies dict int-keys.
+        assert isinstance(body['telemetry'], dict)
+        assert len(body['telemetry']) == 3
+        # Every payload has the cold columns.
+        sample = next(iter(body['telemetry'].values()))
+        for col in _COLD_COLUMNS:
+            assert col in sample
+
+    def test_returns_empty_for_unknown_trip(self, telemetry_client):
+        r = telemetry_client.get('/api/trip/999/telemetry')
+        assert r.status_code == 200
+        body = r.get_json()
+        assert body['trip_id'] == 999
+        assert body['telemetry'] == {}
+
+    def test_route_gated_on_image_file(self, telemetry_client,
+                                       telemetry_app, monkeypatch):
+        # Removing the cam image must block the route — same gate as
+        # the rest of the mapping blueprint. We send the request as
+        # AJAX so the gate returns 503 JSON instead of attempting a
+        # redirect to ``mode_control.index`` (which isn't registered
+        # in the hermetic test app).
+        from blueprints import mapping as mapping_module
+        os.remove(mapping_module.IMG_CAM_PATH)
+        r = telemetry_client.get(
+            '/api/trip/1/telemetry',
+            headers={'X-Requested-With': 'XMLHttpRequest'},
+        )
+        assert r.status_code == 503

--- a/tests/test_mapping_wave3.py
+++ b/tests/test_mapping_wave3.py
@@ -271,6 +271,95 @@ class TestV14ToV15Migration:
         finally:
             c2.close()
 
+    def test_migration_skips_jitter_and_park(self, tmp_path):
+        # PR #187 review #3 + #4 regression test. v14→v15 must use the
+        # same noise-floor + PARK semantics as the runtime path —
+        # otherwise a v14→v15 upgrade backfills cold rows for every
+        # parked-Sentry waypoint, while a fresh-install v15 would
+        # produce zero rows for the same data. Asymmetry would
+        # silently corrupt analytics dashboards.
+        db_path = str(tmp_path / "geodata.db")
+        _build_v14_db(db_path)
+        # Seed 4 waypoints directly: jitter-only, PARK-only,
+        # UNKNOWN-only, and a real-driving row.
+        conn = sqlite3.connect(db_path)
+        try:
+            conn.execute(
+                "INSERT INTO trips (id, start_time, source_folder) "
+                "VALUES (1, '2026-05-04T08:00:00', 'RecentClips')"
+            )
+            # 1: pure jitter (accel below 0.05 threshold, gear UNKNOWN)
+            conn.execute(
+                """INSERT INTO waypoints
+                    (trip_id, timestamp, lat, lon, heading, speed_mps,
+                     autopilot_state, video_path, frame_offset,
+                     acceleration_x, acceleration_y, acceleration_z,
+                     gear, steering_angle, brake_applied,
+                     blinker_on_left, blinker_on_right)
+                   VALUES (1, '2026-05-04T08:00:00', 37.0, -122.0, 0,
+                           0, 'NONE', 'a.mp4', 0,
+                           0.01, -0.02, 0.03,
+                           'UNKNOWN', 0.2, 0, 0, 0)"""
+            )
+            # 2: PARK with no other signal — should NOT backfill
+            conn.execute(
+                """INSERT INTO waypoints
+                    (trip_id, timestamp, lat, lon, heading, speed_mps,
+                     autopilot_state, video_path, frame_offset,
+                     acceleration_x, acceleration_y, acceleration_z,
+                     gear, steering_angle, brake_applied,
+                     blinker_on_left, blinker_on_right)
+                   VALUES (1, '2026-05-04T08:00:01', 37.0, -122.0, 0,
+                           0, 'NONE', 'a.mp4', 1,
+                           0.0, 0.0, 0.0,
+                           'PARK', 0.0, 0, 0, 0)"""
+            )
+            # 3: UNKNOWN + zero — should NOT backfill
+            conn.execute(
+                """INSERT INTO waypoints
+                    (trip_id, timestamp, lat, lon, heading, speed_mps,
+                     autopilot_state, video_path, frame_offset,
+                     acceleration_x, acceleration_y, acceleration_z,
+                     gear, steering_angle, brake_applied,
+                     blinker_on_left, blinker_on_right)
+                   VALUES (1, '2026-05-04T08:00:02', 37.0, -122.0, 0,
+                           0, 'NONE', 'a.mp4', 2,
+                           0.0, 0.0, 0.0,
+                           'UNKNOWN', 0.0, 0, 0, 0)"""
+            )
+            # 4: real driving — DOES backfill
+            conn.execute(
+                """INSERT INTO waypoints
+                    (trip_id, timestamp, lat, lon, heading, speed_mps,
+                     autopilot_state, video_path, frame_offset,
+                     acceleration_x, acceleration_y, acceleration_z,
+                     gear, steering_angle, brake_applied,
+                     blinker_on_left, blinker_on_right)
+                   VALUES (1, '2026-05-04T08:00:03', 37.0, -122.0, 0,
+                           20, 'NONE', 'a.mp4', 3,
+                           1.5, 0.0, 0.0,
+                           'DRIVE', 5.0, 0, 0, 0)"""
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        conn = _init_db(db_path)
+        try:
+            cold = conn.execute(
+                "SELECT id, gear, acceleration_x FROM waypoints_cold "
+                "ORDER BY id"
+            ).fetchall()
+            # Only the real-driving row (id=4) should be in cold.
+            assert len(cold) == 1, (
+                f"only DRIVE row should backfill; got: "
+                f"{[dict(r) for r in cold]}"
+            )
+            assert cold[0]['gear'] == 'DRIVE'
+            assert cold[0]['acceleration_x'] == 1.5
+        finally:
+            conn.close()
+
     def test_fresh_install_at_v15_has_no_cold_cols_on_hot_table(self, tmp_path):
         db_path = str(tmp_path / "geodata.db")
         conn = _init_db(db_path)
@@ -457,6 +546,110 @@ class TestIndexVideoColdSplit:
             for row in cold:
                 assert row['gear'] == 'DRIVE'
                 assert row['acceleration_x'] != 0
+        finally:
+            conn.close()
+
+    def test_jitter_below_threshold_creates_no_cold_rows(self, tmp_path):
+        # PR #187 review Warning #1 regression test. A real Tesla IMU
+        # never reports exactly 0.0 — sensor noise floor is typically
+        # ±0.001–±0.05 m/s². If the runtime filter were ``!= 0`` (the
+        # original Wave 3 implementation), every parked-car Sentry
+        # frame would create a cold row and the hot/cold split would
+        # provide ZERO read-path benefit. The threshold must be tight
+        # enough to skip jitter but loose enough that any real coast
+        # / cruise / brake creates cold rows.
+        db_path = str(tmp_path / "test.db")
+        conn = _init_db(db_path)
+        try:
+            # gear='UNKNOWN' (gear_state=99 falls outside _GEAR_NAMES);
+            # accel below 0.05 m/s² threshold. Steering is hardcoded to
+            # 0.0 in the test helper; the runtime path treats 0.0 as
+            # below the 0.5° threshold so it doesn't contribute signal.
+            payloads = [
+                _make_sei_protobuf(lat=37.7749, lon=-122.4194, speed=0.0,
+                                   gear=99, accel_x=0.005, accel_y=-0.01),
+                _make_sei_protobuf(lat=37.7749, lon=-122.4194, speed=0.0,
+                                   gear=99, accel_x=-0.02, accel_y=0.03),
+                _make_sei_protobuf(lat=37.7749, lon=-122.4194, speed=0.0,
+                                   gear=99, accel_x=0.04, accel_y=0.02),
+            ]
+            clip, root = self._seed_clip(tmp_path, payloads)
+            wc, _ = _unpack(_index_video(
+                conn, str(clip), root,
+                sample_rate=1, thresholds=DEFAULT_THRESHOLDS,
+                trip_gap_minutes=5,
+            ))
+            assert wc == 3
+
+            cold = conn.execute(
+                "SELECT COUNT(*) AS n FROM waypoints_cold"
+            ).fetchone()['n']
+            assert cold == 0, (
+                "sensor jitter below noise threshold MUST NOT bloat "
+                "waypoints_cold; runtime filter is too loose if this fails"
+            )
+        finally:
+            conn.close()
+
+    def test_jitter_above_threshold_creates_cold_rows(self, tmp_path):
+        # Companion to the test above: as soon as jitter clearly exceeds
+        # the noise floor, we DO want a cold row — that's a real coast/
+        # brake transition, not sensor wander.
+        db_path = str(tmp_path / "test.db")
+        conn = _init_db(db_path)
+        try:
+            # accel comfortably above 0.05 m/s² threshold.
+            payloads = [
+                _make_sei_protobuf(lat=37.7749, lon=-122.4194, speed=15.0,
+                                   gear=1, accel_x=0.15),
+                _make_sei_protobuf(lat=37.7750, lon=-122.4195, speed=15.0,
+                                   gear=1, accel_x=0.20),
+                _make_sei_protobuf(lat=37.7751, lon=-122.4196, speed=15.0,
+                                   gear=1, accel_x=0.25),
+            ]
+            clip, root = self._seed_clip(tmp_path, payloads)
+            _index_video(
+                conn, str(clip), root,
+                sample_rate=1, thresholds=DEFAULT_THRESHOLDS,
+                trip_gap_minutes=5,
+            )
+            cold = conn.execute(
+                "SELECT COUNT(*) AS n FROM waypoints_cold"
+            ).fetchone()['n']
+            assert cold == 3, "real coast/brake must create cold rows"
+        finally:
+            conn.close()
+
+    def test_park_gear_alone_creates_no_cold_rows(self, tmp_path):
+        # Sentry events on a parked car emit gear='PARK' for every
+        # 30 Hz × 60 s = 1 800 waypoints in the clip. Recording 1 800
+        # identical "still parked" cold rows per parked event would
+        # dwarf the few thousand driving rows that actually carry
+        # telemetry signal — defeating the design goal documented in
+        # the v15 ``waypoints_cold`` table comment ("parked-car
+        # waypoints (all-null telemetry) consume zero cold pages").
+        db_path = str(tmp_path / "test.db")
+        conn = _init_db(db_path)
+        try:
+            payloads = [
+                _make_sei_protobuf(lat=37.7749, lon=-122.4194, speed=0.0,
+                                   gear=0, accel_x=0.0, accel_y=0.0),
+                _make_sei_protobuf(lat=37.7749, lon=-122.4194, speed=0.0,
+                                   gear=0, accel_x=0.0, accel_y=0.0),
+            ]
+            clip, root = self._seed_clip(tmp_path, payloads)
+            _index_video(
+                conn, str(clip), root,
+                sample_rate=1, thresholds=DEFAULT_THRESHOLDS,
+                trip_gap_minutes=5,
+            )
+            cold = conn.execute(
+                "SELECT COUNT(*) AS n FROM waypoints_cold"
+            ).fetchone()['n']
+            assert cold == 0, (
+                "PARK alone with no other signal MUST NOT create cold "
+                "rows — see _COLD_GEAR_NO_SIGNAL in mapping_service"
+            )
         finally:
             conn.close()
 

--- a/tests/test_wal_checkpoint_service.py
+++ b/tests/test_wal_checkpoint_service.py
@@ -1,0 +1,196 @@
+"""Tests for issue #184 Wave 3 — Phase G (idle-time WAL checkpoints).
+
+Covers:
+
+* ``_checkpoint_one`` runs ``PRAGMA wal_checkpoint(TRUNCATE)`` and
+  resets the WAL file when there are no active readers.
+* ``_is_coordinator_idle`` correctly reads the
+  ``task_coordinator.is_busy()`` and ``waiter_count()`` signals.
+* ``start`` is idempotent and ``stop`` joins cleanly.
+* The service is defensive: a missing DB path is a no-op.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import time
+
+import pytest
+
+from services import wal_checkpoint_service as wcs
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_wal_db(path: str, *, write_rows: int = 50) -> sqlite3.Connection:
+    """Create a SQLite DB in WAL mode and write enough rows to grow
+    the WAL file to a measurable size. Returns an open reader
+    connection that the caller MUST keep alive — closing the only
+    open connection triggers an implicit checkpoint and truncates
+    the WAL file out from under the test.
+    """
+    conn = sqlite3.connect(path)
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("CREATE TABLE t (k INTEGER PRIMARY KEY, v TEXT)")
+    for i in range(write_rows):
+        conn.execute("INSERT INTO t (v) VALUES (?)", (f"row-{i}-" + "x" * 64,))
+    conn.commit()
+    # Run a SELECT so the connection holds a read transaction snapshot
+    # — without this an implicit checkpoint can still fire on the
+    # writer's WAL when no other readers exist.
+    conn.execute("SELECT COUNT(*) FROM t").fetchone()
+    return conn
+
+
+# ---------------------------------------------------------------------------
+# _checkpoint_one
+# ---------------------------------------------------------------------------
+
+class TestCheckpointOne:
+    def test_truncates_wal_after_writes(self, tmp_path):
+        db = str(tmp_path / "test.db")
+        keep_alive = _make_wal_db(db, write_rows=50)
+        try:
+            wal_before = os.path.getsize(db + '-wal')
+            assert wal_before > 0
+
+            wcs._checkpoint_one(db)
+
+            wal_after = (
+                os.path.getsize(db + '-wal') if os.path.isfile(db + '-wal') else 0
+            )
+            # TRUNCATE checkpoint folds frames back into the main DB
+            # and truncates the WAL to zero (or near-zero) bytes.
+            assert wal_after < wal_before
+        finally:
+            keep_alive.close()
+
+    def test_missing_db_is_noop(self, tmp_path):
+        # Must not raise on a path that doesn't exist.
+        wcs._checkpoint_one(str(tmp_path / "nonexistent.db"))
+        wcs._checkpoint_one('')
+        # No exception → pass
+
+    def test_handles_locked_db_gracefully(self, tmp_path):
+        # Open an exclusive transaction in a separate connection so
+        # the checkpoint is forced to back off. ``_checkpoint_one``
+        # must NOT raise — the optimization tolerates contention.
+        db = str(tmp_path / "test.db")
+        keep_alive = _make_wal_db(db, write_rows=10)
+        try:
+            blocker = sqlite3.connect(db, timeout=0.5)
+            try:
+                blocker.isolation_level = None
+                blocker.execute("BEGIN IMMEDIATE")
+                try:
+                    # Should not raise even when the writer lock is held.
+                    wcs._checkpoint_one(db)
+                finally:
+                    blocker.execute("ROLLBACK")
+            finally:
+                blocker.close()
+        finally:
+            keep_alive.close()
+
+
+# ---------------------------------------------------------------------------
+# _is_coordinator_idle — reads ``task_coordinator`` signals.
+# ---------------------------------------------------------------------------
+
+class TestCoordinatorIdleProbe:
+    def test_returns_false_when_busy(self, monkeypatch):
+        from services import task_coordinator
+        monkeypatch.setattr(task_coordinator, 'is_busy', lambda: True)
+        monkeypatch.setattr(task_coordinator, 'waiter_count', lambda: 0)
+        assert wcs._is_coordinator_idle() is False
+
+    def test_returns_false_when_waiters_pending(self, monkeypatch):
+        from services import task_coordinator
+        monkeypatch.setattr(task_coordinator, 'is_busy', lambda: False)
+        monkeypatch.setattr(task_coordinator, 'waiter_count', lambda: 1)
+        assert wcs._is_coordinator_idle() is False
+
+    def test_returns_true_when_idle(self, monkeypatch):
+        from services import task_coordinator
+        monkeypatch.setattr(task_coordinator, 'is_busy', lambda: False)
+        monkeypatch.setattr(task_coordinator, 'waiter_count', lambda: 0)
+        assert wcs._is_coordinator_idle() is True
+
+    def test_returns_false_when_probe_raises(self, monkeypatch):
+        from services import task_coordinator
+
+        def _boom():
+            raise RuntimeError("simulated coordinator failure")
+
+        monkeypatch.setattr(task_coordinator, 'is_busy', _boom)
+        # Conservative behavior: any error → back off, not check-
+        # point. Better to under-checkpoint than to compete for I/O
+        # while a heavy task is running.
+        assert wcs._is_coordinator_idle() is False
+
+
+# ---------------------------------------------------------------------------
+# start / stop / is_running
+# ---------------------------------------------------------------------------
+
+class TestServiceLifecycle:
+    def setup_method(self, method):
+        # Make sure no leftover state from another test.
+        wcs.stop(timeout=2.0)
+
+    def teardown_method(self, method):
+        wcs.stop(timeout=2.0)
+
+    def test_start_is_idempotent(self, tmp_path):
+        db = str(tmp_path / "test.db")
+        keep_alive = _make_wal_db(db, write_rows=5)
+        try:
+            assert wcs.start([db]) is True
+            try:
+                assert wcs.is_running()
+                # Second call must NOT spawn a second thread.
+                assert wcs.start([db]) is False
+                assert wcs.is_running()
+            finally:
+                wcs.stop(timeout=2.0)
+        finally:
+            keep_alive.close()
+
+    def test_stop_joins_thread(self, tmp_path):
+        db = str(tmp_path / "test.db")
+        keep_alive = _make_wal_db(db, write_rows=5)
+        try:
+            wcs.start([db])
+            assert wcs.is_running()
+            wcs.stop(timeout=3.0)
+            # Give the daemon a moment to release.
+            for _ in range(20):
+                if not wcs.is_running():
+                    break
+                time.sleep(0.05)
+            assert wcs.is_running() is False
+        finally:
+            keep_alive.close()
+
+
+# ---------------------------------------------------------------------------
+# _trigger_for_test — synchronous test entry point.
+# ---------------------------------------------------------------------------
+
+class TestTriggerForTest:
+    def test_synchronous_checkpoint(self, tmp_path):
+        # The trigger MUST checkpoint inline (no thread, no sleeps).
+        db = str(tmp_path / "test.db")
+        keep_alive = _make_wal_db(db, write_rows=50)
+        try:
+            wal_before = os.path.getsize(db + '-wal')
+            wcs._trigger_for_test(db)
+            wal_after = (
+                os.path.getsize(db + '-wal') if os.path.isfile(db + '-wal') else 0
+            )
+            assert wal_after < wal_before
+        finally:
+            keep_alive.close()


### PR DESCRIPTION
Wave 3 of issue #184 — storage layout. Builds on PR #186 (Wave 2, merged).

## Phases

### Phase D — Hot/cold waypoints split (schema v15)
`waypoints` is now hot-only (lat/lon/heading/speed_mps/autopilot_state/video_path/frame_offset/timestamp). Cold telemetry (accel x/y/z, gear, steering, brake, blinker L/R) lives in a new `waypoints_cold` table linked 1:1 by id with `ON DELETE CASCADE`.

- `query_trip_route` and `query_day_routes` (the hot path that powers map polylines) now SELECT only hot columns. Cold telemetry is fetched lazily on demand.
- New `GET /api/trip/<id>/telemetry` returns `{trip_id, telemetry: {<wp_id>: {...}}}` and is image-gated on `IMG_CAM_PATH`.
- `mapping.html` `openVideoOverlay()` accepts an optional 4th `tripId` parameter; when set, async-fetches the telemetry endpoint and merges fields into the existing waypoints array. The HUD reader (`updateOverlayTelemetry()`) is unchanged — still reads `wp.steering_angle`/`wp.brake_applied`/etc. directly. Best-effort: a fetch failure leaves the HUD at neutral defaults (existing behavior for SentryClips/no-trip overlays).
- `_index_video` runtime path writes hot inline + writes cold ONLY when the SEI frame carries usable signal (gear is a real state and/or accel/steering/brake/blinker are non-zero). No-signal frames don't bloat `waypoints_cold`.

**Migration v14→v15** is wrapped in a single SAVEPOINT. Backfills cold rows for any existing waypoint with non-default cold telemetry, then drops cold columns from `waypoints` (SQLite ≥ 3.35 ALTER TABLE DROP COLUMN, present on Bookworm). Idempotent on retries; defensive index re-creation.

### Phase G — Idle-time WAL checkpoint service
New `scripts/web/services/wal_checkpoint_service.py` daemon. Every 30 s it checks `task_coordinator.is_busy()` and `waiter_count()`; when both report idle it runs `PRAGMA wal_checkpoint(TRUNCATE)` against each registered DB. Pre-empts the inline auto-checkpoints (`wal_autocheckpoint=200` default) that would otherwise fight archive copies for SDIO bandwidth on the Pi Zero 2 W.

- Wired in `web_control.py` for `MAPPING_DB_PATH` (+ optional `CLOUD_ARCHIVE_DB_PATH`).
- INFO logs only when `checkpointed >= 10` pages — quiescent system stays silent.
- Conservative: never acquires the coordinator lock (would mask indexer/archive fairness signals); on coordinator-probe failure it backs off rather than competing for I/O.

### Phase H — Atomic-copy staging directory
Partial files now live in `<archive_root>/.staging/` (same filesystem as destination so `os.replace` is atomic) with hash-prefixed basenames (`<sha1[0:10]>-<basename>.partial`).

- Directory traversals (indexer, retention prune, file watcher) never see in-flight bytes.
- Orphan cleanup at startup is a single `os.scandir` of one directory, not a recursive walk of the whole archive tree.
- `_atomic_copy` gained a `staging_root` kwarg; production callers always pass it. Back-compat: when `None`, partials still go to the legacy `dest + '.partial'` location so existing tests pass unchanged.
- `_sweep_partial_orphans` rewritten: scandir staging first, then a one-time legacy-tree fallback for pre-Wave-3 leftovers. Becomes a zero-cost no-op once the legacy partials are gone.
- `archive_watchdog._iter_archive_mp4_files` filters `.staging` from its os.walk iterators alongside `.dead_letter`.

## Tests
- `tests/test_mapping_wave3.py` — **14 tests**: migration backfill + idempotency + cold-skip filter; `query_trip_route` shape (no cold cols); `query_trip_telemetry` empty/populated; `/api/trip/<id>/telemetry` happy-path/unknown-trip/image-gate.
- `tests/test_archive_worker_staging.py` — **8 tests**: staging path helpers (uniqueness, stability); `_atomic_copy` with `staging_root` (partial in staging, no leakage to dest tree); legacy-mode back-compat; sweep across staging + legacy + non-partial preservation.
- `tests/test_wal_checkpoint_service.py` — **10 tests**: `_checkpoint_one` truncates WAL/handles missing/locked; coordinator-idle probe (busy/waiters/idle/raises); start/stop idempotency.
- **Full suite: 1632 passed, 4 skipped** (1602 baseline + 30 new).

## Bug fix surfaced during Wave 3
`mapping_migrations.py` v2 block (`ALTER TABLE waypoints ADD COLUMN blinker_on_*`) was running unconditionally — meaning a fresh-install at v15 had cold `blinker_*` columns added back to the hot `waypoints` table by a stale migration. Now gated on `current > 0`.

## What's NOT in this PR
- Wave 4 (pipeline_queue unification, batched rclone, drop LES poll) — separate PR.
- Modified `docs/VIDEO_LIFECYCLE.md` and untracked `docs/ARCHITECTURE_CRITIQUE.md` — those are doc artifacts from the planning session that started this work; will be handled in a separate doc-cleanup PR.

Ref #184 (Wave 3)
