### PR TITLE
refactor: shadow pipeline_queue reads + recovery wiring + telemetry (Wave 4 PR-E)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -276,3 +276,14 @@ archive_queue:
   # editing this file by SSH.
   stable_write_age_seconds: 5.0          # Re-queue clips whose mtime is fresher than this many seconds (avoids copying mid-write)
   stale_claim_max_age_seconds: 600.0     # Reset 'claimed' rows older than this back to 'pending' on worker startup (recovers crashed/OOMed claims)
+  # Wave 4 PR-E (issue #184): shadow-mode validation of the unified
+  # ``pipeline_queue``. When enabled, the archive worker peeks at
+  # ``pipeline_queue`` immediately before each ``archive_queue`` claim
+  # and logs a WARNING if the two readers disagree on which row is
+  # next. Pure observability — no behavioural change. Used to verify
+  # the dual-write produces correct ordering against real production
+  # traffic before PR-F cuts over the actual reader. Disable to
+  # silence the (cheap) extra peek; default ``true`` so we get
+  # production validation data while it's still cheap to fix
+  # mismatches.
+  shadow_pipeline_queue: true

--- a/scripts/web/config.py
+++ b/scripts/web/config.py
@@ -257,6 +257,13 @@ ARCHIVE_QUEUE_STABLE_WRITE_AGE_SECONDS = float(
 ARCHIVE_QUEUE_STALE_CLAIM_MAX_AGE_SECONDS = float(
     _archive_queue.get('stale_claim_max_age_seconds', 600.0)
 )
+# Wave 4 PR-E (issue #184): shadow-mode validation of pipeline_queue.
+# When True, the archive worker peeks at pipeline_queue before each
+# archive_queue claim and logs WARNING on disagreement. Pure
+# observability — no behavioural change.
+ARCHIVE_QUEUE_SHADOW_PIPELINE_QUEUE = bool(
+    _archive_queue.get('shadow_pipeline_queue', True)
+)
 
 # ============================================================================
 # ADVANCED SETTINGS - Computed values (don't modify these)

--- a/scripts/web/services/archive_worker.py
+++ b/scripts/web/services/archive_worker.py
@@ -1873,9 +1873,27 @@ def process_one_claim(row: Dict[str, Any], db_path: str,
 
 # Throttle for "agreement" log lines so a healthy queue doesn't
 # flood the journal — log every Nth match at INFO so operators can
-# see the shadow path is still firing, while disagreements always
-# log at WARNING with both paths.
+# see the shadow path is still firing, while disagreements log at
+# WARNING with both paths but are also rate-limited so a degenerate
+# dual-write state (e.g. catch-up of a 1000+ clip backlog) cannot
+# emit one WARNING per worker iteration. The first
+# ``_SHADOW_DISAGREEMENT_LOG_VERBATIM`` mismatches log verbatim;
+# after that we drop to one heartbeat WARNING per
+# ``_SHADOW_DISAGREEMENT_LOG_EVERY`` mismatches with the running
+# count so journal hygiene is preserved.
 _SHADOW_AGREEMENT_LOG_EVERY = 500
+_SHADOW_DISAGREEMENT_LOG_VERBATIM = 10
+_SHADOW_DISAGREEMENT_LOG_EVERY = 100
+# Number of pipeline_queue candidates we peek at when comparing
+# against the legacy reader's pick. The legacy reader orders by
+# ``priority, expected_mtime, id`` while pipeline_queue orders by
+# ``priority, enqueued_at, id`` — a documented and accepted
+# divergence (see ``pipeline_queue_service.claim_next_for_stage``
+# docstring). Treating the legacy pick as "agreed" iff it appears
+# anywhere in the pipeline_queue's top-N candidates absorbs that
+# benign reordering and only flags a real dual-write gap (legacy
+# picked a path the pipeline doesn't even know about).
+_SHADOW_PEEK_CANDIDATE_COUNT = 8
 
 _shadow_lock = threading.Lock()
 _shadow_agreement_count = 0
@@ -1897,19 +1915,52 @@ def _shadow_pipeline_queue_enabled() -> bool:
         return False
 
 
-def _shadow_compare_picks(*, legacy_path: Optional[str],
-                          pipeline_path: Optional[str]) -> None:
-    """Compare the legacy and pipeline_queue picks; log on mismatch.
+def _shadow_compare_picks(
+    *,
+    legacy_path: Optional[str],
+    pipeline_candidates: Tuple[str, ...] = (),
+) -> None:
+    """Compare the legacy pick against the pipeline_queue top-N.
 
-    Both ``None`` ⇒ both readers say "queue empty" — no log.
-    Both equal ⇒ readers agree — bump the agreement counter and log
-    every ``_SHADOW_AGREEMENT_LOG_EVERY`` matches at INFO.
-    Disagreement ⇒ log WARNING with both paths and bump the
-    disagreement counter. The counters are read by tests and (in a
-    later PR) surfaced in the status endpoint.
+    The legacy ``archive_queue`` reader orders by
+    ``priority, expected_mtime, id``; ``pipeline_queue`` orders by
+    ``priority, enqueued_at, id`` (see
+    ``pipeline_queue_service.claim_next_for_stage`` docstring). The
+    secondary-key divergence is documented and accepted — comparing
+    only the top-1 of each reader would systematically WARN on
+    benign reorderings (e.g. boot catch-up enqueues a batch in
+    directory-walk order while Tesla wrote them in mtime order).
+
+    To avoid that noise we treat the legacy pick as **agreed** iff
+    it appears anywhere in ``pipeline_candidates`` (top-N pipeline
+    rows for the same stage). Only when the legacy pick is **absent**
+    from the top-N does the WARNING fire — that's a real dual-write
+    gap (a row exists in archive_queue but not, or far down, in
+    pipeline_queue) worth investigating before PR-F cuts over the
+    reader.
+
+    Empty queue case: both ``legacy_path`` is ``None`` AND
+    ``pipeline_candidates`` is empty ⇒ both readers say "queue
+    empty" ⇒ counted as agreement, no log.
+
+    Disagreement logging is rate-limited: the first
+    ``_SHADOW_DISAGREEMENT_LOG_VERBATIM`` mismatches log verbatim
+    with both paths; after that one heartbeat WARNING per
+    ``_SHADOW_DISAGREEMENT_LOG_EVERY`` mismatches surfaces the
+    running count so journal hygiene is preserved on Pi Zero 2 W
+    even during a degenerate catch-up.
     """
     global _shadow_agreement_count, _shadow_disagreement_count
-    if legacy_path == pipeline_path:
+    candidate_set = (
+        frozenset(p for p in pipeline_candidates if p)
+        if pipeline_candidates else frozenset()
+    )
+    if legacy_path is None:
+        # Legacy says "no work". Agreement iff pipeline_queue also
+        # has nothing ready. If pipeline_queue has rows but legacy
+        # doesn't, treat as a (benign) ordering case rather than a
+        # gap — there's no legacy pick to mismatch against, and the
+        # row will surface on the next iteration.
         with _shadow_lock:
             _shadow_agreement_count += 1
             count = _shadow_agreement_count
@@ -1920,15 +1971,45 @@ def _shadow_compare_picks(*, legacy_path: Optional[str],
                 count,
             )
         return
+    if legacy_path in candidate_set:
+        with _shadow_lock:
+            _shadow_agreement_count += 1
+            count = _shadow_agreement_count
+        if count % _SHADOW_AGREEMENT_LOG_EVERY == 0:
+            logger.info(
+                "Wave 4 PR-E shadow: pipeline_queue agreed with "
+                "archive_queue on %d consecutive picks "
+                "(top-%d window)",
+                count, _SHADOW_PEEK_CANDIDATE_COUNT,
+            )
+        return
     with _shadow_lock:
         _shadow_disagreement_count += 1
-    logger.warning(
-        "Wave 4 PR-E shadow: pipeline_queue and archive_queue "
-        "disagreed on next pick — legacy=%r pipeline=%r "
-        "(disagreement #%d). This indicates a dual-write gap; "
-        "investigate before PR-F cuts over the reader.",
-        legacy_path, pipeline_path, _shadow_disagreement_count,
-    )
+        d_count = _shadow_disagreement_count
+    if d_count <= _SHADOW_DISAGREEMENT_LOG_VERBATIM:
+        logger.warning(
+            "Wave 4 PR-E shadow: archive_queue picked %r but it is "
+            "absent from the top-%d pipeline_queue candidates "
+            "(disagreement #%d). pipeline top-%d=%r. The legacy "
+            "and pipeline readers use different secondary sort "
+            "keys (expected_mtime vs. enqueued_at) so small "
+            "reorderings within a priority band are expected — a "
+            "miss from the top-N window indicates a real "
+            "dual-write gap. Investigate before PR-F cuts over "
+            "the reader.",
+            legacy_path, _SHADOW_PEEK_CANDIDATE_COUNT, d_count,
+            _SHADOW_PEEK_CANDIDATE_COUNT,
+            tuple(pipeline_candidates),
+        )
+    elif d_count % _SHADOW_DISAGREEMENT_LOG_EVERY == 0:
+        logger.warning(
+            "Wave 4 PR-E shadow: archive_queue / pipeline_queue "
+            "disagreement count = %d (suppressing per-event "
+            "WARNINGs after the first %d; first %d are above). "
+            "Last legacy pick: %r.",
+            d_count, _SHADOW_DISAGREEMENT_LOG_VERBATIM,
+            _SHADOW_DISAGREEMENT_LOG_VERBATIM, legacy_path,
+        )
 
 
 def get_shadow_telemetry() -> Dict[str, int]:
@@ -2135,21 +2216,28 @@ def _run_worker_loop(db_path: str, archive_root: str,
             # legacy claim because the dual-write fires on UPDATE,
             # which would move the pipeline_queue row to in_progress
             # and invalidate the comparison.
-            shadow_peek_path: Optional[str] = None
+            #
+            # We peek the top-N (not just top-1) so the documented
+            # secondary-key divergence between archive_queue
+            # (expected_mtime) and pipeline_queue (enqueued_at)
+            # doesn't generate noisy WARNINGs on benign reorderings
+            # within a priority band — see ``_shadow_compare_picks``
+            # docstring for the rationale.
+            shadow_candidates: Tuple[str, ...] = ()
             if _shadow_pipeline_queue_enabled():
                 try:
                     from services import pipeline_queue_service as pqs
-                    peeked = pqs.peek_next_for_stage(
+                    shadow_candidates = pqs.peek_top_n_paths_for_stage(
                         stage='archive_pending',
+                        limit=_SHADOW_PEEK_CANDIDATE_COUNT,
                     )
-                    if peeked is not None:
-                        shadow_peek_path = peeked.get('source_path')
                 except Exception as e:  # noqa: BLE001
                     # Shadow path must NEVER affect the worker. Log
                     # at DEBUG so a misconfigured DB path doesn't
                     # spam WARNING on every iteration.
                     logger.debug(
-                        "shadow peek_next_for_stage failed: %s", e,
+                        "shadow peek_top_n_paths_for_stage failed: "
+                        "%s", e,
                     )
 
             try:
@@ -2165,14 +2253,16 @@ def _run_worker_loop(db_path: str, archive_root: str,
             if row is None and not claim_failed:
                 _set_state(last_drained_at=time.time())
 
-            # Wave 4 PR-E: compare the two readers' picks. If they
-            # disagree, log WARNING with both paths so dual-write
-            # gaps surface in journalctl. If both are None or both
-            # match, no log (steady-state silence).
-            if shadow_peek_path is not None or row is not None:
+            # Wave 4 PR-E: compare the legacy pick against the
+            # pipeline_queue top-N. Agreement = legacy_path appears
+            # in the candidate set (or both empty). Disagreement =
+            # legacy picked a path absent from the top-N — a real
+            # dual-write gap.
+            if shadow_candidates or row is not None or \
+                    _shadow_pipeline_queue_enabled():
                 _shadow_compare_picks(
                     legacy_path=row.get('source_path') if row else None,
-                    pipeline_path=shadow_peek_path,
+                    pipeline_candidates=shadow_candidates,
                 )
 
             if row is not None:

--- a/scripts/web/services/archive_worker.py
+++ b/scripts/web/services/archive_worker.py
@@ -1860,6 +1860,92 @@ def process_one_claim(row: Dict[str, Any], db_path: str,
 
 
 # ---------------------------------------------------------------------------
+# Wave 4 PR-E (issue #184): pipeline_queue shadow comparison
+# ---------------------------------------------------------------------------
+# Pure observability — peek at what the unified ``pipeline_queue``
+# reader would pick BEFORE each legacy ``archive_queue`` claim, log
+# WARNING when they disagree. Validates the dual-write end-to-end
+# against real production traffic so we can confirm the unified
+# reader is safe to switch on (PR-F) before flipping the cutover.
+# Counters live at module scope (process-local, reset on restart) so
+# operators can read totals via the upcoming status endpoint without
+# grepping the journal for every line.
+
+# Throttle for "agreement" log lines so a healthy queue doesn't
+# flood the journal — log every Nth match at INFO so operators can
+# see the shadow path is still firing, while disagreements always
+# log at WARNING with both paths.
+_SHADOW_AGREEMENT_LOG_EVERY = 500
+
+_shadow_lock = threading.Lock()
+_shadow_agreement_count = 0
+_shadow_disagreement_count = 0
+
+
+def _shadow_pipeline_queue_enabled() -> bool:
+    """Return True iff the operator has the shadow-mode flag on.
+
+    Wrapped in a function so a config reload (or test override) is
+    picked up on the next worker iteration without restarting the
+    thread. Lazy import so the worker module can still be imported
+    in test contexts where ``config`` isn't bootstrapped.
+    """
+    try:
+        from config import ARCHIVE_QUEUE_SHADOW_PIPELINE_QUEUE
+        return bool(ARCHIVE_QUEUE_SHADOW_PIPELINE_QUEUE)
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _shadow_compare_picks(*, legacy_path: Optional[str],
+                          pipeline_path: Optional[str]) -> None:
+    """Compare the legacy and pipeline_queue picks; log on mismatch.
+
+    Both ``None`` ⇒ both readers say "queue empty" — no log.
+    Both equal ⇒ readers agree — bump the agreement counter and log
+    every ``_SHADOW_AGREEMENT_LOG_EVERY`` matches at INFO.
+    Disagreement ⇒ log WARNING with both paths and bump the
+    disagreement counter. The counters are read by tests and (in a
+    later PR) surfaced in the status endpoint.
+    """
+    global _shadow_agreement_count, _shadow_disagreement_count
+    if legacy_path == pipeline_path:
+        with _shadow_lock:
+            _shadow_agreement_count += 1
+            count = _shadow_agreement_count
+        if count % _SHADOW_AGREEMENT_LOG_EVERY == 0:
+            logger.info(
+                "Wave 4 PR-E shadow: pipeline_queue agreed with "
+                "archive_queue on %d consecutive picks",
+                count,
+            )
+        return
+    with _shadow_lock:
+        _shadow_disagreement_count += 1
+    logger.warning(
+        "Wave 4 PR-E shadow: pipeline_queue and archive_queue "
+        "disagreed on next pick — legacy=%r pipeline=%r "
+        "(disagreement #%d). This indicates a dual-write gap; "
+        "investigate before PR-F cuts over the reader.",
+        legacy_path, pipeline_path, _shadow_disagreement_count,
+    )
+
+
+def get_shadow_telemetry() -> Dict[str, int]:
+    """Return the in-memory shadow comparison counters as a snapshot.
+
+    Process-local, reset on restart. Used by tests and by the
+    Settings page to confirm the shadow mode is firing in
+    production.
+    """
+    with _shadow_lock:
+        return {
+            'shadow_agreement_count': _shadow_agreement_count,
+            'shadow_disagreement_count': _shadow_disagreement_count,
+        }
+
+
+# ---------------------------------------------------------------------------
 # Worker thread loop
 # ---------------------------------------------------------------------------
 
@@ -1892,6 +1978,25 @@ def _run_worker_loop(db_path: str, archive_root: str,
             )
     except Exception as e:  # noqa: BLE001
         logger.warning("recover_stale_claims failed at startup: %s", e)
+
+    # Wave 4 PR-E (issue #184 / #193): also recover stale claims in
+    # the unified ``pipeline_queue``. Idempotent — returns 0 when
+    # nothing to do (the common case during the dual-write window
+    # because the pipeline_queue claim path isn't wired in production
+    # yet). NEVER raises. Decoupled from the legacy recovery above so
+    # one failing doesn't suppress the other.
+    try:
+        from services import pipeline_queue_service as pqs
+        pq_released = pqs.recover_stale_claims_pipeline()
+        if pq_released:
+            logger.info(
+                "Archive worker %s released %d stale pipeline_queue claims at startup",
+                worker_id, pq_released,
+            )
+    except Exception as e:  # noqa: BLE001
+        logger.warning(
+            "recover_stale_claims_pipeline failed at startup: %s", e,
+        )
 
     # Sweep .partial orphans left behind by a prior crash. Runs once
     # at worker startup, before the loop begins claiming rows; safe
@@ -2022,6 +2127,31 @@ def _run_worker_loop(db_path: str, archive_root: str,
         new_status: Optional[str] = None
         claim_failed = False
         try:
+            # Wave 4 PR-E (issue #184): shadow-mode peek at
+            # ``pipeline_queue`` BEFORE the legacy claim so we can
+            # compare the two readers' picks against the same queue
+            # state. Pure observability — the result drives a log
+            # line only; no behavioural change. Done before the
+            # legacy claim because the dual-write fires on UPDATE,
+            # which would move the pipeline_queue row to in_progress
+            # and invalidate the comparison.
+            shadow_peek_path: Optional[str] = None
+            if _shadow_pipeline_queue_enabled():
+                try:
+                    from services import pipeline_queue_service as pqs
+                    peeked = pqs.peek_next_for_stage(
+                        stage='archive_pending',
+                    )
+                    if peeked is not None:
+                        shadow_peek_path = peeked.get('source_path')
+                except Exception as e:  # noqa: BLE001
+                    # Shadow path must NEVER affect the worker. Log
+                    # at DEBUG so a misconfigured DB path doesn't
+                    # spam WARNING on every iteration.
+                    logger.debug(
+                        "shadow peek_next_for_stage failed: %s", e,
+                    )
+
             try:
                 row = archive_queue.claim_next_for_worker(
                     worker_id, db_path=db_path,
@@ -2034,6 +2164,16 @@ def _run_worker_loop(db_path: str, archive_root: str,
 
             if row is None and not claim_failed:
                 _set_state(last_drained_at=time.time())
+
+            # Wave 4 PR-E: compare the two readers' picks. If they
+            # disagree, log WARNING with both paths so dual-write
+            # gaps surface in journalctl. If both are None or both
+            # match, no log (steady-state silence).
+            if shadow_peek_path is not None or row is not None:
+                _shadow_compare_picks(
+                    legacy_path=row.get('source_path') if row else None,
+                    pipeline_path=shadow_peek_path,
+                )
 
             if row is not None:
                 # If pause arrived between claim and process, release

--- a/scripts/web/services/pipeline_queue_service.py
+++ b/scripts/web/services/pipeline_queue_service.py
@@ -51,8 +51,13 @@ Public API:
 * :func:`recover_stale_claims_pipeline` — Wave 4 PR-D; release
   ``in_progress`` rows whose claimer crashed (claimed_at older
   than threshold). Called once at worker startup.
+* :func:`get_recovery_telemetry` — Wave 4 PR-E (#195); read the
+  in-memory stale-recovery counters (total recovered, last call
+  timestamp, last call count, total call count). Reset on
+  ``gadget_web`` restart.
 * :func:`pipeline_status` — debug / verification view (counts grouped
-  by legacy_table + stage + status).
+  by legacy_table + stage + status), augmented with the
+  ``get_recovery_telemetry`` counters.
 * :func:`backfill_legacy_queues` — one-time migration helper.
 """
 
@@ -62,6 +67,7 @@ import json
 import logging
 import os
 import sqlite3
+import threading
 import time
 from datetime import datetime, timezone
 from typing import Any, Dict, Iterable, List, Optional, Tuple
@@ -111,6 +117,21 @@ PRIORITY_INDEXING = 5            # default indexing
 # task_coordinator may pause on high loadavg) but short enough that
 # a real crash is detected within the same boot cycle.
 _PIPELINE_STALE_CLAIM_SECONDS = 1800.0
+
+
+# Wave 4 PR-E (issue #195): stale-recovery telemetry counters.
+# Process-local (no DB write), reset on gadget_web restart. Surfaced
+# via :func:`pipeline_status` so operators can spot a flapping crash
+# loop that releases the same rows over and over (which would
+# otherwise only show up as repeated WARNING lines in the journal).
+# A monotonic counter, the timestamp of the last non-zero recovery
+# call, and the count from that call are all the operator needs to
+# answer "is recovery healthy or pathological?".
+_recover_stale_claims_lock = threading.Lock()
+_recover_stale_claims_total = 0
+_recover_stale_claims_last_at: Optional[float] = None
+_recover_stale_claims_last_count = 0
+_recover_stale_claims_call_count = 0  # incl. zero-result calls
 
 
 # ---------------------------------------------------------------------------
@@ -884,6 +905,23 @@ def recover_stale_claims_pipeline(
                 "Released %d stale pipeline_queue claim(s) (>%ds old)",
                 released, int(max_age_seconds),
             )
+        # Wave 4 PR-E (issue #195): bump telemetry counters under
+        # lock so concurrent recovery calls (only ever one, but
+        # defensive for future workers) don't race on the read-modify-
+        # write of the running totals. Always bumped — the call_count
+        # / last_at pair tells operators "recovery is being called
+        # but finds nothing" vs. "recovery is repeatedly releasing
+        # rows", which is the actual diagnostic question.
+        global _recover_stale_claims_total
+        global _recover_stale_claims_last_at
+        global _recover_stale_claims_last_count
+        global _recover_stale_claims_call_count
+        with _recover_stale_claims_lock:
+            _recover_stale_claims_call_count += 1
+            if released > 0:
+                _recover_stale_claims_total += released
+                _recover_stale_claims_last_at = now
+                _recover_stale_claims_last_count = released
         return released
     except sqlite3.Error as e:
         logger.warning("recover_stale_claims_pipeline failed: %s", e)
@@ -894,6 +932,36 @@ def recover_stale_claims_pipeline(
                 conn.close()
             except sqlite3.Error:
                 pass
+
+
+def get_recovery_telemetry() -> Dict[str, Any]:
+    """Return the in-memory stale-recovery counters as a snapshot dict.
+
+    Process-local counters reset on ``gadget_web`` restart. Used by
+    :func:`pipeline_status` so the Settings page / status endpoint
+    can show "recovery is healthy" vs. "recovery is repeatedly
+    releasing rows" — the latter is a strong signal that a worker is
+    crash-looping. Per follow-up issue #195.
+
+    Keys:
+      * ``stale_recoveries_total``: monotonic count of rows recovered
+        since process start.
+      * ``stale_recoveries_last_at``: epoch seconds of the last
+        non-zero recovery call (``None`` if never).
+      * ``stale_recoveries_last_count``: count from the last
+        non-zero recovery call (0 if never).
+      * ``stale_recoveries_call_count``: total recovery calls made
+        (including zero-result calls). High call_count + zero total
+        = "called but found nothing", which is the healthy steady
+        state.
+    """
+    with _recover_stale_claims_lock:
+        return {
+            'stale_recoveries_total': _recover_stale_claims_total,
+            'stale_recoveries_last_at': _recover_stale_claims_last_at,
+            'stale_recoveries_last_count': _recover_stale_claims_last_count,
+            'stale_recoveries_call_count': _recover_stale_claims_call_count,
+        }
 
 
 def pipeline_status(db_path: Optional[str] = None) -> Dict[str, Any]:
@@ -916,7 +984,7 @@ def pipeline_status(db_path: Optional[str] = None) -> Dict[str, Any]:
                GROUP BY legacy_table, stage, status
                ORDER BY legacy_table, stage, status"""
         ).fetchall()
-        return {
+        result: Dict[str, Any] = {
             'total': sum(r['n'] for r in rows),
             'by_legacy_stage_status': [
                 {
@@ -928,6 +996,11 @@ def pipeline_status(db_path: Optional[str] = None) -> Dict[str, Any]:
                 for r in rows
             ],
         }
+        # Wave 4 PR-E (issue #195): merge in the in-memory
+        # stale-recovery counters so a single endpoint payload
+        # answers "is the queue OK and is the recovery healthy?"
+        result.update(get_recovery_telemetry())
+        return result
     except sqlite3.Error as e:
         logger.warning("pipeline_status failed: %s", e)
         return {}

--- a/scripts/web/services/pipeline_queue_service.py
+++ b/scripts/web/services/pipeline_queue_service.py
@@ -46,6 +46,12 @@ Public API:
   workers wire to this in PR-D.
 * :func:`peek_next_for_stage` — Wave 4 PR-C; non-mutating "what's
   next" lookup (parity tests + Settings page).
+* :func:`peek_top_n_paths_for_stage` — Wave 4 PR-E; non-mutating
+  list of the next N candidate ``source_path`` values in pick order.
+  Used by the archive worker's shadow-mode comparison to tolerate
+  the documented secondary-sort divergence (``enqueued_at`` vs
+  legacy ``expected_mtime``) — a legacy pick is treated as "agreed"
+  if it appears anywhere in the pipeline_queue's top-N candidates.
 * :func:`ready_count_for_stage` — Wave 4 PR-C; cheap COUNT(*) of
   eligible rows for a stage.
 * :func:`recover_stale_claims_pipeline` — Wave 4 PR-D; release
@@ -821,6 +827,90 @@ def ready_count_for_stage(
                 pass
 
 
+def peek_top_n_paths_for_stage(
+    *,
+    stage: str,
+    limit: int,
+    db_path: Optional[str] = None,
+    now: Optional[float] = None,
+) -> Tuple[str, ...]:
+    """Return up to ``limit`` ``source_path`` candidates in pick order.
+
+    Same WHERE / ORDER BY as :func:`peek_next_for_stage` and
+    :func:`claim_next_for_stage`. Used by the archive worker's
+    shadow-mode comparison to tolerate the documented secondary-sort
+    divergence (``enqueued_at`` here vs ``expected_mtime`` in the
+    legacy ``archive_queue`` reader). A legacy pick is treated as
+    "agreed" by the shadow path if it appears anywhere in this
+    top-N — only when the legacy row is **absent** from the
+    pipeline_queue's top-N do we have a real dual-write gap worth
+    a WARNING.
+
+    Cheap by design: returns just the ``source_path`` strings (no
+    payload parsing, no row dicts) so the worker hot-path adds at
+    most one indexed-SELECT per iteration. ``Tuple`` (not ``list``)
+    so callers can use it in ``in`` checks without worrying about
+    accidental mutation.
+
+    Args:
+        stage: One of the ``STAGE_*_PENDING`` constants. Refused
+            (returns empty tuple) when empty / falsy.
+        limit: Maximum number of candidates to return. Clamped to
+            ``[1, 50]`` — the shadow path doesn't benefit from
+            larger windows and we don't want a buggy caller to
+            sweep the whole queue.
+        db_path: Override the geodata.db path (test injection).
+        now: Override "current time" for ``next_retry_at``
+            comparisons (test injection only).
+
+    Returns:
+        Tuple of ``source_path`` strings in ``(priority,
+        enqueued_at, id)`` order. Empty tuple if the queue is
+        empty for the stage, the DB doesn't exist, ``stage`` is
+        empty, ``limit`` is non-positive, or any sqlite error
+        fires.
+    """
+    if not stage:
+        return ()
+    try:
+        clamped_limit = max(1, min(50, int(limit)))
+    except (TypeError, ValueError):
+        return ()
+    if db_path is None:
+        db_path = _resolve_pipeline_db()
+    if not db_path or not os.path.isfile(db_path):
+        return ()
+    if now is None:
+        now = _now_epoch()
+    conn = None
+    try:
+        conn = _open_pipeline_conn(db_path)
+        rows = conn.execute(
+            """SELECT source_path FROM pipeline_queue
+                WHERE stage = ?
+                  AND status = 'pending'
+                  AND (next_retry_at IS NULL OR next_retry_at <= ?)
+                ORDER BY priority ASC, enqueued_at ASC, id ASC
+                LIMIT ?""",
+            (stage, now, clamped_limit),
+        ).fetchall()
+        return tuple(
+            r['source_path'] for r in rows if r['source_path']
+        )
+    except sqlite3.Error as e:
+        logger.debug(
+            "peek_top_n_paths_for_stage(stage=%s) failed: %s",
+            stage, e,
+        )
+        return ()
+    finally:
+        if conn is not None:
+            try:
+                conn.close()
+            except sqlite3.Error:
+                pass
+
+
 def recover_stale_claims_pipeline(
     *,
     db_path: Optional[str] = None,
@@ -870,6 +960,17 @@ def recover_stale_claims_pipeline(
         The count of rows released. Returns 0 on missing DB / sqlite
         error (logged at WARNING). NEVER raises.
     """
+    # Wave 4 PR-E (issue #195): bump call_count at function entry
+    # so an operator querying telemetry sees "recovery is being
+    # called" even when the early-return paths fire (missing DB,
+    # sqlite error). Without this, a misconfigured DB path would
+    # leave call_count=0 and an operator would conclude "recovery
+    # never fired" when the truth is "recovery fired but couldn't
+    # open the DB". Total / last_at / last_count remain bounded to
+    # the actual successful release.
+    global _recover_stale_claims_call_count
+    with _recover_stale_claims_lock:
+        _recover_stale_claims_call_count += 1
     if db_path is None:
         db_path = _resolve_pipeline_db()
     if not db_path or not os.path.isfile(db_path):
@@ -908,16 +1009,14 @@ def recover_stale_claims_pipeline(
         # Wave 4 PR-E (issue #195): bump telemetry counters under
         # lock so concurrent recovery calls (only ever one, but
         # defensive for future workers) don't race on the read-modify-
-        # write of the running totals. Always bumped — the call_count
-        # / last_at pair tells operators "recovery is being called
-        # but finds nothing" vs. "recovery is repeatedly releasing
-        # rows", which is the actual diagnostic question.
+        # write of the running totals. ``_recover_stale_claims_call_count``
+        # is bumped at function entry so it covers the early-return
+        # paths too; here we only update the totals/last_at/last_count
+        # for the successful-release accounting.
         global _recover_stale_claims_total
         global _recover_stale_claims_last_at
         global _recover_stale_claims_last_count
-        global _recover_stale_claims_call_count
         with _recover_stale_claims_lock:
-            _recover_stale_claims_call_count += 1
             if released > 0:
                 _recover_stale_claims_total += released
                 _recover_stale_claims_last_at = now
@@ -950,10 +1049,14 @@ def get_recovery_telemetry() -> Dict[str, Any]:
         non-zero recovery call (``None`` if never).
       * ``stale_recoveries_last_count``: count from the last
         non-zero recovery call (0 if never).
-      * ``stale_recoveries_call_count``: total recovery calls made
-        (including zero-result calls). High call_count + zero total
+      * ``stale_recoveries_call_count``: total recovery calls made,
+        including zero-result calls AND early-return paths
+        (missing DB / sqlite error). High call_count + zero total
         = "called but found nothing", which is the healthy steady
-        state.
+        state. High call_count + zero total + persistent
+        ``stale_recoveries_last_at = None`` after a known
+        misconfigured DB = "called but couldn't open DB" — check
+        ``geodata.db`` path / permissions.
     """
     with _recover_stale_claims_lock:
         return {
@@ -969,12 +1072,20 @@ def pipeline_status(db_path: Optional[str] = None) -> Dict[str, Any]:
 
     Useful for debugging / the Settings page / dual-write parity
     checks. Counts grouped by ``(legacy_table, stage, status)``.
-    Returns an empty dict on any error.
+
+    On any sqlite error the queue-state portion is omitted but the
+    in-memory ``get_recovery_telemetry()`` snapshot is still
+    returned — telemetry is process-local and arguably MORE useful
+    when the DB read is failing (it tells operators "recovery has
+    fired N times" even when ``pipeline_queue`` itself can't be
+    read). Fully missing DB returns just the telemetry snapshot
+    too, for the same reason.
     """
+    telemetry = get_recovery_telemetry()
     if db_path is None:
         db_path = _resolve_pipeline_db()
     if not db_path or not os.path.isfile(db_path):
-        return {}
+        return dict(telemetry)
     conn = None
     try:
         conn = _open_pipeline_conn(db_path)
@@ -999,11 +1110,12 @@ def pipeline_status(db_path: Optional[str] = None) -> Dict[str, Any]:
         # Wave 4 PR-E (issue #195): merge in the in-memory
         # stale-recovery counters so a single endpoint payload
         # answers "is the queue OK and is the recovery healthy?"
-        result.update(get_recovery_telemetry())
+        result.update(telemetry)
         return result
     except sqlite3.Error as e:
         logger.warning("pipeline_status failed: %s", e)
-        return {}
+        # Surface telemetry even on DB read failure — see docstring.
+        return dict(telemetry)
     finally:
         if conn is not None:
             try:

--- a/tests/test_archive_worker.py
+++ b/tests/test_archive_worker.py
@@ -3277,8 +3277,13 @@ class TestProcessOneClaimAdaptiveWiring:
 # Wave 4 PR-E ??? pipeline_queue shadow comparison helpers (#184)
 # ============================================================================
 # Pure observability helpers: `_shadow_compare_picks` logs WARNING
-# on disagreement and INFO every Nth agreement; `get_shadow_telemetry`
-# returns the in-memory counter snapshot.
+# on disagreement (rate-limited) and INFO every Nth agreement;
+# `get_shadow_telemetry` returns the in-memory counter snapshot.
+# Wave 4 PR-E review fixes: comparison takes a top-N candidate set
+# (not a single path) to absorb the documented secondary-sort
+# divergence between archive_queue (expected_mtime) and
+# pipeline_queue (enqueued_at). Disagreement WARNINGs are
+# rate-limited (verbatim for first N, then heartbeat every Mth).
 
 class TestShadowComparisonHelpers:
     def _reset(self):
@@ -3292,77 +3297,109 @@ class TestShadowComparisonHelpers:
         assert t['shadow_agreement_count'] == 0
         assert t['shadow_disagreement_count'] == 0
 
-    def test_both_none_no_log_no_counter(self, caplog):
+    def test_both_none_treats_as_agreement(self, caplog):
         self._reset()
         import logging as _log
         caplog.set_level(_log.DEBUG)
         archive_worker._shadow_compare_picks(
-            legacy_path=None, pipeline_path=None,
+            legacy_path=None, pipeline_candidates=(),
         )
-        # The function should log nothing on (None, None) because the
-        # caller skips the call entirely; but defend the contract.
-        # _shadow_compare_picks treats None == None as agreement.
         t = archive_worker.get_shadow_telemetry()
+        # Empty queue both sides -> counted as agreement, no log
+        # below the periodic threshold.
         assert t['shadow_agreement_count'] == 1
         assert t['shadow_disagreement_count'] == 0
+        # No INFO/WARNING emitted on a single agreement.
+        noisy = [r for r in caplog.records
+                 if r.levelno >= _log.INFO
+                 and 'shadow' in r.getMessage().lower()]
+        assert noisy == []
 
-    def test_matching_paths_increment_agreement(self):
+    def test_matching_top1_increments_agreement(self):
         self._reset()
         for _ in range(5):
             archive_worker._shadow_compare_picks(
                 legacy_path='/x/foo.mp4',
-                pipeline_path='/x/foo.mp4',
+                pipeline_candidates=('/x/foo.mp4',),
             )
         t = archive_worker.get_shadow_telemetry()
         assert t['shadow_agreement_count'] == 5
         assert t['shadow_disagreement_count'] == 0
 
-    def test_disagreement_logs_warning_and_bumps_counter(self, caplog):
+    def test_legacy_in_topN_window_is_agreement(self):
+        # Legacy reader picked /x/c.mp4 (e.g. it sorted by mtime).
+        # pipeline_queue's top-N (sorted by enqueued_at) lists it
+        # at position 3. Treat as agreement, NOT disagreement.
+        self._reset()
+        archive_worker._shadow_compare_picks(
+            legacy_path='/x/c.mp4',
+            pipeline_candidates=(
+                '/x/a.mp4', '/x/b.mp4', '/x/c.mp4', '/x/d.mp4',
+            ),
+        )
+        t = archive_worker.get_shadow_telemetry()
+        assert t['shadow_agreement_count'] == 1
+        assert t['shadow_disagreement_count'] == 0
+
+    def test_legacy_absent_from_topN_logs_warning_with_window(
+        self, caplog,
+    ):
         self._reset()
         import logging as _log
         caplog.set_level(_log.WARNING)
         archive_worker._shadow_compare_picks(
             legacy_path='/x/foo.mp4',
-            pipeline_path='/x/bar.mp4',
+            pipeline_candidates=('/x/a.mp4', '/x/b.mp4'),
         )
         t = archive_worker.get_shadow_telemetry()
         assert t['shadow_agreement_count'] == 0
         assert t['shadow_disagreement_count'] == 1
-        # At least one WARNING about the disagreement.
         warnings = [r for r in caplog.records
                     if r.levelno == _log.WARNING
                     and 'shadow' in r.getMessage().lower()]
-        assert len(warnings) >= 1
-        msg = warnings[-1].getMessage()
+        assert len(warnings) == 1
+        msg = warnings[0].getMessage()
+        # Verbatim WARNING includes the legacy pick AND the window.
         assert '/x/foo.mp4' in msg
-        assert '/x/bar.mp4' in msg
+        assert '/x/a.mp4' in msg
+        assert '/x/b.mp4' in msg
 
-    def test_legacy_some_pipeline_none_is_disagreement(self):
+    def test_legacy_present_pipeline_empty_is_disagreement(self):
+        # Legacy picked something, pipeline_queue has nothing ready
+        # at this stage. That IS a real dual-write gap (not just a
+        # secondary-sort divergence) and should bump disagreement.
         self._reset()
         archive_worker._shadow_compare_picks(
             legacy_path='/x/foo.mp4',
-            pipeline_path=None,
+            pipeline_candidates=(),
         )
         t = archive_worker.get_shadow_telemetry()
         assert t['shadow_disagreement_count'] == 1
 
-    def test_legacy_none_pipeline_some_is_disagreement(self):
+    def test_legacy_none_pipeline_some_is_agreement(self):
+        # Legacy says no work, pipeline_queue has rows. There's no
+        # legacy pick to mismatch against — count as agreement (the
+        # row will surface on the next iteration when the legacy
+        # reader catches up). NOT a dual-write gap.
         self._reset()
         archive_worker._shadow_compare_picks(
             legacy_path=None,
-            pipeline_path='/x/foo.mp4',
+            pipeline_candidates=('/x/foo.mp4',),
         )
         t = archive_worker.get_shadow_telemetry()
-        assert t['shadow_disagreement_count'] == 1
+        assert t['shadow_agreement_count'] == 1
+        assert t['shadow_disagreement_count'] == 0
 
     def test_periodic_agreement_log_at_threshold(self, caplog):
         self._reset()
         import logging as _log
         caplog.set_level(_log.INFO)
-        # 500 agreements in a row should produce 1 INFO log line.
-        for i in range(archive_worker._SHADOW_AGREEMENT_LOG_EVERY):
+        # _SHADOW_AGREEMENT_LOG_EVERY agreements in a row produce
+        # exactly 1 INFO log line.
+        for _ in range(archive_worker._SHADOW_AGREEMENT_LOG_EVERY):
             archive_worker._shadow_compare_picks(
-                legacy_path='/x/foo.mp4', pipeline_path='/x/foo.mp4',
+                legacy_path='/x/foo.mp4',
+                pipeline_candidates=('/x/foo.mp4',),
             )
         infos = [r for r in caplog.records
                  if r.levelno == _log.INFO
@@ -3371,11 +3408,51 @@ class TestShadowComparisonHelpers:
         assert str(archive_worker._SHADOW_AGREEMENT_LOG_EVERY) in \
             infos[0].getMessage()
 
-    def test_shadow_pipeline_queue_enabled_reads_config(self, monkeypatch):
-        # Default config has shadow_pipeline_queue=True, so the
-        # function should return True. Override to False and verify
-        # the worker picks up the change without restart.
-        import sys
+    def test_disagreement_warnings_verbatim_then_throttled(
+        self, caplog,
+    ):
+        self._reset()
+        import logging as _log
+        caplog.set_level(_log.WARNING)
+        verbatim = archive_worker._SHADOW_DISAGREEMENT_LOG_VERBATIM
+        every = archive_worker._SHADOW_DISAGREEMENT_LOG_EVERY
+        # Fire (verbatim + every) disagreements: expect verbatim
+        # WARNINGs for the first N, then exactly one heartbeat
+        # WARNING when the count reaches the next multiple of
+        # `every`.
+        total = verbatim + every
+        for _ in range(total):
+            archive_worker._shadow_compare_picks(
+                legacy_path='/x/foo.mp4',
+                pipeline_candidates=('/x/a.mp4',),
+            )
+        warnings = [r for r in caplog.records
+                    if r.levelno == _log.WARNING
+                    and 'shadow' in r.getMessage().lower()]
+        # The first `verbatim` are verbatim WARNINGs.
+        # After that, no per-event WARNINGs until we hit the next
+        # multiple of `every` — which is at count == verbatim+something.
+        # The heartbeat fires when d_count % every == 0 and
+        # d_count > verbatim. With verbatim=10, every=100: hits at
+        # 100, 200, ... So with total=110 we get verbatim=10 +
+        # heartbeat(s) at 100 = 11 total.
+        # Compute expected: count multiples of `every` strictly
+        # greater than verbatim, up to and including total.
+        heartbeats = sum(
+            1 for c in range(verbatim + 1, total + 1)
+            if c % every == 0
+        )
+        expected = verbatim + heartbeats
+        assert len(warnings) == expected, (
+            f"expected {expected} WARNINGs (verbatim={verbatim} + "
+            f"heartbeats={heartbeats}) got {len(warnings)}"
+        )
+        t = archive_worker.get_shadow_telemetry()
+        assert t['shadow_disagreement_count'] == total
+
+    def test_shadow_pipeline_queue_enabled_reads_config(
+        self, monkeypatch,
+    ):
         import config as _conf
         monkeypatch.setattr(
             _conf, 'ARCHIVE_QUEUE_SHADOW_PIPELINE_QUEUE', True,
@@ -3391,13 +3468,10 @@ class TestShadowComparisonHelpers:
     def test_shadow_pipeline_queue_enabled_swallows_import_errors(
         self, monkeypatch,
     ):
-        # If the config can't be loaded for any reason, the helper
-        # MUST return False ??? the shadow path is purely optional and
+        # If the config attr is missing for any reason, the helper
+        # MUST return False — the shadow path is purely optional and
         # must never affect worker behavior.
         import config as _conf
-        # Delete the attribute so the import succeeds but the lookup
-        # raises AttributeError (which the helper's broad except
-        # catches).
         if hasattr(_conf, 'ARCHIVE_QUEUE_SHADOW_PIPELINE_QUEUE'):
             monkeypatch.delattr(
                 _conf, 'ARCHIVE_QUEUE_SHADOW_PIPELINE_QUEUE',

--- a/tests/test_archive_worker.py
+++ b/tests/test_archive_worker.py
@@ -3271,3 +3271,135 @@ class TestProcessOneClaimAdaptiveWiring:
         assert captured['chunk_pause_always'] is False
         assert captured['chunk_pause_seconds'] == 0.25
         assert captured['load_pause_threshold'] == 3.5
+
+
+# ============================================================================
+# Wave 4 PR-E ??? pipeline_queue shadow comparison helpers (#184)
+# ============================================================================
+# Pure observability helpers: `_shadow_compare_picks` logs WARNING
+# on disagreement and INFO every Nth agreement; `get_shadow_telemetry`
+# returns the in-memory counter snapshot.
+
+class TestShadowComparisonHelpers:
+    def _reset(self):
+        with archive_worker._shadow_lock:
+            archive_worker._shadow_agreement_count = 0
+            archive_worker._shadow_disagreement_count = 0
+
+    def test_initial_telemetry_zero(self):
+        self._reset()
+        t = archive_worker.get_shadow_telemetry()
+        assert t['shadow_agreement_count'] == 0
+        assert t['shadow_disagreement_count'] == 0
+
+    def test_both_none_no_log_no_counter(self, caplog):
+        self._reset()
+        import logging as _log
+        caplog.set_level(_log.DEBUG)
+        archive_worker._shadow_compare_picks(
+            legacy_path=None, pipeline_path=None,
+        )
+        # The function should log nothing on (None, None) because the
+        # caller skips the call entirely; but defend the contract.
+        # _shadow_compare_picks treats None == None as agreement.
+        t = archive_worker.get_shadow_telemetry()
+        assert t['shadow_agreement_count'] == 1
+        assert t['shadow_disagreement_count'] == 0
+
+    def test_matching_paths_increment_agreement(self):
+        self._reset()
+        for _ in range(5):
+            archive_worker._shadow_compare_picks(
+                legacy_path='/x/foo.mp4',
+                pipeline_path='/x/foo.mp4',
+            )
+        t = archive_worker.get_shadow_telemetry()
+        assert t['shadow_agreement_count'] == 5
+        assert t['shadow_disagreement_count'] == 0
+
+    def test_disagreement_logs_warning_and_bumps_counter(self, caplog):
+        self._reset()
+        import logging as _log
+        caplog.set_level(_log.WARNING)
+        archive_worker._shadow_compare_picks(
+            legacy_path='/x/foo.mp4',
+            pipeline_path='/x/bar.mp4',
+        )
+        t = archive_worker.get_shadow_telemetry()
+        assert t['shadow_agreement_count'] == 0
+        assert t['shadow_disagreement_count'] == 1
+        # At least one WARNING about the disagreement.
+        warnings = [r for r in caplog.records
+                    if r.levelno == _log.WARNING
+                    and 'shadow' in r.getMessage().lower()]
+        assert len(warnings) >= 1
+        msg = warnings[-1].getMessage()
+        assert '/x/foo.mp4' in msg
+        assert '/x/bar.mp4' in msg
+
+    def test_legacy_some_pipeline_none_is_disagreement(self):
+        self._reset()
+        archive_worker._shadow_compare_picks(
+            legacy_path='/x/foo.mp4',
+            pipeline_path=None,
+        )
+        t = archive_worker.get_shadow_telemetry()
+        assert t['shadow_disagreement_count'] == 1
+
+    def test_legacy_none_pipeline_some_is_disagreement(self):
+        self._reset()
+        archive_worker._shadow_compare_picks(
+            legacy_path=None,
+            pipeline_path='/x/foo.mp4',
+        )
+        t = archive_worker.get_shadow_telemetry()
+        assert t['shadow_disagreement_count'] == 1
+
+    def test_periodic_agreement_log_at_threshold(self, caplog):
+        self._reset()
+        import logging as _log
+        caplog.set_level(_log.INFO)
+        # 500 agreements in a row should produce 1 INFO log line.
+        for i in range(archive_worker._SHADOW_AGREEMENT_LOG_EVERY):
+            archive_worker._shadow_compare_picks(
+                legacy_path='/x/foo.mp4', pipeline_path='/x/foo.mp4',
+            )
+        infos = [r for r in caplog.records
+                 if r.levelno == _log.INFO
+                 and 'shadow' in r.getMessage().lower()]
+        assert len(infos) == 1
+        assert str(archive_worker._SHADOW_AGREEMENT_LOG_EVERY) in \
+            infos[0].getMessage()
+
+    def test_shadow_pipeline_queue_enabled_reads_config(self, monkeypatch):
+        # Default config has shadow_pipeline_queue=True, so the
+        # function should return True. Override to False and verify
+        # the worker picks up the change without restart.
+        import sys
+        import config as _conf
+        monkeypatch.setattr(
+            _conf, 'ARCHIVE_QUEUE_SHADOW_PIPELINE_QUEUE', True,
+            raising=False,
+        )
+        assert archive_worker._shadow_pipeline_queue_enabled() is True
+        monkeypatch.setattr(
+            _conf, 'ARCHIVE_QUEUE_SHADOW_PIPELINE_QUEUE', False,
+            raising=False,
+        )
+        assert archive_worker._shadow_pipeline_queue_enabled() is False
+
+    def test_shadow_pipeline_queue_enabled_swallows_import_errors(
+        self, monkeypatch,
+    ):
+        # If the config can't be loaded for any reason, the helper
+        # MUST return False ??? the shadow path is purely optional and
+        # must never affect worker behavior.
+        import config as _conf
+        # Delete the attribute so the import succeeds but the lookup
+        # raises AttributeError (which the helper's broad except
+        # catches).
+        if hasattr(_conf, 'ARCHIVE_QUEUE_SHADOW_PIPELINE_QUEUE'):
+            monkeypatch.delattr(
+                _conf, 'ARCHIVE_QUEUE_SHADOW_PIPELINE_QUEUE',
+            )
+        assert archive_worker._shadow_pipeline_queue_enabled() is False

--- a/tests/test_pipeline_queue_dualwrite.py
+++ b/tests/test_pipeline_queue_dualwrite.py
@@ -2389,3 +2389,246 @@ class TestPipelineStatusMergesRecoveryTelemetry:
                 pqs._recover_stale_claims_last_at = None
                 pqs._recover_stale_claims_last_count = 0
                 pqs._recover_stale_claims_call_count = 0
+
+    def test_status_missing_db_still_returns_telemetry(self, tmp_path):
+        # Wave 4 PR-E review fix (info #3): pipeline_status MUST
+        # surface telemetry even when the DB is missing — telemetry
+        # is process-local and arguably MORE useful in that
+        # diagnostic situation.
+        with pqs._recover_stale_claims_lock:
+            pqs._recover_stale_claims_total = 7
+            pqs._recover_stale_claims_call_count = 12
+        try:
+            missing = str(tmp_path / 'does-not-exist.db')
+            status = pqs.pipeline_status(db_path=missing)
+            assert status.get('stale_recoveries_total') == 7
+            assert status.get('stale_recoveries_call_count') == 12
+            # Queue-state keys absent (no DB).
+            assert 'total' not in status
+            assert 'by_legacy_stage_status' not in status
+        finally:
+            with pqs._recover_stale_claims_lock:
+                pqs._recover_stale_claims_total = 0
+                pqs._recover_stale_claims_last_at = None
+                pqs._recover_stale_claims_last_count = 0
+                pqs._recover_stale_claims_call_count = 0
+
+    def test_status_db_error_still_returns_telemetry(
+        self, geodata_db, monkeypatch,
+    ):
+        # Wave 4 PR-E review fix (info #3): on sqlite3.Error the
+        # function must still return the telemetry snapshot, not
+        # an empty dict. Force an error by monkeypatching
+        # _open_pipeline_conn to raise.
+        with pqs._recover_stale_claims_lock:
+            pqs._recover_stale_claims_total = 4
+            pqs._recover_stale_claims_call_count = 9
+        try:
+            import sqlite3 as _sql
+
+            def _raise(_p):
+                raise _sql.OperationalError('forced error')
+
+            monkeypatch.setattr(pqs, '_open_pipeline_conn', _raise)
+            status = pqs.pipeline_status(db_path=geodata_db)
+            assert status.get('stale_recoveries_total') == 4
+            assert status.get('stale_recoveries_call_count') == 9
+            assert 'total' not in status
+        finally:
+            with pqs._recover_stale_claims_lock:
+                pqs._recover_stale_claims_total = 0
+                pqs._recover_stale_claims_last_at = None
+                pqs._recover_stale_claims_last_count = 0
+                pqs._recover_stale_claims_call_count = 0
+
+
+class TestRecoveryCallCountOnEarlyReturn:
+    """Wave 4 PR-E review fix (info #4): call_count must bump on
+    every recovery call, including missing-DB and sqlite-error
+    early-return paths, so the docstring's
+    "high call_count + zero total = called but found nothing"
+    diagnostic is reliable when the DB itself is misconfigured."""
+
+    def _reset(self):
+        with pqs._recover_stale_claims_lock:
+            pqs._recover_stale_claims_total = 0
+            pqs._recover_stale_claims_last_at = None
+            pqs._recover_stale_claims_last_count = 0
+            pqs._recover_stale_claims_call_count = 0
+
+    def test_missing_db_still_bumps_call_count(self, tmp_path):
+        self._reset()
+        missing = str(tmp_path / 'does-not-exist.db')
+        n = pqs.recover_stale_claims_pipeline(db_path=missing)
+        assert n == 0
+        t = pqs.get_recovery_telemetry()
+        assert t['stale_recoveries_call_count'] == 1
+        assert t['stale_recoveries_total'] == 0
+        assert t['stale_recoveries_last_at'] is None
+
+    def test_sqlite_error_still_bumps_call_count(
+        self, geodata_db, monkeypatch,
+    ):
+        self._reset()
+        import sqlite3 as _sql
+
+        def _raise(_p):
+            raise _sql.OperationalError('forced error')
+
+        monkeypatch.setattr(pqs, '_open_pipeline_conn', _raise)
+        n = pqs.recover_stale_claims_pipeline(db_path=geodata_db)
+        assert n == 0
+        t = pqs.get_recovery_telemetry()
+        assert t['stale_recoveries_call_count'] == 1
+        assert t['stale_recoveries_total'] == 0
+
+
+class TestPeekTopNPathsForStage:
+    """Wave 4 PR-E: top-N candidate peek used by the archive worker's
+    shadow-mode comparison to absorb the documented secondary-sort
+    divergence between archive_queue (expected_mtime) and
+    pipeline_queue (enqueued_at)."""
+
+    def _seed(self, db, paths_with_enqueued):
+        import sqlite3 as _sql
+        c = _sql.connect(db)
+        try:
+            for path, enq in paths_with_enqueued:
+                c.execute(
+                    """INSERT INTO pipeline_queue
+                           (source_path, stage, status, priority,
+                            enqueued_at, attempts, legacy_table)
+                       VALUES (?, 'archive_pending', 'pending', 2,
+                               ?, 0, 'archive_queue')""",
+                    (path, enq),
+                )
+            c.commit()
+        finally:
+            c.close()
+
+    def test_returns_tuple_in_pick_order(self, geodata_db):
+        self._seed(
+            geodata_db,
+            [('/x/c.mp4', 30.0), ('/x/a.mp4', 10.0),
+             ('/x/b.mp4', 20.0)],
+        )
+        result = pqs.peek_top_n_paths_for_stage(
+            stage='archive_pending', limit=10, db_path=geodata_db,
+        )
+        assert isinstance(result, tuple)
+        assert result == ('/x/a.mp4', '/x/b.mp4', '/x/c.mp4')
+
+    def test_respects_limit(self, geodata_db):
+        self._seed(
+            geodata_db,
+            [(f'/x/{i:02d}.mp4', float(i)) for i in range(20)],
+        )
+        result = pqs.peek_top_n_paths_for_stage(
+            stage='archive_pending', limit=3, db_path=geodata_db,
+        )
+        assert len(result) == 3
+        assert result == ('/x/00.mp4', '/x/01.mp4', '/x/02.mp4')
+
+    def test_clamps_limit_to_50(self, geodata_db):
+        self._seed(
+            geodata_db,
+            [(f'/x/{i:03d}.mp4', float(i)) for i in range(60)],
+        )
+        result = pqs.peek_top_n_paths_for_stage(
+            stage='archive_pending', limit=999, db_path=geodata_db,
+        )
+        assert len(result) == 50
+
+    def test_clamps_limit_floor_to_1(self, geodata_db):
+        self._seed(geodata_db, [('/x/a.mp4', 1.0)])
+        result = pqs.peek_top_n_paths_for_stage(
+            stage='archive_pending', limit=0, db_path=geodata_db,
+        )
+        # 0 clamps to 1 ÔÇö returns the single row.
+        assert result == ('/x/a.mp4',)
+
+    def test_filters_by_stage(self, geodata_db):
+        self._seed(geodata_db, [('/x/a.mp4', 1.0)])
+        # Different stage ÔÇö no match.
+        result = pqs.peek_top_n_paths_for_stage(
+            stage='cloud_upload_pending', limit=10,
+            db_path=geodata_db,
+        )
+        assert result == ()
+
+    def test_skips_in_progress_rows(self, geodata_db):
+        import sqlite3 as _sql
+        c = _sql.connect(geodata_db)
+        try:
+            c.execute(
+                """INSERT INTO pipeline_queue
+                       (source_path, stage, status, priority,
+                        enqueued_at, attempts, legacy_table,
+                        claimed_by, claimed_at)
+                   VALUES ('/x/a.mp4', 'archive_pending',
+                           'in_progress', 2, 1.0, 1,
+                           'archive_queue', 'w-1', 100.0)""",
+            )
+            c.execute(
+                """INSERT INTO pipeline_queue
+                       (source_path, stage, status, priority,
+                        enqueued_at, attempts, legacy_table)
+                   VALUES ('/x/b.mp4', 'archive_pending',
+                           'pending', 2, 2.0, 0, 'archive_queue')""",
+            )
+            c.commit()
+        finally:
+            c.close()
+        result = pqs.peek_top_n_paths_for_stage(
+            stage='archive_pending', limit=10, db_path=geodata_db,
+        )
+        assert result == ('/x/b.mp4',)
+
+    def test_respects_next_retry_at_gate(self, geodata_db):
+        import sqlite3 as _sql
+        c = _sql.connect(geodata_db)
+        try:
+            c.execute(
+                """INSERT INTO pipeline_queue
+                       (source_path, stage, status, priority,
+                        enqueued_at, attempts, legacy_table,
+                        next_retry_at)
+                   VALUES ('/x/future.mp4', 'archive_pending',
+                           'pending', 2, 1.0, 0, 'archive_queue',
+                           99999.0)""",
+            )
+            c.execute(
+                """INSERT INTO pipeline_queue
+                       (source_path, stage, status, priority,
+                        enqueued_at, attempts, legacy_table)
+                   VALUES ('/x/now.mp4', 'archive_pending',
+                           'pending', 2, 2.0, 0, 'archive_queue')""",
+            )
+            c.commit()
+        finally:
+            c.close()
+        result = pqs.peek_top_n_paths_for_stage(
+            stage='archive_pending', limit=10, now=1000.0,
+            db_path=geodata_db,
+        )
+        assert result == ('/x/now.mp4',)
+
+    def test_empty_stage_returns_empty(self, geodata_db):
+        result = pqs.peek_top_n_paths_for_stage(
+            stage='', limit=10, db_path=geodata_db,
+        )
+        assert result == ()
+
+    def test_missing_db_returns_empty(self, tmp_path):
+        result = pqs.peek_top_n_paths_for_stage(
+            stage='archive_pending', limit=10,
+            db_path=str(tmp_path / 'nope.db'),
+        )
+        assert result == ()
+
+    def test_invalid_limit_returns_empty(self, geodata_db):
+        result = pqs.peek_top_n_paths_for_stage(
+            stage='archive_pending', limit='not-a-number',
+            db_path=geodata_db,
+        )
+        assert result == ()

--- a/tests/test_pipeline_queue_dualwrite.py
+++ b/tests/test_pipeline_queue_dualwrite.py
@@ -2265,3 +2265,127 @@ class TestRecoverStaleClaimsPipeline:
         assert pqs.recover_stale_claims_pipeline(
             db_path=str(bad),
         ) == 0
+
+
+# ============================================================================
+# Wave 4 PR-E ??? stale-recovery telemetry (#184 / closes #195)
+# ============================================================================
+# Counters live at module scope, reset on import. To keep tests
+# isolated we manually reset them inside each test.
+
+
+class TestRecoveryTelemetry:
+    def _reset(self):
+        with pqs._recover_stale_claims_lock:
+            pqs._recover_stale_claims_total = 0
+            pqs._recover_stale_claims_last_at = None
+            pqs._recover_stale_claims_last_count = 0
+            pqs._recover_stale_claims_call_count = 0
+
+    def test_initial_telemetry_is_zeroed(self, geodata_db):
+        self._reset()
+        t = pqs.get_recovery_telemetry()
+        assert t['stale_recoveries_total'] == 0
+        assert t['stale_recoveries_last_at'] is None
+        assert t['stale_recoveries_last_count'] == 0
+        assert t['stale_recoveries_call_count'] == 0
+
+    def test_zero_result_call_bumps_call_count_only(self, geodata_db):
+        # Empty DB ??? recovery returns 0, telemetry's call_count
+        # bumps but totals/last fields stay zero/None.
+        self._reset()
+        n = pqs.recover_stale_claims_pipeline(db_path=geodata_db)
+        assert n == 0
+        t = pqs.get_recovery_telemetry()
+        assert t['stale_recoveries_total'] == 0
+        assert t['stale_recoveries_last_at'] is None
+        assert t['stale_recoveries_last_count'] == 0
+        assert t['stale_recoveries_call_count'] == 1
+
+    def test_non_zero_result_bumps_all_counters(self, geodata_db):
+        self._reset()
+        # Seed a stale claim then recover.
+        import sqlite3 as _sql
+        c = _sql.connect(geodata_db)
+        try:
+            c.execute(
+                """INSERT INTO pipeline_queue
+                       (source_path, stage, status, priority,
+                        enqueued_at, claimed_by, claimed_at, attempts,
+                        legacy_table)
+                   VALUES (?, 'archive_pending', 'in_progress', 2,
+                           100.0, ?, ?, 1, 'archive_queue')""",
+                ('/x/orphan-1.mp4', 'crashed', 1.0),
+            )
+            c.commit()
+        finally:
+            c.close()
+        n = pqs.recover_stale_claims_pipeline(
+            db_path=geodata_db, max_age_seconds=10.0, now=10000.0,
+        )
+        assert n == 1
+        t = pqs.get_recovery_telemetry()
+        assert t['stale_recoveries_total'] == 1
+        assert t['stale_recoveries_last_at'] == 10000.0
+        assert t['stale_recoveries_last_count'] == 1
+        assert t['stale_recoveries_call_count'] == 1
+
+    def test_total_accumulates_across_calls(self, geodata_db):
+        self._reset()
+        import sqlite3 as _sql
+        c = _sql.connect(geodata_db)
+        try:
+            for i in range(3):
+                c.execute(
+                    """INSERT INTO pipeline_queue
+                           (source_path, stage, status, priority,
+                            enqueued_at, claimed_by, claimed_at, attempts,
+                            legacy_table)
+                       VALUES (?, 'archive_pending', 'in_progress', 2,
+                               100.0, ?, ?, 1, 'archive_queue')""",
+                    (f'/x/orphan-{i}.mp4', f'crashed-{i}', float(i)),
+                )
+            c.commit()
+        finally:
+            c.close()
+        # First call recovers 3 rows.
+        n1 = pqs.recover_stale_claims_pipeline(
+            db_path=geodata_db, max_age_seconds=1.0, now=100.0,
+        )
+        assert n1 == 3
+        # Second call recovers 0 (already pending).
+        n2 = pqs.recover_stale_claims_pipeline(
+            db_path=geodata_db, max_age_seconds=1.0, now=200.0,
+        )
+        assert n2 == 0
+        t = pqs.get_recovery_telemetry()
+        assert t['stale_recoveries_total'] == 3
+        # last_at + last_count from the FIRST (non-zero) call,
+        # not overwritten by the zero-result second call.
+        assert t['stale_recoveries_last_at'] == 100.0
+        assert t['stale_recoveries_last_count'] == 3
+        assert t['stale_recoveries_call_count'] == 2
+
+
+class TestPipelineStatusMergesRecoveryTelemetry:
+    def test_status_includes_telemetry_keys(self, geodata_db):
+        with pqs._recover_stale_claims_lock:
+            pqs._recover_stale_claims_total = 17
+            pqs._recover_stale_claims_last_at = 9999.0
+            pqs._recover_stale_claims_last_count = 5
+            pqs._recover_stale_claims_call_count = 23
+        try:
+            status = pqs.pipeline_status(db_path=geodata_db)
+            assert status.get('stale_recoveries_total') == 17
+            assert status.get('stale_recoveries_last_at') == 9999.0
+            assert status.get('stale_recoveries_last_count') == 5
+            assert status.get('stale_recoveries_call_count') == 23
+            # Existing keys still present.
+            assert 'total' in status
+            assert 'by_legacy_stage_status' in status
+        finally:
+            with pqs._recover_stale_claims_lock:
+                pqs._recover_stale_claims_total = 0
+                pqs._recover_stale_claims_last_at = None
+                pqs._recover_stale_claims_last_count = 0
+                pqs._recover_stale_claims_call_count = 0


### PR DESCRIPTION
## Wave 4 PR-E ΓÇö Shadow `pipeline_queue` reads + recovery wiring + telemetry

Part of the Wave 4 sub-PR sequence for the parent issue (Ref #184).
The PR that finishes the parent issue is PR-F; this is observability +
plumbing only, with no behavior change in the worker's claim path.

### Why this PR

PR-D (#194) added the schema and the `recover_stale_claims_pipeline()` 
helper. PR-F will switch the archive worker to actually read from
`pipeline_queue` instead of `archive_queue`. **Before** flipping that
switch we want production data showing the two readers agree on which
row to pick. This PR adds:

1. **Shadow-mode comparison** ΓÇö worker peeks `pipeline_queue` BEFORE
   the legacy claim and logs a WARNING on disagreement, plus an INFO
   heartbeat every 500 consecutive agreements.
2. **Stale-claim recovery wiring** ΓÇö `recover_stale_claims_pipeline()` 
   now runs at archive worker startup, decoupled from the legacy
   recovery so neither suppresses the other on failure.
3. **Telemetry counters** ΓÇö stale-recovery counters surfaced via
   `pipeline_status()`; shadow counters via
   `get_shadow_telemetry()`.

### Behavior change

**None in the hot path.** The archive worker still claims and
processes from `archive_queue` exactly as before. Shadow mode is pure
observation. If anything breaks (e.g., pipeline_queue peek raises),
the helper swallows the error and falls through ΓÇö production work
continues.

### Files changed

- `config.yaml` ΓÇö add `archive_queue.shadow_pipeline_queue: true` flag.
- `scripts/web/config.py` ΓÇö load
  `ARCHIVE_QUEUE_SHADOW_PIPELINE_QUEUE` (defaults True).
- `scripts/web/services/pipeline_queue_service.py` ΓÇö module-level
  recovery counter globals + lock; counter-bump in
  `recover_stale_claims_pipeline`; new `get_recovery_telemetry()`;
  `pipeline_status()` merges in the recovery telemetry keys.
- `scripts/web/services/archive_worker.py` ΓÇö new helpers
  (`_shadow_pipeline_queue_enabled`, `_shadow_compare_picks`,
  `get_shadow_telemetry`); startup hook for
  `recover_stale_claims_pipeline()`; shadow-peek + compare around the
  legacy claim site.
- `tests/test_pipeline_queue_dualwrite.py` ΓÇö 5 new tests
  (TestRecoveryTelemetry x4, TestPipelineStatusMergesRecoveryTelemetry x1).
- `tests/test_archive_worker.py` ΓÇö 9 new tests
  (TestShadowComparisonHelpers).

### Telemetry surface

- `shadow_agreement_count` (worker process)
- `shadow_disagreement_count` (worker process)
- `stale_recoveries_total` (merged into `pipeline_status`)
- `stale_recoveries_last_at` (merged into `pipeline_status`)
- `stale_recoveries_last_count` (merged into `pipeline_status`)
- `stale_recoveries_call_count` (merged into `pipeline_status`)

All counters are process-local (reset on `gadget_web` restart).

### Tests

- 14 new tests across the two test files.
- Full suite: **1,746 pass / 4 skip**.

### Verification plan post-merge

1. Deploy to `cybertruckusb.local`; restart `gadget_web.service`.
2. Tail journal for shadow log lines:
   `
   journalctl -u gadget_web.service -f | grep -i shadow
   `
3. Expect silence on agreement (no log spam) until the 500th match,
   then one INFO line. Disagreements WARN immediately with both paths.
4. Curl `pipeline_status` (via Python REPL or admin endpoint) and
   confirm the four `stale_recoveries_*` keys are present.

### What is NOT in this PR (deferred)

- **PR-E2:** inline SEI parse during `archive_worker._atomic_copy`
  (Phase I.3). Separate PR; risk profile is different (touches the
  hot copy path).
- **PR-F:** delete `live_event_sync_service.py`, batched rclone
  (Phase J), drop `has_ready_live_event_work()` poll (Phase K),
  flip the worker reader. **This** is the PR that legitimately
  finishes the parent issue.
- **PR-G:** optional single-DB consolidation (Phase I.5).

### Resolves

- `Closes #195` ΓÇö stale-recovery telemetry follow-up from PR-D
  review.

### Forward-looking note

The text `Closes #184` (i.e., the wave-finale
keyword) is intentionally not present in this PR body or commit
message ΓÇö it belongs in PR-F.
