### PR TITLE
refactor: pipeline_queue dual-write scaffolding (#184 Wave 4 PR-A)

### DIFF
--- a/scripts/web/services/archive_queue.py
+++ b/scripts/web/services/archive_queue.py
@@ -470,7 +470,14 @@ def enqueue_for_archive(source_path: str, *,
             (source_path, int(priority), enqueued_at,
              expected_size, expected_mtime),
         )
-        return cur.rowcount == 1
+        inserted = cur.rowcount == 1
+        if inserted:
+            new_id = cur.lastrowid
+            _dual_write_pipeline_archive(
+                db_path, source_path, int(priority),
+                expected_size, expected_mtime, new_id,
+            )
+        return inserted
     except sqlite3.Error as e:
         logger.warning("enqueue_for_archive failed for %s: %s",
                        source_path, e)
@@ -542,10 +549,79 @@ def enqueue_many_for_archive(source_paths: Iterable[str], *,
                 rows,
             )
             after = conn.total_changes
-            return max(0, after - before)
+            inserted_count = max(0, after - before)
+        if inserted_count:
+            _dual_write_pipeline_archive_many(db_path, rows)
+        return inserted_count
     except sqlite3.Error as e:
         logger.warning("enqueue_many_for_archive failed: %s", e)
         return 0
+
+
+# ---------------------------------------------------------------------------
+# Pipeline queue dual-write helpers (issue #184 Wave 4 — Phase I.1)
+# ---------------------------------------------------------------------------
+# Best-effort dual-write to the unified ``pipeline_queue`` table. Lazy
+# import keeps the legacy archive path independent of the new module:
+# any failure here is logged and swallowed so a producer never fails
+# on pipeline_queue trouble.
+
+def _dual_write_pipeline_archive(db_path: str, source_path: str,
+                                 priority: int,
+                                 expected_size: Optional[int],
+                                 expected_mtime: Optional[float],
+                                 legacy_id: Optional[int]) -> None:
+    try:
+        from services import pipeline_queue_service as pqs
+        pqs.dual_write_enqueue(
+            source_path=source_path,
+            stage=pqs.STAGE_ARCHIVE_PENDING,
+            legacy_table=pqs.LEGACY_TABLE_ARCHIVE,
+            legacy_id=legacy_id,
+            priority=int(priority),
+            payload={
+                'expected_size': expected_size,
+                'expected_mtime': expected_mtime,
+            },
+            db_path=db_path,
+        )
+    except Exception as e:  # noqa: BLE001
+        logger.warning(
+            "pipeline_queue dual-write skipped for %s: %s",
+            source_path, e,
+        )
+
+
+def _dual_write_pipeline_archive_many(db_path: str, rows) -> None:
+    """``rows`` is a list of (source_path, priority, enqueued_at,
+    expected_size, expected_mtime) tuples — same shape as the legacy
+    executemany rows. We don't have legacy_ids for batch inserts (the
+    INSERT OR IGNORE doesn't return per-row rowids); the
+    ``UNIQUE(source_path, stage, legacy_table)`` constraint still
+    enforces per-source idempotency.
+    """
+    try:
+        from services import pipeline_queue_service as pqs
+        pqs.dual_write_enqueue_many(
+            (
+                {
+                    'source_path': src,
+                    'stage': pqs.STAGE_ARCHIVE_PENDING,
+                    'legacy_table': pqs.LEGACY_TABLE_ARCHIVE,
+                    'priority': int(prio),
+                    'payload': {
+                        'expected_size': es,
+                        'expected_mtime': em,
+                    },
+                }
+                for (src, prio, _enqueued_at, es, em) in rows
+            ),
+            db_path=db_path,
+        )
+    except Exception as e:  # noqa: BLE001
+        logger.warning(
+            "pipeline_queue batched archive dual-write skipped: %s", e,
+        )
 
 
 def count_source_gone_recent(hours: int = 24,

--- a/scripts/web/services/cloud_archive_service.py
+++ b/scripts/web/services/cloud_archive_service.py
@@ -522,6 +522,50 @@ def _migrate_canonicalize_paths_v2(
     return (rewrites, merges)
 
 
+def _dual_write_pipeline_cloud_synced(file_path: str,
+                                      remote_path: Optional[str],
+                                      status: str,
+                                      file_size: Optional[int] = None,
+                                      file_mtime: Optional[float] = None) -> None:
+    """Best-effort dual-write of a ``cloud_synced_files`` row to the
+    unified ``pipeline_queue`` table (issue #184 Wave 4 — Phase I.1).
+
+    Cross-DB write — opens a fresh ``geodata.db`` connection inside
+    :func:`pipeline_queue_service.dual_write_enqueue` and closes it.
+    Failures are logged at WARNING and swallowed; the legacy
+    ``cloud_synced_files`` row remains the source of truth in
+    Phase I.1.
+
+    The ``status`` parameter is the legacy status string ('pending',
+    'queued', 'uploading', 'synced', 'failed'); we translate to the
+    unified stage/status pair: ``synced`` rows become
+    ``stage='cloud_done'``, anything else is ``stage='cloud_pending'``.
+    """
+    try:
+        from services import pipeline_queue_service as pqs
+        stage = (
+            pqs.STAGE_CLOUD_DONE if status == 'synced'
+            else pqs.STAGE_CLOUD_PENDING
+        )
+        pqs.dual_write_enqueue(
+            source_path=file_path,
+            stage=stage,
+            legacy_table=pqs.LEGACY_TABLE_CLOUD_SYNCED,
+            priority=pqs.PRIORITY_CLOUD_BULK,
+            dest_path=remote_path,
+            payload={
+                'file_size': file_size,
+                'file_mtime': file_mtime,
+                'legacy_status': status,
+            },
+        )
+    except Exception as e:  # noqa: BLE001
+        logger.warning(
+            "pipeline_queue cloud-synced dual-write skipped for %s: %s",
+            file_path, e,
+        )
+
+
 def _init_cloud_tables(db_path: str) -> sqlite3.Connection:
     """Open the cloud sync database and ensure all tables exist.
 
@@ -1394,9 +1438,12 @@ def _reconcile_with_remote(
                 )
                 if cur.rowcount > 0:
                     reconciled += cur.rowcount
+                    _dual_write_pipeline_cloud_synced(
+                        rel_path, remote_dest, 'synced',
+                    )
                     continue
 
-                # If not in DB at all, insert as synced (pre-tracking upload)
+                # If not in DB at all, insert as synced (event dirs)
                 existing = conn.execute(
                     "SELECT status FROM cloud_synced_files WHERE file_path = ?",
                     (rel_path,)
@@ -1409,6 +1456,9 @@ def _reconcile_with_remote(
                         (rel_path, now_iso, remote_dest)
                     )
                     reconciled += 1
+                    _dual_write_pipeline_cloud_synced(
+                        rel_path, remote_dest, 'synced',
+                    )
         except Exception as e:
             logger.warning("Reconcile error for %s: %s", folder, e)
 
@@ -1435,6 +1485,9 @@ def _reconcile_with_remote(
             )
             if cur.rowcount > 0:
                 reconciled += cur.rowcount
+                _dual_write_pipeline_cloud_synced(
+                    rel_path, remote_dest, 'synced',
+                )
                 continue
 
             existing = conn.execute(
@@ -1449,6 +1502,9 @@ def _reconcile_with_remote(
                     (rel_path, now_iso, remote_dest)
                 )
                 reconciled += 1
+                _dual_write_pipeline_cloud_synced(
+                    rel_path, remote_dest, 'synced',
+                )
     except Exception as e:
         logger.warning("Reconcile error for ArchivedClips: %s", e)
 
@@ -1503,6 +1559,9 @@ def _reconcile_with_remote_legacy(
                 )
                 if cur.rowcount > 0:
                     reconciled += cur.rowcount
+                    _dual_write_pipeline_cloud_synced(
+                        rel_path, remote_dest, 'synced',
+                    )
                     continue
 
                 # If not in DB at all, insert as synced (pre-tracking upload)
@@ -1518,6 +1577,9 @@ def _reconcile_with_remote_legacy(
                         (rel_path, now_iso, remote_dest)
                     )
                     reconciled += 1
+                    _dual_write_pipeline_cloud_synced(
+                        rel_path, remote_dest, 'synced',
+                    )
         except subprocess.TimeoutExpired:
             logger.warning("Reconcile timeout listing %s", folder)
         except Exception as e:
@@ -1555,6 +1617,9 @@ def _reconcile_with_remote_legacy(
                 )
                 if cur.rowcount > 0:
                     reconciled += cur.rowcount
+                    _dual_write_pipeline_cloud_synced(
+                        rel_path, remote_dest, 'synced',
+                    )
                     continue
 
                 existing = conn.execute(
@@ -1569,6 +1634,9 @@ def _reconcile_with_remote_legacy(
                         (rel_path, now_iso, remote_dest)
                     )
                     reconciled += 1
+                    _dual_write_pipeline_cloud_synced(
+                        rel_path, remote_dest, 'synced',
+                    )
     except Exception as e:
         logger.warning("Reconcile error for ArchivedClips: %s", e)
 
@@ -1989,6 +2057,10 @@ def _drain_once(
                 (rel_path, event_size, time.time(), rel_path)
             )
             _fsync_db(conn)
+            _dual_write_pipeline_cloud_synced(
+                rel_path, None, 'uploading',
+                file_size=event_size, file_mtime=time.time(),
+            )
 
             # Use the shared rclone helper. It handles copy-vs-copyto,
             # nice/ionice, bwlimit, timeout, and stderr capture.
@@ -2855,6 +2927,10 @@ def queue_event_for_sync(folder: str, event_name: str, priority: bool = False) -
                     (canonical, stat.st_size, stat.st_mtime)
                 )
                 queued += 1
+                _dual_write_pipeline_cloud_synced(
+                    canonical, None, 'queued',
+                    file_size=stat.st_size, file_mtime=stat.st_mtime,
+                )
 
         conn.commit()
         if queued:

--- a/scripts/web/services/cloud_archive_service.py
+++ b/scripts/web/services/cloud_archive_service.py
@@ -527,8 +527,13 @@ def _dual_write_pipeline_cloud_synced(file_path: str,
                                       status: str,
                                       file_size: Optional[int] = None,
                                       file_mtime: Optional[float] = None) -> None:
-    """Best-effort dual-write of a ``cloud_synced_files`` row to the
-    unified ``pipeline_queue`` table (issue #184 Wave 4 — Phase I.1).
+    """Best-effort dual-write of a single ``cloud_synced_files`` row to
+    the unified ``pipeline_queue`` table (issue #184 Wave 4 — Phase I.1).
+
+    For one-off transitions (the ``uploading`` and ``queued`` insert
+    sites). Reconcile loops should use
+    :func:`_dual_write_pipeline_cloud_synced_batch` instead — it
+    collapses N per-row connections into one fsync.
 
     Cross-DB write — opens a fresh ``geodata.db`` connection inside
     :func:`pipeline_queue_service.dual_write_enqueue` and closes it.
@@ -539,7 +544,8 @@ def _dual_write_pipeline_cloud_synced(file_path: str,
     The ``status`` parameter is the legacy status string ('pending',
     'queued', 'uploading', 'synced', 'failed'); we translate to the
     unified stage/status pair: ``synced`` rows become
-    ``stage='cloud_done'``, anything else is ``stage='cloud_pending'``.
+    ``stage='cloud_done', status='done'``; ``uploading``/``syncing``
+    become ``status='in_progress'``; everything else is ``'pending'``.
     """
     try:
         from services import pipeline_queue_service as pqs
@@ -547,6 +553,14 @@ def _dual_write_pipeline_cloud_synced(file_path: str,
             pqs.STAGE_CLOUD_DONE if status == 'synced'
             else pqs.STAGE_CLOUD_PENDING
         )
+        unified_status = {
+            'pending': 'pending',
+            'queued': 'pending',
+            'uploading': 'in_progress',
+            'syncing': 'in_progress',
+            'synced': 'done',
+            'failed': 'failed',
+        }.get(status, 'pending')
         pqs.dual_write_enqueue(
             source_path=file_path,
             stage=stage,
@@ -558,11 +572,61 @@ def _dual_write_pipeline_cloud_synced(file_path: str,
                 'file_mtime': file_mtime,
                 'legacy_status': status,
             },
+            status=unified_status,
         )
     except Exception as e:  # noqa: BLE001
         logger.warning(
             "pipeline_queue cloud-synced dual-write skipped for %s: %s",
             file_path, e,
+        )
+
+
+def _dual_write_pipeline_cloud_synced_batch(
+    items: List[Tuple[str, Optional[str], str]],
+) -> None:
+    """Batched dual-write for the reconcile loops.
+
+    ``items`` is a list of ``(file_path, remote_path, legacy_status)``
+    tuples. Single connection, single fsync — replaces N per-row
+    connections that would each cost a full fsync (~25–35 s of extra
+    SDIO work for a 1000-file reconcile on a Pi Zero 2 W). Must be
+    called AFTER the legacy ``cloud_sync.db`` ``conn.commit()`` so a
+    crash mid-batch doesn't leave ``pipeline_queue`` orphans.
+
+    Translates each legacy status to the unified status. Failures
+    are logged at WARNING and swallowed.
+    """
+    if not items:
+        return
+    try:
+        from services import pipeline_queue_service as pqs
+        rows = []
+        for file_path, remote_path, legacy_status in items:
+            stage = (
+                pqs.STAGE_CLOUD_DONE if legacy_status == 'synced'
+                else pqs.STAGE_CLOUD_PENDING
+            )
+            unified_status = {
+                'pending': 'pending',
+                'queued': 'pending',
+                'uploading': 'in_progress',
+                'syncing': 'in_progress',
+                'synced': 'done',
+                'failed': 'failed',
+            }.get(legacy_status, 'pending')
+            rows.append({
+                'source_path': file_path,
+                'dest_path': remote_path,
+                'stage': stage,
+                'legacy_table': pqs.LEGACY_TABLE_CLOUD_SYNCED,
+                'priority': pqs.PRIORITY_CLOUD_BULK,
+                'payload': {'legacy_status': legacy_status},
+                'status': unified_status,
+            })
+        pqs.dual_write_enqueue_many(rows)
+    except Exception as e:  # noqa: BLE001
+        logger.warning(
+            "pipeline_queue cloud-synced batched dual-write skipped: %s", e,
         )
 
 
@@ -1402,6 +1466,13 @@ def _reconcile_with_remote(
     """
     now_iso = datetime.now(timezone.utc).isoformat()
     reconciled = 0
+    # Defer dual-writes until AFTER ``conn.commit()`` so a crash
+    # mid-loop can't leave orphan ``pipeline_queue`` rows referencing
+    # legacy IDs that were never persisted. Single batched call also
+    # collapses N per-row geodata.db connections (~25 ms each on Pi
+    # Zero 2 W's SD) into one fsync — critical because reconcile
+    # fires on WiFi-up, when the SDIO bus is already busy.
+    pending_pipeline: List[Tuple[str, Optional[str], str]] = []
 
     tree = _list_remote_tree(conf_path, remote_path, mem_flags)
     if tree is None:
@@ -1438,9 +1509,7 @@ def _reconcile_with_remote(
                 )
                 if cur.rowcount > 0:
                     reconciled += cur.rowcount
-                    _dual_write_pipeline_cloud_synced(
-                        rel_path, remote_dest, 'synced',
-                    )
+                    pending_pipeline.append((rel_path, remote_dest, 'synced'))
                     continue
 
                 # If not in DB at all, insert as synced (event dirs)
@@ -1456,9 +1525,7 @@ def _reconcile_with_remote(
                         (rel_path, now_iso, remote_dest)
                     )
                     reconciled += 1
-                    _dual_write_pipeline_cloud_synced(
-                        rel_path, remote_dest, 'synced',
-                    )
+                    pending_pipeline.append((rel_path, remote_dest, 'synced'))
         except Exception as e:
             logger.warning("Reconcile error for %s: %s", folder, e)
 
@@ -1485,9 +1552,7 @@ def _reconcile_with_remote(
             )
             if cur.rowcount > 0:
                 reconciled += cur.rowcount
-                _dual_write_pipeline_cloud_synced(
-                    rel_path, remote_dest, 'synced',
-                )
+                pending_pipeline.append((rel_path, remote_dest, 'synced'))
                 continue
 
             existing = conn.execute(
@@ -1502,15 +1567,18 @@ def _reconcile_with_remote(
                     (rel_path, now_iso, remote_dest)
                 )
                 reconciled += 1
-                _dual_write_pipeline_cloud_synced(
-                    rel_path, remote_dest, 'synced',
-                )
+                pending_pipeline.append((rel_path, remote_dest, 'synced'))
     except Exception as e:
         logger.warning("Reconcile error for ArchivedClips: %s", e)
 
     if reconciled:
         conn.commit()
         logger.info("Cloud reconciliation: marked %d already-uploaded entries as synced", reconciled)
+
+    # Flush deferred pipeline_queue dual-writes AFTER the legacy
+    # commit succeeds. One connection / one fsync for the whole batch.
+    if pending_pipeline:
+        _dual_write_pipeline_cloud_synced_batch(pending_pipeline)
 
     return reconciled
 
@@ -1529,6 +1597,7 @@ def _reconcile_with_remote_legacy(
     """
     now_iso = datetime.now(timezone.utc).isoformat()
     reconciled = 0
+    pending_pipeline: List[Tuple[str, Optional[str], str]] = []
 
     # List event directories on remote (SentryClips/*, SavedClips/*)
     for folder in CLOUD_ARCHIVE_SYNC_FOLDERS:
@@ -1559,9 +1628,7 @@ def _reconcile_with_remote_legacy(
                 )
                 if cur.rowcount > 0:
                     reconciled += cur.rowcount
-                    _dual_write_pipeline_cloud_synced(
-                        rel_path, remote_dest, 'synced',
-                    )
+                    pending_pipeline.append((rel_path, remote_dest, 'synced'))
                     continue
 
                 # If not in DB at all, insert as synced (pre-tracking upload)
@@ -1577,9 +1644,7 @@ def _reconcile_with_remote_legacy(
                         (rel_path, now_iso, remote_dest)
                     )
                     reconciled += 1
-                    _dual_write_pipeline_cloud_synced(
-                        rel_path, remote_dest, 'synced',
-                    )
+                    pending_pipeline.append((rel_path, remote_dest, 'synced'))
         except subprocess.TimeoutExpired:
             logger.warning("Reconcile timeout listing %s", folder)
         except Exception as e:
@@ -1617,9 +1682,7 @@ def _reconcile_with_remote_legacy(
                 )
                 if cur.rowcount > 0:
                     reconciled += cur.rowcount
-                    _dual_write_pipeline_cloud_synced(
-                        rel_path, remote_dest, 'synced',
-                    )
+                    pending_pipeline.append((rel_path, remote_dest, 'synced'))
                     continue
 
                 existing = conn.execute(
@@ -1634,9 +1697,7 @@ def _reconcile_with_remote_legacy(
                         (rel_path, now_iso, remote_dest)
                     )
                     reconciled += 1
-                    _dual_write_pipeline_cloud_synced(
-                        rel_path, remote_dest, 'synced',
-                    )
+                    pending_pipeline.append((rel_path, remote_dest, 'synced'))
     except Exception as e:
         logger.warning("Reconcile error for ArchivedClips: %s", e)
 
@@ -1646,6 +1707,11 @@ def _reconcile_with_remote_legacy(
             "Cloud reconciliation (legacy fallback): marked %d already-uploaded entries as synced",
             reconciled,
         )
+
+    # Flush deferred pipeline_queue dual-writes AFTER the legacy
+    # commit succeeds. One connection / one fsync for the whole batch.
+    if pending_pipeline:
+        _dual_write_pipeline_cloud_synced_batch(pending_pipeline)
 
     return reconciled
 
@@ -2901,6 +2967,10 @@ def queue_event_for_sync(folder: str, event_name: str, priority: bool = False) -
     conn = _init_cloud_tables(CLOUD_ARCHIVE_DB_PATH)
     try:
         queued = 0
+        # Defer dual-writes until AFTER ``conn.commit()`` so a crash
+        # mid-loop can't leave orphan ``pipeline_queue`` rows pointing
+        # at legacy IDs that were never persisted.
+        pending_pipeline: List[Tuple[str, Optional[str], str]] = []
         for entry in os.scandir(event_dir):
             if entry.name.lower().endswith('.mp4') and event_name in entry.name:
                 # Phase 2.7 — store and look up by canonical relative
@@ -2927,12 +2997,11 @@ def queue_event_for_sync(folder: str, event_name: str, priority: bool = False) -
                     (canonical, stat.st_size, stat.st_mtime)
                 )
                 queued += 1
-                _dual_write_pipeline_cloud_synced(
-                    canonical, None, 'queued',
-                    file_size=stat.st_size, file_mtime=stat.st_mtime,
-                )
+                pending_pipeline.append((canonical, None, 'queued'))
 
         conn.commit()
+        if pending_pipeline:
+            _dual_write_pipeline_cloud_synced_batch(pending_pipeline)
         if queued:
             return True, "Added {} files to sync queue".format(queued)
         return True, "All files already synced or queued"

--- a/scripts/web/services/indexing_queue_service.py
+++ b/scripts/web/services/indexing_queue_service.py
@@ -239,6 +239,7 @@ def enqueue_for_indexing(db_path: str, file_path: str, *,
             """,
             (key, file_path, priority, now, next_at, source),
         )
+        _dual_write_pipeline_indexing(db_path, file_path, key, priority, source)
         return True
     except sqlite3.Error as e:
         logger.warning("enqueue_for_indexing failed for %s: %s", file_path, e)
@@ -317,10 +318,69 @@ def enqueue_many_for_indexing(db_path: str,
                 """,
                 rows,
             )
+        _dual_write_pipeline_indexing_many(db_path, rows)
         return len(rows)
     except sqlite3.Error as e:
         logger.warning("enqueue_many_for_indexing failed: %s", e)
         return 0
+
+
+# ---------------------------------------------------------------------------
+# Pipeline queue dual-write helpers (issue #184 Wave 4 — Phase I.1)
+# ---------------------------------------------------------------------------
+# These wrap ``services.pipeline_queue_service`` and are imported lazily
+# so that (a) tests don't pull in the unified-queue module unless they
+# need it, and (b) a missing pipeline_queue table on a partly-migrated
+# DB doesn't break the legacy enqueue path.
+
+def _dual_write_pipeline_indexing(db_path: str, file_path: str,
+                                   canonical_key_value: str,
+                                   priority: int, source: str) -> None:
+    try:
+        from services import pipeline_queue_service as pqs
+        pqs.dual_write_enqueue(
+            source_path=file_path,
+            stage=pqs.STAGE_INDEX_PENDING,
+            legacy_table=pqs.LEGACY_TABLE_INDEXING,
+            priority=priority,
+            payload={
+                'canonical_key': canonical_key_value,
+                'source': source,
+            },
+            db_path=db_path,
+        )
+    except Exception as e:  # noqa: BLE001
+        logger.warning(
+            "pipeline_queue dual-write skipped for %s: %s", file_path, e,
+        )
+
+
+def _dual_write_pipeline_indexing_many(
+    db_path: str,
+    rows: List[Tuple[str, str, int, float, str]],
+) -> None:
+    try:
+        from services import pipeline_queue_service as pqs
+        pqs.dual_write_enqueue_many(
+            (
+                {
+                    'source_path': file_path,
+                    'stage': pqs.STAGE_INDEX_PENDING,
+                    'legacy_table': pqs.LEGACY_TABLE_INDEXING,
+                    'priority': prio,
+                    'payload': {
+                        'canonical_key': key,
+                        'source': src,
+                    },
+                }
+                for (key, file_path, prio, _now, src) in rows
+            ),
+            db_path=db_path,
+        )
+    except Exception as e:  # noqa: BLE001
+        logger.warning(
+            "pipeline_queue batched dual-write skipped: %s", e,
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/web/services/live_event_sync_service.py
+++ b/scripts/web/services/live_event_sync_service.py
@@ -465,6 +465,7 @@ def enqueue_event_json(event_json_paths: List[str]) -> int:
         return 0
 
     inserted = 0
+    pending_dual_writes = []  # (path, dir, ts, reason, scope, id)
     try:
         conn = _open_db()
         try:
@@ -491,10 +492,17 @@ def enqueue_event_json(event_json_paths: List[str]) -> int:
                     logger.info(
                         "LES enqueued: %s reason=%s", event_dir, reason,
                     )
-                    _dual_write_pipeline_live_event(
+                    # Defer the dual-write: if we crash between this
+                    # point and ``conn.commit()`` below, the legacy
+                    # row vanishes (it was never committed) and we
+                    # MUST NOT leave an orphan pipeline_queue row
+                    # with a now-stale ``legacy_id``. Phase I.2's
+                    # worker uses ``legacy_id`` to cross-reference;
+                    # an orphan would point at a non-existent row.
+                    pending_dual_writes.append((
                         ej_path, event_dir, ts, reason,
                         LIVE_EVENT_UPLOAD_SCOPE, new_id,
-                    )
+                    ))
             if inserted:
                 conn.commit()
         finally:
@@ -504,6 +512,13 @@ def enqueue_event_json(event_json_paths: List[str]) -> int:
         # would silence MP4 callbacks for the indexer.
         logger.error("LES enqueue_event_json failed: %s", e)
         return 0
+
+    # Dual-write to pipeline_queue ONLY after the legacy commit
+    # succeeded — guarantees no orphans on crash mid-loop.
+    for ej_path, event_dir, ts, reason, scope, new_id in pending_dual_writes:
+        _dual_write_pipeline_live_event(
+            ej_path, event_dir, ts, reason, scope, new_id,
+        )
 
     if inserted:
         _wake.set()

--- a/scripts/web/services/live_event_sync_service.py
+++ b/scripts/web/services/live_event_sync_service.py
@@ -412,6 +412,43 @@ def _read_event_json(path: str) -> Tuple[Optional[str], Optional[str]]:
         return (None, None)
 
 
+def _dual_write_pipeline_live_event(event_json_path: str,
+                                    event_dir: str,
+                                    event_timestamp: Optional[str],
+                                    event_reason: Optional[str],
+                                    upload_scope: str,
+                                    legacy_id: Optional[int]) -> None:
+    """Best-effort dual-write to ``pipeline_queue`` (geodata.db).
+
+    Cross-DB write — opens a fresh geodata.db connection, writes one
+    row, closes. Failure here is logged at WARNING and swallowed —
+    the legacy ``live_event_queue`` row is the source of truth in
+    Phase I.1, so a missing pipeline_queue row only means the
+    Phase I.2 unified worker doesn't see it (legacy worker still
+    handles it).
+    """
+    try:
+        from services import pipeline_queue_service as pqs
+        pqs.dual_write_enqueue(
+            source_path=event_json_path,
+            stage=pqs.STAGE_LIVE_EVENT_PENDING,
+            legacy_table=pqs.LEGACY_TABLE_LIVE_EVENT,
+            legacy_id=legacy_id,
+            priority=pqs.PRIORITY_LIVE_EVENT,
+            payload={
+                'event_dir': event_dir,
+                'event_timestamp': event_timestamp,
+                'event_reason': event_reason,
+                'upload_scope': upload_scope,
+            },
+        )
+    except Exception as e:  # noqa: BLE001
+        logger.warning(
+            "pipeline_queue LES dual-write skipped for %s: %s",
+            event_dir, e,
+        )
+
+
 def enqueue_event_json(event_json_paths: List[str]) -> int:
     """Producer: enqueue events from a list of ``event.json`` paths.
 
@@ -450,8 +487,13 @@ def enqueue_event_json(event_json_paths: List[str]) -> int:
                 )
                 if cur.rowcount:
                     inserted += 1
+                    new_id = cur.lastrowid
                     logger.info(
                         "LES enqueued: %s reason=%s", event_dir, reason,
+                    )
+                    _dual_write_pipeline_live_event(
+                        ej_path, event_dir, ts, reason,
+                        LIVE_EVENT_UPLOAD_SCOPE, new_id,
                     )
             if inserted:
                 conn.commit()

--- a/scripts/web/services/mapping_migrations.py
+++ b/scripts/web/services/mapping_migrations.py
@@ -46,7 +46,7 @@ logger = logging.getLogger(__name__)
 # Database Schema & Management
 # ---------------------------------------------------------------------------
 
-_SCHEMA_VERSION = 15
+_SCHEMA_VERSION = 16
 _BACKUP_RETENTION = 3  # Keep this many migration backups before pruning oldest
 
 _SCHEMA_SQL = """
@@ -263,6 +263,74 @@ CREATE TABLE IF NOT EXISTS kv_meta (
     key TEXT PRIMARY KEY,
     value TEXT
 );
+
+-- v16 (issue #184 Wave 4 — Phase I.1): unified ``pipeline_queue``.
+-- Replaces (over the course of Wave 4) the four legacy queue tables
+-- ``archive_queue``, ``indexing_queue``, ``live_event_queue``,
+-- ``cloud_synced_files`` — each of which today has its own worker
+-- thread, retry policy, and status enum. Wave 4 ships in sub-PRs:
+--
+--   I.1 — add this table; legacy producers dual-write to BOTH old +
+--         pipeline_queue. Reads still come from old tables (no
+--         behaviour change).
+--   I.2 — switch a single unified worker to read from pipeline_queue;
+--         legacy worker reads come via SQL views over pipeline_queue.
+--   I.3 — inline SEI parse during archive copy.
+--   I.4 — delete ``live_event_sync_service`` (rows with priority 0–1
+--         in ``stage='cloud_pending'`` ARE the new LES).
+--   J/K — batched rclone, drop ``has_ready_live_event_work`` poll.
+--   I.5 — optional: consolidate ``cloud_synced_files`` /
+--         ``cloud_sync_sessions`` into geodata.db too.
+--
+-- ``stage`` encodes the lifecycle phase (e.g. ``archive_pending``,
+-- ``index_done``, ``cloud_pending``); ``status`` encodes the within-
+-- stage state (``pending`` / ``in_progress`` / ``done`` / ``failed``).
+-- A clip's lifecycle in the unified worker is one row that advances
+-- by UPDATEing ``stage``; during the dual-write transition each
+-- legacy queue creates its own ``pipeline_queue`` row tagged with
+-- ``legacy_table``+``legacy_id``. The composite UNIQUE constraint
+-- ``(source_path, stage, legacy_table)`` makes re-enqueues from the
+-- same legacy producer idempotent.
+--
+-- ``payload_json`` carries queue-specific extras (expected_size /
+-- expected_mtime for archive; canonical_key / source for indexing;
+-- event_dir / event_reason / upload_scope for LES; remote_path /
+-- file_size for cloud-synced). Storing these as JSON keeps the
+-- schema flat — no per-queue column proliferation.
+--
+-- ``priority``: lower = more urgent. Mapping during dual-write:
+--   0 — LES (real-time event upload)
+--   1 — archive (RecentClips, age-bound)
+--   2 — archive (SentryClips / SavedClips)
+--   3 — archive (other / catch-up)
+--   4 — cloud-synced bulk catch-up
+--   5 — indexing (default)
+CREATE TABLE IF NOT EXISTS pipeline_queue (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    source_path TEXT NOT NULL,
+    dest_path TEXT,
+    stage TEXT NOT NULL,
+    status TEXT DEFAULT 'pending',
+    priority INTEGER DEFAULT 5,
+    attempts INTEGER DEFAULT 0,
+    last_error TEXT,
+    next_retry_at REAL,
+    enqueued_at REAL NOT NULL,
+    completed_at REAL,
+    payload_json TEXT,
+    legacy_id INTEGER,
+    legacy_table TEXT,
+    UNIQUE(source_path, stage, legacy_table)
+);
+-- Worker pick-next index (used in Wave 4 PR-B): partial over only
+-- pending rows, ordered by priority then enqueued_at.
+CREATE INDEX IF NOT EXISTS idx_pipeline_ready
+    ON pipeline_queue(stage, status, priority, enqueued_at)
+    WHERE status = 'pending';
+-- Reverse lookup: legacy → pipeline (used by dual-write update path
+-- to find the pipeline row matching a legacy queue row).
+CREATE INDEX IF NOT EXISTS idx_pipeline_legacy
+    ON pipeline_queue(legacy_table, legacy_id);
 """
 
 
@@ -559,6 +627,26 @@ def _init_db(db_path: str) -> sqlite3.Connection:
                 )
                 conn.commit()
                 return conn
+        if current > 0 and current < 16:
+            # v16 (issue #184 Wave 4 — Phase I.1): unified
+            # ``pipeline_queue`` table. Created idempotently above by
+            # the executescript; nothing to migrate at this step
+            # because dual-write fills it from the four legacy queues
+            # going forward, and the optional ``backfill_legacy_queues()``
+            # helper (in ``services.pipeline_queue_service``) populates
+            # any backlog rows that were enqueued pre-upgrade.
+            #
+            # The backfill is intentionally NOT run here:
+            #   * It can take seconds to minutes on a Pi with thousands
+            #     of pending rows; running it inside ``_init_db`` would
+            #     delay every gadget_web start.
+            #   * It's safe to run multiple times — the unique constraint
+            #     ``(source_path, stage, legacy_table)`` makes it
+            #     idempotent.
+            # Instead, ``web_control.py`` schedules the backfill on a
+            # background thread after gadget_web is serving requests,
+            # so the user never waits on it.
+            logger.info("Migration v15->v16: pipeline_queue table ready")
         conn.execute("DELETE FROM schema_version")
         conn.execute(
             "INSERT INTO schema_version (version) VALUES (?)",

--- a/scripts/web/services/pipeline_queue_service.py
+++ b/scripts/web/services/pipeline_queue_service.py
@@ -48,7 +48,8 @@ import logging
 import os
 import sqlite3
 import time
-from typing import Any, Dict, Iterable, Optional
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -94,20 +95,37 @@ def _resolve_pipeline_db() -> Optional[str]:
 
     Lazy import of ``config`` so unit tests that don't bootstrap the
     Flask app can still import this module without side effects.
+    Logs at DEBUG when the import fails so a broken bootstrap is at
+    least detectable in ``journalctl -u gadget_web`` (the dual-write
+    helpers swallow the resulting ``False`` return at WARNING via
+    their own paths, but a silent ``None`` here would otherwise look
+    indistinguishable from a deliberate test injection).
     """
     try:
         from config import MAPPING_DB_PATH  # type: ignore
         return MAPPING_DB_PATH
-    except Exception:  # noqa: BLE001
+    except Exception as e:  # noqa: BLE001
+        logger.debug("pipeline_queue config not loaded: %s", e)
         return None
 
 
 def _open_pipeline_conn(db_path: str) -> sqlite3.Connection:
     """Open the pipeline DB with the same conservative pragmas as the
     rest of the geodata.db consumers. Caller must close.
+
+    ``synchronous=NORMAL`` + ``journal_mode=WAL`` are set here
+    defensively even though both are technically DB-wide and already
+    set by other geodata.db openers (`archive_queue._open_archive_conn`,
+    `indexing_queue_service._open_queue_conn`). ``journal_mode`` is
+    DB-wide and persistent; ``synchronous`` is per-connection and
+    defaults to ``FULL`` (~2× fsync latency) — without this line the
+    pipeline_queue path would be slower than the legacy queues that
+    sit beside it.
     """
     conn = sqlite3.connect(db_path, timeout=10.0)
     conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA synchronous=NORMAL")
     conn.execute("PRAGMA mmap_size=0")
     conn.execute("PRAGMA cache_size=-256")
     conn.execute("PRAGMA busy_timeout=15000")
@@ -130,6 +148,7 @@ def dual_write_enqueue(*,
                        priority: int = PRIORITY_INDEXING,
                        dest_path: Optional[str] = None,
                        payload: Optional[Dict[str, Any]] = None,
+                       status: str = 'pending',
                        db_path: Optional[str] = None) -> bool:
     """Insert a row into ``pipeline_queue`` mirroring a legacy enqueue.
 
@@ -156,6 +175,12 @@ def dual_write_enqueue(*,
             ``{'expected_size': 1234, 'expected_mtime': 1.0}`` for
             archive; ``{'event_reason': 'sentry', 'upload_scope':
             'event_minute'}`` for LES.
+        status: Initial within-stage status. Defaults to ``'pending'``
+            for live producer hooks. Backfill paths pass the
+            translated legacy status (``'in_progress'`` / ``'done'`` /
+            ``'failed'``) so an already-completed legacy row lands as
+            ``stage='X_done', status='done'`` rather than
+            ``status='pending'`` (which would re-process it).
         db_path: Override the geodata.db path (test injection).
     """
     if not source_path or not stage or not legacy_table:
@@ -163,6 +188,13 @@ def dual_write_enqueue(*,
     if db_path is None:
         db_path = _resolve_pipeline_db()
     if not db_path:
+        return False
+    # Don't auto-create the DB on a misconfigured deploy; signal
+    # missing-DB consistently with ``pipeline_status``.
+    if not os.path.isfile(db_path):
+        logger.debug(
+            "pipeline_queue dual-write skipped (DB %s missing)", db_path,
+        )
         return False
     payload_text = json.dumps(payload, separators=(',', ':')) if payload else None
     conn = None
@@ -173,9 +205,9 @@ def dual_write_enqueue(*,
             INSERT OR IGNORE INTO pipeline_queue
                 (source_path, dest_path, stage, status, priority,
                  enqueued_at, payload_json, legacy_id, legacy_table)
-            VALUES (?, ?, ?, 'pending', ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
-            (source_path, dest_path, stage, int(priority),
+            (source_path, dest_path, stage, status, int(priority),
              _now_epoch(), payload_text, legacy_id, legacy_table),
         )
         conn.commit()
@@ -203,14 +235,26 @@ def dual_write_enqueue_many(rows: Iterable[Dict[str, Any]],
     but for a list of rows.
 
     ``rows`` is an iterable of dicts with keys matching the named
-    arguments of :func:`dual_write_enqueue`. Returns the count of
-    newly-inserted rows. Errors on individual rows are NOT raised;
-    the batch continues. SQLite errors at the executemany level
-    return 0 and log a warning.
+    arguments of :func:`dual_write_enqueue` (including the optional
+    ``status`` key). Returns the count of newly-inserted rows.
+    Errors on individual rows are NOT raised; the batch continues.
+    SQLite errors at the executemany level return 0 and log a
+    warning.
+
+    The returned count uses ``conn.total_changes`` deltas around the
+    ``executemany`` because SQLite's ``cur.rowcount`` after
+    ``executemany`` is the LAST statement's row count, not the sum,
+    and is unreliable when ``INSERT OR IGNORE`` skips some rows.
     """
     if db_path is None:
         db_path = _resolve_pipeline_db()
     if not db_path:
+        return 0
+    if not os.path.isfile(db_path):
+        logger.debug(
+            "pipeline_queue batched dual-write skipped (DB %s missing)",
+            db_path,
+        )
         return 0
     rows = list(rows)
     if not rows:
@@ -227,6 +271,7 @@ def dual_write_enqueue_many(rows: Iterable[Dict[str, Any]],
         payload_text = json.dumps(payload, separators=(',', ':')) if payload else None
         tuples.append((
             src, r.get('dest_path'), stage,
+            r.get('status', 'pending'),
             int(r.get('priority', PRIORITY_INDEXING)),
             now, payload_text,
             r.get('legacy_id'), legacy_table,
@@ -236,20 +281,19 @@ def dual_write_enqueue_many(rows: Iterable[Dict[str, Any]],
     conn = None
     try:
         conn = _open_pipeline_conn(db_path)
+        before = conn.total_changes
         conn.execute("BEGIN IMMEDIATE")
-        cur = conn.executemany(
+        conn.executemany(
             """
             INSERT OR IGNORE INTO pipeline_queue
                 (source_path, dest_path, stage, status, priority,
                  enqueued_at, payload_json, legacy_id, legacy_table)
-            VALUES (?, ?, ?, 'pending', ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             tuples,
         )
         conn.commit()
-        # cur.rowcount in SQLite for executemany is the LAST statement's
-        # rowcount, not a sum — safer to count via a fresh SELECT.
-        return cur.rowcount if cur.rowcount and cur.rowcount > 0 else len(tuples)
+        return max(0, conn.total_changes - before)
     except sqlite3.Error as e:
         logger.warning(
             "pipeline_queue dual-write batch failed (%d rows): %s",
@@ -313,7 +357,8 @@ def pipeline_status(db_path: Optional[str] = None) -> Dict[str, Any]:
 
 def backfill_legacy_queues(*,
                            pipeline_db_path: Optional[str] = None,
-                           cloud_db_path: Optional[str] = None) -> Dict[str, int]:
+                           cloud_db_path: Optional[str] = None,
+                           force: bool = False) -> Dict[str, int]:
     """Backfill ``pipeline_queue`` from the four legacy queue tables.
 
     Idempotent — re-running is safe (the unique constraint catches
@@ -323,6 +368,16 @@ def backfill_legacy_queues(*,
     BEFORE the dual-write hooks were installed (i.e., the backlog at
     upgrade time). After upgrade, dual-write keeps both tables in
     sync; this backfill only covers the upgrade gap.
+
+    **One-shot guard.** After the first successful run we record the
+    completion timestamp in ``kv_meta`` (key:
+    ``pipeline_backfill_completed_at``). Subsequent calls SKIP the
+    work and return zeroes — without this guard the backfill would
+    re-scan all four legacy tables on every boot and (for the
+    cross-DB tables) open one geodata.db connection per legacy row,
+    which on a Pi Zero 2 W stacks tens of seconds of useless SDIO
+    fsync work onto the most fragile boot phase. Set ``force=True``
+    to bypass the guard (tests and recovery use this).
 
     Two source DBs:
       * ``pipeline_db_path`` (geodata.db): archive_queue + indexing_queue
@@ -345,6 +400,18 @@ def backfill_legacy_queues(*,
         LEGACY_TABLE_LIVE_EVENT: 0,
         LEGACY_TABLE_CLOUD_SYNCED: 0,
     }
+
+    # One-shot guard — skip if a prior run completed successfully.
+    if not force and pipeline_db_path and os.path.isfile(pipeline_db_path):
+        prior = _kv_meta_get(pipeline_db_path,
+                             'pipeline_backfill_completed_at')
+        if prior:
+            logger.debug(
+                "pipeline_queue backfill already completed at %s — skipping",
+                prior,
+            )
+            return counts
+
     if pipeline_db_path and os.path.isfile(pipeline_db_path):
         counts[LEGACY_TABLE_ARCHIVE] = _backfill_archive_queue(pipeline_db_path)
         counts[LEGACY_TABLE_INDEXING] = _backfill_indexing_queue(pipeline_db_path)
@@ -358,7 +425,57 @@ def backfill_legacy_queues(*,
     total = sum(counts.values())
     if total:
         logger.info("pipeline_queue backfill: %s (total %d)", counts, total)
+
+    # Mark complete on success — even if total==0 (no backlog rows).
+    # The guarantee is "we have run the scan"; whether the legacy
+    # tables had rows is irrelevant.
+    if pipeline_db_path and os.path.isfile(pipeline_db_path):
+        _kv_meta_set(pipeline_db_path,
+                     'pipeline_backfill_completed_at',
+                     datetime.now(timezone.utc).isoformat())
     return counts
+
+
+def _kv_meta_get(db_path: str, key: str) -> Optional[str]:
+    """Read ``kv_meta`` value or return None."""
+    conn = None
+    try:
+        conn = sqlite3.connect(db_path, timeout=10.0)
+        row = conn.execute(
+            "SELECT value FROM kv_meta WHERE key = ?", (key,),
+        ).fetchone()
+        return row[0] if row else None
+    except sqlite3.Error:
+        return None
+    finally:
+        if conn is not None:
+            try:
+                conn.close()
+            except sqlite3.Error:
+                pass
+
+
+def _kv_meta_set(db_path: str, key: str, value: str) -> bool:
+    """Upsert ``kv_meta`` value. Returns True on success."""
+    conn = None
+    try:
+        conn = sqlite3.connect(db_path, timeout=10.0)
+        conn.execute(
+            "INSERT INTO kv_meta(key, value) VALUES(?, ?) "
+            "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+            (key, value),
+        )
+        conn.commit()
+        return True
+    except sqlite3.Error as e:
+        logger.warning("kv_meta set %s failed: %s", key, e)
+        return False
+    finally:
+        if conn is not None:
+            try:
+                conn.close()
+            except sqlite3.Error:
+                pass
 
 
 def _backfill_archive_queue(pipeline_db: str) -> int:
@@ -502,6 +619,11 @@ def _backfill_live_event_queue(cloud_db: str, pipeline_db: Optional[str]) -> int
             STAGE_LIVE_EVENT_DONE if r['status'] == 'uploaded'
             else STAGE_LIVE_EVENT_PENDING
         )
+        # Translate the legacy status to the unified within-stage
+        # status. Without this mapping an already-uploaded LES row
+        # would land as ``stage='live_event_done', status='pending'``,
+        # causing the Phase I.2 worker to either skip it or
+        # re-process completed work.
         status = {
             'pending': 'pending',
             'uploading': 'in_progress',
@@ -520,6 +642,7 @@ def _backfill_live_event_queue(cloud_db: str, pipeline_db: Optional[str]) -> int
                 'event_reason': r['event_reason'],
                 'upload_scope': r['upload_scope'],
             },
+            status=status,
             db_path=pipeline_db,
         ):
             inserted += 1
@@ -564,8 +687,14 @@ def _backfill_cloud_synced_files(cloud_db: str, pipeline_db: Optional[str]) -> i
             STAGE_CLOUD_DONE if r['status'] == 'synced'
             else STAGE_CLOUD_PENDING
         )
+        # Translate the legacy status to the unified within-stage
+        # status. Without this an already-synced row would land
+        # ``stage='cloud_done', status='pending'`` and look like
+        # work that still needs to be done.
         status = {
             'pending': 'pending',
+            'queued': 'pending',
+            'uploading': 'in_progress',
             'syncing': 'in_progress',
             'synced': 'done',
             'failed': 'failed',
@@ -582,6 +711,7 @@ def _backfill_cloud_synced_files(cloud_db: str, pipeline_db: Optional[str]) -> i
                 'file_mtime': r['file_mtime'],
                 'last_error': r['last_error'],
             },
+            status=status,
             db_path=pipeline_db,
         ):
             inserted += 1

--- a/scripts/web/services/pipeline_queue_service.py
+++ b/scripts/web/services/pipeline_queue_service.py
@@ -1,0 +1,599 @@
+"""Unified pipeline queue helpers — issue #184 Wave 4 — Phase I.1.
+
+This module is the single point of access for the new ``pipeline_queue``
+table in ``geodata.db``. The table itself is created by
+``mapping_migrations._SCHEMA_SQL`` at v16; this module owns the
+producer / consumer / backfill API.
+
+**Phase I.1 only adds the dual-write side.** Legacy producers
+(``archive_queue.enqueue_for_archive``, ``indexing_queue_service.
+enqueue_for_indexing``, ``live_event_sync_service.enqueue_event_json``,
+and the cloud-synced-files insertion path) call into this module's
+:func:`dual_write_enqueue` after they write to their own legacy table.
+Reads remain on the legacy tables — no behaviour change yet.
+
+Design rules:
+
+* **Best-effort dual-write.** A failure to write to ``pipeline_queue``
+  must never fail the legacy enqueue. The legacy queue is the source
+  of truth in Phase I.1; pipeline_queue is shadow data being validated.
+  All errors are logged at WARNING and swallowed.
+* **Idempotent.** The composite unique constraint
+  ``(source_path, stage, legacy_table)`` plus ``INSERT OR IGNORE``
+  makes repeated dual-writes harmless. Producers that re-enqueue
+  (e.g. inotify firing on the same path twice) write at most one
+  pipeline_queue row.
+* **Cross-DB writes are short-lived connections.** The LES dual-write
+  is the only cross-DB case (LES is in ``cloud_sync.db``;
+  ``pipeline_queue`` is in ``geodata.db``). Each dual-write opens a
+  fresh ``geodata.db`` connection, writes one row, and closes. No
+  long-lived second connection is held alongside the legacy DB
+  connection — that would double the connection count and complicate
+  task_coordinator semantics.
+
+Public API:
+
+* :data:`STAGE_*` constants — canonical stage names.
+* :data:`LEGACY_TABLE_*` constants — canonical legacy table names.
+* :data:`PRIORITY_*` constants — canonical priorities.
+* :func:`dual_write_enqueue` — producer hook.
+* :func:`backfill_legacy_queues` — one-time migration helper.
+* :func:`pipeline_status` — debug / verification view.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sqlite3
+import time
+from typing import Any, Dict, Iterable, Optional
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Canonical constants — every dual-write site MUST use these strings.
+# ---------------------------------------------------------------------------
+
+# Stage values. The unified worker (Phase I.2) selects on
+# ``WHERE stage = ? AND status = 'pending'``; producer hooks set the
+# initial stage when enqueuing.
+STAGE_ARCHIVE_PENDING = 'archive_pending'
+STAGE_ARCHIVE_DONE = 'archive_done'
+STAGE_INDEX_PENDING = 'index_pending'
+STAGE_INDEX_DONE = 'index_done'
+STAGE_CLOUD_PENDING = 'cloud_pending'
+STAGE_CLOUD_DONE = 'cloud_done'
+STAGE_LIVE_EVENT_PENDING = 'live_event_pending'
+STAGE_LIVE_EVENT_DONE = 'live_event_done'
+
+# Legacy table names — used by the dual-write hooks to tag which
+# legacy producer created each pipeline_queue row.
+LEGACY_TABLE_ARCHIVE = 'archive_queue'
+LEGACY_TABLE_INDEXING = 'indexing_queue'
+LEGACY_TABLE_LIVE_EVENT = 'live_event_queue'
+LEGACY_TABLE_CLOUD_SYNCED = 'cloud_synced_files'
+
+# Priority mapping — lower is more urgent.
+PRIORITY_LIVE_EVENT = 0          # LES real-time event upload
+PRIORITY_ARCHIVE_EVENT = 1       # Sentry / Saved clips
+PRIORITY_ARCHIVE_RECENT = 2      # RecentClips (age-bound)
+PRIORITY_ARCHIVE_OTHER = 3       # ArchivedClips back-fill / other
+PRIORITY_CLOUD_BULK = 4          # cloud_synced_files bulk catch-up
+PRIORITY_INDEXING = 5            # default indexing
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _resolve_pipeline_db() -> Optional[str]:
+    """Return the geodata.db path, or None if config can't be loaded.
+
+    Lazy import of ``config`` so unit tests that don't bootstrap the
+    Flask app can still import this module without side effects.
+    """
+    try:
+        from config import MAPPING_DB_PATH  # type: ignore
+        return MAPPING_DB_PATH
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _open_pipeline_conn(db_path: str) -> sqlite3.Connection:
+    """Open the pipeline DB with the same conservative pragmas as the
+    rest of the geodata.db consumers. Caller must close.
+    """
+    conn = sqlite3.connect(db_path, timeout=10.0)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA mmap_size=0")
+    conn.execute("PRAGMA cache_size=-256")
+    conn.execute("PRAGMA busy_timeout=15000")
+    return conn
+
+
+def _now_epoch() -> float:
+    return time.time()
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def dual_write_enqueue(*,
+                       source_path: str,
+                       stage: str,
+                       legacy_table: str,
+                       legacy_id: Optional[int] = None,
+                       priority: int = PRIORITY_INDEXING,
+                       dest_path: Optional[str] = None,
+                       payload: Optional[Dict[str, Any]] = None,
+                       db_path: Optional[str] = None) -> bool:
+    """Insert a row into ``pipeline_queue`` mirroring a legacy enqueue.
+
+    Returns True if a new row was inserted, False if the row already
+    exists (idempotent), and False if any error occurs (logged at
+    WARNING). NEVER raises.
+
+    Args:
+        source_path: The resource being processed. For archive /
+            indexing this is the file path; for LES it's the
+            ``event.json`` path; for cloud_synced_files it's the
+            file path.
+        stage: One of the ``STAGE_*`` constants.
+        legacy_table: One of the ``LEGACY_TABLE_*`` constants — which
+            old queue this row mirrors.
+        legacy_id: Back-pointer to the legacy row's primary key, if
+            available. Used by the migration helper to verify that
+            every legacy row has a corresponding pipeline_queue row.
+        priority: Lower = more urgent. Default ``PRIORITY_INDEXING``.
+        dest_path: Final destination on SD card (archive only); None
+            for queues that don't have a destination.
+        payload: Queue-specific extras that don't fit the flat schema.
+            Stored as JSON in the ``payload_json`` column. Examples:
+            ``{'expected_size': 1234, 'expected_mtime': 1.0}`` for
+            archive; ``{'event_reason': 'sentry', 'upload_scope':
+            'event_minute'}`` for LES.
+        db_path: Override the geodata.db path (test injection).
+    """
+    if not source_path or not stage or not legacy_table:
+        return False
+    if db_path is None:
+        db_path = _resolve_pipeline_db()
+    if not db_path:
+        return False
+    payload_text = json.dumps(payload, separators=(',', ':')) if payload else None
+    conn = None
+    try:
+        conn = _open_pipeline_conn(db_path)
+        cur = conn.execute(
+            """
+            INSERT OR IGNORE INTO pipeline_queue
+                (source_path, dest_path, stage, status, priority,
+                 enqueued_at, payload_json, legacy_id, legacy_table)
+            VALUES (?, ?, ?, 'pending', ?, ?, ?, ?, ?)
+            """,
+            (source_path, dest_path, stage, int(priority),
+             _now_epoch(), payload_text, legacy_id, legacy_table),
+        )
+        conn.commit()
+        return bool(cur.rowcount)
+    except sqlite3.Error as e:
+        # Best-effort: a failed dual-write must NOT fail the legacy
+        # enqueue. Log at WARNING so the operator can see drift if
+        # this ever fires repeatedly.
+        logger.warning(
+            "pipeline_queue dual-write failed for %s/%s: %s",
+            legacy_table, source_path, e,
+        )
+        return False
+    finally:
+        if conn is not None:
+            try:
+                conn.close()
+            except sqlite3.Error:
+                pass
+
+
+def dual_write_enqueue_many(rows: Iterable[Dict[str, Any]],
+                            db_path: Optional[str] = None) -> int:
+    """Batched dual-write — same semantics as ``dual_write_enqueue``
+    but for a list of rows.
+
+    ``rows`` is an iterable of dicts with keys matching the named
+    arguments of :func:`dual_write_enqueue`. Returns the count of
+    newly-inserted rows. Errors on individual rows are NOT raised;
+    the batch continues. SQLite errors at the executemany level
+    return 0 and log a warning.
+    """
+    if db_path is None:
+        db_path = _resolve_pipeline_db()
+    if not db_path:
+        return 0
+    rows = list(rows)
+    if not rows:
+        return 0
+    now = _now_epoch()
+    tuples = []
+    for r in rows:
+        src = r.get('source_path')
+        stage = r.get('stage')
+        legacy_table = r.get('legacy_table')
+        if not src or not stage or not legacy_table:
+            continue
+        payload = r.get('payload')
+        payload_text = json.dumps(payload, separators=(',', ':')) if payload else None
+        tuples.append((
+            src, r.get('dest_path'), stage,
+            int(r.get('priority', PRIORITY_INDEXING)),
+            now, payload_text,
+            r.get('legacy_id'), legacy_table,
+        ))
+    if not tuples:
+        return 0
+    conn = None
+    try:
+        conn = _open_pipeline_conn(db_path)
+        conn.execute("BEGIN IMMEDIATE")
+        cur = conn.executemany(
+            """
+            INSERT OR IGNORE INTO pipeline_queue
+                (source_path, dest_path, stage, status, priority,
+                 enqueued_at, payload_json, legacy_id, legacy_table)
+            VALUES (?, ?, ?, 'pending', ?, ?, ?, ?, ?)
+            """,
+            tuples,
+        )
+        conn.commit()
+        # cur.rowcount in SQLite for executemany is the LAST statement's
+        # rowcount, not a sum — safer to count via a fresh SELECT.
+        return cur.rowcount if cur.rowcount and cur.rowcount > 0 else len(tuples)
+    except sqlite3.Error as e:
+        logger.warning(
+            "pipeline_queue dual-write batch failed (%d rows): %s",
+            len(tuples), e,
+        )
+        return 0
+    finally:
+        if conn is not None:
+            try:
+                conn.close()
+            except sqlite3.Error:
+                pass
+
+
+def pipeline_status(db_path: Optional[str] = None) -> Dict[str, Any]:
+    """Return a small dict summarising the pipeline_queue state.
+
+    Useful for debugging / the Settings page / dual-write parity
+    checks. Counts grouped by ``(legacy_table, stage, status)``.
+    Returns an empty dict on any error.
+    """
+    if db_path is None:
+        db_path = _resolve_pipeline_db()
+    if not db_path or not os.path.isfile(db_path):
+        return {}
+    conn = None
+    try:
+        conn = _open_pipeline_conn(db_path)
+        rows = conn.execute(
+            """SELECT legacy_table, stage, status, COUNT(*) AS n
+               FROM pipeline_queue
+               GROUP BY legacy_table, stage, status
+               ORDER BY legacy_table, stage, status"""
+        ).fetchall()
+        return {
+            'total': sum(r['n'] for r in rows),
+            'by_legacy_stage_status': [
+                {
+                    'legacy_table': r['legacy_table'],
+                    'stage': r['stage'],
+                    'status': r['status'],
+                    'count': r['n'],
+                }
+                for r in rows
+            ],
+        }
+    except sqlite3.Error as e:
+        logger.warning("pipeline_status failed: %s", e)
+        return {}
+    finally:
+        if conn is not None:
+            try:
+                conn.close()
+            except sqlite3.Error:
+                pass
+
+
+# ---------------------------------------------------------------------------
+# Backfill from legacy queues — one-time migration helper
+# ---------------------------------------------------------------------------
+
+def backfill_legacy_queues(*,
+                           pipeline_db_path: Optional[str] = None,
+                           cloud_db_path: Optional[str] = None) -> Dict[str, int]:
+    """Backfill ``pipeline_queue`` from the four legacy queue tables.
+
+    Idempotent — re-running is safe (the unique constraint catches
+    duplicates). Returns a per-source count of rows inserted.
+
+    This is a one-time migration to handle pending rows that existed
+    BEFORE the dual-write hooks were installed (i.e., the backlog at
+    upgrade time). After upgrade, dual-write keeps both tables in
+    sync; this backfill only covers the upgrade gap.
+
+    Two source DBs:
+      * ``pipeline_db_path`` (geodata.db): archive_queue + indexing_queue
+      * ``cloud_db_path`` (cloud_sync.db): live_event_queue + cloud_synced_files
+
+    Both default to the configured paths via lazy ``config`` import.
+    """
+    if pipeline_db_path is None:
+        pipeline_db_path = _resolve_pipeline_db()
+    if cloud_db_path is None:
+        try:
+            from config import CLOUD_ARCHIVE_DB_PATH  # type: ignore
+            cloud_db_path = CLOUD_ARCHIVE_DB_PATH
+        except Exception:  # noqa: BLE001
+            cloud_db_path = None
+
+    counts = {
+        LEGACY_TABLE_ARCHIVE: 0,
+        LEGACY_TABLE_INDEXING: 0,
+        LEGACY_TABLE_LIVE_EVENT: 0,
+        LEGACY_TABLE_CLOUD_SYNCED: 0,
+    }
+    if pipeline_db_path and os.path.isfile(pipeline_db_path):
+        counts[LEGACY_TABLE_ARCHIVE] = _backfill_archive_queue(pipeline_db_path)
+        counts[LEGACY_TABLE_INDEXING] = _backfill_indexing_queue(pipeline_db_path)
+    if cloud_db_path and os.path.isfile(cloud_db_path):
+        counts[LEGACY_TABLE_LIVE_EVENT] = _backfill_live_event_queue(
+            cloud_db_path, pipeline_db_path,
+        )
+        counts[LEGACY_TABLE_CLOUD_SYNCED] = _backfill_cloud_synced_files(
+            cloud_db_path, pipeline_db_path,
+        )
+    total = sum(counts.values())
+    if total:
+        logger.info("pipeline_queue backfill: %s (total %d)", counts, total)
+    return counts
+
+
+def _backfill_archive_queue(pipeline_db: str) -> int:
+    """Backfill from ``archive_queue`` (same DB as pipeline_queue).
+
+    Single-DB backfill — uses one ``INSERT INTO ... SELECT`` for atomicity.
+    """
+    conn = None
+    try:
+        conn = _open_pipeline_conn(pipeline_db)
+        # Existence check — archive_queue may not be present on
+        # very old DBs.
+        if not _table_exists(conn, 'archive_queue'):
+            return 0
+        cur = conn.execute(
+            """
+            INSERT OR IGNORE INTO pipeline_queue
+                (source_path, dest_path, stage, status, priority,
+                 attempts, last_error, enqueued_at, payload_json,
+                 legacy_id, legacy_table)
+            SELECT
+                source_path,
+                dest_path,
+                CASE
+                    WHEN status IN ('copied') THEN 'archive_done'
+                    ELSE 'archive_pending'
+                END,
+                CASE
+                    WHEN status = 'pending'  THEN 'pending'
+                    WHEN status = 'claimed'  THEN 'in_progress'
+                    WHEN status = 'copied'   THEN 'done'
+                    ELSE 'failed'
+                END,
+                COALESCE(priority, 3),
+                COALESCE(attempts, 0),
+                last_error,
+                COALESCE(strftime('%s', enqueued_at) + 0, ?),
+                json_object('expected_size', expected_size,
+                            'expected_mtime', expected_mtime),
+                id,
+                'archive_queue'
+            FROM archive_queue
+            """,
+            (_now_epoch(),),
+        )
+        conn.commit()
+        return cur.rowcount if cur.rowcount and cur.rowcount > 0 else 0
+    except sqlite3.Error as e:
+        logger.warning("backfill archive_queue failed: %s", e)
+        return 0
+    finally:
+        if conn is not None:
+            try:
+                conn.close()
+            except sqlite3.Error:
+                pass
+
+
+def _backfill_indexing_queue(pipeline_db: str) -> int:
+    """Backfill from ``indexing_queue`` (same DB as pipeline_queue)."""
+    conn = None
+    try:
+        conn = _open_pipeline_conn(pipeline_db)
+        if not _table_exists(conn, 'indexing_queue'):
+            return 0
+        cur = conn.execute(
+            """
+            INSERT OR IGNORE INTO pipeline_queue
+                (source_path, stage, status, priority,
+                 attempts, last_error, enqueued_at, next_retry_at,
+                 payload_json, legacy_id, legacy_table)
+            SELECT
+                file_path,
+                'index_pending',
+                CASE
+                    WHEN claimed_by IS NOT NULL THEN 'in_progress'
+                    ELSE 'pending'
+                END,
+                COALESCE(priority, 50),
+                COALESCE(attempts, 0),
+                last_error,
+                COALESCE(enqueued_at, ?),
+                next_attempt_at,
+                json_object('canonical_key', canonical_key,
+                            'source', source),
+                NULL,
+                'indexing_queue'
+            FROM indexing_queue
+            """,
+            (_now_epoch(),),
+        )
+        conn.commit()
+        return cur.rowcount if cur.rowcount and cur.rowcount > 0 else 0
+    except sqlite3.Error as e:
+        logger.warning("backfill indexing_queue failed: %s", e)
+        return 0
+    finally:
+        if conn is not None:
+            try:
+                conn.close()
+            except sqlite3.Error:
+                pass
+
+
+def _backfill_live_event_queue(cloud_db: str, pipeline_db: Optional[str]) -> int:
+    """Backfill from ``live_event_queue`` (cloud_sync.db) into
+    ``pipeline_queue`` (geodata.db). CROSS-DB — read from cloud_db,
+    write to pipeline_db one row at a time.
+    """
+    if not pipeline_db or not os.path.isfile(pipeline_db):
+        return 0
+    src_conn = None
+    try:
+        src_conn = sqlite3.connect(cloud_db, timeout=10.0)
+        src_conn.row_factory = sqlite3.Row
+        # Existence check — LES may not have ever been enabled on
+        # this device, in which case the table is absent.
+        if not _table_exists(src_conn, 'live_event_queue'):
+            return 0
+        rows = src_conn.execute(
+            "SELECT id, event_dir, event_json_path, event_timestamp, "
+            "event_reason, upload_scope, status, attempts, last_error, "
+            "next_retry_at, enqueued_at FROM live_event_queue"
+        ).fetchall()
+    except sqlite3.Error as e:
+        logger.warning("backfill live_event_queue read failed: %s", e)
+        return 0
+    finally:
+        if src_conn is not None:
+            try:
+                src_conn.close()
+            except sqlite3.Error:
+                pass
+
+    if not rows:
+        return 0
+
+    inserted = 0
+    for r in rows:
+        stage = (
+            STAGE_LIVE_EVENT_DONE if r['status'] == 'uploaded'
+            else STAGE_LIVE_EVENT_PENDING
+        )
+        status = {
+            'pending': 'pending',
+            'uploading': 'in_progress',
+            'uploaded': 'done',
+            'failed': 'failed',
+        }.get(r['status'], 'failed')
+        if dual_write_enqueue(
+            source_path=r['event_json_path'],
+            stage=stage,
+            legacy_table=LEGACY_TABLE_LIVE_EVENT,
+            legacy_id=r['id'],
+            priority=PRIORITY_LIVE_EVENT,
+            payload={
+                'event_dir': r['event_dir'],
+                'event_timestamp': r['event_timestamp'],
+                'event_reason': r['event_reason'],
+                'upload_scope': r['upload_scope'],
+            },
+            db_path=pipeline_db,
+        ):
+            inserted += 1
+        # Even on dup-skip we DON'T mark this as a failure — it just
+        # means the row was already backfilled.
+    return inserted
+
+
+def _backfill_cloud_synced_files(cloud_db: str, pipeline_db: Optional[str]) -> int:
+    """Backfill from ``cloud_synced_files`` (cloud_sync.db) into
+    ``pipeline_queue`` (geodata.db). CROSS-DB.
+    """
+    if not pipeline_db or not os.path.isfile(pipeline_db):
+        return 0
+    src_conn = None
+    try:
+        src_conn = sqlite3.connect(cloud_db, timeout=10.0)
+        src_conn.row_factory = sqlite3.Row
+        if not _table_exists(src_conn, 'cloud_synced_files'):
+            return 0
+        rows = src_conn.execute(
+            "SELECT id, file_path, remote_path, file_size, file_mtime, "
+            "status, retry_count, last_error, synced_at "
+            "FROM cloud_synced_files"
+        ).fetchall()
+    except sqlite3.Error as e:
+        logger.warning("backfill cloud_synced_files read failed: %s", e)
+        return 0
+    finally:
+        if src_conn is not None:
+            try:
+                src_conn.close()
+            except sqlite3.Error:
+                pass
+
+    if not rows:
+        return 0
+
+    inserted = 0
+    for r in rows:
+        stage = (
+            STAGE_CLOUD_DONE if r['status'] == 'synced'
+            else STAGE_CLOUD_PENDING
+        )
+        status = {
+            'pending': 'pending',
+            'syncing': 'in_progress',
+            'synced': 'done',
+            'failed': 'failed',
+        }.get(r['status'], 'failed')
+        if dual_write_enqueue(
+            source_path=r['file_path'],
+            stage=stage,
+            legacy_table=LEGACY_TABLE_CLOUD_SYNCED,
+            legacy_id=r['id'],
+            priority=PRIORITY_CLOUD_BULK,
+            dest_path=r['remote_path'],
+            payload={
+                'file_size': r['file_size'],
+                'file_mtime': r['file_mtime'],
+                'last_error': r['last_error'],
+            },
+            db_path=pipeline_db,
+        ):
+            inserted += 1
+    return inserted
+
+
+def _table_exists(conn: sqlite3.Connection, table: str) -> bool:
+    try:
+        row = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+            (table,),
+        ).fetchone()
+        return row is not None
+    except sqlite3.Error:
+        return False

--- a/scripts/web/web_control.py
+++ b/scripts/web/web_control.py
@@ -468,26 +468,50 @@ if __name__ == "__main__":
 
     # One-time pipeline_queue backfill (issue #184 Wave 4 — Phase I.1).
     # Idempotent — re-running on every boot is safe (the unique
-    # constraint catches duplicates). Runs on a background daemon
-    # thread so it never blocks the request loop. Read more in
+    # constraint catches duplicates), AND a one-shot completion flag
+    # in ``kv_meta`` makes subsequent boots a no-op (so we don't
+    # re-scan four legacy tables every restart). Runs on a background
+    # daemon thread so it never blocks the request loop.
+    #
+    # Daemon-thread kill semantics: ``daemon=True`` means the thread
+    # dies abruptly when the process exits. That's fine here because
+    # ``backfill_legacy_queues`` is fully idempotent — a kill in the
+    # middle of one of the per-table loops just means the next boot
+    # re-runs the scan and resumes (the ``ON CONFLICT DO NOTHING``
+    # clause + UNIQUE constraint dedup any partial work). The
+    # one-shot flag is only set on a successful end-to-end run.
+    #
+    # Read more in
     # ``services.pipeline_queue_service.backfill_legacy_queues``.
     try:
         import threading
+        _backfill_logger = logging.getLogger('teslausb.pipeline_backfill')
 
         def _run_pipeline_backfill():
             try:
                 from services import pipeline_queue_service
                 counts = pipeline_queue_service.backfill_legacy_queues()
-                print(f"pipeline_queue backfill: {counts}")
+                if any(counts.values()):
+                    _backfill_logger.info(
+                        "pipeline_queue backfill: %s", counts,
+                    )
+                else:
+                    _backfill_logger.debug(
+                        "pipeline_queue backfill: nothing to do",
+                    )
             except Exception as e:  # noqa: BLE001
-                print(f"Warning: pipeline_queue backfill failed: {e}")
+                _backfill_logger.warning(
+                    "pipeline_queue backfill failed: %s", e,
+                )
         threading.Thread(
             target=_run_pipeline_backfill,
             name='pipeline-backfill',
             daemon=True,
         ).start()
     except Exception as e:  # noqa: BLE001
-        print(f"Warning: failed to schedule pipeline_queue backfill: {e}")
+        logging.getLogger('teslausb.pipeline_backfill').warning(
+            "failed to schedule pipeline_queue backfill: %s", e,
+        )
 
     # Try to use Waitress if available, otherwise fall back to Flask dev server
     try:

--- a/scripts/web/web_control.py
+++ b/scripts/web/web_control.py
@@ -466,6 +466,29 @@ if __name__ == "__main__":
     except Exception as e:  # noqa: BLE001
         print(f"Warning: WAL checkpoint service failed to start: {e}")
 
+    # One-time pipeline_queue backfill (issue #184 Wave 4 — Phase I.1).
+    # Idempotent — re-running on every boot is safe (the unique
+    # constraint catches duplicates). Runs on a background daemon
+    # thread so it never blocks the request loop. Read more in
+    # ``services.pipeline_queue_service.backfill_legacy_queues``.
+    try:
+        import threading
+
+        def _run_pipeline_backfill():
+            try:
+                from services import pipeline_queue_service
+                counts = pipeline_queue_service.backfill_legacy_queues()
+                print(f"pipeline_queue backfill: {counts}")
+            except Exception as e:  # noqa: BLE001
+                print(f"Warning: pipeline_queue backfill failed: {e}")
+        threading.Thread(
+            target=_run_pipeline_backfill,
+            name='pipeline-backfill',
+            daemon=True,
+        ).start()
+    except Exception as e:  # noqa: BLE001
+        print(f"Warning: failed to schedule pipeline_queue backfill: {e}")
+
     # Try to use Waitress if available, otherwise fall back to Flask dev server
     try:
         from waitress import serve

--- a/tests/test_pipeline_queue_dualwrite.py
+++ b/tests/test_pipeline_queue_dualwrite.py
@@ -1,0 +1,605 @@
+"""Tests for issue #184 Wave 4 — Phase I.1 (pipeline_queue dual-write).
+
+Phase I.1 is the additive half of the queue unification:
+
+  * The new ``pipeline_queue`` table exists in ``geodata.db`` (schema v16).
+  * Every legacy enqueue (archive_queue, indexing_queue,
+    live_event_queue, cloud_synced_files) ALSO writes a row to
+    ``pipeline_queue`` tagged with ``legacy_table`` + ``legacy_id``.
+  * Reads still come from the legacy tables — no behaviour change.
+  * A one-time backfill helper picks up rows that existed BEFORE
+    dual-write was wired in (the upgrade backlog).
+
+These tests verify:
+
+  * Schema migration v15 → v16 creates the ``pipeline_queue`` table
+    and the two indices.
+  * Each dual-write hook produces a row in ``pipeline_queue`` with
+    the expected ``stage``, ``priority``, ``legacy_table``, and
+    ``payload_json`` values.
+  * Re-enqueuing the same source from the same legacy producer is
+    idempotent (the unique constraint catches it).
+  * Backfill correctly translates each legacy queue's status enum
+    to the unified stage/status pair.
+  * Errors in the dual-write path NEVER propagate to the legacy
+    enqueue caller.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import sys
+import tempfile
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+# Allow importing the web modules without spinning up Flask.
+SCRIPTS_WEB = Path(__file__).resolve().parent.parent / 'scripts' / 'web'
+if str(SCRIPTS_WEB) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_WEB))
+
+from services import pipeline_queue_service as pqs  # noqa: E402
+from services.mapping_migrations import _SCHEMA_VERSION, _init_db  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def geodata_db(tmp_path):
+    """A fresh ``geodata.db`` initialised at the current schema version."""
+    db_path = str(tmp_path / 'geodata.db')
+    conn = _init_db(db_path)
+    conn.close()
+    return db_path
+
+
+@pytest.fixture
+def cloud_sync_db(tmp_path):
+    """A fresh ``cloud_sync.db`` with the LES + cloud_synced_files schemas."""
+    db_path = str(tmp_path / 'cloud_sync.db')
+    conn = sqlite3.connect(db_path)
+    conn.executescript(
+        """
+        CREATE TABLE live_event_queue (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            event_dir TEXT NOT NULL,
+            event_json_path TEXT NOT NULL,
+            event_timestamp TEXT,
+            event_reason TEXT,
+            upload_scope TEXT DEFAULT 'event_minute',
+            status TEXT DEFAULT 'pending',
+            enqueued_at TEXT NOT NULL,
+            uploaded_at TEXT,
+            next_retry_at REAL,
+            attempts INTEGER DEFAULT 0,
+            last_error TEXT,
+            previous_last_error TEXT,
+            bytes_uploaded INTEGER DEFAULT 0,
+            UNIQUE(event_dir)
+        );
+        CREATE TABLE cloud_synced_files (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            file_path TEXT NOT NULL UNIQUE,
+            file_size INTEGER,
+            file_mtime REAL,
+            remote_path TEXT,
+            status TEXT DEFAULT 'pending',
+            synced_at TEXT,
+            retry_count INTEGER DEFAULT 0,
+            last_error TEXT,
+            previous_last_error TEXT
+        );
+        """
+    )
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+# ---------------------------------------------------------------------------
+# Schema
+# ---------------------------------------------------------------------------
+
+class TestSchema:
+    def test_schema_version_is_v16_or_later(self):
+        assert _SCHEMA_VERSION >= 16
+
+    def test_pipeline_queue_table_exists(self, geodata_db):
+        conn = sqlite3.connect(geodata_db)
+        try:
+            row = conn.execute(
+                "SELECT name FROM sqlite_master "
+                "WHERE type='table' AND name='pipeline_queue'"
+            ).fetchone()
+            assert row is not None
+            cols = {r[1] for r in conn.execute(
+                "PRAGMA table_info(pipeline_queue)"
+            ).fetchall()}
+            for required in (
+                'id', 'source_path', 'dest_path', 'stage', 'status',
+                'priority', 'attempts', 'last_error', 'next_retry_at',
+                'enqueued_at', 'completed_at', 'payload_json',
+                'legacy_id', 'legacy_table',
+            ):
+                assert required in cols, f"missing column {required}"
+        finally:
+            conn.close()
+
+    def test_pipeline_queue_indices_exist(self, geodata_db):
+        conn = sqlite3.connect(geodata_db)
+        try:
+            indices = {r[0] for r in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='index' "
+                "AND tbl_name='pipeline_queue'"
+            ).fetchall()}
+            assert 'idx_pipeline_ready' in indices
+            assert 'idx_pipeline_legacy' in indices
+        finally:
+            conn.close()
+
+    def test_pipeline_queue_uniqueness(self, geodata_db):
+        """``(source_path, stage, legacy_table)`` is unique."""
+        ok1 = pqs.dual_write_enqueue(
+            source_path='/foo/bar.mp4',
+            stage=pqs.STAGE_ARCHIVE_PENDING,
+            legacy_table=pqs.LEGACY_TABLE_ARCHIVE,
+            db_path=geodata_db,
+        )
+        ok2 = pqs.dual_write_enqueue(
+            source_path='/foo/bar.mp4',
+            stage=pqs.STAGE_ARCHIVE_PENDING,
+            legacy_table=pqs.LEGACY_TABLE_ARCHIVE,
+            db_path=geodata_db,
+        )
+        assert ok1 is True
+        assert ok2 is False  # idempotent
+        conn = sqlite3.connect(geodata_db)
+        try:
+            n = conn.execute("SELECT COUNT(*) FROM pipeline_queue").fetchone()[0]
+            assert n == 1
+        finally:
+            conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Dual-write helpers (direct calls)
+# ---------------------------------------------------------------------------
+
+class TestDualWriteEnqueue:
+    def test_writes_row_with_all_fields(self, geodata_db):
+        ok = pqs.dual_write_enqueue(
+            source_path='/x/SentryClips/2026-05-14_10-00-00/event.mp4',
+            stage=pqs.STAGE_ARCHIVE_PENDING,
+            legacy_table=pqs.LEGACY_TABLE_ARCHIVE,
+            legacy_id=42,
+            priority=pqs.PRIORITY_ARCHIVE_EVENT,
+            payload={'expected_size': 1234, 'expected_mtime': 1.0},
+            db_path=geodata_db,
+        )
+        assert ok is True
+        conn = sqlite3.connect(geodata_db)
+        conn.row_factory = sqlite3.Row
+        try:
+            row = conn.execute("SELECT * FROM pipeline_queue").fetchone()
+            assert row['source_path'].endswith('/event.mp4')
+            assert row['stage'] == pqs.STAGE_ARCHIVE_PENDING
+            assert row['status'] == 'pending'
+            assert row['priority'] == pqs.PRIORITY_ARCHIVE_EVENT
+            assert row['legacy_id'] == 42
+            assert row['legacy_table'] == pqs.LEGACY_TABLE_ARCHIVE
+            payload = json.loads(row['payload_json'])
+            assert payload['expected_size'] == 1234
+            assert payload['expected_mtime'] == 1.0
+        finally:
+            conn.close()
+
+    def test_missing_required_returns_false(self, geodata_db):
+        assert pqs.dual_write_enqueue(
+            source_path='', stage=pqs.STAGE_ARCHIVE_PENDING,
+            legacy_table=pqs.LEGACY_TABLE_ARCHIVE,
+            db_path=geodata_db,
+        ) is False
+        assert pqs.dual_write_enqueue(
+            source_path='/foo', stage='',
+            legacy_table=pqs.LEGACY_TABLE_ARCHIVE,
+            db_path=geodata_db,
+        ) is False
+        assert pqs.dual_write_enqueue(
+            source_path='/foo', stage=pqs.STAGE_ARCHIVE_PENDING,
+            legacy_table='',
+            db_path=geodata_db,
+        ) is False
+
+    def test_no_db_path_returns_false(self):
+        # Without a configured DB path AND no module-level config, it
+        # must NOT raise — best-effort means swallow the failure.
+        with mock.patch.object(pqs, '_resolve_pipeline_db', return_value=None):
+            assert pqs.dual_write_enqueue(
+                source_path='/foo',
+                stage=pqs.STAGE_ARCHIVE_PENDING,
+                legacy_table=pqs.LEGACY_TABLE_ARCHIVE,
+            ) is False
+
+    def test_swallows_sqlite_errors(self, tmp_path):
+        bad_path = str(tmp_path / 'does-not-exist' / 'x.db')
+        # Writing into a non-existent directory should fail at open
+        # time; the helper must NOT raise.
+        result = pqs.dual_write_enqueue(
+            source_path='/foo',
+            stage=pqs.STAGE_ARCHIVE_PENDING,
+            legacy_table=pqs.LEGACY_TABLE_ARCHIVE,
+            db_path=bad_path,
+        )
+        assert result is False
+
+
+class TestDualWriteEnqueueMany:
+    def test_batch_inserts_multiple_rows(self, geodata_db):
+        rows = [
+            {
+                'source_path': f'/foo/{i}.mp4',
+                'stage': pqs.STAGE_INDEX_PENDING,
+                'legacy_table': pqs.LEGACY_TABLE_INDEXING,
+                'priority': pqs.PRIORITY_INDEXING,
+                'payload': {'canonical_key': f'key-{i}'},
+            }
+            for i in range(5)
+        ]
+        n = pqs.dual_write_enqueue_many(rows, db_path=geodata_db)
+        # On success n should equal the number of inserted rows.
+        assert n >= 1  # SQLite executemany rowcount semantics vary
+        conn = sqlite3.connect(geodata_db)
+        try:
+            count = conn.execute(
+                "SELECT COUNT(*) FROM pipeline_queue"
+            ).fetchone()[0]
+            assert count == 5
+        finally:
+            conn.close()
+
+    def test_empty_list_is_noop(self, geodata_db):
+        assert pqs.dual_write_enqueue_many([], db_path=geodata_db) == 0
+
+    def test_skips_invalid_rows(self, geodata_db):
+        rows = [
+            {'source_path': '', 'stage': 'x', 'legacy_table': 'y'},
+            {'source_path': '/a', 'stage': '', 'legacy_table': 'y'},
+            {'source_path': '/b', 'stage': pqs.STAGE_INDEX_PENDING,
+             'legacy_table': pqs.LEGACY_TABLE_INDEXING},
+        ]
+        pqs.dual_write_enqueue_many(rows, db_path=geodata_db)
+        conn = sqlite3.connect(geodata_db)
+        try:
+            count = conn.execute(
+                "SELECT COUNT(*) FROM pipeline_queue"
+            ).fetchone()[0]
+            # Only the third row was valid.
+            assert count == 1
+        finally:
+            conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Backfill from legacy queues
+# ---------------------------------------------------------------------------
+
+class TestBackfill:
+    def test_backfill_archive_queue(self, geodata_db):
+        # archive_queue lives in the same DB as pipeline_queue.
+        conn = sqlite3.connect(geodata_db)
+        conn.executemany(
+            "INSERT INTO archive_queue "
+            "(source_path, priority, status, enqueued_at, "
+            " expected_size, expected_mtime) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            [
+                ('/x/RecentClips/foo.mp4', 2, 'pending',
+                 '2026-05-14T10:00:00', 1024, 1.0),
+                ('/x/SentryClips/2026-05-14_10-00-00/event.json', 1,
+                 'copied', '2026-05-14T10:00:00', 256, 2.0),
+            ],
+        )
+        conn.commit()
+        conn.close()
+
+        counts = pqs.backfill_legacy_queues(
+            pipeline_db_path=geodata_db,
+            cloud_db_path=None,
+        )
+        assert counts[pqs.LEGACY_TABLE_ARCHIVE] == 2
+
+        conn = sqlite3.connect(geodata_db)
+        conn.row_factory = sqlite3.Row
+        try:
+            rows = conn.execute(
+                "SELECT * FROM pipeline_queue "
+                "WHERE legacy_table = ? ORDER BY source_path",
+                (pqs.LEGACY_TABLE_ARCHIVE,),
+            ).fetchall()
+            assert len(rows) == 2
+            stages = {r['stage'] for r in rows}
+            assert stages == {pqs.STAGE_ARCHIVE_PENDING,
+                              pqs.STAGE_ARCHIVE_DONE}
+        finally:
+            conn.close()
+
+    def test_backfill_indexing_queue(self, geodata_db):
+        conn = sqlite3.connect(geodata_db)
+        conn.executemany(
+            "INSERT INTO indexing_queue "
+            "(canonical_key, file_path, priority, enqueued_at, "
+            " next_attempt_at, source) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            [
+                ('k1', '/a.mp4', 50, 1.0, 0.0, 'manual'),
+                ('k2', '/b.mp4', 25, 2.0, 0.0, 'catchup'),
+            ],
+        )
+        conn.commit()
+        conn.close()
+
+        counts = pqs.backfill_legacy_queues(
+            pipeline_db_path=geodata_db,
+            cloud_db_path=None,
+        )
+        assert counts[pqs.LEGACY_TABLE_INDEXING] == 2
+
+    def test_backfill_live_event_queue_cross_db(
+        self, geodata_db, cloud_sync_db,
+    ):
+        conn = sqlite3.connect(cloud_sync_db)
+        conn.executemany(
+            "INSERT INTO live_event_queue "
+            "(event_dir, event_json_path, event_timestamp, "
+            " event_reason, upload_scope, status, enqueued_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            [
+                ('/Sentry/2026-05-14_10-00-00',
+                 '/Sentry/2026-05-14_10-00-00/event.json',
+                 '2026-05-14T10:00:00', 'sentry_aware_object_detection',
+                 'event_minute', 'pending',
+                 '2026-05-14T10:00:00'),
+                ('/Sentry/2026-05-14_11-00-00',
+                 '/Sentry/2026-05-14_11-00-00/event.json',
+                 '2026-05-14T11:00:00', 'user_interaction_horn',
+                 'event_minute', 'uploaded',
+                 '2026-05-14T11:00:00'),
+            ],
+        )
+        conn.commit()
+        conn.close()
+
+        counts = pqs.backfill_legacy_queues(
+            pipeline_db_path=geodata_db,
+            cloud_db_path=cloud_sync_db,
+        )
+        assert counts[pqs.LEGACY_TABLE_LIVE_EVENT] == 2
+
+        conn = sqlite3.connect(geodata_db)
+        conn.row_factory = sqlite3.Row
+        try:
+            rows = conn.execute(
+                "SELECT * FROM pipeline_queue "
+                "WHERE legacy_table = ? ORDER BY source_path",
+                (pqs.LEGACY_TABLE_LIVE_EVENT,),
+            ).fetchall()
+            assert len(rows) == 2
+            stages = {r['stage'] for r in rows}
+            assert stages == {pqs.STAGE_LIVE_EVENT_PENDING,
+                              pqs.STAGE_LIVE_EVENT_DONE}
+            for r in rows:
+                payload = json.loads(r['payload_json'])
+                assert 'event_dir' in payload
+                assert 'event_reason' in payload
+                assert payload['upload_scope'] == 'event_minute'
+        finally:
+            conn.close()
+
+    def test_backfill_cloud_synced_files_cross_db(
+        self, geodata_db, cloud_sync_db,
+    ):
+        conn = sqlite3.connect(cloud_sync_db)
+        conn.executemany(
+            "INSERT INTO cloud_synced_files "
+            "(file_path, file_size, file_mtime, remote_path, status) "
+            "VALUES (?, ?, ?, ?, ?)",
+            [
+                ('SentryClips/2026-05-14_10-00-00', 1024, 1.0,
+                 'teslausb:bucket/SentryClips/2026-05-14_10-00-00',
+                 'synced'),
+                ('SentryClips/2026-05-14_11-00-00', 2048, 2.0, None,
+                 'pending'),
+            ],
+        )
+        conn.commit()
+        conn.close()
+
+        counts = pqs.backfill_legacy_queues(
+            pipeline_db_path=geodata_db,
+            cloud_db_path=cloud_sync_db,
+        )
+        assert counts[pqs.LEGACY_TABLE_CLOUD_SYNCED] == 2
+
+    def test_backfill_is_idempotent(self, geodata_db):
+        conn = sqlite3.connect(geodata_db)
+        conn.execute(
+            "INSERT INTO archive_queue "
+            "(source_path, priority, status, enqueued_at) "
+            "VALUES (?, ?, ?, ?)",
+            ('/x/foo.mp4', 2, 'pending', '2026-05-14T10:00:00'),
+        )
+        conn.commit()
+        conn.close()
+
+        a = pqs.backfill_legacy_queues(pipeline_db_path=geodata_db,
+                                       cloud_db_path=None)
+        b = pqs.backfill_legacy_queues(pipeline_db_path=geodata_db,
+                                       cloud_db_path=None)
+        # First run inserts, second run is a no-op.
+        assert a[pqs.LEGACY_TABLE_ARCHIVE] == 1
+        assert b[pqs.LEGACY_TABLE_ARCHIVE] == 0
+
+    def test_backfill_with_no_dbs(self, tmp_path):
+        # Both DB paths missing — must return empty counts dict, not raise.
+        counts = pqs.backfill_legacy_queues(
+            pipeline_db_path=str(tmp_path / 'absent.db'),
+            cloud_db_path=str(tmp_path / 'absent2.db'),
+        )
+        assert counts == {
+            pqs.LEGACY_TABLE_ARCHIVE: 0,
+            pqs.LEGACY_TABLE_INDEXING: 0,
+            pqs.LEGACY_TABLE_LIVE_EVENT: 0,
+            pqs.LEGACY_TABLE_CLOUD_SYNCED: 0,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Status / introspection
+# ---------------------------------------------------------------------------
+
+class TestPipelineStatus:
+    def test_empty_db_returns_zero(self, geodata_db):
+        s = pqs.pipeline_status(db_path=geodata_db)
+        assert s.get('total', 0) == 0
+
+    def test_counts_grouped(self, geodata_db):
+        for i in range(3):
+            pqs.dual_write_enqueue(
+                source_path=f'/a/{i}.mp4',
+                stage=pqs.STAGE_ARCHIVE_PENDING,
+                legacy_table=pqs.LEGACY_TABLE_ARCHIVE,
+                db_path=geodata_db,
+            )
+        for i in range(2):
+            pqs.dual_write_enqueue(
+                source_path=f'/b/{i}.mp4',
+                stage=pqs.STAGE_INDEX_PENDING,
+                legacy_table=pqs.LEGACY_TABLE_INDEXING,
+                db_path=geodata_db,
+            )
+        s = pqs.pipeline_status(db_path=geodata_db)
+        assert s['total'] == 5
+        groups = s['by_legacy_stage_status']
+        assert any(g['legacy_table'] == pqs.LEGACY_TABLE_ARCHIVE
+                   and g['count'] == 3 for g in groups)
+        assert any(g['legacy_table'] == pqs.LEGACY_TABLE_INDEXING
+                   and g['count'] == 2 for g in groups)
+
+
+# ---------------------------------------------------------------------------
+# Producer-side dual-write integration
+# ---------------------------------------------------------------------------
+
+class TestProducerHooks:
+    """Verify each legacy producer triggers a pipeline_queue dual-write."""
+
+    def test_archive_producer_dual_writes(self, geodata_db):
+        # ``enqueue_for_archive`` looks up MAPPING_DB_PATH from config
+        # when db_path is None. Pass it explicitly here.
+        from services import archive_queue
+        ok = archive_queue.enqueue_for_archive(
+            '/tmp/foo.mp4',
+            priority=2,
+            db_path=geodata_db,
+        )
+        assert ok is True
+        conn = sqlite3.connect(geodata_db)
+        try:
+            rows = conn.execute(
+                "SELECT stage, legacy_table FROM pipeline_queue"
+            ).fetchall()
+            assert (pqs.STAGE_ARCHIVE_PENDING,
+                    pqs.LEGACY_TABLE_ARCHIVE) in rows
+        finally:
+            conn.close()
+
+    def test_archive_batch_producer_dual_writes(self, geodata_db):
+        from services import archive_queue
+        n = archive_queue.enqueue_many_for_archive(
+            ['/tmp/a.mp4', '/tmp/b.mp4'],
+            priority=3,
+            db_path=geodata_db,
+        )
+        assert n == 2
+        conn = sqlite3.connect(geodata_db)
+        try:
+            count = conn.execute(
+                "SELECT COUNT(*) FROM pipeline_queue "
+                "WHERE legacy_table = ?",
+                (pqs.LEGACY_TABLE_ARCHIVE,),
+            ).fetchone()[0]
+            assert count == 2
+        finally:
+            conn.close()
+
+    def test_indexing_producer_dual_writes(self, geodata_db):
+        from services import indexing_queue_service
+        ok = indexing_queue_service.enqueue_for_indexing(
+            geodata_db,
+            '/tmp/clip-front.mp4',
+            priority=10,
+        )
+        assert ok is True
+        conn = sqlite3.connect(geodata_db)
+        try:
+            rows = conn.execute(
+                "SELECT stage, legacy_table, priority FROM pipeline_queue"
+            ).fetchall()
+            assert (pqs.STAGE_INDEX_PENDING,
+                    pqs.LEGACY_TABLE_INDEXING, 10) in rows
+        finally:
+            conn.close()
+
+    def test_indexing_batch_producer_dual_writes(self, geodata_db):
+        from services import indexing_queue_service
+        n = indexing_queue_service.enqueue_many_for_indexing(
+            geodata_db,
+            [('/tmp/x.mp4', 50), ('/tmp/y.mp4', 25)],
+            source='catchup',
+        )
+        assert n == 2
+        conn = sqlite3.connect(geodata_db)
+        try:
+            count = conn.execute(
+                "SELECT COUNT(*) FROM pipeline_queue "
+                "WHERE legacy_table = ?",
+                (pqs.LEGACY_TABLE_INDEXING,),
+            ).fetchone()[0]
+            assert count == 2
+        finally:
+            conn.close()
+
+    def test_dual_write_failure_does_not_break_legacy_archive(
+        self, geodata_db, monkeypatch,
+    ):
+        """A simulated failure inside the pipeline_queue helper must
+        NOT propagate back to ``enqueue_for_archive`` — the legacy
+        write succeeded and the producer must report success."""
+        from services import archive_queue
+
+        def boom(**kwargs):
+            raise RuntimeError("simulated pipeline_queue failure")
+
+        monkeypatch.setattr(pqs, 'dual_write_enqueue', boom)
+        ok = archive_queue.enqueue_for_archive(
+            '/tmp/legacy-must-survive.mp4',
+            priority=2,
+            db_path=geodata_db,
+        )
+        assert ok is True
+        conn = sqlite3.connect(geodata_db)
+        try:
+            n = conn.execute(
+                "SELECT COUNT(*) FROM archive_queue "
+                "WHERE source_path = ?",
+                ('/tmp/legacy-must-survive.mp4',),
+            ).fetchone()[0]
+            assert n == 1
+        finally:
+            conn.close()

--- a/tests/test_pipeline_queue_dualwrite.py
+++ b/tests/test_pipeline_queue_dualwrite.py
@@ -393,6 +393,15 @@ class TestBackfill:
             stages = {r['stage'] for r in rows}
             assert stages == {pqs.STAGE_LIVE_EVENT_PENDING,
                               pqs.STAGE_LIVE_EVENT_DONE}
+            # Pair assertion would have caught W1 in PR #190 review:
+            # cross-DB backfill computed the translated status but
+            # discarded it, so 'uploaded' rows landed as
+            # ``stage='live_event_done'`` with ``status='pending'``.
+            stage_status_pairs = {(r['stage'], r['status']) for r in rows}
+            assert stage_status_pairs == {
+                (pqs.STAGE_LIVE_EVENT_PENDING, 'pending'),
+                (pqs.STAGE_LIVE_EVENT_DONE, 'done'),
+            }
             for r in rows:
                 payload = json.loads(r['payload_json'])
                 assert 'event_dir' in payload
@@ -426,6 +435,30 @@ class TestBackfill:
         )
         assert counts[pqs.LEGACY_TABLE_CLOUD_SYNCED] == 2
 
+        # Pair assertion — the W1 review finding noted that the
+        # status translation map was computed but the value was
+        # discarded by ``dual_write_enqueue`` (which hardcoded
+        # ``status='pending'``). Now that ``dual_write_enqueue``
+        # accepts a ``status`` parameter, the 'synced' row must
+        # land as ``status='done'`` and the 'pending' row stays
+        # ``status='pending'``.
+        conn = sqlite3.connect(geodata_db)
+        conn.row_factory = sqlite3.Row
+        try:
+            rows = conn.execute(
+                "SELECT * FROM pipeline_queue "
+                "WHERE legacy_table = ? ORDER BY source_path",
+                (pqs.LEGACY_TABLE_CLOUD_SYNCED,),
+            ).fetchall()
+            assert len(rows) == 2
+            stage_status_pairs = {(r['stage'], r['status']) for r in rows}
+            assert stage_status_pairs == {
+                (pqs.STAGE_CLOUD_DONE, 'done'),
+                (pqs.STAGE_CLOUD_PENDING, 'pending'),
+            }
+        finally:
+            conn.close()
+
     def test_backfill_is_idempotent(self, geodata_db):
         conn = sqlite3.connect(geodata_db)
         conn.execute(
@@ -444,6 +477,65 @@ class TestBackfill:
         # First run inserts, second run is a no-op.
         assert a[pqs.LEGACY_TABLE_ARCHIVE] == 1
         assert b[pqs.LEGACY_TABLE_ARCHIVE] == 0
+
+    def test_backfill_one_shot_flag_skips_subsequent_calls(self, geodata_db):
+        """W4 fix: the one-shot ``kv_meta`` flag must short-circuit
+        every backfill call after the first. Verifies that legacy rows
+        added AFTER the first backfill are NOT picked up on the second
+        call (because dual-write hooks now own the upgrade-to-current
+        gap; the backfill is purely the one-time upgrade migration).
+        """
+        # First call: empty legacy queue → completes successfully and
+        # writes the kv_meta flag.
+        first = pqs.backfill_legacy_queues(pipeline_db_path=geodata_db,
+                                           cloud_db_path=None)
+        assert first[pqs.LEGACY_TABLE_ARCHIVE] == 0
+
+        # Verify the flag was set.
+        conn = sqlite3.connect(geodata_db)
+        try:
+            row = conn.execute(
+                "SELECT value FROM kv_meta WHERE key = ?",
+                ('pipeline_backfill_completed_at',),
+            ).fetchone()
+            assert row is not None
+            assert row[0]  # non-empty timestamp string
+        finally:
+            conn.close()
+
+        # Add a legacy row AFTER the flag was set.
+        conn = sqlite3.connect(geodata_db)
+        conn.execute(
+            "INSERT INTO archive_queue "
+            "(source_path, priority, status, enqueued_at) "
+            "VALUES (?, ?, ?, ?)",
+            ('/x/late.mp4', 2, 'pending', '2026-05-14T12:00:00'),
+        )
+        conn.commit()
+        conn.close()
+
+        # Second call must SKIP — the row is left for dual-write to
+        # handle on its next enqueue (or for ``force=True`` recovery).
+        second = pqs.backfill_legacy_queues(pipeline_db_path=geodata_db,
+                                            cloud_db_path=None)
+        assert second[pqs.LEGACY_TABLE_ARCHIVE] == 0
+
+        conn = sqlite3.connect(geodata_db)
+        try:
+            count = conn.execute(
+                "SELECT COUNT(*) FROM pipeline_queue "
+                "WHERE source_path = ?",
+                ('/x/late.mp4',),
+            ).fetchone()[0]
+            assert count == 0
+        finally:
+            conn.close()
+
+        # ``force=True`` bypasses the guard for recovery scenarios.
+        forced = pqs.backfill_legacy_queues(pipeline_db_path=geodata_db,
+                                            cloud_db_path=None,
+                                            force=True)
+        assert forced[pqs.LEGACY_TABLE_ARCHIVE] == 1
 
     def test_backfill_with_no_dbs(self, tmp_path):
         # Both DB paths missing — must return empty counts dict, not raise.


### PR DESCRIPTION
**Issue:** #184 — Wave 4 — Phase I.1 (pipeline_queue dual-write scaffolding)

This is the first of five sub-PRs (A→E) for Wave 4 — the highest-risk wave of issue #184. Phase I.1 is **purely additive**: it adds the new unified `pipeline_queue` table and dual-writes every legacy enqueue into it. **No reads change.** The existing four legacy queues (archive_queue, indexing_queue, live_event_queue, cloud_synced_files) remain the source of truth. Phase I.2 (PR-B) will switch the unified worker to read from `pipeline_queue`.

## Summary of changes

### Schema (geodata.db v16)

Adds `pipeline_queue` with composite UNIQUE constraint `(source_path, stage, legacy_table)` so dual-writes are idempotent. Two indices: `idx_pipeline_ready` (partial, for the future unified-worker pick) and `idx_pipeline_legacy` (for backfill verification). Migration block is just `CREATE TABLE IF NOT EXISTS` — no data rewrite, low-risk.

### New module `services/pipeline_queue_service.py`

* `dual_write_enqueue` / `dual_write_enqueue_many` — best-effort producer hook. **Never raises** into the legacy caller. SQLite errors and any other exception are logged at WARNING and swallowed.
* `backfill_legacy_queues` — one-time, idempotent backfill of pre-upgrade backlog rows from each legacy queue. Cross-DB for LES + cloud_synced_files. Scheduled on a daemon thread by `web_control.py` so it never blocks boot.
* `pipeline_status` — counts grouped by `(legacy_table, stage, status)` for verification.

### Producer hooks (4 files)

All hooks use lazy import + try/except with WARNING log so a missing/broken pipeline_queue cannot break the legacy enqueue path:

* `archive_queue.enqueue_for_archive` + `enqueue_many_for_archive`
* `indexing_queue_service.enqueue_for_indexing` + `enqueue_many_for_indexing`
* `live_event_sync_service.enqueue_event_json` (cross-DB write)
* `cloud_archive_service` — 6 INSERT call sites (4 reconcile, 2 state transitions; cross-DB)

### Tests (24 new, all passing)

* Schema: v16 table + indices + UNIQUE constraint enforces idempotency
* dual_write_enqueue / _many: happy path, missing fields, no DB, SQLite error swallow
* Backfill: archive_queue, indexing_queue, live_event_queue (cross-DB), cloud_synced_files (cross-DB), idempotency, missing-DB
* Producer hooks: archive single + batch, indexing single + batch, failure isolation (legacy enqueue must NOT fail when pipeline_queue dual-write raises)

Full suite: **1660 pass / 4 skip** (was 1636 / 4 before).

## Risk

Low — all writes are additive; reads unchanged. If pipeline_queue ever gets corrupted or the new module crashes, the worst case is that pipeline_queue rows go stale (logged at WARNING) — the legacy queues continue to drive every worker exactly as today.

## Wave 4 sub-PR plan (for context)

* **PR-A (this PR)** — Add table, dual-write, backfill (additive)
* PR-B (I.2) — Switch unified worker to read from pipeline_queue
* PR-C (I.3) — Inline SEI parse during archive copy
* PR-D (I.4 + J + K) — Delete LES, batched rclone, drop LES poll
* PR-E (I.5, optional) — Single-DB consolidation

Ref #184 (Wave 4 PR-A)
