### PR TITLE
refactor: pipeline_queue claim persistence + stale-recovery (Wave 4 PR-D)

### DIFF
--- a/scripts/web/services/mapping_migrations.py
+++ b/scripts/web/services/mapping_migrations.py
@@ -46,7 +46,7 @@ logger = logging.getLogger(__name__)
 # Database Schema & Management
 # ---------------------------------------------------------------------------
 
-_SCHEMA_VERSION = 16
+_SCHEMA_VERSION = 17
 _BACKUP_RETENTION = 3  # Keep this many migration backups before pruning oldest
 
 _SCHEMA_SQL = """
@@ -320,6 +320,16 @@ CREATE TABLE IF NOT EXISTS pipeline_queue (
     payload_json TEXT,
     legacy_id INTEGER,
     legacy_table TEXT,
+    -- v17 (issue #184 Wave 4 PR-D / issue #193): worker-claim
+    -- bookkeeping. ``claimed_by`` is the worker id stamped at claim
+    -- time (e.g. ``"archive_worker-12345"``). ``claimed_at`` is the
+    -- epoch seconds the claim was acquired — used by
+    -- ``recover_stale_claims_pipeline()`` to detect crashed workers
+    -- and recycle their rows back to ``status='pending'``. Without
+    -- these columns an ``in_progress`` row whose claimer crashes
+    -- mid-work would be orphaned forever (no timeout, no recovery).
+    claimed_by TEXT,
+    claimed_at REAL,
     UNIQUE(source_path, stage, legacy_table)
 );
 -- Worker pick-next index (used in Wave 4 PR-B): partial over only
@@ -331,6 +341,12 @@ CREATE INDEX IF NOT EXISTS idx_pipeline_ready
 -- to find the pipeline row matching a legacy queue row).
 CREATE INDEX IF NOT EXISTS idx_pipeline_legacy
     ON pipeline_queue(legacy_table, legacy_id);
+-- v17: stale-claim recovery scan (used by recover_stale_claims_pipeline).
+-- Partial index covers only rows that COULD be stale — keeps the
+-- index small even on a queue with thousands of done rows.
+CREATE INDEX IF NOT EXISTS idx_pipeline_stale_claims
+    ON pipeline_queue(claimed_at)
+    WHERE status = 'in_progress' AND claimed_at IS NOT NULL;
 """
 
 
@@ -402,6 +418,41 @@ def _init_db(db_path: str) -> sqlite3.Connection:
         # is being upgraded, not on first install)
         if current > 0:
             _backup_db(db_path, _SCHEMA_VERSION)
+
+        # v16 -> v17 pre-script ALTER TABLE: must run BEFORE
+        # executescript because the schema's
+        # ``idx_pipeline_stale_claims`` index references columns
+        # (``claimed_at``, ``status``) that don't exist yet on a
+        # legacy v16 ``pipeline_queue`` table. Without this, the
+        # CREATE INDEX IF NOT EXISTS would raise
+        # ``sqlite3.OperationalError: no such column: claimed_at``.
+        # Adding the columns first is safe — the schema's CREATE
+        # TABLE IF NOT EXISTS won't touch the existing table, and
+        # subsequent indices then reference real columns. On a
+        # fresh install the table doesn't exist yet so this block
+        # is a no-op (caught OperationalError).
+        if current > 0 and current < 17:
+            try:
+                cols = {r[1] for r in conn.execute(
+                    "PRAGMA table_info(pipeline_queue)"
+                ).fetchall()}
+                if cols:  # table exists from v16
+                    if 'claimed_by' not in cols:
+                        conn.execute(
+                            "ALTER TABLE pipeline_queue "
+                            "ADD COLUMN claimed_by TEXT"
+                        )
+                    if 'claimed_at' not in cols:
+                        conn.execute(
+                            "ALTER TABLE pipeline_queue "
+                            "ADD COLUMN claimed_at REAL"
+                        )
+            except sqlite3.OperationalError as e:
+                # Table absent (pre-v16 install path) — schema script
+                # will create it WITH the v17 columns. Safe to ignore.
+                logger.debug(
+                    "Pre-script v16->v17 ALTER TABLE skipped: %s", e,
+                )
 
         conn.executescript(_SCHEMA_SQL)
         # Migrations for existing databases
@@ -647,6 +698,19 @@ def _init_db(db_path: str) -> sqlite3.Connection:
             # background thread after gadget_web is serving requests,
             # so the user never waits on it.
             logger.info("Migration v15->v16: pipeline_queue table ready")
+        if current > 0 and current < 17:
+            # v17 (issue #184 Wave 4 PR-D / issue #193): the
+            # ``claimed_by`` and ``claimed_at`` columns and the
+            # ``idx_pipeline_stale_claims`` partial index were
+            # already added by the v16->v17 pre-script ALTER TABLE
+            # block (above) and the ``executescript(_SCHEMA_SQL)``
+            # call (CREATE INDEX IF NOT EXISTS). This block exists
+            # only to log the version bump for operators tailing
+            # the journal during upgrade.
+            logger.info(
+                "Migration v16->v17: pipeline_queue claim-bookkeeping "
+                "columns + idx_pipeline_stale_claims ready"
+            )
         conn.execute("DELETE FROM schema_version")
         conn.execute(
             "INSERT INTO schema_version (version) VALUES (?)",

--- a/scripts/web/services/mapping_migrations.py
+++ b/scripts/web/services/mapping_migrations.py
@@ -49,6 +49,14 @@ logger = logging.getLogger(__name__)
 _SCHEMA_VERSION = 17
 _BACKUP_RETENTION = 3  # Keep this many migration backups before pruning oldest
 
+# Schema version that introduced ``pipeline_queue.claimed_by`` and
+# ``pipeline_queue.claimed_at`` (issue #184 Wave 4 PR-D / #193).
+# Used by both the v16->v17 pre-script ALTER TABLE block and the
+# post-script log block so the threshold lives in one place — when
+# the next migration (v18+) is added, both blocks must keep referring
+# to this constant rather than a magic number.
+_PIPELINE_CLAIM_COLS_VERSION = 17
+
 _SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS schema_version (
     version INTEGER PRIMARY KEY
@@ -431,7 +439,7 @@ def _init_db(db_path: str) -> sqlite3.Connection:
         # subsequent indices then reference real columns. On a
         # fresh install the table doesn't exist yet so this block
         # is a no-op (caught OperationalError).
-        if current > 0 and current < 17:
+        if current > 0 and current < _PIPELINE_CLAIM_COLS_VERSION:
             try:
                 cols = {r[1] for r in conn.execute(
                     "PRAGMA table_info(pipeline_queue)"
@@ -447,9 +455,16 @@ def _init_db(db_path: str) -> sqlite3.Connection:
                             "ALTER TABLE pipeline_queue "
                             "ADD COLUMN claimed_at REAL"
                         )
-            except sqlite3.OperationalError as e:
-                # Table absent (pre-v16 install path) — schema script
-                # will create it WITH the v17 columns. Safe to ignore.
+            except sqlite3.Error as e:
+                # Table absent (pre-v16 install path) OR transient
+                # corruption/lock during PRAGMA — schema script will
+                # create the table WITH the v17 columns on a fresh
+                # install, and a truly broken DB will surface again on
+                # the next ``executescript(_SCHEMA_SQL)`` call so we
+                # don't lose the failure signal. Caught broadly
+                # (``sqlite3.Error`` rather than ``OperationalError``)
+                # to mirror the defensive style used elsewhere in
+                # this module.
                 logger.debug(
                     "Pre-script v16->v17 ALTER TABLE skipped: %s", e,
                 )
@@ -698,7 +713,7 @@ def _init_db(db_path: str) -> sqlite3.Connection:
             # background thread after gadget_web is serving requests,
             # so the user never waits on it.
             logger.info("Migration v15->v16: pipeline_queue table ready")
-        if current > 0 and current < 17:
+        if current > 0 and current < _PIPELINE_CLAIM_COLS_VERSION:
             # v17 (issue #184 Wave 4 PR-D / issue #193): the
             # ``claimed_by`` and ``claimed_at`` columns and the
             # ``idx_pipeline_stale_claims`` partial index were

--- a/scripts/web/services/pipeline_queue_service.py
+++ b/scripts/web/services/pipeline_queue_service.py
@@ -48,6 +48,9 @@ Public API:
   next" lookup (parity tests + Settings page).
 * :func:`ready_count_for_stage` — Wave 4 PR-C; cheap COUNT(*) of
   eligible rows for a stage.
+* :func:`recover_stale_claims_pipeline` — Wave 4 PR-D; release
+  ``in_progress`` rows whose claimer crashed (claimed_at older
+  than threshold). Called once at worker startup.
 * :func:`pipeline_status` — debug / verification view (counts grouped
   by legacy_table + stage + status).
 * :func:`backfill_legacy_queues` — one-time migration helper.
@@ -96,6 +99,18 @@ PRIORITY_ARCHIVE_RECENT = 2      # RecentClips (age-bound)
 PRIORITY_ARCHIVE_OTHER = 3       # ArchivedClips back-fill / other
 PRIORITY_CLOUD_BULK = 4          # cloud_synced_files bulk catch-up
 PRIORITY_INDEXING = 5            # default indexing
+
+
+# Stale-claim threshold for ``recover_stale_claims_pipeline`` — same
+# default as ``indexing_queue_service._STALE_CLAIM_SECONDS`` (30 min).
+# A claim older than this is presumed orphaned by a crashed worker
+# and recycled back to ``status='pending'`` on the next worker
+# startup. Tuned to be longer than the longest legitimate
+# single-row processing time (an extreme archive copy of a 60s
+# multi-camera Sentry event may take ~5 minutes under load + the
+# task_coordinator may pause on high loadavg) but short enough that
+# a real crash is detected within the same boot cycle.
+_PIPELINE_STALE_CLAIM_SECONDS = 1800.0
 
 
 # ---------------------------------------------------------------------------
@@ -574,15 +589,19 @@ def claim_next_for_stage(
             on stage is required — this function refuses to operate
             without one (returns ``None``) so a caller bug can't
             sweep the entire queue indiscriminately.
-        claimed_by: Operator-readable string for diagnostics. Stamped
-            into the returned dict's ``_claimed_by`` key only — NOT
-            written to the DB. The legacy queue's ``claimed_by``
-            column remains the operational record during the dual-
-            write transition; pipeline_queue gets a dedicated
-            ``claimed_by`` column when PR-D adds the column.
+        claimed_by: Operator-readable string for diagnostics.
+            Persisted to the row's ``claimed_by`` column AND echoed
+            back as the synthesised ``_claimed_by`` key in the
+            returned dict (the latter is preserved for backward
+            compat with PR-C callers — it equals the persisted
+            value). The persistence (added in PR-D / schema v17)
+            lets :func:`recover_stale_claims_pipeline` detect rows
+            whose claimer crashed and recycle them back to
+            ``status='pending'``.
         db_path: Override the geodata.db path (test injection).
         now: Override the "current time" used for ``next_retry_at``
-            comparisons. Test injection only.
+            comparisons AND for the ``claimed_at`` timestamp
+            written into the row. Test injection only.
 
     Returns:
         A dict snapshot of the claimed row, augmented with two
@@ -627,9 +646,11 @@ def claim_next_for_stage(
         cur = conn.execute(
             """UPDATE pipeline_queue
                   SET status = 'in_progress',
-                      attempts = attempts + 1
+                      attempts = attempts + 1,
+                      claimed_by = ?,
+                      claimed_at = ?
                 WHERE id = ? AND status = 'pending'""",
-            (sel['id'],),
+            (claimed_by, now, sel['id']),
         )
         if cur.rowcount != 1:
             # Another worker raced us between the SELECT and the
@@ -642,6 +663,12 @@ def claim_next_for_stage(
         row = dict(sel)
         row['status'] = 'in_progress'
         row['attempts'] = (sel['attempts'] or 0) + 1
+        # v17: persist the claim so ``recover_stale_claims_pipeline``
+        # can detect crashed workers. The legacy ``_claimed_by``
+        # synthesised key is preserved for callers that already
+        # consume it (it's identical to the new persisted column).
+        row['claimed_by'] = claimed_by
+        row['claimed_at'] = now
         if row.get('payload_json'):
             try:
                 parsed = json.loads(row['payload_json'])
@@ -760,6 +787,79 @@ def ready_count_for_stage(
         logger.debug(
             "ready_count_for_stage(stage=%s) failed: %s", stage, e,
         )
+        return 0
+    finally:
+        if conn is not None:
+            try:
+                conn.close()
+            except sqlite3.Error:
+                pass
+
+
+def recover_stale_claims_pipeline(
+    *,
+    db_path: Optional[str] = None,
+    max_age_seconds: float = _PIPELINE_STALE_CLAIM_SECONDS,
+    now: Optional[float] = None,
+) -> int:
+    """Release ``in_progress`` rows whose ``claimed_at`` is older
+    than ``max_age_seconds``, recycling them back to ``status='pending'``.
+
+    Mirror of :func:`indexing_queue_service.recover_stale_claims` for
+    ``pipeline_queue``. Called once at worker startup so a previous
+    crash can't permanently lock a row in ``in_progress``. Without
+    this, an ``in_progress`` row whose claimer crashed mid-work
+    would be orphaned forever (no ``claimed_at`` timeout, no
+    recovery mechanism — exactly the gap PR-D closes per issue #193).
+
+    The reset clears ``claimed_by`` and ``claimed_at`` (returning the
+    row to its pre-claim state) but DELIBERATELY preserves
+    ``attempts`` so a row that has already been attempted N times
+    isn't given a free retry — the next ``claim_next_for_stage``
+    will increment to N+1. ``next_retry_at`` is left untouched so a
+    failure-driven backoff (set by the failed-claim path) still
+    fires correctly.
+
+    Args:
+        db_path: Override the geodata.db path.
+        max_age_seconds: Claims older than this are released.
+            Default ``_PIPELINE_STALE_CLAIM_SECONDS`` (1800 s = 30 min).
+        now: Override "current time" (test injection only).
+
+    Returns:
+        The count of rows released. Returns 0 on missing DB / sqlite
+        error (logged at WARNING). NEVER raises.
+    """
+    if db_path is None:
+        db_path = _resolve_pipeline_db()
+    if not db_path or not os.path.isfile(db_path):
+        return 0
+    if now is None:
+        now = _now_epoch()
+    cutoff = now - max_age_seconds
+    conn = None
+    try:
+        conn = _open_pipeline_conn(db_path)
+        cur = conn.execute(
+            """UPDATE pipeline_queue
+                  SET status = 'pending',
+                      claimed_by = NULL,
+                      claimed_at = NULL
+                WHERE status = 'in_progress'
+                  AND claimed_at IS NOT NULL
+                  AND claimed_at < ?""",
+            (cutoff,),
+        )
+        released = cur.rowcount or 0
+        conn.commit()
+        if released:
+            logger.warning(
+                "Released %d stale pipeline_queue claim(s) (>%ds old)",
+                released, int(max_age_seconds),
+            )
+        return released
+    except sqlite3.Error as e:
+        logger.warning("recover_stale_claims_pipeline failed: %s", e)
         return 0
     finally:
         if conn is not None:

--- a/scripts/web/services/pipeline_queue_service.py
+++ b/scripts/web/services/pipeline_queue_service.py
@@ -601,7 +601,11 @@ def claim_next_for_stage(
         db_path: Override the geodata.db path (test injection).
         now: Override the "current time" used for ``next_retry_at``
             comparisons AND for the ``claimed_at`` timestamp
-            written into the row. Test injection only.
+            written into the row. **Production code MUST pass
+            ``None`` (or omit the argument) so the persisted
+            ``claimed_at`` reflects the wall-clock time used by
+            :func:`recover_stale_claims_pipeline` to detect stale
+            claims.** Hard-coded values are for test injection only.
 
     Returns:
         A dict snapshot of the claimed row, augmented with two
@@ -812,13 +816,28 @@ def recover_stale_claims_pipeline(
     would be orphaned forever (no ``claimed_at`` timeout, no
     recovery mechanism — exactly the gap PR-D closes per issue #193).
 
-    The reset clears ``claimed_by`` and ``claimed_at`` (returning the
-    row to its pre-claim state) but DELIBERATELY preserves
-    ``attempts`` so a row that has already been attempted N times
-    isn't given a free retry — the next ``claim_next_for_stage``
-    will increment to N+1. ``next_retry_at`` is left untouched so a
-    failure-driven backoff (set by the failed-claim path) still
-    fires correctly.
+    **API note:** unlike ``indexing_queue_service.recover_stale_claims``
+    (positional ``db_path, max_age_seconds``), this function is
+    **keyword-only** to match the ``claim_next_for_stage`` /
+    ``peek_next_for_stage`` / ``ready_count_for_stage`` style of the
+    rest of this module. The reader-API consistency is the priority;
+    callers wiring both helpers into a unified worker should pass
+    arguments by name.
+
+    The reset:
+      * Flips ``status`` from ``'in_progress'`` to ``'pending'``.
+      * Clears ``claimed_by`` and ``claimed_at`` (returning the row
+        to its pre-claim state).
+      * **Preserves** every other field — ``attempts``,
+        ``next_retry_at``, ``last_error``, ``payload_json``,
+        ``priority``, ``enqueued_at``, ``source_path``, ``stage``,
+        ``legacy_id``, ``legacy_table``. ``attempts`` is preserved
+        so a row that has already been attempted N times isn't given
+        a free retry — the next ``claim_next_for_stage`` will
+        increment to N+1. ``next_retry_at`` is preserved so a
+        failure-driven backoff (set by the failed-claim path) still
+        fires correctly. ``last_error`` is preserved as a forensic
+        breadcrumb so operators can see why the claim was retried.
 
     Args:
         db_path: Override the geodata.db path.
@@ -840,6 +859,14 @@ def recover_stale_claims_pipeline(
     conn = None
     try:
         conn = _open_pipeline_conn(db_path)
+        # NOTE: Single-statement UPDATE — relies on sqlite3's implicit
+        # ``BEGIN`` for atomicity, which is functionally equivalent to
+        # ``BEGIN IMMEDIATE`` for a one-shot UPDATE because the write
+        # lock is acquired before any rows are scanned. If this is
+        # ever extended to a SELECT-then-UPDATE pattern (e.g. logging
+        # which row IDs were released), the transaction MUST be
+        # promoted to ``BEGIN IMMEDIATE`` to defend against the same
+        # race that ``claim_next_for_stage`` already handles.
         cur = conn.execute(
             """UPDATE pipeline_queue
                   SET status = 'pending',

--- a/tests/test_pipeline_queue_dualwrite.py
+++ b/tests/test_pipeline_queue_dualwrite.py
@@ -1890,3 +1890,335 @@ class TestReadyCountForStage:
         assert pqs.ready_count_for_stage(
             stage='archive_pending', db_path=missing,
         ) == 0
+
+
+# ============================================================================
+# Wave 4 PR-D ? schema v17 + recover_stale_claims_pipeline (issue #184 / #193)
+# ============================================================================
+# Covers the new `claimed_by` / `claimed_at` column persistence on
+# claim, the new `recover_stale_claims_pipeline()` helper, and the
+# v16 -> v17 migration path.
+
+
+class TestSchemaV17:
+    def test_schema_version_is_v17_or_later(self):
+        assert _SCHEMA_VERSION >= 17
+
+    def test_pipeline_queue_has_claim_columns(self, geodata_db):
+        import sqlite3 as _sql
+        c = _sql.connect(geodata_db)
+        try:
+            cols = {r[1] for r in c.execute(
+                "PRAGMA table_info(pipeline_queue)"
+            ).fetchall()}
+            assert 'claimed_by' in cols
+            assert 'claimed_at' in cols
+        finally:
+            c.close()
+
+    def test_idx_pipeline_stale_claims_exists(self, geodata_db):
+        import sqlite3 as _sql
+        c = _sql.connect(geodata_db)
+        try:
+            indices = {r[0] for r in c.execute(
+                "SELECT name FROM sqlite_master WHERE type='index' "
+                "AND tbl_name='pipeline_queue'"
+            ).fetchall()}
+            assert 'idx_pipeline_stale_claims' in indices
+        finally:
+            c.close()
+
+    def test_v16_to_v17_alter_table_idempotent(self, tmp_path):
+        # Build a v16 DB by hand (no claim columns) and simulate the
+        # _init_db migration path running against it. The schema's
+        # CREATE TABLE IF NOT EXISTS won't re-create the table, so
+        # the only path that adds the columns is the v16->v17
+        # ALTER TABLE block in _init_db.
+        import sqlite3 as _sql
+        db = str(tmp_path / 'v16-style.db')
+        c = _sql.connect(db)
+        try:
+            c.executescript(
+                """
+                CREATE TABLE schema_version (version INTEGER PRIMARY KEY);
+                INSERT INTO schema_version (version) VALUES (16);
+                CREATE TABLE pipeline_queue (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    source_path TEXT NOT NULL,
+                    dest_path TEXT,
+                    stage TEXT NOT NULL,
+                    status TEXT DEFAULT 'pending',
+                    priority INTEGER DEFAULT 5,
+                    attempts INTEGER DEFAULT 0,
+                    last_error TEXT,
+                    next_retry_at REAL,
+                    enqueued_at REAL NOT NULL,
+                    completed_at REAL,
+                    payload_json TEXT,
+                    legacy_id INTEGER,
+                    legacy_table TEXT,
+                    UNIQUE(source_path, stage, legacy_table)
+                );
+                INSERT INTO pipeline_queue
+                    (source_path, stage, enqueued_at)
+                VALUES ('/legacy/v16-row.mp4', 'archive_pending', 100.0);
+                """
+            )
+            c.commit()
+        finally:
+            c.close()
+        # Run the migration.
+        conn = _init_db(db)
+        conn.close()
+        # Verify columns exist and the v16 row survived.
+        c = _sql.connect(db)
+        c.row_factory = _sql.Row
+        try:
+            cols = {r[1] for r in c.execute(
+                "PRAGMA table_info(pipeline_queue)"
+            ).fetchall()}
+            assert 'claimed_by' in cols
+            assert 'claimed_at' in cols
+            row = c.execute(
+                "SELECT claimed_by, claimed_at, source_path FROM pipeline_queue "
+                "WHERE source_path = '/legacy/v16-row.mp4'"
+            ).fetchone()
+            assert row is not None
+            assert row['claimed_by'] is None
+            assert row['claimed_at'] is None
+            v = c.execute("SELECT version FROM schema_version").fetchone()[0]
+            assert v == _SCHEMA_VERSION
+        finally:
+            c.close()
+        # Run _init_db again to verify the v16->v17 path is idempotent
+        # (re-running on an already-v17 DB must not raise).
+        conn2 = _init_db(db)
+        conn2.close()
+
+
+class TestClaimPersistsClaimMetadata:
+    def test_claim_writes_claimed_by_and_claimed_at(self, geodata_db):
+        pqs.dual_write_enqueue(
+            source_path='/x/persist.mp4',
+            stage=pqs.STAGE_ARCHIVE_PENDING,
+            legacy_table=pqs.LEGACY_TABLE_ARCHIVE,
+            db_path=geodata_db,
+        )
+        result = pqs.claim_next_for_stage(
+            stage='archive_pending', claimed_by='persistence-worker',
+            db_path=geodata_db, now=12345.0,
+        )
+        assert result is not None
+        assert result['claimed_by'] == 'persistence-worker'
+        assert result['claimed_at'] == 12345.0
+        # Synthesised back-compat key still set, equal to persisted.
+        assert result['_claimed_by'] == 'persistence-worker'
+        # Verify against DB.
+        import sqlite3 as _sql
+        c = _sql.connect(geodata_db)
+        c.row_factory = _sql.Row
+        try:
+            row = c.execute(
+                "SELECT claimed_by, claimed_at, status FROM pipeline_queue "
+                "WHERE source_path = ?", ('/x/persist.mp4',),
+            ).fetchone()
+            assert row['claimed_by'] == 'persistence-worker'
+            assert row['claimed_at'] == 12345.0
+            assert row['status'] == 'in_progress'
+        finally:
+            c.close()
+
+
+class TestRecoverStaleClaimsPipeline:
+    def _seed_in_progress(self, db, source, claimed_by, claimed_at):
+        # Insert a row directly in the in_progress state ? simulates a
+        # claim from a worker that subsequently crashed.
+        import sqlite3 as _sql
+        c = _sql.connect(db)
+        try:
+            c.execute(
+                """INSERT INTO pipeline_queue
+                       (source_path, stage, status, priority,
+                        enqueued_at, claimed_by, claimed_at, attempts,
+                        legacy_table)
+                   VALUES (?, 'archive_pending', 'in_progress', 2,
+                           100.0, ?, ?, 1, 'archive_queue')""",
+                (source, claimed_by, claimed_at),
+            )
+            c.commit()
+        finally:
+            c.close()
+
+    def test_returns_zero_on_empty(self, geodata_db):
+        assert pqs.recover_stale_claims_pipeline(
+            db_path=geodata_db,
+        ) == 0
+
+    def test_returns_zero_when_db_missing(self, tmp_path):
+        missing = str(tmp_path / 'absent.db')
+        assert pqs.recover_stale_claims_pipeline(
+            db_path=missing,
+        ) == 0
+
+    def test_releases_old_claim(self, geodata_db):
+        self._seed_in_progress(
+            geodata_db, '/x/orphan.mp4', 'crashed-worker',
+            claimed_at=100.0,
+        )
+        # 'now' = 5000, max_age = 1800 -> cutoff = 3200; row's
+        # claimed_at=100 < 3200 -> stale.
+        released = pqs.recover_stale_claims_pipeline(
+            db_path=geodata_db, max_age_seconds=1800.0, now=5000.0,
+        )
+        assert released == 1
+        # Verify row is now pending and claim metadata cleared.
+        import sqlite3 as _sql
+        c = _sql.connect(geodata_db)
+        c.row_factory = _sql.Row
+        try:
+            row = c.execute(
+                "SELECT status, claimed_by, claimed_at, attempts "
+                "FROM pipeline_queue WHERE source_path = ?",
+                ('/x/orphan.mp4',),
+            ).fetchone()
+            assert row['status'] == 'pending'
+            assert row['claimed_by'] is None
+            assert row['claimed_at'] is None
+            # Attempts preserved ? stale recovery doesn't gift retries.
+            assert row['attempts'] == 1
+        finally:
+            c.close()
+
+    def test_does_not_release_recent_claim(self, geodata_db):
+        self._seed_in_progress(
+            geodata_db, '/x/fresh.mp4', 'live-worker',
+            claimed_at=4500.0,
+        )
+        # cutoff = 5000 - 1800 = 3200; claimed_at=4500 > 3200 -> not stale.
+        released = pqs.recover_stale_claims_pipeline(
+            db_path=geodata_db, max_age_seconds=1800.0, now=5000.0,
+        )
+        assert released == 0
+        import sqlite3 as _sql
+        c = _sql.connect(geodata_db)
+        c.row_factory = _sql.Row
+        try:
+            row = c.execute(
+                "SELECT status, claimed_by FROM pipeline_queue "
+                "WHERE source_path = ?", ('/x/fresh.mp4',),
+            ).fetchone()
+            assert row['status'] == 'in_progress'
+            assert row['claimed_by'] == 'live-worker'
+        finally:
+            c.close()
+
+    def test_does_not_touch_pending_or_done_rows(self, geodata_db):
+        # Build one row in each status; only the in_progress one with
+        # an old claim should be touched.
+        pqs.dual_write_enqueue(
+            source_path='/x/pending.mp4',
+            stage=pqs.STAGE_ARCHIVE_PENDING,
+            legacy_table=pqs.LEGACY_TABLE_ARCHIVE,
+            db_path=geodata_db,
+        )
+        pqs.dual_write_enqueue(
+            source_path='/x/done.mp4',
+            stage=pqs.STAGE_ARCHIVE_DONE,
+            legacy_table=pqs.LEGACY_TABLE_ARCHIVE,
+            status='done',
+            db_path=geodata_db,
+        )
+        self._seed_in_progress(
+            geodata_db, '/x/stale.mp4', 'gone', claimed_at=1.0,
+        )
+        released = pqs.recover_stale_claims_pipeline(
+            db_path=geodata_db, max_age_seconds=10.0, now=10000.0,
+        )
+        assert released == 1
+        import sqlite3 as _sql
+        c = _sql.connect(geodata_db)
+        c.row_factory = _sql.Row
+        try:
+            statuses = {
+                r['source_path']: r['status']
+                for r in c.execute(
+                    "SELECT source_path, status FROM pipeline_queue"
+                ).fetchall()
+            }
+            assert statuses['/x/pending.mp4'] == 'pending'
+            assert statuses['/x/done.mp4'] == 'done'
+            assert statuses['/x/stale.mp4'] == 'pending'  # was in_progress
+        finally:
+            c.close()
+
+    def test_recovered_row_picked_by_next_claim(self, geodata_db):
+        # End-to-end: seed an orphan, recover it, claim_next_for_stage
+        # should return it (and bump attempts to 2).
+        self._seed_in_progress(
+            geodata_db, '/x/recycle.mp4', 'crashed', claimed_at=1.0,
+        )
+        released = pqs.recover_stale_claims_pipeline(
+            db_path=geodata_db, max_age_seconds=10.0, now=10000.0,
+        )
+        assert released == 1
+        claimed = pqs.claim_next_for_stage(
+            stage='archive_pending', claimed_by='retry-worker',
+            db_path=geodata_db, now=10001.0,
+        )
+        assert claimed is not None
+        assert claimed['source_path'] == '/x/recycle.mp4'
+        assert claimed['attempts'] == 2  # was 1, recovered, then bumped
+        assert claimed['claimed_by'] == 'retry-worker'
+        assert claimed['claimed_at'] == 10001.0
+
+    def test_releases_multiple_stale_in_one_call(self, geodata_db):
+        for i in range(5):
+            self._seed_in_progress(
+                geodata_db, f'/x/orphan-{i}.mp4', f'crashed-{i}',
+                claimed_at=float(i),
+            )
+        released = pqs.recover_stale_claims_pipeline(
+            db_path=geodata_db, max_age_seconds=1.0, now=10.0,
+        )
+        assert released == 5
+
+    def test_preserves_next_retry_at(self, geodata_db):
+        # A row with a backoff timer set must keep its next_retry_at
+        # ? recovery resets the claim, not the failure-driven
+        # backoff state.
+        self._seed_in_progress(
+            geodata_db, '/x/backoff.mp4', 'gone', claimed_at=1.0,
+        )
+        import sqlite3 as _sql
+        c = _sql.connect(geodata_db)
+        try:
+            c.execute(
+                "UPDATE pipeline_queue SET next_retry_at = 99999.0 "
+                "WHERE source_path = ?", ('/x/backoff.mp4',),
+            )
+            c.commit()
+        finally:
+            c.close()
+        pqs.recover_stale_claims_pipeline(
+            db_path=geodata_db, max_age_seconds=10.0, now=10000.0,
+        )
+        c = _sql.connect(geodata_db)
+        c.row_factory = _sql.Row
+        try:
+            row = c.execute(
+                "SELECT status, claimed_by, next_retry_at "
+                "FROM pipeline_queue WHERE source_path = ?",
+                ('/x/backoff.mp4',),
+            ).fetchone()
+            assert row['status'] == 'pending'
+            assert row['claimed_by'] is None
+            assert row['next_retry_at'] == 99999.0
+        finally:
+            c.close()
+
+    def test_returns_zero_when_db_corrupt(self, tmp_path):
+        bad = tmp_path / 'corrupt.db'
+        bad.write_bytes(b'not a sqlite db at all\x00')
+        assert pqs.recover_stale_claims_pipeline(
+            db_path=str(bad),
+        ) == 0

--- a/tests/test_pipeline_queue_dualwrite.py
+++ b/tests/test_pipeline_queue_dualwrite.py
@@ -1917,14 +1917,32 @@ class TestSchemaV17:
             c.close()
 
     def test_idx_pipeline_stale_claims_exists(self, geodata_db):
+        # Findings #8: assert not just the index name but also that
+        # the partial WHERE clause is intact. A future change that
+        # drops "WHERE status='in_progress' AND claimed_at IS NOT NULL"
+        # (turning it into a full index) would silently pass a
+        # name-only check — and a full index defeats the
+        # "stay small even on a queue with thousands of done rows"
+        # optimisation that justifies the column.
         import sqlite3 as _sql
         c = _sql.connect(geodata_db)
         try:
-            indices = {r[0] for r in c.execute(
-                "SELECT name FROM sqlite_master WHERE type='index' "
-                "AND tbl_name='pipeline_queue'"
-            ).fetchall()}
-            assert 'idx_pipeline_stale_claims' in indices
+            row = c.execute(
+                "SELECT name, sql FROM sqlite_master "
+                "WHERE type='index' AND name='idx_pipeline_stale_claims'"
+            ).fetchone()
+            assert row is not None, \
+                "idx_pipeline_stale_claims missing"
+            sql = row[1] or ''
+            # SQLite normalises CREATE INDEX SQL but preserves the
+            # column references and the WHERE clause body.
+            assert 'claimed_at' in sql, \
+                f"index missing claimed_at column: {sql!r}"
+            assert "status='in_progress'" in sql.replace(' ', '') \
+                or "status = 'in_progress'" in sql, \
+                f"index missing partial WHERE on status: {sql!r}"
+            assert 'claimed_at IS NOT NULL' in sql.replace('  ', ' '), \
+                f"index missing claimed_at IS NOT NULL: {sql!r}"
         finally:
             c.close()
 
@@ -1994,6 +2012,31 @@ class TestSchemaV17:
         # (re-running on an already-v17 DB must not raise).
         conn2 = _init_db(db)
         conn2.close()
+        # Findings #9: post-assertion that the second migration didn't
+        # reset anything — schema_version should still be _SCHEMA_VERSION,
+        # the v16 row's claim metadata should still be NULL, and the
+        # columns should still be present.
+        c = _sql.connect(db)
+        c.row_factory = _sql.Row
+        try:
+            v = c.execute("SELECT version FROM schema_version").fetchone()[0]
+            assert v == _SCHEMA_VERSION, \
+                f"second _init_db reset schema_version to {v}"
+            cols = {r[1] for r in c.execute(
+                "PRAGMA table_info(pipeline_queue)"
+            ).fetchall()}
+            assert 'claimed_by' in cols
+            assert 'claimed_at' in cols
+            row = c.execute(
+                "SELECT claimed_by, claimed_at FROM pipeline_queue "
+                "WHERE source_path = '/legacy/v16-row.mp4'"
+            ).fetchone()
+            assert row is not None, \
+                "second _init_db lost the v16 row"
+            assert row['claimed_by'] is None
+            assert row['claimed_at'] is None
+        finally:
+            c.close()
 
 
 class TestClaimPersistsClaimMetadata:


### PR DESCRIPTION
## Wave 4 PR-D — pipeline_queue claim persistence + stale-recovery

**Closes #193 — prerequisite for worker reader-switch (PR-E)**
**Ref #184 (Wave 4 PR-D)**

### What this PR does

Schema **v17** for `geodata.db` adds the bookkeeping the unified
worker needs to detect crashed claimers, plus the public API to
recycle their rows back to `pending`. NO production code is
wired to read from `pipeline_queue` yet — PR-E does that with a
feature flag.

### Changes

#### `scripts/web/services/mapping_migrations.py`

- `_SCHEMA_VERSION = 17` (was 16).
- `pipeline_queue` schema gains `claimed_by TEXT` and
  `claimed_at REAL` columns plus the
  `idx_pipeline_stale_claims` partial index
  (`WHERE status='in_progress' AND claimed_at IS NOT NULL`).
- v16→v17 migration runs an **ALTER TABLE pre-script** *before*
  `executescript(_SCHEMA_SQL)` because the schema's
  `CREATE INDEX IF NOT EXISTS idx_pipeline_stale_claims` would
  otherwise raise `no such column: claimed_at` on a legacy v16
  table that doesn't have the column yet. Adding the columns
  first keeps the index creation safe. Fresh installs are
  unaffected (the table is created with the v17 columns).
- The post-script v17 block is now log-only; the pre-script does
  all the structural work. Documented inline.

#### `scripts/web/services/pipeline_queue_service.py`

- New constant `_PIPELINE_STALE_CLAIM_SECONDS = 1800.0` (30 min,
  matches `indexing_queue_service`).
- `claim_next_for_stage` now persists `claimed_by` and
  `claimed_at` (epoch seconds = `now`) inside the same
  `UPDATE` that sets `status='in_progress'` and bumps
  `attempts`. Single round-trip, atomic under
  `BEGIN IMMEDIATE`. The returned dict surfaces
  `row['claimed_by']` and `row['claimed_at']` as top-level
  keys; `_claimed_by` is preserved equal to the persisted value
  for back-compat with PR-C callers.
- New `recover_stale_claims_pipeline(db_path, max_age_seconds,
  now)` mirrors `indexing_queue_service.recover_stale_claims`.
  Releases `in_progress` rows whose `claimed_at < now -
  max_age_seconds` back to `pending`; clears
  `claimed_by` / `claimed_at`; **preserves** `attempts`
  (no free retry) and `next_retry_at` (failure backoff still
  fires).
- Module docstring's Public API section updated.
- `claim_next_for_stage` docstring updated — the previous text
  said the `claimed_by` column wasn't written to the DB; that's
  now wrong.

#### `tests/test_pipeline_queue_dualwrite.py` (+ 14 tests, total 96)

- `TestSchemaV17` (3): schema version is ≥ 17, columns exist,
  index exists, v16→v17 ALTER TABLE works on a hand-built v16 DB
  and is idempotent on re-run.
- `TestClaimPersistsClaimMetadata` (1): `claim_next_for_stage`
  writes `claimed_by` + `claimed_at` to the DB row (verified
  via direct `SELECT`), not just into the returned dict.
- `TestRecoverStaleClaimsPipeline` (10): empty DB → 0; missing
  DB → 0; corrupt DB → 0 (errors swallowed); old claim released;
  recent claim preserved; `pending`/`done` rows untouched;
  recovered row picked by next claim with attempts bumped to 2;
  multiple stale rows released in one call; preserves
  `next_retry_at`.

### Verification

- `python -m pytest tests/test_pipeline_queue_dualwrite.py -x`
  → 96 pass.
- `python -m pytest tests/ -q` → **1732 pass / 4 skip**.
- `python -m py_compile scripts/web/services/pipeline_queue_service.py
  scripts/web/services/mapping_migrations.py` → OK.
- `python -c "from web_control import app"` → OK.

### Risk

Pure additive change. No production code path reads from the new
columns yet. The migration is O(1) (`ALTER TABLE ADD COLUMN`
with no default — no full table rewrite). Both columns nullable.
Existing v16 rows are unaffected.

### Next sub-PRs (after this lands)

- **PR-E**: Switch `archive_worker` to use
  `claim_next_for_stage` (with feature flag). Wire
  `recover_stale_claims_pipeline()` into worker startup.
- **PR-F**: Delete `live_event_sync_service.py` entirely.
  Real-time event uploads become priority=0 rows in
  `pipeline_queue`. Add batched-rclone subprocess (Phase J).
  Remove `has_ready_live_event_work()` poll (Phase K).
  **Closes #184.**
