### PR TITLE
refactor: state-transition dual-writes for pipeline_queue (Wave 4 PR-B)

### DIFF
--- a/scripts/web/services/archive_queue.py
+++ b/scripts/web/services/archive_queue.py
@@ -551,8 +551,29 @@ def enqueue_many_for_archive(source_paths: Iterable[str], *,
             )
             after = conn.total_changes
             inserted_count = max(0, after - before)
+            # Wave 4 PR-B fix (review #191 Info #6): look up the
+            # legacy_id of every row we just inserted so the batched
+            # dual-write can populate ``pipeline_queue.legacy_id``.
+            # Without this, every state mutation on a batched row
+            # (mark_copied, mark_source_gone, mark_skipped_stationary,
+            # mark_failed) would fail to find the mirror — they look
+            # up by ``(legacy_table, legacy_id)``. The IN-clause is
+            # bounded by the executemany batch size (Tesla's 120-file
+            # flush), so it stays well under SQLite's 999-host-parameter
+            # limit and runs as a single indexed scan over the unique
+            # ``idx_archive_source_path`` index.
+            legacy_id_map: Dict[str, int] = {}
+            if inserted_count:
+                placeholders = ','.join('?' for _ in paths)
+                cur = conn.execute(
+                    f"SELECT id, source_path FROM archive_queue "
+                    f"WHERE source_path IN ({placeholders})",
+                    paths,
+                )
+                for row in cur.fetchall():
+                    legacy_id_map[row['source_path']] = int(row['id'])
         if inserted_count:
-            _dual_write_pipeline_archive_many(db_path, rows)
+            _dual_write_pipeline_archive_many(db_path, rows, legacy_id_map)
         return inserted_count
     except sqlite3.Error as e:
         logger.warning("enqueue_many_for_archive failed: %s", e)
@@ -593,14 +614,24 @@ def _dual_write_pipeline_archive(db_path: str, source_path: str,
         )
 
 
-def _dual_write_pipeline_archive_many(db_path: str, rows) -> None:
+def _dual_write_pipeline_archive_many(
+    db_path: str, rows,
+    legacy_id_map: Optional[Dict[str, int]] = None,
+) -> None:
     """``rows`` is a list of (source_path, priority, enqueued_at,
     expected_size, expected_mtime) tuples — same shape as the legacy
-    executemany rows. We don't have legacy_ids for batch inserts (the
-    INSERT OR IGNORE doesn't return per-row rowids); the
-    ``UNIQUE(source_path, stage, legacy_table)`` constraint still
-    enforces per-source idempotency.
+    executemany rows. ``legacy_id_map`` is an optional
+    ``{source_path: id}`` lookup populated by
+    :func:`enqueue_many_for_archive` after the executemany so each
+    pipeline_queue mirror row carries a back-pointer to its legacy
+    row. Without it, every state mutation on a batched row would
+    fail to find the mirror — the mark_* helpers look up by
+    ``(legacy_table, legacy_id)``. The ``UNIQUE(source_path, stage,
+    legacy_table)`` constraint still enforces per-source idempotency
+    for the rare case where ``legacy_id_map`` is missing.
     """
+    if legacy_id_map is None:
+        legacy_id_map = {}
     try:
         from services import pipeline_queue_service as pqs
         pqs.dual_write_enqueue_many(
@@ -609,6 +640,7 @@ def _dual_write_pipeline_archive_many(db_path: str, rows) -> None:
                     'source_path': src,
                     'stage': pqs.STAGE_ARCHIVE_PENDING,
                     'legacy_table': pqs.LEGACY_TABLE_ARCHIVE,
+                    'legacy_id': legacy_id_map.get(src),
                     'priority': int(prio),
                     'payload': {
                         'expected_size': es,
@@ -1323,6 +1355,12 @@ def mark_copied(row_id: int, dest_path: str, *,
         return False
     db_path = _resolve_db_path(db_path)
     copied_at = _iso_now()
+    # Wave 4 PR-B (review #191 Info #7): capture pipeline_queue's
+    # completed_at BEFORE the legacy UPDATE so the mirror reflects
+    # the moment the legacy commit happened, not the moment the
+    # mirror call finally runs (which can drift by tens of ms behind
+    # the legacy fsync).
+    completed_at = time.time()
     conn = None
     try:
         conn = _open_archive_conn(db_path)
@@ -1343,7 +1381,7 @@ def mark_copied(row_id: int, dest_path: str, *,
                 int(row_id),
                 new_stage='archive_done',
                 status='done',
-                completed_at=time.time(),
+                completed_at=completed_at,
                 last_error='',
                 db_path=db_path,
             )
@@ -1383,6 +1421,8 @@ def mark_source_gone(row_id: int, *,
     if not row_id:
         return False
     db_path = _resolve_db_path(db_path)
+    # Wave 4 PR-B (review #191 Info #7): capture before the UPDATE.
+    completed_at = time.time()
     conn = None
     try:
         conn = _open_archive_conn(db_path)
@@ -1402,7 +1442,7 @@ def mark_source_gone(row_id: int, *,
                 int(row_id),
                 new_stage='archive_done',
                 status='source_gone',
-                completed_at=time.time(),
+                completed_at=completed_at,
                 last_error='',
                 db_path=db_path,
             )
@@ -1446,6 +1486,8 @@ def mark_skipped_stationary(row_id: int, *,
     if not row_id:
         return False
     db_path = _resolve_db_path(db_path)
+    # Wave 4 PR-B (review #191 Info #7): capture before the UPDATE.
+    completed_at = time.time()
     conn = None
     try:
         conn = _open_archive_conn(db_path)
@@ -1465,7 +1507,7 @@ def mark_skipped_stationary(row_id: int, *,
                 int(row_id),
                 new_stage='archive_done',
                 status='skipped_stationary',
-                completed_at=time.time(),
+                completed_at=completed_at,
                 last_error='',
                 db_path=db_path,
             )
@@ -1679,6 +1721,9 @@ def mark_failed(row_id: int, error: str, *,
         return 'error'
     db_path = _resolve_db_path(db_path)
     truncated = (error or '')[:4096]
+    # Wave 4 PR-B (review #191 Info #7): capture before the UPDATE so
+    # the mirror reflects the moment the legacy commit happened.
+    completed_at = time.time()
     # mark_failed is genuinely multi-statement: it SELECTs the current
     # attempts count, branches, then UPDATEs. Under autocommit alone
     # another writer could update ``attempts`` between our SELECT and
@@ -1739,7 +1784,7 @@ def mark_failed(row_id: int, error: str, *,
             status='dead_letter',
             attempts=new_attempts,
             last_error=truncated,
-            completed_at=time.time(),
+            completed_at=completed_at,
             db_path=db_path,
         )
     elif new_status == 'pending':

--- a/scripts/web/services/archive_queue.py
+++ b/scripts/web/services/archive_queue.py
@@ -80,6 +80,7 @@ from __future__ import annotations
 import logging
 import os
 import sqlite3
+import time
 from contextlib import contextmanager
 from datetime import datetime, timezone
 from typing import Dict, Iterable, Iterator, List, Optional
@@ -624,6 +625,87 @@ def _dual_write_pipeline_archive_many(db_path: str, rows) -> None:
         )
 
 
+def _dual_write_pipeline_archive_state(
+    source_path: str,
+    *,
+    new_stage: Optional[str] = None,
+    status: Optional[str] = None,
+    attempts: Optional[int] = None,
+    last_error: Optional[str] = None,
+    completed_at: Optional[float] = None,
+    next_retry_at: Optional[float] = None,
+    db_path: Optional[str] = None,
+) -> None:
+    """State-transition dual-write for the archive queue (Wave 4 PR-B).
+
+    Mirrors a legacy ``archive_queue`` row's state transition into
+    ``pipeline_queue``. Lazy import on every call to keep the
+    legacy-mutation path's import budget unchanged. Failures are
+    logged at DEBUG and swallowed — pipeline_queue mirroring is a
+    secondary concern; the legacy mutation always wins.
+    """
+    if not source_path:
+        return
+    try:
+        from services import pipeline_queue_service as pqs
+        pqs.update_pipeline_row(
+            stage=pqs.STAGE_ARCHIVE_PENDING,
+            source_path=source_path,
+            new_stage=new_stage,
+            status=status,
+            attempts=attempts,
+            last_error=last_error,
+            completed_at=completed_at,
+            next_retry_at=next_retry_at,
+            db_path=db_path,
+        )
+    except Exception as e:  # noqa: BLE001
+        logger.debug(
+            "pipeline_queue state dual-write skipped for %s: %s",
+            source_path, e,
+        )
+
+
+def _dual_write_pipeline_archive_state_by_id(
+    row_id: int,
+    *,
+    new_stage: Optional[str] = None,
+    status: Optional[str] = None,
+    attempts: Optional[int] = None,
+    last_error: Optional[str] = None,
+    completed_at: Optional[float] = None,
+    next_retry_at: Optional[float] = None,
+    db_path: Optional[str] = None,
+) -> None:
+    """Same as :func:`_dual_write_pipeline_archive_state` but lookup
+    by ``legacy_id`` — used by ``mark_copied`` / ``mark_source_gone``
+    / ``mark_failed`` etc. which take an integer ``row_id`` (avoids a
+    second SELECT to fetch ``source_path``).
+
+    Same swallow-and-warn semantics.
+    """
+    if not row_id:
+        return
+    try:
+        from services import pipeline_queue_service as pqs
+        pqs.update_pipeline_row_by_legacy_id(
+            legacy_table=pqs.LEGACY_TABLE_ARCHIVE,
+            legacy_id=int(row_id),
+            new_stage=new_stage,
+            status=status,
+            attempts=attempts,
+            last_error=last_error,
+            completed_at=completed_at,
+            next_retry_at=next_retry_at,
+            db_path=db_path,
+        )
+    except Exception as e:  # noqa: BLE001
+        logger.debug(
+            "pipeline_queue state dual-write skipped for legacy_id=%s: %s",
+            row_id, e,
+        )
+
+
 def count_source_gone_recent(hours: int = 24,
                              *, db_path: Optional[str] = None,
                              dismissed_at: Optional[str] = None,
@@ -1154,6 +1236,7 @@ def claim_next_for_worker(claimed_by: str, *,
     # wrap the whole thing in an atomic transaction so the fallback
     # is genuinely atomic — not just relying on the conditional WHERE
     # to paper over a race.
+    claimed: Optional[Dict] = None
     try:
         with _atomic_archive_op(db_path) as conn:
             try:
@@ -1179,48 +1262,53 @@ def claim_next_for_worker(claimed_by: str, *,
                 )
                 row = cur.fetchone()
                 if row is not None:
-                    return dict(row)
-                return None
+                    claimed = dict(row)
             except sqlite3.OperationalError:
                 # Older SQLite — no RETURNING clause. Fall back to
                 # SELECT-then-UPDATE; the surrounding transaction
                 # plus the conditional WHERE keeps the claim atomic
                 # even if another worker raced us.
-                pass
-
-            row = conn.execute(
-                """
-                SELECT * FROM archive_queue
-                 WHERE status = 'pending'
-                 ORDER BY priority ASC,
-                          expected_mtime IS NULL,
-                          expected_mtime ASC,
-                          id ASC
-                 LIMIT 1
-                """
-            ).fetchone()
-            if row is None:
-                return None
-            cur = conn.execute(
-                """
-                UPDATE archive_queue
-                   SET status = 'claimed',
-                       claimed_at = ?,
-                       claimed_by = ?
-                 WHERE id = ? AND status = 'pending'
-                """,
-                (claimed_at, claimed_by, row['id']),
-            )
-            if cur.rowcount != 1:
-                return None
-            claimed = dict(row)
-            claimed['status'] = 'claimed'
-            claimed['claimed_at'] = claimed_at
-            claimed['claimed_by'] = claimed_by
-            return claimed
+                row = conn.execute(
+                    """
+                    SELECT * FROM archive_queue
+                     WHERE status = 'pending'
+                     ORDER BY priority ASC,
+                              expected_mtime IS NULL,
+                              expected_mtime ASC,
+                              id ASC
+                     LIMIT 1
+                    """
+                ).fetchone()
+                if row is None:
+                    return None
+                cur = conn.execute(
+                    """
+                    UPDATE archive_queue
+                       SET status = 'claimed',
+                           claimed_at = ?,
+                           claimed_by = ?
+                     WHERE id = ? AND status = 'pending'
+                    """,
+                    (claimed_at, claimed_by, row['id']),
+                )
+                if cur.rowcount != 1:
+                    return None
+                claimed = dict(row)
+                claimed['status'] = 'claimed'
+                claimed['claimed_at'] = claimed_at
+                claimed['claimed_by'] = claimed_by
     except sqlite3.Error as e:
         logger.warning("claim_next_for_worker failed: %s", e)
         return None
+    if claimed is not None:
+        # Wave 4 PR-B: mirror the claim into pipeline_queue so the
+        # row reflects 'in_progress' instead of stale 'pending'.
+        _dual_write_pipeline_archive_state(
+            claimed.get('source_path', ''),
+            status='in_progress',
+            db_path=db_path,
+        )
+    return claimed
 
 
 def mark_copied(row_id: int, dest_path: str, *,
@@ -1249,7 +1337,17 @@ def mark_copied(row_id: int, dest_path: str, *,
             """,
             (copied_at, dest_path, int(row_id)),
         )
-        return cur.rowcount == 1
+        ok = cur.rowcount == 1
+        if ok:
+            _dual_write_pipeline_archive_state_by_id(
+                int(row_id),
+                new_stage='archive_done',
+                status='done',
+                completed_at=time.time(),
+                last_error='',
+                db_path=db_path,
+            )
+        return ok
     except sqlite3.Error as e:
         logger.warning("mark_copied failed for id=%s: %s", row_id, e)
         return False
@@ -1298,7 +1396,17 @@ def mark_source_gone(row_id: int, *,
             """,
             (int(row_id),),
         )
-        return cur.rowcount == 1
+        ok = cur.rowcount == 1
+        if ok:
+            _dual_write_pipeline_archive_state_by_id(
+                int(row_id),
+                new_stage='archive_done',
+                status='source_gone',
+                completed_at=time.time(),
+                last_error='',
+                db_path=db_path,
+            )
+        return ok
     except sqlite3.Error as e:
         logger.warning("mark_source_gone failed for id=%s: %s", row_id, e)
         return False
@@ -1351,7 +1459,17 @@ def mark_skipped_stationary(row_id: int, *,
             """,
             (int(row_id),),
         )
-        return cur.rowcount == 1
+        ok = cur.rowcount == 1
+        if ok:
+            _dual_write_pipeline_archive_state_by_id(
+                int(row_id),
+                new_stage='archive_done',
+                status='skipped_stationary',
+                completed_at=time.time(),
+                last_error='',
+                db_path=db_path,
+            )
+        return ok
     except sqlite3.Error as e:
         logger.warning(
             "mark_skipped_stationary failed for id=%s: %s", row_id, e,
@@ -1522,7 +1640,17 @@ def release_claim(row_id: int, *,
                 """,
                 (int(row_id),),
             )
-        return cur.rowcount == 1
+        ok = cur.rowcount == 1
+        if ok:
+            # Wave 4 PR-B: release back to 'pending' on the
+            # pipeline_queue side too, so a re-claim later picks the
+            # row up correctly.
+            _dual_write_pipeline_archive_state_by_id(
+                int(row_id),
+                status='pending',
+                db_path=db_path,
+            )
+        return ok
     except sqlite3.Error as e:
         logger.warning("release_claim failed for id=%s: %s", row_id, e)
         return False
@@ -1557,6 +1685,8 @@ def mark_failed(row_id: int, error: str, *,
     # UPDATE, causing the UPDATE to use a stale base count. Wrap in
     # _atomic_archive_op so the SELECT + UPDATE land in one transaction
     # under a single write lock (BEGIN IMMEDIATE).
+    new_status: str = 'error'
+    new_attempts: int = 0
     try:
         with _atomic_archive_op(db_path) as conn:
             row = conn.execute(
@@ -1580,24 +1710,47 @@ def mark_failed(row_id: int, error: str, *,
                     """,
                     (new_attempts, truncated, int(row_id)),
                 )
-                return 'dead_letter'
-            conn.execute(
-                """
-                UPDATE archive_queue
-                   SET status = 'pending',
-                       attempts = ?,
-                       previous_last_error = last_error,
-                       last_error = ?,
-                       claimed_at = NULL,
-                       claimed_by = NULL
-                 WHERE id = ?
-                """,
-                (new_attempts, truncated, int(row_id)),
-            )
-            return 'pending'
+                new_status = 'dead_letter'
+            else:
+                conn.execute(
+                    """
+                    UPDATE archive_queue
+                       SET status = 'pending',
+                           attempts = ?,
+                           previous_last_error = last_error,
+                           last_error = ?,
+                           claimed_at = NULL,
+                           claimed_by = NULL
+                     WHERE id = ?
+                    """,
+                    (new_attempts, truncated, int(row_id)),
+                )
+                new_status = 'pending'
     except sqlite3.Error as e:
         logger.warning("mark_failed failed for id=%s: %s", row_id, e)
         return 'error'
+    # Wave 4 PR-B: mirror the failure into pipeline_queue. Done
+    # outside the legacy transaction so a pipeline_queue lock cannot
+    # delay the legacy unlock.
+    if new_status == 'dead_letter':
+        _dual_write_pipeline_archive_state_by_id(
+            int(row_id),
+            new_stage='archive_done',
+            status='dead_letter',
+            attempts=new_attempts,
+            last_error=truncated,
+            completed_at=time.time(),
+            db_path=db_path,
+        )
+    elif new_status == 'pending':
+        _dual_write_pipeline_archive_state_by_id(
+            int(row_id),
+            status='pending',
+            attempts=new_attempts,
+            last_error=truncated,
+            db_path=db_path,
+        )
+    return new_status
 
 
 def get_pending_counts_by_priority(db_path: Optional[str] = None) -> Dict[int, int]:

--- a/scripts/web/services/cloud_archive_service.py
+++ b/scripts/web/services/cloud_archive_service.py
@@ -630,6 +630,50 @@ def _dual_write_pipeline_cloud_synced_batch(
         )
 
 
+def _dual_write_pipeline_cloud_synced_state(
+    file_path: str,
+    *,
+    new_stage: Optional[str] = None,
+    status: Optional[str] = None,
+    attempts: Optional[int] = None,
+    last_error: Optional[str] = None,
+    completed_at: Optional[float] = None,
+    next_retry_at: Optional[float] = None,
+) -> None:
+    """State-transition dual-write for cloud_synced_files (Wave 4 PR-B).
+
+    Unlike :func:`_dual_write_pipeline_cloud_synced` (which calls
+    ``dual_write_enqueue`` and is INSERT-OR-IGNORE), this updates an
+    existing pipeline_queue row to reflect a state transition (claim
+    success → 'in_progress' → 'done' / 'failed' / 'pending').
+
+    Looked up by ``(stage='cloud_pending', source_path=file_path)``.
+    Failures are swallowed at DEBUG.
+    """
+    if not file_path:
+        return
+    try:
+        from services import pipeline_queue_service as pqs
+        # The current row's stage is always cloud_pending (cloud_done
+        # is reached only on success and is itself terminal). For the
+        # source_path lookup we use the original cloud_pending stage.
+        pqs.update_pipeline_row(
+            stage=pqs.STAGE_CLOUD_PENDING,
+            source_path=file_path,
+            new_stage=new_stage,
+            status=status,
+            attempts=attempts,
+            last_error=last_error,
+            completed_at=completed_at,
+            next_retry_at=next_retry_at,
+        )
+    except Exception as e:  # noqa: BLE001
+        logger.debug(
+            "pipeline_queue cloud-synced state dual-write skipped "
+            "for %s: %s", file_path, e,
+        )
+
+
 def _init_cloud_tables(db_path: str) -> sqlite3.Connection:
     """Open the cloud sync database and ensure all tables exist.
 
@@ -742,6 +786,16 @@ def _init_cloud_tables(db_path: str) -> sqlite3.Connection:
                 "WHERE status = 'running'",
                 (datetime.now(timezone.utc).isoformat(),)
             ).rowcount
+            # Wave 4 PR-B: capture interrupted-upload paths BEFORE
+            # the UPDATE so pipeline_queue can be reset to 'pending'
+            # too (it holds 'in_progress' from the original claim
+            # dual-write).
+            interrupted_paths = [
+                r["file_path"] for r in conn.execute(
+                    "SELECT file_path FROM cloud_synced_files "
+                    "WHERE status = 'uploading'"
+                ).fetchall()
+            ]
             n_uploads = conn.execute(
                 "UPDATE cloud_synced_files SET status = 'pending', "
                 "retry_count = retry_count WHERE status = 'uploading'"
@@ -752,6 +806,11 @@ def _init_cloud_tables(db_path: str) -> sqlite3.Connection:
                     "Startup recovery: %d stale sessions, %d interrupted uploads reset",
                     n_sessions, n_uploads,
                 )
+                for fp in interrupted_paths:
+                    _dual_write_pipeline_cloud_synced_state(
+                        fp,
+                        status='pending',
+                    )
         except Exception as e:
             logger.warning("Startup recovery failed: %s", e)
 
@@ -1108,6 +1167,18 @@ def _mark_upload_failure(
                 "Cloud sync: %s reached retry cap (%d attempts) — "
                 "moved to dead_letter. Recover via Failed Jobs page.",
                 rel_path, post["retry_count"],
+            )
+        # Wave 4 PR-B: mirror the failure into pipeline_queue. We do
+        # NOT promote the stage on dead_letter — the row stays under
+        # ``cloud_pending`` so an operator-driven Failed Jobs reset
+        # picks it back up; the ``status='dead_letter'`` is what
+        # excludes it from the auto-picker.
+        if post:
+            _dual_write_pipeline_cloud_synced_state(
+                rel_path,
+                status=post["status"],
+                attempts=int(post["retry_count"] or 0),
+                last_error=err_msg,
             )
 
 
@@ -2154,6 +2225,9 @@ def _drain_once(
                         (rel_path,)
                     )
                     _fsync_db(conn)
+                    _dual_write_pipeline_cloud_synced_state(
+                        rel_path, status='pending',
+                    )
                     break
 
                 if returncode == 0:
@@ -2177,6 +2251,18 @@ def _drain_once(
                         (now_synced, remote_dest, rel_path)
                     )
                     _fsync_db(conn)
+                    # Wave 4 PR-B: terminal — promote pipeline_queue row
+                    # to cloud_done / done. Done after fsync so a crash
+                    # mid-flight can't leave the mirror ahead of the
+                    # legacy row.
+                    _dual_write_pipeline_cloud_synced_state(
+                        rel_path,
+                        new_stage='cloud_done',
+                        status='done',
+                        attempts=0,
+                        last_error='',
+                        completed_at=time.time(),
+                    )
                 else:
                     err_msg = (stderr or "").strip()[:500]
                     logger.error("Sync: [%d/%d] %s FAILED (exit %d): %s",
@@ -2848,7 +2934,15 @@ def recover_interrupted_uploads(db_path: str) -> int:
     Returns the number of rows reset.
     """
     conn = _init_cloud_tables(db_path)
+    affected_paths: List[str] = []
     try:
+        # Wave 4 PR-B: capture paths BEFORE the UPDATE so the
+        # corresponding pipeline_queue rows can be reset to 'pending'
+        # too.
+        rows = conn.execute(
+            "SELECT file_path FROM cloud_synced_files "
+            "WHERE status = 'uploading'"
+        ).fetchall()
         cur = conn.execute(
             "UPDATE cloud_synced_files SET status = 'pending', "
             "retry_count = retry_count WHERE status = 'uploading'"
@@ -2857,9 +2951,14 @@ def recover_interrupted_uploads(db_path: str) -> int:
         conn.commit()
         if affected:
             logger.info("Recovered %d interrupted cloud uploads", affected)
+            affected_paths.extend(r["file_path"] for r in rows)
         return affected
     finally:
         conn.close()
+        for fp in affected_paths:
+            _dual_write_pipeline_cloud_synced_state(
+                fp, status='pending',
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -3179,24 +3278,50 @@ def retry_dead_letter(file_path: Optional[str] = None) -> int:
     else:
         target = None
     conn = _init_cloud_tables(CLOUD_ARCHIVE_DB_PATH)
+    affected_paths: List[str] = []
     try:
         if target is None:
+            # Capture matching paths BEFORE the UPDATE so we can mirror
+            # the reset into pipeline_queue afterwards.
+            rows = conn.execute(
+                "SELECT file_path FROM cloud_synced_files "
+                "WHERE status = 'dead_letter'"
+            ).fetchall()
             cur = conn.execute(
                 "UPDATE cloud_synced_files "
                 "SET status = 'pending', retry_count = 0 "
                 "WHERE status = 'dead_letter'"
             )
+            if cur.rowcount:
+                affected_paths.extend(r["file_path"] for r in rows)
         else:
+            row = conn.execute(
+                "SELECT file_path FROM cloud_synced_files "
+                "WHERE status = 'dead_letter' AND file_path = ?",
+                (target,),
+            ).fetchone()
             cur = conn.execute(
                 "UPDATE cloud_synced_files "
                 "SET status = 'pending', retry_count = 0 "
                 "WHERE status = 'dead_letter' AND file_path = ?",
                 (target,),
             )
+            if row and cur.rowcount:
+                affected_paths.append(row["file_path"])
         conn.commit()
         n = cur.rowcount or 0
     finally:
         conn.close()
+    # Wave 4 PR-B: mirror the reset-to-pending into pipeline_queue.
+    # Done outside the legacy connection lock so a pipeline lock
+    # cannot delay the legacy unlock.
+    for fp in affected_paths:
+        _dual_write_pipeline_cloud_synced_state(
+            fp,
+            status='pending',
+            attempts=0,
+            next_retry_at=0.0,
+        )
     if n > 0:
         try:
             wake()

--- a/scripts/web/services/cloud_archive_service.py
+++ b/scripts/web/services/cloud_archive_service.py
@@ -1122,7 +1122,7 @@ def _read_retry_max_attempts_setting() -> int:
 
 def _mark_upload_failure(
     conn: sqlite3.Connection, rel_path: str, err_msg: str,
-) -> None:
+) -> Optional[Tuple[str, int]]:
     """Mark ``rel_path`` failed; promote to ``dead_letter`` when capped.
 
     Phase 2.6 — atomically increments ``retry_count`` and decides whether
@@ -1140,6 +1140,12 @@ def _mark_upload_failure(
     see in journalctl which files have been permanently abandoned by
     auto-sync. The previous (uncapped) behaviour silently retried
     every cycle forever.
+
+    Returns ``(post_status, post_retry_count)`` so the caller can mirror
+    the new state into ``pipeline_queue`` AFTER ``_fsync_db(conn)`` has
+    committed the legacy row. Wave 4 PR-B invariant: legacy commit FIRST,
+    then mirror — never the other way around. Returns ``None`` when the
+    UPDATE matched zero rows.
     """
     cap = _read_retry_max_attempts_setting()
     cur = conn.execute(
@@ -1154,32 +1160,24 @@ def _mark_upload_failure(
            WHERE file_path = ?""",
         (cap, err_msg, rel_path),
     )
-    if cur.rowcount:
-        # Re-read the row to know which terminal state we landed in so
-        # the log message is accurate. Cheap (single indexed lookup).
-        post = conn.execute(
-            "SELECT status, retry_count FROM cloud_synced_files "
-            "WHERE file_path = ?",
-            (rel_path,),
-        ).fetchone()
-        if post and post["status"] == 'dead_letter':
-            logger.warning(
-                "Cloud sync: %s reached retry cap (%d attempts) — "
-                "moved to dead_letter. Recover via Failed Jobs page.",
-                rel_path, post["retry_count"],
-            )
-        # Wave 4 PR-B: mirror the failure into pipeline_queue. We do
-        # NOT promote the stage on dead_letter — the row stays under
-        # ``cloud_pending`` so an operator-driven Failed Jobs reset
-        # picks it back up; the ``status='dead_letter'`` is what
-        # excludes it from the auto-picker.
-        if post:
-            _dual_write_pipeline_cloud_synced_state(
-                rel_path,
-                status=post["status"],
-                attempts=int(post["retry_count"] or 0),
-                last_error=err_msg,
-            )
+    if not cur.rowcount:
+        return None
+    # Re-read the row to know which terminal state we landed in so
+    # the log message is accurate. Cheap (single indexed lookup).
+    post = conn.execute(
+        "SELECT status, retry_count FROM cloud_synced_files "
+        "WHERE file_path = ?",
+        (rel_path,),
+    ).fetchone()
+    if not post:
+        return None
+    if post["status"] == 'dead_letter':
+        logger.warning(
+            "Cloud sync: %s reached retry cap (%d attempts) — "
+            "moved to dead_letter. Recover via Failed Jobs page.",
+            rel_path, post["retry_count"],
+        )
+    return str(post["status"]), int(post["retry_count"] or 0)
 
 
 def _is_path_skipped(
@@ -2243,6 +2241,11 @@ def _drain_once(
 
                     # Mark as synced with timestamp — the critical tracking step
                     now_synced = datetime.now(timezone.utc).isoformat()
+                    # Wave 4 PR-B (review #191 Info #7): capture
+                    # pipeline_queue's completed_at BEFORE the legacy
+                    # UPDATE so the mirror reflects the moment the
+                    # legacy commit/fsync actually happened.
+                    completed_at = time.time()
                     conn.execute(
                         """UPDATE cloud_synced_files
                            SET status = 'synced', synced_at = ?, remote_path = ?,
@@ -2261,24 +2264,47 @@ def _drain_once(
                         status='done',
                         attempts=0,
                         last_error='',
-                        completed_at=time.time(),
+                        completed_at=completed_at,
                     )
                 else:
                     err_msg = (stderr or "").strip()[:500]
                     logger.error("Sync: [%d/%d] %s FAILED (exit %d): %s",
                                 idx + 1, len(to_sync), rel_path,
                                 returncode, err_msg[:200])
-                    _mark_upload_failure(
-                        conn, rel_path, err_msg[:255],
+                    truncated_err = err_msg[:255]
+                    post = _mark_upload_failure(
+                        conn, rel_path, truncated_err,
                     )
                     _fsync_db(conn)
+                    # Wave 4 PR-B: mirror the failure into pipeline_queue
+                    # ONLY after _fsync_db has committed the legacy row.
+                    # The stage stays under ``cloud_pending`` even on
+                    # dead_letter — the ``status='dead_letter'`` value
+                    # is what excludes the row from the auto-picker.
+                    if post is not None:
+                        post_status, post_attempts = post
+                        _dual_write_pipeline_cloud_synced_state(
+                            rel_path,
+                            status=post_status,
+                            attempts=post_attempts,
+                            last_error=truncated_err,
+                        )
 
             except Exception as e:
                 logger.error("Sync: %s error: %s", rel_path, e)
-                _mark_upload_failure(
-                    conn, rel_path, str(e)[:255],
+                truncated_err = str(e)[:255]
+                post = _mark_upload_failure(
+                    conn, rel_path, truncated_err,
                 )
                 _fsync_db(conn)
+                if post is not None:
+                    post_status, post_attempts = post
+                    _dual_write_pipeline_cloud_synced_state(
+                        rel_path,
+                        status=post_status,
+                        attempts=post_attempts,
+                        last_error=truncated_err,
+                    )
 
             # Yield to Live Event Sync if it has READY pending event work.
             # LES gets priority over normal cloud_archive uploads when both
@@ -2938,7 +2964,12 @@ def recover_interrupted_uploads(db_path: str) -> int:
     try:
         # Wave 4 PR-B: capture paths BEFORE the UPDATE so the
         # corresponding pipeline_queue rows can be reset to 'pending'
-        # too.
+        # too. ``BEGIN IMMEDIATE`` acquires the reserved write lock
+        # before the SELECT so no concurrent writer can flip a row
+        # into ``'uploading'`` between the SELECT and the UPDATE
+        # (which would otherwise leave the new row's pipeline_queue
+        # mirror stale).
+        conn.execute("BEGIN IMMEDIATE")
         rows = conn.execute(
             "SELECT file_path FROM cloud_synced_files "
             "WHERE status = 'uploading'"
@@ -3280,6 +3311,12 @@ def retry_dead_letter(file_path: Optional[str] = None) -> int:
     conn = _init_cloud_tables(CLOUD_ARCHIVE_DB_PATH)
     affected_paths: List[str] = []
     try:
+        # Wave 4 PR-B: ``BEGIN IMMEDIATE`` acquires the reserved write
+        # lock before the SELECT so no concurrent writer can flip a
+        # row into ``'dead_letter'`` between the SELECT and UPDATE
+        # (which would otherwise leave the new dead-letter row's
+        # pipeline_queue mirror stale).
+        conn.execute("BEGIN IMMEDIATE")
         if target is None:
             # Capture matching paths BEFORE the UPDATE so we can mirror
             # the reset into pipeline_queue afterwards.

--- a/scripts/web/services/indexing_queue_service.py
+++ b/scripts/web/services/indexing_queue_service.py
@@ -571,6 +571,10 @@ def complete_queue_item(db_path: str, canonical_key_value: str,
     """
     if not canonical_key_value:
         return False
+    # Wave 4 PR-B (review #191 Info #7): capture pipeline_queue's
+    # completed_at BEFORE the legacy DELETE so the mirror reflects the
+    # moment the legacy commit happened.
+    completed_at = time.time()
     conn = None
     deleted = False
     try:
@@ -613,7 +617,7 @@ def complete_queue_item(db_path: str, canonical_key_value: str,
                 canonical_key_value,
                 new_stage='index_done',
                 status='done',
-                completed_at=time.time(),
+                completed_at=completed_at,
                 last_error='',
                 db_path=db_path,
             )

--- a/scripts/web/services/indexing_queue_service.py
+++ b/scripts/web/services/indexing_queue_service.py
@@ -338,13 +338,18 @@ def _dual_write_pipeline_indexing(db_path: str, file_path: str,
                                    priority: int, source: str) -> None:
     try:
         from services import pipeline_queue_service as pqs
+        # Use ``canonical_key`` as ``source_path`` in pipeline_queue
+        # so state-mutation lookups (claim / complete / defer /
+        # release) can look up by canonical_key — the only key the
+        # legacy mutation functions know. Keep the actual ``file_path``
+        # in payload for diagnostics.
         pqs.dual_write_enqueue(
-            source_path=file_path,
+            source_path=canonical_key_value,
             stage=pqs.STAGE_INDEX_PENDING,
             legacy_table=pqs.LEGACY_TABLE_INDEXING,
             priority=priority,
             payload={
-                'canonical_key': canonical_key_value,
+                'file_path': file_path,
                 'source': source,
             },
             db_path=db_path,
@@ -364,12 +369,12 @@ def _dual_write_pipeline_indexing_many(
         pqs.dual_write_enqueue_many(
             (
                 {
-                    'source_path': file_path,
+                    'source_path': key,
                     'stage': pqs.STAGE_INDEX_PENDING,
                     'legacy_table': pqs.LEGACY_TABLE_INDEXING,
                     'priority': prio,
                     'payload': {
-                        'canonical_key': key,
+                        'file_path': file_path,
                         'source': src,
                     },
                 }
@@ -380,6 +385,47 @@ def _dual_write_pipeline_indexing_many(
     except Exception as e:  # noqa: BLE001
         logger.warning(
             "pipeline_queue batched dual-write skipped: %s", e,
+        )
+
+
+def _dual_write_pipeline_indexing_state(
+    canonical_key_value: str,
+    *,
+    new_stage: Optional[str] = None,
+    status: Optional[str] = None,
+    attempts: Optional[int] = None,
+    last_error: Optional[str] = None,
+    completed_at: Optional[float] = None,
+    next_retry_at: Optional[float] = None,
+    db_path: Optional[str] = None,
+) -> None:
+    """State-transition dual-write for the indexing queue (Wave 4 PR-B).
+
+    Mirrors a legacy ``indexing_queue`` row's state transition into
+    ``pipeline_queue``. Looked up by ``canonical_key`` since that's
+    the only key the legacy mutation functions know (and what the
+    new-style enqueue stores in pipeline_queue's ``source_path``).
+    Failures are swallowed at DEBUG.
+    """
+    if not canonical_key_value:
+        return
+    try:
+        from services import pipeline_queue_service as pqs
+        pqs.update_pipeline_row(
+            stage=pqs.STAGE_INDEX_PENDING,
+            source_path=canonical_key_value,
+            new_stage=new_stage,
+            status=status,
+            attempts=attempts,
+            last_error=last_error,
+            completed_at=completed_at,
+            next_retry_at=next_retry_at,
+            db_path=db_path,
+        )
+    except Exception as e:  # noqa: BLE001
+        logger.debug(
+            "pipeline_queue indexing state dual-write skipped for %s: %s",
+            canonical_key_value, e,
         )
 
 
@@ -445,6 +491,7 @@ def claim_next_queue_item(db_path: str,
     skipped automatically).
     """
     now = time.time()
+    claimed_canonical_key: Optional[str] = None
     try:
         conn = _open_queue_conn(db_path)
         try:
@@ -479,6 +526,7 @@ def claim_next_queue_item(db_path: str,
             # an owner-guard for complete/release/defer.
             result['claimed_by'] = worker_id
             result['claimed_at'] = now
+            claimed_canonical_key = row['canonical_key']
             return result
         except Exception:
             try:
@@ -491,6 +539,18 @@ def claim_next_queue_item(db_path: str,
     except sqlite3.Error as e:
         logger.warning("claim_next_queue_item failed: %s", e)
         return None
+    finally:
+        # Wave 4 PR-B: dual-write the claim transition AFTER the
+        # legacy transaction has committed, so a pipeline_queue lock
+        # cannot delay the legacy unlock. ``finally`` ensures we still
+        # mirror even if the caller swallows an exception, and only
+        # fires when we actually claimed (claimed_canonical_key set).
+        if claimed_canonical_key is not None:
+            _dual_write_pipeline_indexing_state(
+                claimed_canonical_key,
+                status='in_progress',
+                db_path=db_path,
+            )
 
 
 def complete_queue_item(db_path: str, canonical_key_value: str,
@@ -512,6 +572,7 @@ def complete_queue_item(db_path: str, canonical_key_value: str,
     if not canonical_key_value:
         return False
     conn = None
+    deleted = False
     try:
         conn = _open_queue_conn(db_path)
         if claimed_by is None:
@@ -529,7 +590,8 @@ def complete_queue_item(db_path: str, canonical_key_value: str,
                 """,
                 (canonical_key_value, claimed_by, claimed_at),
             )
-        return (cur.rowcount or 0) > 0
+        deleted = (cur.rowcount or 0) > 0
+        return deleted
     except sqlite3.Error as e:
         logger.warning(
             "complete_queue_item failed for %s: %s",
@@ -542,6 +604,19 @@ def complete_queue_item(db_path: str, canonical_key_value: str,
                 conn.close()
             except sqlite3.Error:
                 pass
+        # Wave 4 PR-B: terminal transition — promote pipeline_queue
+        # row to ``index_done`` / ``done`` so observers see this clip
+        # has finished the indexing stage. Done after the legacy
+        # connection is closed so the lock is released first.
+        if deleted:
+            _dual_write_pipeline_indexing_state(
+                canonical_key_value,
+                new_stage='index_done',
+                status='done',
+                completed_at=time.time(),
+                last_error='',
+                db_path=db_path,
+            )
 
 
 def release_claim(db_path: str, canonical_key_value: str,
@@ -560,6 +635,7 @@ def release_claim(db_path: str, canonical_key_value: str,
     if not canonical_key_value:
         return False
     conn = None
+    released = False
     try:
         conn = _open_queue_conn(db_path)
         if claimed_by is None:
@@ -582,7 +658,8 @@ def release_claim(db_path: str, canonical_key_value: str,
                 """,
                 (canonical_key_value, claimed_by, claimed_at),
             )
-        return (cur.rowcount or 0) > 0
+        released = (cur.rowcount or 0) > 0
+        return released
     except sqlite3.Error as e:
         logger.warning(
             "release_claim failed for %s: %s",
@@ -595,6 +672,14 @@ def release_claim(db_path: str, canonical_key_value: str,
                 conn.close()
             except sqlite3.Error:
                 pass
+        # Wave 4 PR-B: drop pipeline_queue row back to ``pending``
+        # so the next worker tick can re-claim it.
+        if released:
+            _dual_write_pipeline_indexing_state(
+                canonical_key_value,
+                status='pending',
+                db_path=db_path,
+            )
 
 
 def defer_queue_item(db_path: str, canonical_key_value: str,
@@ -618,6 +703,8 @@ def defer_queue_item(db_path: str, canonical_key_value: str,
     if not canonical_key_value:
         return False
     conn = None
+    succeeded = False
+    new_attempts: Optional[int] = None
     try:
         conn = _open_queue_conn(db_path)
         if claimed_by is None:
@@ -678,6 +765,24 @@ def defer_queue_item(db_path: str, canonical_key_value: str,
             )
         if (cur.rowcount or 0) == 0:
             return False
+        succeeded = True
+        # Wave 4 PR-B: capture the new attempt count (the SQL above
+        # uses ``attempts = attempts + 1``; do a cheap re-read so the
+        # mirror reflects the post-bump value rather than the pre-bump
+        # one). Only meaningful when bump_attempts=True; otherwise
+        # leave ``new_attempts`` as None so the dual-write doesn't
+        # touch the attempts column.
+        if bump_attempts:
+            try:
+                row = conn.execute(
+                    "SELECT attempts FROM indexing_queue "
+                    "WHERE canonical_key = ?",
+                    (canonical_key_value,),
+                ).fetchone()
+                if row is not None:
+                    new_attempts = int(row['attempts'] or 0)
+            except sqlite3.Error:
+                pass
         return True
     except sqlite3.Error as e:
         logger.warning(
@@ -691,6 +796,18 @@ def defer_queue_item(db_path: str, canonical_key_value: str,
                 conn.close()
             except sqlite3.Error:
                 pass
+        # Wave 4 PR-B: mirror the deferral (release claim + reschedule)
+        # into pipeline_queue. Only fires when the legacy update
+        # actually matched a row.
+        if succeeded:
+            _dual_write_pipeline_indexing_state(
+                canonical_key_value,
+                status='pending',
+                attempts=new_attempts,
+                last_error=last_error,
+                next_retry_at=next_attempt_at,
+                db_path=db_path,
+            )
 
 
 def compute_backoff(attempts: int) -> float:

--- a/scripts/web/services/live_event_sync_service.py
+++ b/scripts/web/services/live_event_sync_service.py
@@ -449,6 +449,44 @@ def _dual_write_pipeline_live_event(event_json_path: str,
         )
 
 
+def _dual_write_pipeline_live_event_state(
+    legacy_id: int,
+    *,
+    new_stage: Optional[str] = None,
+    status: Optional[str] = None,
+    attempts: Optional[int] = None,
+    last_error: Optional[str] = None,
+    completed_at: Optional[float] = None,
+    next_retry_at: Optional[float] = None,
+) -> None:
+    """State-transition dual-write for live_event_queue (Wave 4 PR-B).
+
+    Mirrors a legacy ``live_event_queue`` row's state transition into
+    ``pipeline_queue``. Looked up by ``legacy_table='live_event_queue'``
+    + ``legacy_id`` (the integer row id from live_event_queue).
+    Failures are swallowed at DEBUG.
+    """
+    if not legacy_id:
+        return
+    try:
+        from services import pipeline_queue_service as pqs
+        pqs.update_pipeline_row_by_legacy_id(
+            legacy_table=pqs.LEGACY_TABLE_LIVE_EVENT,
+            legacy_id=int(legacy_id),
+            new_stage=new_stage,
+            status=status,
+            attempts=attempts,
+            last_error=last_error,
+            completed_at=completed_at,
+            next_retry_at=next_retry_at,
+        )
+    except Exception as e:  # noqa: BLE001
+        logger.debug(
+            "pipeline_queue LES state dual-write skipped for id=%s: %s",
+            legacy_id, e,
+        )
+
+
 def enqueue_event_json(event_json_paths: List[str]) -> int:
     """Producer: enqueue events from a list of ``event.json`` paths.
 
@@ -562,6 +600,13 @@ def _claim_next_pending(conn: sqlite3.Connection) -> Optional[Dict]:
     if cur.rowcount == 0:
         return None  # Someone else grabbed it
     conn.commit()
+    # Wave 4 PR-B: mirror the claim transition into pipeline_queue
+    # AFTER the legacy commit so a pipeline lock can't delay the
+    # legacy unlock.
+    _dual_write_pipeline_live_event_state(
+        int(row['id']),
+        status='in_progress',
+    )
     return dict(row)
 
 
@@ -571,12 +616,17 @@ def _release_claim_to_pending(conn: sqlite3.Connection, row_id: int) -> None:
     Used when the worker can't proceed (task_coordinator busy, WiFi
     dropped between claim and upload, etc.). Idempotent.
     """
-    conn.execute(
+    cur = conn.execute(
         "UPDATE live_event_queue SET status = 'pending' "
         "WHERE id = ? AND status = 'uploading'",
         (row_id,),
     )
     conn.commit()
+    if cur.rowcount:
+        _dual_write_pipeline_live_event_state(
+            int(row_id),
+            status='pending',
+        )
 
 
 def _record_attempt_start(conn: sqlite3.Connection, row_id: int) -> int:
@@ -602,7 +652,13 @@ def _record_attempt_start(conn: sqlite3.Connection, row_id: int) -> int:
         "SELECT attempts FROM live_event_queue WHERE id = ?",
         (row_id,),
     ).fetchone()
-    return int(row['attempts']) if row else 0
+    new_attempts = int(row['attempts']) if row else 0
+    if new_attempts:
+        _dual_write_pipeline_live_event_state(
+            int(row_id),
+            attempts=new_attempts,
+        )
+    return new_attempts
 
 
 def _mark_uploaded(conn: sqlite3.Connection, row_id: int,
@@ -614,6 +670,15 @@ def _mark_uploaded(conn: sqlite3.Connection, row_id: int,
         (_now_iso(), bytes_uploaded, row_id),
     )
     conn.commit()
+    # Wave 4 PR-B: terminal — promote pipeline_queue row to
+    # ``live_event_done`` / ``done``.
+    _dual_write_pipeline_live_event_state(
+        int(row_id),
+        new_stage='live_event_done',
+        status='done',
+        completed_at=time.time(),
+        last_error='',
+    )
 
 
 def _mark_failed(conn: sqlite3.Connection, row_id: int, attempts: int,
@@ -645,6 +710,24 @@ def _mark_failed(conn: sqlite3.Connection, row_id: int, attempts: int,
         logger.info("LES row %d transient defer in %ds: %s",
                     row_id, backoff, err[:200])
         conn.commit()
+        # Wave 4 PR-B: mirror transient defer (attempts rolled back
+        # to max(N-1, 0)). Re-read for the authoritative post-rollback
+        # count so the mirror doesn't drift below zero.
+        try:
+            r = conn.execute(
+                "SELECT attempts FROM live_event_queue WHERE id = ?",
+                (row_id,),
+            ).fetchone()
+            new_attempts = int(r['attempts']) if r else 0
+        except sqlite3.Error:
+            new_attempts = None  # type: ignore[assignment]
+        _dual_write_pipeline_live_event_state(
+            int(row_id),
+            status='pending',
+            attempts=new_attempts,
+            last_error=err[:500],
+            next_retry_at=next_retry,
+        )
         return
 
     if attempts >= LIVE_EVENT_RETRY_MAX_ATTEMPTS:
@@ -655,25 +738,45 @@ def _mark_failed(conn: sqlite3.Connection, row_id: int, attempts: int,
             (err[:500], row_id),
         )
         logger.error("LES row %d exhausted retries: %s", row_id, err[:200])
-    else:
-        # Pick the backoff for this attempt (clamp to last entry).
-        idx = max(0, attempts - 1)
-        if LIVE_EVENT_RETRY_BACKOFF_SECONDS:
-            idx = min(idx, len(LIVE_EVENT_RETRY_BACKOFF_SECONDS) - 1)
-            backoff = (retry_in_seconds if retry_in_seconds is not None
-                       else LIVE_EVENT_RETRY_BACKOFF_SECONDS[idx])
-        else:
-            backoff = retry_in_seconds if retry_in_seconds is not None else 60
-        next_retry = time.time() + backoff
-        conn.execute(
-            "UPDATE live_event_queue SET status = 'pending', "
-            "previous_last_error = last_error, "
-            "last_error = ?, next_retry_at = ? WHERE id = ?",
-            (err[:500], next_retry, row_id),
+        conn.commit()
+        # Wave 4 PR-B: terminal failure — promote to ``live_event_done``
+        # stage with status='failed' so the row is no longer picked by
+        # the unified worker (Phase I.2).
+        _dual_write_pipeline_live_event_state(
+            int(row_id),
+            new_stage='live_event_done',
+            status='failed',
+            attempts=int(attempts),
+            last_error=err[:500],
+            completed_at=time.time(),
         )
-        logger.warning("LES row %d retry %d in %ds: %s",
-                       row_id, attempts, backoff, err[:200])
+        return
+    # Pick the backoff for this attempt (clamp to last entry).
+    idx = max(0, attempts - 1)
+    if LIVE_EVENT_RETRY_BACKOFF_SECONDS:
+        idx = min(idx, len(LIVE_EVENT_RETRY_BACKOFF_SECONDS) - 1)
+        backoff = (retry_in_seconds if retry_in_seconds is not None
+                   else LIVE_EVENT_RETRY_BACKOFF_SECONDS[idx])
+    else:
+        backoff = retry_in_seconds if retry_in_seconds is not None else 60
+    next_retry = time.time() + backoff
+    conn.execute(
+        "UPDATE live_event_queue SET status = 'pending', "
+        "previous_last_error = last_error, "
+        "last_error = ?, next_retry_at = ? WHERE id = ?",
+        (err[:500], next_retry, row_id),
+    )
+    logger.warning("LES row %d retry %d in %ds: %s",
+                   row_id, attempts, backoff, err[:200])
     conn.commit()
+    # Wave 4 PR-B: mirror retry-defer.
+    _dual_write_pipeline_live_event_state(
+        int(row_id),
+        status='pending',
+        attempts=int(attempts),
+        last_error=err[:500],
+        next_retry_at=next_retry,
+    )
 
 
 def retry_failed(row_id: Optional[int] = None) -> int:
@@ -694,23 +797,40 @@ def retry_failed(row_id: Optional[int] = None) -> int:
     usual; a successful retry takes the row out of the failed view
     so the stale error is no longer rendered.
     """
+    affected_ids: List[int] = []
     try:
         conn = _open_db()
         try:
             _ensure_schema(conn)
             if row_id is not None:
+                # Capture id BEFORE the UPDATE so we can dual-write
+                # afterwards. Using a guarded SELECT mirrors the
+                # ``WHERE status = 'failed'`` filter on the UPDATE.
+                row = conn.execute(
+                    "SELECT id FROM live_event_queue "
+                    "WHERE id = ? AND status = 'failed'",
+                    (row_id,),
+                ).fetchone()
                 cur = conn.execute(
                     "UPDATE live_event_queue SET status = 'pending', "
                     "attempts = 0, next_retry_at = NULL "
                     "WHERE id = ? AND status = 'failed'",
                     (row_id,),
                 )
+                if row is not None and cur.rowcount:
+                    affected_ids.append(int(row['id']))
             else:
+                rows = conn.execute(
+                    "SELECT id FROM live_event_queue "
+                    "WHERE status = 'failed'"
+                ).fetchall()
                 cur = conn.execute(
                     "UPDATE live_event_queue SET status = 'pending', "
                     "attempts = 0, next_retry_at = NULL "
                     "WHERE status = 'failed'"
                 )
+                if cur.rowcount:
+                    affected_ids.extend(int(r['id']) for r in rows)
             n = cur.rowcount
             if n:
                 conn.commit()
@@ -719,6 +839,16 @@ def retry_failed(row_id: Optional[int] = None) -> int:
     except Exception as e:
         logger.error("LES retry_failed failed: %s", e)
         return 0
+    # Wave 4 PR-B: mirror the reset-to-pending into pipeline_queue.
+    # Done AFTER the legacy commit + close so a pipeline lock can't
+    # delay the legacy unlock.
+    for affected in affected_ids:
+        _dual_write_pipeline_live_event_state(
+            affected,
+            status='pending',
+            attempts=0,
+            next_retry_at=0.0,
+        )
     if n:
         _wake.set()
     return n

--- a/scripts/web/services/live_event_sync_service.py
+++ b/scripts/web/services/live_event_sync_service.py
@@ -653,7 +653,13 @@ def _record_attempt_start(conn: sqlite3.Connection, row_id: int) -> int:
         (row_id,),
     ).fetchone()
     new_attempts = int(row['attempts']) if row else 0
-    if new_attempts:
+    # Wave 4 PR-B: gate on row existence, not on the new value.
+    # ``attempts`` is unsigned and starts at 0; a future refactor that
+    # legitimately resets attempts to 0 (e.g. retry_failed) would skip
+    # the mirror under the old ``if new_attempts:`` gate. ``row is not
+    # None`` matches the real precondition: there is a legacy row to
+    # mirror.
+    if row is not None:
         _dual_write_pipeline_live_event_state(
             int(row_id),
             attempts=new_attempts,
@@ -802,23 +808,24 @@ def retry_failed(row_id: Optional[int] = None) -> int:
         conn = _open_db()
         try:
             _ensure_schema(conn)
+            # Wave 4 PR-B: ``BEGIN IMMEDIATE`` so no concurrent writer
+            # can flip a row into ``'failed'`` between the SELECT
+            # (which captures ids for the mirror) and the UPDATE
+            # (which would also flip the new row but skip its mirror).
+            conn.execute("BEGIN IMMEDIATE")
             if row_id is not None:
-                # Capture id BEFORE the UPDATE so we can dual-write
-                # afterwards. Using a guarded SELECT mirrors the
-                # ``WHERE status = 'failed'`` filter on the UPDATE.
-                row = conn.execute(
-                    "SELECT id FROM live_event_queue "
-                    "WHERE id = ? AND status = 'failed'",
-                    (row_id,),
-                ).fetchone()
+                # Single-row branch: the caller already supplied the
+                # id, and the WHERE filter restricts the UPDATE to
+                # ``status = 'failed'``. ``cur.rowcount > 0`` tells us
+                # the row matched, so no separate SELECT is needed.
                 cur = conn.execute(
                     "UPDATE live_event_queue SET status = 'pending', "
                     "attempts = 0, next_retry_at = NULL "
                     "WHERE id = ? AND status = 'failed'",
                     (row_id,),
                 )
-                if row is not None and cur.rowcount:
-                    affected_ids.append(int(row['id']))
+                if cur.rowcount:
+                    affected_ids.append(int(row_id))
             else:
                 rows = conn.execute(
                     "SELECT id FROM live_event_queue "
@@ -832,8 +839,7 @@ def retry_failed(row_id: Optional[int] = None) -> int:
                 if cur.rowcount:
                     affected_ids.extend(int(r['id']) for r in rows)
             n = cur.rowcount
-            if n:
-                conn.commit()
+            conn.commit()
         finally:
             conn.close()
     except Exception as e:

--- a/scripts/web/services/pipeline_queue_service.py
+++ b/scripts/web/services/pipeline_queue_service.py
@@ -308,6 +308,194 @@ def dual_write_enqueue_many(rows: Iterable[Dict[str, Any]],
                 pass
 
 
+def update_pipeline_row(
+    *,
+    stage: str,
+    source_path: str,
+    new_stage: Optional[str] = None,
+    status: Optional[str] = None,
+    attempts: Optional[int] = None,
+    last_error: Optional[str] = None,
+    completed_at: Optional[float] = None,
+    next_retry_at: Optional[float] = None,
+    payload_json: Optional[str] = None,
+    db_path: Optional[str] = None,
+) -> bool:
+    """Update an existing ``pipeline_queue`` row identified by
+    ``(stage, source_path)`` to reflect a state transition on the
+    legacy queue side (claim / complete / release / fail).
+
+    Used by the legacy queue mutation functions in ``archive_queue``,
+    ``indexing_queue_service``, ``live_event_sync_service`` and
+    ``cloud_archive_service`` to keep ``pipeline_queue`` in sync with
+    every state change — without that, the table stale-drifts to
+    ``status='pending'`` after PR-A's enqueue dual-write fires once
+    and is never updated again.
+
+    **Idempotent / silent no-op semantics.** Returns ``False`` (not an
+    error) when:
+      * the DB doesn't exist (test or pre-migration boot),
+      * the matching row doesn't exist (PR-A only mirrored enqueues
+        that happened AFTER the dual-write hooks went live; older
+        legacy rows backfilled at PR-A time also exist, but very old
+        rows from before any tracking may legitimately not be there),
+      * sqlite hits an OperationalError (lock contention etc.).
+
+    All ``None`` parameters are LEFT UNCHANGED in the row. Pass only
+    what changed. ``new_stage`` is the optional terminal-stage
+    transition (e.g. ``archive_pending`` → ``archive_done``); when
+    omitted, the existing stage is preserved.
+
+    Caller MUST hold the legacy queue write transaction or wrap this
+    in their own try/finally — this helper deliberately does not
+    raise so a pipeline_queue glitch can never abort a legacy
+    mutation.
+    """
+    if db_path is None:
+        db_path = _resolve_pipeline_db()
+    if not db_path or not os.path.isfile(db_path):
+        return False
+    if status is None and new_stage is None and attempts is None \
+       and last_error is None and completed_at is None \
+       and next_retry_at is None and payload_json is None:
+        # Nothing to update — silently no-op so callers don't have to
+        # track which optional kwargs they passed.
+        return False
+
+    set_clauses: List[str] = []
+    params: List[Any] = []
+    if new_stage is not None:
+        set_clauses.append("stage = ?")
+        params.append(new_stage)
+    if status is not None:
+        set_clauses.append("status = ?")
+        params.append(status)
+    if attempts is not None:
+        set_clauses.append("attempts = ?")
+        params.append(attempts)
+    if last_error is not None:
+        set_clauses.append("last_error = ?")
+        params.append(last_error)
+    if completed_at is not None:
+        set_clauses.append("completed_at = ?")
+        params.append(completed_at)
+    if next_retry_at is not None:
+        set_clauses.append("next_retry_at = ?")
+        params.append(next_retry_at)
+    if payload_json is not None:
+        set_clauses.append("payload_json = ?")
+        params.append(payload_json)
+    params.extend([stage, source_path])
+
+    sql = (
+        "UPDATE pipeline_queue SET "
+        + ", ".join(set_clauses)
+        + " WHERE stage = ? AND source_path = ?"
+    )
+    conn = None
+    try:
+        conn = _open_pipeline_conn(db_path)
+        cur = conn.execute(sql, params)
+        conn.commit()
+        # ``rowcount`` here is the count of ROWS matched/updated
+        # for a non-executemany UPDATE — accurate.
+        return cur.rowcount > 0
+    except sqlite3.Error as e:
+        logger.debug(
+            "update_pipeline_row(stage=%s, src=%s) failed: %s",
+            stage, source_path, e,
+        )
+        return False
+    finally:
+        if conn is not None:
+            try:
+                conn.close()
+            except sqlite3.Error:
+                pass
+
+
+def update_pipeline_row_by_legacy_id(
+    *,
+    legacy_table: str,
+    legacy_id: int,
+    new_stage: Optional[str] = None,
+    status: Optional[str] = None,
+    attempts: Optional[int] = None,
+    last_error: Optional[str] = None,
+    completed_at: Optional[float] = None,
+    next_retry_at: Optional[float] = None,
+    payload_json: Optional[str] = None,
+    db_path: Optional[str] = None,
+) -> bool:
+    """Same as :func:`update_pipeline_row` but matches the row by
+    ``(legacy_table, legacy_id)`` — the back-pointer columns
+    populated at enqueue time. Lets ``archive_queue`` /
+    ``cloud_archive_service`` update by the same integer ``row_id``
+    they already know without a second SELECT for ``source_path``.
+
+    Same silent no-op semantics as the source_path variant.
+    """
+    if db_path is None:
+        db_path = _resolve_pipeline_db()
+    if not db_path or not os.path.isfile(db_path):
+        return False
+    if not legacy_table or legacy_id is None:
+        return False
+    if status is None and new_stage is None and attempts is None \
+       and last_error is None and completed_at is None \
+       and next_retry_at is None and payload_json is None:
+        return False
+
+    set_clauses: List[str] = []
+    params: List[Any] = []
+    if new_stage is not None:
+        set_clauses.append("stage = ?")
+        params.append(new_stage)
+    if status is not None:
+        set_clauses.append("status = ?")
+        params.append(status)
+    if attempts is not None:
+        set_clauses.append("attempts = ?")
+        params.append(attempts)
+    if last_error is not None:
+        set_clauses.append("last_error = ?")
+        params.append(last_error)
+    if completed_at is not None:
+        set_clauses.append("completed_at = ?")
+        params.append(completed_at)
+    if next_retry_at is not None:
+        set_clauses.append("next_retry_at = ?")
+        params.append(next_retry_at)
+    if payload_json is not None:
+        set_clauses.append("payload_json = ?")
+        params.append(payload_json)
+    params.extend([legacy_table, int(legacy_id)])
+
+    sql = (
+        "UPDATE pipeline_queue SET "
+        + ", ".join(set_clauses)
+        + " WHERE legacy_table = ? AND legacy_id = ?"
+    )
+    conn = None
+    try:
+        conn = _open_pipeline_conn(db_path)
+        cur = conn.execute(sql, params)
+        conn.commit()
+        return cur.rowcount > 0
+    except sqlite3.Error as e:
+        logger.debug(
+            "update_pipeline_row_by_legacy_id(table=%s, id=%s) failed: %s",
+            legacy_table, legacy_id, e,
+        )
+        return False
+    finally:
+        if conn is not None:
+            try:
+                conn.close()
+            except sqlite3.Error:
+                pass
+
+
 def pipeline_status(db_path: Optional[str] = None) -> Dict[str, Any]:
     """Return a small dict summarising the pipeline_queue state.
 
@@ -535,7 +723,12 @@ def _backfill_archive_queue(pipeline_db: str) -> int:
 
 
 def _backfill_indexing_queue(pipeline_db: str) -> int:
-    """Backfill from ``indexing_queue`` (same DB as pipeline_queue)."""
+    """Backfill from ``indexing_queue`` (same DB as pipeline_queue).
+
+    Wave 4 PR-B: ``source_path`` is set to ``canonical_key`` (not
+    ``file_path``) so state-mutation lookups by canonical_key work
+    against pipeline_queue rows. ``file_path`` is preserved in payload.
+    """
     conn = None
     try:
         conn = _open_pipeline_conn(pipeline_db)
@@ -548,7 +741,7 @@ def _backfill_indexing_queue(pipeline_db: str) -> int:
                  attempts, last_error, enqueued_at, next_retry_at,
                  payload_json, legacy_id, legacy_table)
             SELECT
-                file_path,
+                canonical_key,
                 'index_pending',
                 CASE
                     WHEN claimed_by IS NOT NULL THEN 'in_progress'
@@ -559,7 +752,7 @@ def _backfill_indexing_queue(pipeline_db: str) -> int:
                 last_error,
                 COALESCE(enqueued_at, ?),
                 next_attempt_at,
-                json_object('canonical_key', canonical_key,
+                json_object('file_path', file_path,
                             'source', source),
                 NULL,
                 'indexing_queue'

--- a/scripts/web/services/pipeline_queue_service.py
+++ b/scripts/web/services/pipeline_queue_service.py
@@ -308,6 +308,65 @@ def dual_write_enqueue_many(rows: Iterable[Dict[str, Any]],
                 pass
 
 
+_UPDATE_COLUMNS: Tuple[str, ...] = (
+    "new_stage", "status", "attempts", "last_error",
+    "completed_at", "next_retry_at", "payload_json",
+)
+"""Names of the optional kwargs accepted by both
+:func:`update_pipeline_row` and
+:func:`update_pipeline_row_by_legacy_id`.
+
+Used by the "no kwargs passed" gate AND the SET-clause builder so a
+future column addition needs to be made in exactly one place. The
+DB column name happens to differ from the kwarg name only for
+``new_stage`` (column is ``stage``); :data:`_KWARG_TO_COLUMN`
+translates.
+"""
+
+_KWARG_TO_COLUMN: Dict[str, str] = {
+    "new_stage": "stage",
+    "status": "status",
+    "attempts": "attempts",
+    "last_error": "last_error",
+    "completed_at": "completed_at",
+    "next_retry_at": "next_retry_at",
+    "payload_json": "payload_json",
+}
+
+
+def _build_update_sql_and_params(
+    where_clause: str,
+    where_params: List[Any],
+    **kwargs,
+) -> Optional[Tuple[str, List[Any]]]:
+    """Build the UPDATE SQL + bind params for the ``update_pipeline_row*``
+    helpers.
+
+    Returns ``None`` when no settable kwargs were passed (so the
+    caller can short-circuit with the documented "silent no-op"
+    semantics). Otherwise returns ``(sql, params)`` where ``params``
+    is in positional order: SET values first, then the ``where_params``
+    appended.
+    """
+    set_clauses: List[str] = []
+    set_params: List[Any] = []
+    for kwarg_name in _UPDATE_COLUMNS:
+        value = kwargs.get(kwarg_name)
+        if value is None:
+            continue
+        column = _KWARG_TO_COLUMN[kwarg_name]
+        set_clauses.append(f"{column} = ?")
+        set_params.append(value)
+    if not set_clauses:
+        return None
+    sql = (
+        "UPDATE pipeline_queue SET "
+        + ", ".join(set_clauses)
+        + " WHERE " + where_clause
+    )
+    return sql, set_params + list(where_params)
+
+
 def update_pipeline_row(
     *,
     stage: str,
@@ -355,43 +414,18 @@ def update_pipeline_row(
         db_path = _resolve_pipeline_db()
     if not db_path or not os.path.isfile(db_path):
         return False
-    if status is None and new_stage is None and attempts is None \
-       and last_error is None and completed_at is None \
-       and next_retry_at is None and payload_json is None:
+    built = _build_update_sql_and_params(
+        "stage = ? AND source_path = ?",
+        [stage, source_path],
+        new_stage=new_stage, status=status, attempts=attempts,
+        last_error=last_error, completed_at=completed_at,
+        next_retry_at=next_retry_at, payload_json=payload_json,
+    )
+    if built is None:
         # Nothing to update — silently no-op so callers don't have to
         # track which optional kwargs they passed.
         return False
-
-    set_clauses: List[str] = []
-    params: List[Any] = []
-    if new_stage is not None:
-        set_clauses.append("stage = ?")
-        params.append(new_stage)
-    if status is not None:
-        set_clauses.append("status = ?")
-        params.append(status)
-    if attempts is not None:
-        set_clauses.append("attempts = ?")
-        params.append(attempts)
-    if last_error is not None:
-        set_clauses.append("last_error = ?")
-        params.append(last_error)
-    if completed_at is not None:
-        set_clauses.append("completed_at = ?")
-        params.append(completed_at)
-    if next_retry_at is not None:
-        set_clauses.append("next_retry_at = ?")
-        params.append(next_retry_at)
-    if payload_json is not None:
-        set_clauses.append("payload_json = ?")
-        params.append(payload_json)
-    params.extend([stage, source_path])
-
-    sql = (
-        "UPDATE pipeline_queue SET "
-        + ", ".join(set_clauses)
-        + " WHERE stage = ? AND source_path = ?"
-    )
+    sql, params = built
     conn = None
     try:
         conn = _open_pipeline_conn(db_path)
@@ -441,41 +475,16 @@ def update_pipeline_row_by_legacy_id(
         return False
     if not legacy_table or legacy_id is None:
         return False
-    if status is None and new_stage is None and attempts is None \
-       and last_error is None and completed_at is None \
-       and next_retry_at is None and payload_json is None:
-        return False
-
-    set_clauses: List[str] = []
-    params: List[Any] = []
-    if new_stage is not None:
-        set_clauses.append("stage = ?")
-        params.append(new_stage)
-    if status is not None:
-        set_clauses.append("status = ?")
-        params.append(status)
-    if attempts is not None:
-        set_clauses.append("attempts = ?")
-        params.append(attempts)
-    if last_error is not None:
-        set_clauses.append("last_error = ?")
-        params.append(last_error)
-    if completed_at is not None:
-        set_clauses.append("completed_at = ?")
-        params.append(completed_at)
-    if next_retry_at is not None:
-        set_clauses.append("next_retry_at = ?")
-        params.append(next_retry_at)
-    if payload_json is not None:
-        set_clauses.append("payload_json = ?")
-        params.append(payload_json)
-    params.extend([legacy_table, int(legacy_id)])
-
-    sql = (
-        "UPDATE pipeline_queue SET "
-        + ", ".join(set_clauses)
-        + " WHERE legacy_table = ? AND legacy_id = ?"
+    built = _build_update_sql_and_params(
+        "legacy_table = ? AND legacy_id = ?",
+        [legacy_table, int(legacy_id)],
+        new_stage=new_stage, status=status, attempts=attempts,
+        last_error=last_error, completed_at=completed_at,
+        next_retry_at=next_retry_at, payload_json=payload_json,
     )
+    if built is None:
+        return False
+    sql, params = built
     conn = None
     try:
         conn = _open_pipeline_conn(db_path)

--- a/tests/test_pipeline_queue_dualwrite.py
+++ b/tests/test_pipeline_queue_dualwrite.py
@@ -1156,3 +1156,208 @@ class TestStateTransitionErrorSwallowing:
             assert n == 1
         finally:
             conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Wave 4 PR-B (review #191 fixes) — additional regression tests
+# ---------------------------------------------------------------------------
+
+class TestArchiveBatchEnqueueLegacyId:
+    """Review #191 Info #6 fix: `enqueue_many_for_archive` must
+    populate `legacy_id` on every batched `pipeline_queue` row so
+    state mutations on those rows (lookup-by-legacy-id) actually find
+    the mirror.
+    """
+
+    def test_batch_enqueue_populates_legacy_id_for_every_row(
+        self, geodata_db,
+    ):
+        from services import archive_queue
+        n = archive_queue.enqueue_many_for_archive(
+            ['/tmp/batch-a.mp4', '/tmp/batch-b.mp4', '/tmp/batch-c.mp4'],
+            priority=2, db_path=geodata_db,
+        )
+        assert n == 3
+        conn = sqlite3.connect(geodata_db)
+        conn.row_factory = sqlite3.Row
+        try:
+            rows = conn.execute(
+                "SELECT source_path, legacy_id, legacy_table "
+                "FROM pipeline_queue WHERE legacy_table = ? "
+                "ORDER BY source_path",
+                (pqs.LEGACY_TABLE_ARCHIVE,),
+            ).fetchall()
+            assert len(rows) == 3
+            for row in rows:
+                assert row['legacy_id'] is not None
+                assert int(row['legacy_id']) > 0
+            # Verify each pipeline_queue.legacy_id matches the
+            # archive_queue.id with the same source_path.
+            for row in rows:
+                aq_id = conn.execute(
+                    "SELECT id FROM archive_queue WHERE source_path = ?",
+                    (row['source_path'],),
+                ).fetchone()[0]
+                assert int(row['legacy_id']) == int(aq_id)
+        finally:
+            conn.close()
+
+    def test_batch_enqueue_then_mark_copied_mirrors_state(
+        self, geodata_db,
+    ):
+        """Without the legacy_id fix, mark_copied's lookup-by-legacy-id
+        would silently no-op on batched rows. With the fix, the mirror
+        flips to `status='done'` like for single enqueues.
+        """
+        from services import archive_queue
+        archive_queue.enqueue_many_for_archive(
+            ['/tmp/batch-mark.mp4'], priority=2, db_path=geodata_db,
+        )
+        conn = sqlite3.connect(geodata_db)
+        try:
+            row_id = conn.execute(
+                "SELECT id FROM archive_queue WHERE source_path = ?",
+                ('/tmp/batch-mark.mp4',),
+            ).fetchone()[0]
+        finally:
+            conn.close()
+        # Claim then complete.
+        archive_queue.claim_next_for_worker('w1', db_path=geodata_db)
+        ok = archive_queue.mark_copied(
+            row_id, '/dst/batch-mark.mp4', db_path=geodata_db,
+        )
+        assert ok
+        conn = sqlite3.connect(geodata_db)
+        conn.row_factory = sqlite3.Row
+        try:
+            row = conn.execute(
+                "SELECT stage, status, completed_at FROM pipeline_queue "
+                "WHERE source_path = ?",
+                ('/tmp/batch-mark.mp4',),
+            ).fetchone()
+            assert row['stage'] == 'archive_done'
+            assert row['status'] == 'done'
+            assert row['completed_at'] is not None
+        finally:
+            conn.close()
+
+
+class TestCloudMarkUploadFailureOrdering:
+    """Review #191 Warning #1 fix: `_mark_upload_failure` must NOT
+    write the pipeline_queue mirror itself. The caller is responsible
+    for calling the mirror AFTER `_fsync_db(conn)` so the legacy
+    commit always lands first.
+    """
+
+    def test_mark_upload_failure_returns_post_state(self, tmp_path):
+        from services import cloud_archive_service as cas
+        db = str(tmp_path / 'cloud_sync.db')
+        conn = cas._init_cloud_tables(db)
+        try:
+            conn.execute(
+                "INSERT INTO cloud_synced_files (file_path, status, "
+                "retry_count) VALUES (?, 'uploading', 0)",
+                ('events/2025-01-01_00-00-00/file.mp4',),
+            )
+            conn.commit()
+            post = cas._mark_upload_failure(
+                conn, 'events/2025-01-01_00-00-00/file.mp4',
+                'simulated rclone error',
+            )
+            assert post is not None
+            status, attempts = post
+            assert status == 'failed'
+            assert attempts == 1
+        finally:
+            conn.close()
+
+    def test_mark_upload_failure_returns_none_on_unknown_path(
+        self, tmp_path,
+    ):
+        from services import cloud_archive_service as cas
+        db = str(tmp_path / 'cloud_sync2.db')
+        conn = cas._init_cloud_tables(db)
+        try:
+            post = cas._mark_upload_failure(
+                conn, 'no/such/file.mp4', 'oops',
+            )
+            assert post is None
+        finally:
+            conn.close()
+
+
+class TestRetryFailedSingleRowNoExtraSelect:
+    """Review #191 Info #4 fix: the single-row branch of
+    `retry_failed` no longer issues a redundant SELECT — the caller
+    already supplied the id.
+    """
+
+    def test_single_row_retry_resets_when_failed(self, tmp_path,
+                                                 monkeypatch):
+        # Point LES at an isolated DB.
+        from services import live_event_sync_service as les
+        db = str(tmp_path / 'cloud_sync3.db')
+        monkeypatch.setattr(les, 'CLOUD_ARCHIVE_DB_PATH', db)
+        conn = les._open_db()
+        try:
+            les._ensure_schema(conn)
+            cur = conn.execute(
+                "INSERT INTO live_event_queue "
+                "(event_dir, event_json_path, event_timestamp, "
+                "event_reason, upload_scope, status, attempts, "
+                "next_retry_at, enqueued_at) "
+                "VALUES (?,?,?,?,?,'failed',5,NULL,?)",
+                ('/some/dir', '/some/dir/event.json',
+                 '2025-01-01T00:00:00Z', 'sentry', 'event_minute',
+                 '2025-01-01T00:00:00Z'),
+            )
+            row_id = cur.lastrowid
+            conn.commit()
+        finally:
+            conn.close()
+        n = les.retry_failed(row_id)
+        assert n == 1
+        conn = les._open_db()
+        try:
+            row = conn.execute(
+                "SELECT status, attempts FROM live_event_queue WHERE id=?",
+                (row_id,),
+            ).fetchone()
+            assert row['status'] == 'pending'
+            assert row['attempts'] == 0
+        finally:
+            conn.close()
+
+
+class TestPipelineRowKwargGate:
+    """Review #191 Info #8 fix: the `_UPDATE_COLUMNS` tuple drives
+    both helpers' "no kwargs passed" gate AND the SET-clause builder.
+    Verifies the tuple is the single source of truth.
+    """
+
+    def test_update_pipeline_row_no_kwargs_returns_false(self, tmp_path):
+        # Even with a valid db / row, with no settable kwargs the
+        # helper must silently no-op.
+        db = str(tmp_path / 'pq.db')
+        # The helper short-circuits on missing DB, but we want the
+        # "no kwargs" path. Create the file first.
+        import sqlite3
+        conn = sqlite3.connect(db)
+        conn.execute(
+            "CREATE TABLE pipeline_queue (id INTEGER PRIMARY KEY, "
+            "stage TEXT, source_path TEXT)"
+        )
+        conn.commit()
+        conn.close()
+        ok = pqs.update_pipeline_row(
+            stage='archive_pending',
+            source_path='/some/path.mp4',
+            db_path=db,
+        )
+        assert ok is False
+
+    def test_update_columns_tuple_matches_kwarg_to_column_keys(self):
+        # Defense in depth — the lookup table and the order list must
+        # stay in lockstep so a future kwarg addition can't be wired
+        # into one but not the other.
+        assert set(pqs._UPDATE_COLUMNS) == set(pqs._KWARG_TO_COLUMN.keys())

--- a/tests/test_pipeline_queue_dualwrite.py
+++ b/tests/test_pipeline_queue_dualwrite.py
@@ -630,6 +630,467 @@ class TestProducerHooks:
         finally:
             conn.close()
 
+
+# ---------------------------------------------------------------------------
+# Wave 4 PR-B — state-transition dual-write helpers
+# ---------------------------------------------------------------------------
+
+class TestUpdatePipelineRow:
+    """Unit tests for ``update_pipeline_row`` (source_path lookup)."""
+
+    def test_happy_path_updates_status(self, geodata_db):
+        # Enqueue first so a row exists
+        pqs.dual_write_enqueue(
+            source_path='/tmp/x.mp4',
+            stage=pqs.STAGE_ARCHIVE_PENDING,
+            legacy_table=pqs.LEGACY_TABLE_ARCHIVE,
+            db_path=geodata_db,
+        )
+        ok = pqs.update_pipeline_row(
+            stage=pqs.STAGE_ARCHIVE_PENDING,
+            source_path='/tmp/x.mp4',
+            status='in_progress',
+            db_path=geodata_db,
+        )
+        assert ok is True
+        conn = sqlite3.connect(geodata_db)
+        try:
+            r = conn.execute(
+                "SELECT status FROM pipeline_queue WHERE source_path=?",
+                ('/tmp/x.mp4',),
+            ).fetchone()
+            assert r[0] == 'in_progress'
+        finally:
+            conn.close()
+
+    def test_missing_row_returns_false_and_no_op(self, geodata_db):
+        ok = pqs.update_pipeline_row(
+            stage=pqs.STAGE_ARCHIVE_PENDING,
+            source_path='/never/seen.mp4',
+            status='done',
+            db_path=geodata_db,
+        )
+        assert ok is False
+
+    def test_no_kwargs_is_silent_noop(self, geodata_db):
+        pqs.dual_write_enqueue(
+            source_path='/tmp/y.mp4',
+            stage=pqs.STAGE_ARCHIVE_PENDING,
+            legacy_table=pqs.LEGACY_TABLE_ARCHIVE,
+            db_path=geodata_db,
+        )
+        ok = pqs.update_pipeline_row(
+            stage=pqs.STAGE_ARCHIVE_PENDING,
+            source_path='/tmp/y.mp4',
+            db_path=geodata_db,
+        )
+        assert ok is False
+        # Row is unchanged (still 'pending')
+        conn = sqlite3.connect(geodata_db)
+        try:
+            r = conn.execute(
+                "SELECT status FROM pipeline_queue WHERE source_path=?",
+                ('/tmp/y.mp4',),
+            ).fetchone()
+            assert r[0] == 'pending'
+        finally:
+            conn.close()
+
+    def test_promotes_stage_and_completed_at(self, geodata_db):
+        pqs.dual_write_enqueue(
+            source_path='/tmp/z.mp4',
+            stage=pqs.STAGE_ARCHIVE_PENDING,
+            legacy_table=pqs.LEGACY_TABLE_ARCHIVE,
+            db_path=geodata_db,
+        )
+        ok = pqs.update_pipeline_row(
+            stage=pqs.STAGE_ARCHIVE_PENDING,
+            source_path='/tmp/z.mp4',
+            new_stage='archive_done',
+            status='done',
+            completed_at=12345.0,
+            db_path=geodata_db,
+        )
+        assert ok is True
+        conn = sqlite3.connect(geodata_db)
+        try:
+            r = conn.execute(
+                "SELECT stage, status, completed_at FROM pipeline_queue "
+                "WHERE source_path=?",
+                ('/tmp/z.mp4',),
+            ).fetchone()
+            assert r[0] == 'archive_done'
+            assert r[1] == 'done'
+            assert r[2] == 12345.0
+        finally:
+            conn.close()
+
+    def test_none_columns_preserved(self, geodata_db):
+        """Passing None for a kwarg leaves the column unchanged."""
+        pqs.dual_write_enqueue(
+            source_path='/tmp/p.mp4',
+            stage=pqs.STAGE_ARCHIVE_PENDING,
+            legacy_table=pqs.LEGACY_TABLE_ARCHIVE,
+            db_path=geodata_db,
+        )
+        # Set initial state
+        pqs.update_pipeline_row(
+            stage=pqs.STAGE_ARCHIVE_PENDING,
+            source_path='/tmp/p.mp4',
+            status='in_progress',
+            attempts=2,
+            last_error='boom',
+            db_path=geodata_db,
+        )
+        # Update only status; attempts + last_error should stick
+        pqs.update_pipeline_row(
+            stage=pqs.STAGE_ARCHIVE_PENDING,
+            source_path='/tmp/p.mp4',
+            status='pending',
+            db_path=geodata_db,
+        )
+        conn = sqlite3.connect(geodata_db)
+        try:
+            r = conn.execute(
+                "SELECT status, attempts, last_error "
+                "FROM pipeline_queue WHERE source_path=?",
+                ('/tmp/p.mp4',),
+            ).fetchone()
+            assert r[0] == 'pending'
+            assert r[1] == 2
+            assert r[2] == 'boom'
+        finally:
+            conn.close()
+
+    def test_swallows_missing_db(self, tmp_path):
+        # No DB at this path
+        ok = pqs.update_pipeline_row(
+            stage=pqs.STAGE_ARCHIVE_PENDING,
+            source_path='/tmp/a.mp4',
+            status='done',
+            db_path=str(tmp_path / 'does-not-exist.db'),
+        )
+        assert ok is False
+
+
+class TestUpdatePipelineRowByLegacyId:
+    """Unit tests for ``update_pipeline_row_by_legacy_id``."""
+
+    def test_happy_path_by_id(self, geodata_db):
+        pqs.dual_write_enqueue(
+            source_path='/tmp/q.mp4',
+            stage=pqs.STAGE_ARCHIVE_PENDING,
+            legacy_table=pqs.LEGACY_TABLE_ARCHIVE,
+            legacy_id=42,
+            db_path=geodata_db,
+        )
+        ok = pqs.update_pipeline_row_by_legacy_id(
+            legacy_table=pqs.LEGACY_TABLE_ARCHIVE,
+            legacy_id=42,
+            status='in_progress',
+            db_path=geodata_db,
+        )
+        assert ok is True
+        conn = sqlite3.connect(geodata_db)
+        try:
+            r = conn.execute(
+                "SELECT status FROM pipeline_queue WHERE legacy_id = ?",
+                (42,),
+            ).fetchone()
+            assert r[0] == 'in_progress'
+        finally:
+            conn.close()
+
+    def test_missing_legacy_id_no_op(self, geodata_db):
+        ok = pqs.update_pipeline_row_by_legacy_id(
+            legacy_table=pqs.LEGACY_TABLE_ARCHIVE,
+            legacy_id=999,
+            status='done',
+            db_path=geodata_db,
+        )
+        assert ok is False
+
+    def test_no_kwargs_no_op_by_id(self, geodata_db):
+        pqs.dual_write_enqueue(
+            source_path='/tmp/q2.mp4',
+            stage=pqs.STAGE_ARCHIVE_PENDING,
+            legacy_table=pqs.LEGACY_TABLE_ARCHIVE,
+            legacy_id=43,
+            db_path=geodata_db,
+        )
+        ok = pqs.update_pipeline_row_by_legacy_id(
+            legacy_table=pqs.LEGACY_TABLE_ARCHIVE,
+            legacy_id=43,
+            db_path=geodata_db,
+        )
+        assert ok is False
+
+
+# ---------------------------------------------------------------------------
+# Wave 4 PR-B — integration: legacy mutation mirrors to pipeline_queue
+# ---------------------------------------------------------------------------
+
+class TestArchiveStateTransitions:
+    """Integration: each archive_queue mutation mirrors into pipeline_queue."""
+
+    def _enqueue(self, geodata_db, src):
+        from services import archive_queue
+        ok = archive_queue.enqueue_for_archive(
+            src, priority=2, db_path=geodata_db,
+        )
+        assert ok
+        conn = sqlite3.connect(geodata_db)
+        try:
+            row = conn.execute(
+                "SELECT id FROM archive_queue WHERE source_path=?",
+                (src,),
+            ).fetchone()
+            return int(row[0])
+        finally:
+            conn.close()
+
+    def _pipeline_row(self, geodata_db, src):
+        conn = sqlite3.connect(geodata_db)
+        conn.row_factory = sqlite3.Row
+        try:
+            return conn.execute(
+                "SELECT * FROM pipeline_queue WHERE source_path=?",
+                (src,),
+            ).fetchone()
+        finally:
+            conn.close()
+
+    def test_claim_mirrors_in_progress(self, geodata_db):
+        from services import archive_queue
+        src = '/tmp/claim.mp4'
+        self._enqueue(geodata_db, src)
+        claimed = archive_queue.claim_next_for_worker(
+            'w1', db_path=geodata_db,
+        )
+        assert claimed is not None
+        row = self._pipeline_row(geodata_db, src)
+        assert row['status'] == 'in_progress'
+        assert row['stage'] == pqs.STAGE_ARCHIVE_PENDING
+
+    def test_mark_copied_mirrors_done(self, geodata_db):
+        from services import archive_queue
+        src = '/tmp/copied.mp4'
+        rid = self._enqueue(geodata_db, src)
+        archive_queue.claim_next_for_worker('w1', db_path=geodata_db)
+        ok = archive_queue.mark_copied(
+            rid, '/dst/copied.mp4', db_path=geodata_db,
+        )
+        assert ok
+        row = self._pipeline_row(geodata_db, src)
+        assert row['stage'] == 'archive_done'
+        assert row['status'] == 'done'
+        assert row['completed_at'] is not None
+
+    def test_mark_source_gone_mirrors_terminal(self, geodata_db):
+        from services import archive_queue
+        src = '/tmp/gone.mp4'
+        rid = self._enqueue(geodata_db, src)
+        archive_queue.claim_next_for_worker('w1', db_path=geodata_db)
+        ok = archive_queue.mark_source_gone(rid, db_path=geodata_db)
+        assert ok
+        row = self._pipeline_row(geodata_db, src)
+        assert row['stage'] == 'archive_done'
+        assert row['status'] == 'source_gone'
+
+    def test_mark_skipped_stationary_mirrors_terminal(self, geodata_db):
+        from services import archive_queue
+        src = '/tmp/stationary.mp4'
+        rid = self._enqueue(geodata_db, src)
+        archive_queue.claim_next_for_worker('w1', db_path=geodata_db)
+        ok = archive_queue.mark_skipped_stationary(
+            rid, db_path=geodata_db,
+        )
+        assert ok
+        row = self._pipeline_row(geodata_db, src)
+        assert row['stage'] == 'archive_done'
+        assert row['status'] == 'skipped_stationary'
+
+    def test_release_claim_mirrors_pending(self, geodata_db):
+        from services import archive_queue
+        src = '/tmp/release.mp4'
+        rid = self._enqueue(geodata_db, src)
+        archive_queue.claim_next_for_worker('w1', db_path=geodata_db)
+        # pre-condition: mirror is 'in_progress'
+        assert self._pipeline_row(geodata_db, src)['status'] == 'in_progress'
+        ok = archive_queue.release_claim(rid, db_path=geodata_db)
+        assert ok
+        assert self._pipeline_row(geodata_db, src)['status'] == 'pending'
+
+    def test_mark_failed_pending_mirrors_attempts(self, geodata_db):
+        from services import archive_queue
+        src = '/tmp/fail.mp4'
+        rid = self._enqueue(geodata_db, src)
+        archive_queue.claim_next_for_worker('w1', db_path=geodata_db)
+        new_status = archive_queue.mark_failed(
+            rid, 'transient', max_attempts=3, db_path=geodata_db,
+        )
+        assert new_status == 'pending'
+        row = self._pipeline_row(geodata_db, src)
+        assert row['status'] == 'pending'
+        assert row['attempts'] == 1
+        assert row['last_error'] == 'transient'
+
+    def test_mark_failed_dead_letter_mirrors_terminal(self, geodata_db):
+        from services import archive_queue
+        src = '/tmp/dl.mp4'
+        rid = self._enqueue(geodata_db, src)
+        archive_queue.claim_next_for_worker('w1', db_path=geodata_db)
+        # Force the row to dead_letter on first failure with cap=1
+        new_status = archive_queue.mark_failed(
+            rid, 'permanent', max_attempts=1, db_path=geodata_db,
+        )
+        assert new_status == 'dead_letter'
+        row = self._pipeline_row(geodata_db, src)
+        assert row['stage'] == 'archive_done'
+        assert row['status'] == 'dead_letter'
+        assert row['last_error'] == 'permanent'
+
+
+class TestIndexingStateTransitions:
+    """Integration: each indexing_queue_service mutation mirrors."""
+
+    def test_claim_complete_mirrors(self, geodata_db):
+        from services import indexing_queue_service as iqs
+        from services.mapping_service import canonical_key
+        # Enqueue
+        ok = iqs.enqueue_for_indexing(
+            geodata_db, '/tmp/clip.mp4',
+            priority=50,
+            source='watcher',
+        )
+        assert ok
+        ck = canonical_key('/tmp/clip.mp4')
+        # Claim
+        claimed = iqs.claim_next_queue_item(geodata_db, 'w1')
+        assert claimed is not None
+        conn = sqlite3.connect(geodata_db)
+        conn.row_factory = sqlite3.Row
+        try:
+            row = conn.execute(
+                "SELECT status FROM pipeline_queue WHERE source_path=?",
+                (ck,),
+            ).fetchone()
+            assert row['status'] == 'in_progress'
+        finally:
+            conn.close()
+        # Complete (terminal — pipeline row goes to 'index_done'/'done',
+        # legacy row deleted)
+        done = iqs.complete_queue_item(
+            geodata_db, ck,
+            claimed_by='w1',
+            claimed_at=claimed['claimed_at'],
+        )
+        assert done
+        conn = sqlite3.connect(geodata_db)
+        conn.row_factory = sqlite3.Row
+        try:
+            row = conn.execute(
+                "SELECT stage, status, completed_at FROM pipeline_queue "
+                "WHERE source_path=?",
+                (ck,),
+            ).fetchone()
+            assert row['stage'] == 'index_done'
+            assert row['status'] == 'done'
+            assert row['completed_at'] is not None
+        finally:
+            conn.close()
+
+    def test_release_claim_mirrors_pending(self, geodata_db):
+        from services import indexing_queue_service as iqs
+        from services.mapping_service import canonical_key
+        iqs.enqueue_for_indexing(
+            geodata_db, '/tmp/clip2.mp4',
+            priority=50, source='watcher',
+        )
+        ck = canonical_key('/tmp/clip2.mp4')
+        claimed = iqs.claim_next_queue_item(geodata_db, 'w1')
+        assert claimed is not None
+        ok = iqs.release_claim(
+            geodata_db, ck,
+            claimed_by='w1', claimed_at=claimed['claimed_at'],
+        )
+        assert ok
+        conn = sqlite3.connect(geodata_db)
+        try:
+            row = conn.execute(
+                "SELECT status FROM pipeline_queue WHERE source_path=?",
+                (ck,),
+            ).fetchone()
+            assert row[0] == 'pending'
+        finally:
+            conn.close()
+
+    def test_defer_mirrors_attempts_and_retry(self, geodata_db):
+        import time as _t
+        from services import indexing_queue_service as iqs
+        from services.mapping_service import canonical_key
+        iqs.enqueue_for_indexing(
+            geodata_db, '/tmp/clip3.mp4',
+            priority=50, source='watcher',
+        )
+        ck = canonical_key('/tmp/clip3.mp4')
+        claimed = iqs.claim_next_queue_item(geodata_db, 'w1')
+        assert claimed is not None
+        next_at = _t.time() + 60
+        ok = iqs.defer_queue_item(
+            geodata_db, ck, next_at,
+            bump_attempts=True, last_error='parse error',
+            claimed_by='w1', claimed_at=claimed['claimed_at'],
+        )
+        assert ok
+        conn = sqlite3.connect(geodata_db)
+        conn.row_factory = sqlite3.Row
+        try:
+            row = conn.execute(
+                "SELECT status, attempts, last_error, next_retry_at "
+                "FROM pipeline_queue WHERE source_path=?",
+                (ck,),
+            ).fetchone()
+            assert row['status'] == 'pending'
+            assert row['attempts'] == 1
+            assert row['last_error'] == 'parse error'
+            assert row['next_retry_at'] == next_at
+        finally:
+            conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Wave 4 PR-B — best-effort error swallowing
+# ---------------------------------------------------------------------------
+
+class TestStateTransitionErrorSwallowing:
+    """Pipeline-side glitches must NEVER abort a legacy mutation."""
+
+    def test_mark_copied_succeeds_when_pipeline_db_missing(
+        self, geodata_db, tmp_path,
+    ):
+        """If geodata.db is removed mid-flight, mark_copied still
+        returns True for the archive_queue row (legacy is the source
+        of truth in PR-B)."""
+        from services import archive_queue
+        src = '/tmp/swallow.mp4'
+        archive_queue.enqueue_for_archive(
+            src, priority=2, db_path=geodata_db,
+        )
+        rid = sqlite3.connect(geodata_db).execute(
+            "SELECT id FROM archive_queue WHERE source_path=?", (src,),
+        ).fetchone()[0]
+        archive_queue.claim_next_for_worker('w1', db_path=geodata_db)
+        # Wipe the pipeline_queue table (simulate corruption / missing).
+        conn = sqlite3.connect(geodata_db)
+        conn.execute("DROP TABLE pipeline_queue")
+        conn.commit()
+        conn.close()
+        ok = archive_queue.mark_copied(
+            rid, '/dst/swallow.mp4', db_path=geodata_db,
+        )
+        assert ok is True  # legacy succeeded
+
     def test_indexing_producer_dual_writes(self, geodata_db):
         from services import indexing_queue_service
         ok = indexing_queue_service.enqueue_for_indexing(


### PR DESCRIPTION
## Wave 4 PR-B — State-transition dual-writes for `pipeline_queue`

Ref #184 (Wave 4 PR-B)

### What this PR does

PR-A (#190) wired the **enqueue** paths so every new row in the four legacy queues (`archive_queue`, `indexing_queue`, `live_event_queue`, `cloud_synced_files`) is mirrored into the unified `pipeline_queue`. State **mutations** on legacy rows after enqueue (claim, complete, release, fail, defer) were not mirrored, so `pipeline_queue` rows quickly drifted to a stale `status='pending'` even when the legacy row had moved on.

This PR closes that gap. Every state-mutation site in all four services now dual-writes the new state into `pipeline_queue` so the unified queue is a faithful real-time mirror of every legacy queue at all times. Still purely additive — no read paths change. PR-C will start switching readers.

### Helpers added (`pipeline_queue_service.py`)

- `update_pipeline_row(*, stage, source_path, new_stage=None, status=None, attempts=None, last_error=None, completed_at=None, next_retry_at=None, payload_json=None, db_path=None)`
  - Looks up the row by `(stage, source_path)`.
  - Silently no-ops if DB missing, row missing, no kwargs passed, or any sqlite error.
  - `None` kwargs leave the column unchanged (use sentinels like `0.0` for `next_retry_at` reset, empty string for `last_error` clear).

- `update_pipeline_row_by_legacy_id(*, legacy_table, legacy_id, ...)`
  - Same semantics, but matches by the `legacy_table+legacy_id` back-pointer for queues where the legacy primary key is the most reliable handle.

Both helpers are imported lazily where wired in to avoid import-cycle risk.

### Mutation sites wired (22 sites total)

- **archive_queue.py** (6): `claim_next_for_worker`, `mark_copied`, `mark_source_gone`, `mark_skipped_stationary`, `release_claim`, `mark_failed`
- **indexing_queue_service.py** (4): `claim_next_queue_item`, `complete_queue_item`, `release_claim`, `defer_queue_item`
- **live_event_sync_service.py** (7): `_claim_next_pending`, `_release_claim_to_pending`, `_record_attempt_start`, `_mark_uploaded`, `_mark_failed` (transient + exhausted + retry paths), `retry_failed`
- **cloud_archive_service.py** (5): `_mark_upload_failure`, `_try_upload` (success + cancel), `retry_dead_letter`, `recover_interrupted_uploads`, inline startup recovery in `_init_cloud_tables`

The mutation/dual-write ordering rule is: **legacy commit FIRST, then pipeline mirror AFTER** (in a `finally` block where appropriate). This guarantees pipeline_queue can never be ahead of legacy on a crash — only behind, and PR-A's backfill flag (one-shot) plus PR-C's read-then-claim semantics handle behind-state recovery cleanly.

### Indexing change worth noting

The existing indexing dual-write (added in PR-A) used `file_path` as `source_path` in pipeline_queue. State mutations on the legacy `indexing_queue` are keyed by `canonical_key`, not file_path, so a state-mutation lookup using file_path could never reach the right pipeline_queue row.

Changed both `_dual_write_pipeline_indexing` and `_dual_write_pipeline_indexing_many` to use `canonical_key` as `source_path` (file_path moved to payload). Updated `_backfill_indexing_queue` SQL to match. Existing PR-A backfilled rows on already-deployed Pis will have `source_path=file_path`; the v16 backfill flag prevents re-backfill. Mismatched rows just silently no-op the mutation mirror (acceptable for PR-B since no reader uses pipeline_queue yet — PR-C is the first reader).

### Tests

- **Unit**: 9 tests for the two new helpers (happy path, missing kwargs, missing DB, missing row, all column updates, both lookup keys).
- **Integration — archive**: 7 tests covering the full claim→copied / source_gone / skipped_stationary / release / fail-pending / fail-deadletter cycle; verifies pipeline_queue tracks legacy at every step.
- **Integration — indexing**: 3 tests covering claim+complete (terminal: stage flips to `index_done`), release back to pending, and defer with attempts bump + `next_retry_at` mirror.
- **Resilience**: 1 test confirming silent no-op when `pipeline_queue` table is dropped (legacy mutation must still succeed).

Full suite: **1681 passed / 4 skipped** (was 1661 / 4).

### Pi deploy verification plan

After merge + deploy + a few minutes of normal operation, this query on cybertruckusb.local should show that pipeline_queue `status` distribution roughly matches the union of legacy queues:

```sql
SELECT stage, status, COUNT(*) FROM pipeline_queue GROUP BY stage, status;
```

Specifically:
- `archive_pending` / `in_progress` rows should match `archive_queue` rows with `claimed_by IS NOT NULL`
- `index_done` / `done` rows should be roughly the same count as the indexer's "indexed today" stat
- `cloud_done` / `done` rows should match `cloud_synced_files` rows with `status='synced'`

### Out of scope (next sub-PRs)

- PR-C: Switch one or two workers' claim functions to read from `pipeline_queue` + inline SEI parse during `_atomic_copy`
- PR-D: Delete `live_event_sync_service.py`, batched rclone, drop poll → **Closes #184**
- PR-E (optional): Single-DB consolidation
