### PR TITLE
Wave 4 PR-F1: feature-flagged unified-queue reader cutover (Ref #184)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -287,3 +287,14 @@ archive_queue:
   # production validation data while it's still cheap to fix
   # mismatches.
   shadow_pipeline_queue: true
+
+  # Wave 4 PR-F1 (issue #184): unified-queue reader cutover.
+  # When enabled, the archive worker claims its next row from
+  # ``pipeline_queue`` (via ``claim_next_for_stage``) instead of from
+  # the legacy ``archive_queue``. The legacy table continues to receive
+  # state mirrors via the existing dual-write hooks so it stays a
+  # consistent shadow during the cutover. Default ``false`` so a fresh
+  # deploy is a no-op; flip to ``true`` after PR-E shadow telemetry
+  # confirms the two readers agree on production traffic. Reverting is
+  # a single config-flag flip — no DB rollback needed.
+  use_pipeline_reader: false

--- a/scripts/web/config.py
+++ b/scripts/web/config.py
@@ -265,6 +265,14 @@ ARCHIVE_QUEUE_SHADOW_PIPELINE_QUEUE = bool(
     _archive_queue.get('shadow_pipeline_queue', True)
 )
 
+# Wave 4 PR-F1 (issue #184): unified-queue reader cutover. When True,
+# the archive worker claims via pipeline_queue.claim_next_for_stage
+# instead of archive_queue.claim_next_for_worker. Defaults False so a
+# fresh deploy is a no-op; flip on after shadow telemetry agrees.
+ARCHIVE_QUEUE_USE_PIPELINE_READER = bool(
+    _archive_queue.get('use_pipeline_reader', False)
+)
+
 # ============================================================================
 # ADVANCED SETTINGS - Computed values (don't modify these)
 # ============================================================================

--- a/scripts/web/services/archive_queue.py
+++ b/scripts/web/services/archive_queue.py
@@ -1362,10 +1362,15 @@ def claim_specific_pending(row_id: int, claimed_by: str, *,
       If the row was already claimed, deleted, or never existed, the
       rowcount is 0 and we return ``None``.
     * On success, returns the row dict (post-update) AND fires the
-      pipeline_queue dual-write hook — which is a NO-OP in PR-F1
-      because the pipeline_queue row is already ``in_progress``
-      (we just claimed it). Keeping the hook call is intentional so
-      future state-mirror invariants stay enforced.
+      pipeline_queue dual-write hook. In the PR-F1 caller flow the
+      hook is **functionally idempotent** — the pipeline_queue row
+      is already ``in_progress`` because the caller claimed it via
+      ``pipeline_queue_service.claim_next_for_stage`` before invoking
+      us, so re-writing ``status='in_progress'`` is a write of the
+      same value and does not reset ``attempts``, ``claimed_at``, or
+      any other column. Keeping the hook call is intentional so a
+      future caller invoking this helper directly (without a prior
+      pipeline_queue claim) still keeps the two tables in sync.
 
     Args:
         row_id: ``archive_queue.id`` to claim.
@@ -1431,11 +1436,15 @@ def claim_specific_pending(row_id: int, claimed_by: str, *,
         )
         return None
     if claimed is not None:
-        # Mirror the claim into pipeline_queue. This is a NO-OP in
-        # PR-F1 (the pipeline row is already 'in_progress' because
-        # the caller claimed it via pipeline_queue.claim_next_for_stage
-        # before invoking us) but kept for invariant consistency in
-        # case a future caller invokes this helper directly.
+        # Mirror the claim into pipeline_queue. In PR-F1's caller flow
+        # this is **functionally idempotent** — the pipeline row is
+        # already 'in_progress' because the caller claimed it via
+        # pipeline_queue.claim_next_for_stage before invoking us, so
+        # re-writing status='in_progress' is a write of the same
+        # value (does not reset attempts/claimed_at/claimed_by). Kept
+        # intentionally so a future caller invoking this helper
+        # directly (without a prior pipeline_queue claim) still keeps
+        # the two tables in sync.
         _dual_write_pipeline_archive_state(
             claimed.get('source_path', ''),
             status='in_progress',

--- a/scripts/web/services/archive_queue.py
+++ b/scripts/web/services/archive_queue.py
@@ -1343,6 +1343,107 @@ def claim_next_for_worker(claimed_by: str, *,
     return claimed
 
 
+def claim_specific_pending(row_id: int, claimed_by: str, *,
+                           db_path: Optional[str] = None
+                           ) -> Optional[Dict]:
+    """Claim a SPECIFIC pending row by primary key, if it is pending.
+
+    Wave 4 PR-F1 (issue #184): used by the archive worker when
+    claiming from the unified ``pipeline_queue`` reader. The pipeline
+    claim is atomic on the pipeline row but the legacy ``archive_queue``
+    row is still ``pending`` until we mirror the status here. This
+    helper exists to keep that mirror narrowly-scoped (one row by id)
+    so it cannot accidentally claim some OTHER pending row in a race
+    with the legacy reader.
+
+    Behaviour mirrors ``claim_next_for_worker`` for one specific row:
+
+    * Atomic conditional UPDATE — ``WHERE id=? AND status='pending'``.
+      If the row was already claimed, deleted, or never existed, the
+      rowcount is 0 and we return ``None``.
+    * On success, returns the row dict (post-update) AND fires the
+      pipeline_queue dual-write hook — which is a NO-OP in PR-F1
+      because the pipeline_queue row is already ``in_progress``
+      (we just claimed it). Keeping the hook call is intentional so
+      future state-mirror invariants stay enforced.
+
+    Args:
+        row_id: ``archive_queue.id`` to claim.
+        claimed_by: Stamped into ``claimed_by`` for diagnostics.
+        db_path: Override the default ``geodata.db`` path.
+
+    Returns:
+        The claimed row as a plain ``dict`` (with the post-update
+        ``status='claimed'`` / ``claimed_at`` / ``claimed_by``
+        values), or ``None`` if the row is missing / already claimed
+        / on any sqlite error.
+    """
+    if not row_id:
+        return None
+    db_path = _resolve_db_path(db_path)
+    claimed_at = _iso_now()
+    claimed: Optional[Dict] = None
+    try:
+        with _atomic_archive_op(db_path) as conn:
+            try:
+                cur = conn.execute(
+                    """
+                    UPDATE archive_queue
+                       SET status = 'claimed',
+                           claimed_at = ?,
+                           claimed_by = ?
+                     WHERE id = ? AND status = 'pending'
+                    RETURNING *
+                    """,
+                    (claimed_at, claimed_by, int(row_id)),
+                )
+                row = cur.fetchone()
+                if row is not None:
+                    claimed = dict(row)
+            except sqlite3.OperationalError:
+                # Older SQLite — no RETURNING clause. Fall back to
+                # SELECT-then-UPDATE within the same transaction.
+                row = conn.execute(
+                    "SELECT * FROM archive_queue WHERE id = ?",
+                    (int(row_id),),
+                ).fetchone()
+                if row is None or row['status'] != 'pending':
+                    return None
+                cur = conn.execute(
+                    """
+                    UPDATE archive_queue
+                       SET status = 'claimed',
+                           claimed_at = ?,
+                           claimed_by = ?
+                     WHERE id = ? AND status = 'pending'
+                    """,
+                    (claimed_at, claimed_by, int(row_id)),
+                )
+                if cur.rowcount != 1:
+                    return None
+                claimed = dict(row)
+                claimed['status'] = 'claimed'
+                claimed['claimed_at'] = claimed_at
+                claimed['claimed_by'] = claimed_by
+    except sqlite3.Error as e:
+        logger.warning(
+            "claim_specific_pending failed for id=%s: %s", row_id, e,
+        )
+        return None
+    if claimed is not None:
+        # Mirror the claim into pipeline_queue. This is a NO-OP in
+        # PR-F1 (the pipeline row is already 'in_progress' because
+        # the caller claimed it via pipeline_queue.claim_next_for_stage
+        # before invoking us) but kept for invariant consistency in
+        # case a future caller invokes this helper directly.
+        _dual_write_pipeline_archive_state(
+            claimed.get('source_path', ''),
+            status='in_progress',
+            db_path=db_path,
+        )
+    return claimed
+
+
 def mark_copied(row_id: int, dest_path: str, *,
                 db_path: Optional[str] = None) -> bool:
     """Mark a claimed row as successfully copied.

--- a/scripts/web/services/archive_worker.py
+++ b/scripts/web/services/archive_worker.py
@@ -2027,6 +2027,210 @@ def get_shadow_telemetry() -> Dict[str, int]:
 
 
 # ---------------------------------------------------------------------------
+# Wave 4 PR-F1 (issue #184): unified-queue reader cutover
+# ---------------------------------------------------------------------------
+# Switches the worker's claim site from ``archive_queue.claim_next_for_worker``
+# to ``pipeline_queue_service.claim_next_for_stage`` when the
+# ``archive_queue.use_pipeline_reader`` config flag is on. The legacy
+# ``archive_queue`` row is mirrored to ``status='claimed'`` immediately
+# after the pipeline claim succeeds so:
+#
+#   * single-worker invariants hold (archive_queue.pending count
+#     reflects reality even before mark_copied/mark_failed fires);
+#   * the existing dual-write hooks on archive_queue.mark_copied /
+#     mark_failed / release_claim continue to mirror state changes
+#     back to pipeline_queue with no further wiring;
+#   * a flag-flip back to OFF immediately reverts to the legacy path
+#     with no DB rollback needed (both tables stay consistent
+#     because dual-write was active throughout).
+#
+# When the flag is on the shadow comparison is skipped — we ARE the
+# pipeline reader now, so comparing to the legacy reader is moot
+# (PR-F2 will add an inverse shadow that compares legacy-pick against
+# the unified worker's actual pick).
+
+
+def _use_pipeline_reader_enabled() -> bool:
+    """Return True iff the operator has the reader-cutover flag on.
+
+    Wrapped in a function so a config reload (or test override) is
+    picked up on the next worker iteration without restarting the
+    thread. Lazy import so the worker module can still be imported
+    in test contexts where ``config`` isn't bootstrapped.
+    """
+    try:
+        from config import ARCHIVE_QUEUE_USE_PIPELINE_READER
+        return bool(ARCHIVE_QUEUE_USE_PIPELINE_READER)
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _adapt_pipeline_row_to_legacy_shape(
+    pipeline_row: Optional[Dict[str, Any]],
+) -> Optional[Dict[str, Any]]:
+    """Convert a ``pipeline_queue`` row into the dict shape that
+    ``process_one_claim`` and the existing legacy ``mark_*`` helpers
+    expect.
+
+    The pipeline row carries:
+      * ``id`` — the pipeline_queue PK (NOT what process_one_claim
+        wants).
+      * ``legacy_id`` — back-pointer to ``archive_queue.id``. **This
+        is what the legacy ``mark_*`` helpers expect as ``id``.**
+      * ``source_path`` / ``dest_path`` — pass through as-is.
+      * ``priority`` / ``attempts`` / ``enqueued_at`` / ``last_error``
+        — pass through as-is.
+      * ``payload`` (deserialised) — carries ``expected_size`` and
+        ``expected_mtime`` (the legacy stable-write gate inputs).
+
+    Returns ``None`` when ``pipeline_row`` is ``None`` so the caller
+    can use the same "is None?" idiom the legacy claim path used.
+    Returns ``None`` when ``legacy_id`` is missing — that would mean
+    the row was enqueued without a back-pointer (data corruption);
+    we refuse to process it via the legacy ``mark_*`` helpers
+    because they key on ``archive_queue.id`` which we don't have.
+    """
+    if pipeline_row is None:
+        return None
+    legacy_id = pipeline_row.get('legacy_id')
+    if legacy_id is None:
+        return None
+    payload = pipeline_row.get('payload') or {}
+    return {
+        'id': int(legacy_id),
+        'source_path': pipeline_row.get('source_path'),
+        'dest_path': (
+            pipeline_row.get('dest_path')
+            or payload.get('dest_path')
+        ),
+        'expected_size': payload.get('expected_size'),
+        'expected_mtime': payload.get('expected_mtime'),
+        'priority': pipeline_row.get('priority'),
+        'attempts': pipeline_row.get('attempts'),
+        'status': 'claimed',
+        'claimed_at': pipeline_row.get('claimed_at'),
+        'claimed_by': pipeline_row.get('claimed_by'),
+        'enqueued_at': pipeline_row.get('enqueued_at'),
+        'last_error': pipeline_row.get('last_error'),
+    }
+
+
+def _claim_via_pipeline_reader(
+    worker_id: str,
+    db_path: str,
+) -> Optional[Dict[str, Any]]:
+    """Claim the next ``archive_pending`` row via ``pipeline_queue``,
+    mirror to ``archive_queue``, and return a legacy-shaped row dict.
+
+    Three failure paths, all return ``None`` (worker treats as "no
+    work this iteration", same as legacy ``claim_next_for_worker``):
+
+    1. ``pipeline_queue.claim_next_for_stage`` returns ``None`` —
+       queue empty, missing DB, or sqlite error. Already logged
+       inside the helper (DEBUG / WARNING as appropriate).
+    2. The pipeline row has no ``legacy_id`` (data-shape gap).
+       Logged at WARNING because it indicates a dual-write
+       enqueue that didn't supply the back-pointer — should never
+       happen in production but handled defensively. The pipeline
+       row stays ``in_progress`` with ``last_error`` updated to
+       describe the gap; the next ``recover_stale_claims_pipeline``
+       cycle will release it once ``claimed_at`` ages past the
+       stale window.
+    3. ``archive_queue.claim_specific_pending`` returns ``None`` —
+       the legacy row was deleted, already-claimed by a stale
+       process, or never existed. We release the pipeline claim back
+       to ``pending`` so the next iteration can reconcile, and log
+       at WARNING with the legacy_id for forensics.
+
+    Success path: pipeline_queue row is in_progress, archive_queue
+    row is claimed, returned dict is legacy-shaped. The downstream
+    ``mark_copied`` / ``mark_failed`` / ``release_claim`` calls all
+    take the legacy id and dual-write back to pipeline_queue via
+    the existing PR-B hooks — no further wiring required.
+    """
+    try:
+        from services import pipeline_queue_service as pqs
+    except Exception as e:  # noqa: BLE001
+        logger.warning(
+            "PR-F1 reader switch: pipeline_queue_service import "
+            "failed (%s) — falling back to no-op", e,
+        )
+        return None
+    pipeline_row = pqs.claim_next_for_stage(
+        stage='archive_pending',
+        claimed_by=worker_id,
+        db_path=db_path,
+    )
+    if pipeline_row is None:
+        return None
+    legacy_id = pipeline_row.get('legacy_id')
+    if legacy_id is None:
+        # The dual-write enqueue did not set legacy_id — treat as
+        # data-shape failure. Update the pipeline row to surface
+        # the gap; a subsequent recover_stale_claims_pipeline will
+        # reclaim it and re-attempt.
+        try:
+            pqs.update_pipeline_row(
+                stage='archive_pending',
+                source_path=pipeline_row.get('source_path') or '',
+                last_error='PR-F1: pipeline row missing legacy_id',
+                db_path=db_path,
+            )
+        except Exception:  # noqa: BLE001
+            pass
+        logger.warning(
+            "PR-F1 reader switch: pipeline_queue row id=%s has no "
+            "legacy_id — skipping. Source: %r",
+            pipeline_row.get('id'), pipeline_row.get('source_path'),
+        )
+        return None
+    legacy_row = archive_queue.claim_specific_pending(
+        int(legacy_id), worker_id, db_path=db_path,
+    )
+    if legacy_row is None:
+        # Legacy row missing or already-claimed — release the
+        # pipeline claim back to pending so the next iteration can
+        # reconcile (or recover_stale_claims_pipeline will sweep
+        # it). This handles the rare race where the legacy reader
+        # was still active during a flag-flip and grabbed the row
+        # first; the worker simply tries again next tick.
+        try:
+            pqs.update_pipeline_row_by_legacy_id(
+                legacy_table=pqs.LEGACY_TABLE_ARCHIVE,
+                legacy_id=int(legacy_id),
+                status='pending',
+                db_path=db_path,
+            )
+        except Exception:  # noqa: BLE001
+            pass
+        logger.warning(
+            "PR-F1 reader switch: archive_queue row id=%s not "
+            "claimable (deleted, already claimed, or status changed) "
+            "— released pipeline_queue claim and skipping",
+            legacy_id,
+        )
+        return None
+    adapted = _adapt_pipeline_row_to_legacy_shape(pipeline_row)
+    # The adapter takes its expected_size/expected_mtime from the
+    # pipeline payload, but the legacy row may carry fresher values
+    # (release_claim refreshes them on stable-write gate failures).
+    # Prefer the legacy row's values when present so the
+    # process_one_claim stable-write gate sees the same data the
+    # legacy claim path would have.
+    if adapted is not None:
+        if legacy_row.get('expected_size') is not None:
+            adapted['expected_size'] = legacy_row.get('expected_size')
+        if legacy_row.get('expected_mtime') is not None:
+            adapted['expected_mtime'] = legacy_row.get('expected_mtime')
+        # Authoritative legacy_row fields override the adapted
+        # snapshot for diagnostic correctness (claimed_at/by are
+        # what the DB actually persisted).
+        adapted['claimed_at'] = legacy_row.get('claimed_at')
+        adapted['claimed_by'] = legacy_row.get('claimed_by')
+    return adapted
+
+
+# ---------------------------------------------------------------------------
 # Worker thread loop
 # ---------------------------------------------------------------------------
 
@@ -2208,62 +2412,81 @@ def _run_worker_loop(db_path: str, archive_root: str,
         new_status: Optional[str] = None
         claim_failed = False
         try:
-            # Wave 4 PR-E (issue #184): shadow-mode peek at
-            # ``pipeline_queue`` BEFORE the legacy claim so we can
-            # compare the two readers' picks against the same queue
-            # state. Pure observability — the result drives a log
-            # line only; no behavioural change. Done before the
-            # legacy claim because the dual-write fires on UPDATE,
-            # which would move the pipeline_queue row to in_progress
-            # and invalidate the comparison.
-            #
-            # We peek the top-N (not just top-1) so the documented
-            # secondary-key divergence between archive_queue
-            # (expected_mtime) and pipeline_queue (enqueued_at)
-            # doesn't generate noisy WARNINGs on benign reorderings
-            # within a priority band — see ``_shadow_compare_picks``
-            # docstring for the rationale.
-            shadow_candidates: Tuple[str, ...] = ()
-            if _shadow_pipeline_queue_enabled():
+            # Wave 4 PR-F1 (issue #184): when the cutover flag is on,
+            # claim from pipeline_queue and mirror to archive_queue.
+            # Skip the shadow comparison — we ARE the pipeline reader
+            # now, so comparing against the legacy reader is moot.
+            # Default OFF preserves the legacy claim path (and its
+            # PR-E shadow comparison) so a fresh deploy is a no-op.
+            if _use_pipeline_reader_enabled():
                 try:
-                    from services import pipeline_queue_service as pqs
-                    shadow_candidates = pqs.peek_top_n_paths_for_stage(
-                        stage='archive_pending',
-                        limit=_SHADOW_PEEK_CANDIDATE_COUNT,
+                    row = _claim_via_pipeline_reader(worker_id, db_path)
+                except Exception as e:  # noqa: BLE001
+                    logger.warning(
+                        "_claim_via_pipeline_reader raised: %s", e,
+                    )
+                    _set_state(last_error=f'claim (pipeline): {e!r}')
+                    claim_failed = True
+                    row = None
+                if row is None and not claim_failed:
+                    _set_state(last_drained_at=time.time())
+            else:
+                # Wave 4 PR-E (issue #184): shadow-mode peek at
+                # ``pipeline_queue`` BEFORE the legacy claim so we can
+                # compare the two readers' picks against the same queue
+                # state. Pure observability — the result drives a log
+                # line only; no behavioural change. Done before the
+                # legacy claim because the dual-write fires on UPDATE,
+                # which would move the pipeline_queue row to in_progress
+                # and invalidate the comparison.
+                #
+                # We peek the top-N (not just top-1) so the documented
+                # secondary-key divergence between archive_queue
+                # (expected_mtime) and pipeline_queue (enqueued_at)
+                # doesn't generate noisy WARNINGs on benign reorderings
+                # within a priority band — see ``_shadow_compare_picks``
+                # docstring for the rationale.
+                shadow_candidates: Tuple[str, ...] = ()
+                if _shadow_pipeline_queue_enabled():
+                    try:
+                        from services import pipeline_queue_service as pqs
+                        shadow_candidates = pqs.peek_top_n_paths_for_stage(
+                            stage='archive_pending',
+                            limit=_SHADOW_PEEK_CANDIDATE_COUNT,
+                        )
+                    except Exception as e:  # noqa: BLE001
+                        # Shadow path must NEVER affect the worker. Log
+                        # at DEBUG so a misconfigured DB path doesn't
+                        # spam WARNING on every iteration.
+                        logger.debug(
+                            "shadow peek_top_n_paths_for_stage failed: "
+                            "%s", e,
+                        )
+
+                try:
+                    row = archive_queue.claim_next_for_worker(
+                        worker_id, db_path=db_path,
                     )
                 except Exception as e:  # noqa: BLE001
-                    # Shadow path must NEVER affect the worker. Log
-                    # at DEBUG so a misconfigured DB path doesn't
-                    # spam WARNING on every iteration.
-                    logger.debug(
-                        "shadow peek_top_n_paths_for_stage failed: "
-                        "%s", e,
+                    logger.warning("claim_next_for_worker raised: %s", e)
+                    _set_state(last_error=f'claim: {e!r}')
+                    claim_failed = True
+                    row = None
+
+                if row is None and not claim_failed:
+                    _set_state(last_drained_at=time.time())
+
+                # Wave 4 PR-E: compare the legacy pick against the
+                # pipeline_queue top-N. Agreement = legacy_path appears
+                # in the candidate set (or both empty). Disagreement =
+                # legacy picked a path absent from the top-N — a real
+                # dual-write gap.
+                if shadow_candidates or row is not None or \
+                        _shadow_pipeline_queue_enabled():
+                    _shadow_compare_picks(
+                        legacy_path=row.get('source_path') if row else None,
+                        pipeline_candidates=shadow_candidates,
                     )
-
-            try:
-                row = archive_queue.claim_next_for_worker(
-                    worker_id, db_path=db_path,
-                )
-            except Exception as e:  # noqa: BLE001
-                logger.warning("claim_next_for_worker raised: %s", e)
-                _set_state(last_error=f'claim: {e!r}')
-                claim_failed = True
-                row = None
-
-            if row is None and not claim_failed:
-                _set_state(last_drained_at=time.time())
-
-            # Wave 4 PR-E: compare the legacy pick against the
-            # pipeline_queue top-N. Agreement = legacy_path appears
-            # in the candidate set (or both empty). Disagreement =
-            # legacy picked a path absent from the top-N — a real
-            # dual-write gap.
-            if shadow_candidates or row is not None or \
-                    _shadow_pipeline_queue_enabled():
-                _shadow_compare_picks(
-                    legacy_path=row.get('source_path') if row else None,
-                    pipeline_candidates=shadow_candidates,
-                )
 
             if row is not None:
                 # If pause arrived between claim and process, release

--- a/scripts/web/services/archive_worker.py
+++ b/scripts/web/services/archive_worker.py
@@ -2165,22 +2165,35 @@ def _claim_via_pipeline_reader(
         return None
     legacy_id = pipeline_row.get('legacy_id')
     if legacy_id is None:
-        # The dual-write enqueue did not set legacy_id — treat as
-        # data-shape failure. Update the pipeline row to surface
-        # the gap; a subsequent recover_stale_claims_pipeline will
-        # reclaim it and re-attempt.
+        # Wave 4 PR-F1 review fix #1 (PR #198): the dual-write
+        # enqueue did not set legacy_id. This is a permanent
+        # data-shape corruption that retrying cannot fix — the
+        # back-pointer was never set, so no number of recovery
+        # cycles will produce one. Move the row to ``dead_letter``
+        # immediately (instead of leaving it in_progress and letting
+        # ``recover_stale_claims_pipeline`` keep recycling it back to
+        # pending in a tight loop). Operators can inspect the
+        # dead-letter rows via the upcoming /api/pipeline_queue/
+        # dead_letter endpoint and either manually backfill the
+        # legacy_id or drop the row.
         try:
             pqs.update_pipeline_row(
                 stage='archive_pending',
                 source_path=pipeline_row.get('source_path') or '',
-                last_error='PR-F1: pipeline row missing legacy_id',
+                status='dead_letter',
+                last_error=(
+                    'PR-F1: pipeline_queue row missing legacy_id '
+                    '(unrecoverable data-shape corruption); manual '
+                    'intervention required'
+                ),
                 db_path=db_path,
             )
         except Exception:  # noqa: BLE001
             pass
         logger.warning(
             "PR-F1 reader switch: pipeline_queue row id=%s has no "
-            "legacy_id — skipping. Source: %r",
+            "legacy_id — moved to dead_letter (unrecoverable). "
+            "Source: %r",
             pipeline_row.get('id'), pipeline_row.get('source_path'),
         )
         return None
@@ -2188,17 +2201,27 @@ def _claim_via_pipeline_reader(
         int(legacy_id), worker_id, db_path=db_path,
     )
     if legacy_row is None:
-        # Legacy row missing or already-claimed — release the
-        # pipeline claim back to pending so the next iteration can
-        # reconcile (or recover_stale_claims_pipeline will sweep
-        # it). This handles the rare race where the legacy reader
-        # was still active during a flag-flip and grabbed the row
-        # first; the worker simply tries again next tick.
+        # Wave 4 PR-F1 review fix #2 (PR #198): legacy row missing
+        # or already-claimed. Release the pipeline_queue claim back
+        # to ``pending`` AND clear ``claimed_by`` / ``claimed_at`` so
+        # the row presents as a clean ``pending`` row to operators
+        # and to ``recover_stale_claims_pipeline``. (Leaving the
+        # claim metadata stale on a ``pending`` row would look like
+        # a stuck active claim AND would NOT be picked up by
+        # recovery — which filters on ``status='in_progress'``.)
+        # The next worker iteration will re-attempt; since the
+        # legacy row is missing, the same code path will fire
+        # again — but the legacy reader (or stale-recovery in the
+        # legacy queue) will eventually reconcile the gap.
         try:
-            pqs.update_pipeline_row_by_legacy_id(
+            pqs.release_pipeline_claim(
                 legacy_table=pqs.LEGACY_TABLE_ARCHIVE,
                 legacy_id=int(legacy_id),
-                status='pending',
+                last_error=(
+                    'PR-F1: archive_queue row not claimable '
+                    '(deleted, already claimed, or status changed) '
+                    '— pipeline claim released'
+                ),
                 db_path=db_path,
             )
         except Exception:  # noqa: BLE001
@@ -2210,6 +2233,16 @@ def _claim_via_pipeline_reader(
             legacy_id,
         )
         return None
+    # Wave 4 PR-F1 review fix #4 (PR #198): note that
+    # ``pipeline_queue.attempts`` was already bumped by
+    # ``claim_next_for_stage`` above, but ``archive_queue.attempts``
+    # was NOT bumped by ``claim_specific_pending`` (the legacy claim
+    # path historically does not increment attempts on claim). The
+    # two counters intentionally drift on the success path — the
+    # legacy ``attempts`` is bumped only on ``mark_failed``, while
+    # the pipeline ``attempts`` reflects every claim. Operators
+    # cross-comparing the two during the cutover window will see
+    # this divergence; it is not a dual-write bug.
     adapted = _adapt_pipeline_row_to_legacy_shape(pipeline_row)
     # The adapter takes its expected_size/expected_mtime from the
     # pipeline payload, but the legacy row may carry fresher values
@@ -2418,6 +2451,20 @@ def _run_worker_loop(db_path: str, archive_root: str,
             # now, so comparing against the legacy reader is moot.
             # Default OFF preserves the legacy claim path (and its
             # PR-E shadow comparison) so a fresh deploy is a no-op.
+            #
+            # TODO(PR-F2 / future): consider an *inverse* shadow when
+            # the flag is ON — peek the legacy reader's pick (via a
+            # non-mutating SELECT against archive_queue, mirroring
+            # ``peek_next_for_stage``) and compare against the
+            # pipeline pick we just claimed. Same purpose as PR-E's
+            # shadow but in the opposite direction, giving operators
+            # confidence during the cutover window. Out of scope for
+            # PR-F1 because (a) the single-worker invariant means a
+            # divergence couldn't actually starve the legacy queue,
+            # and (b) the legacy reader has no equivalent of
+            # ``peek_top_n_paths_for_stage`` yet — would need a new
+            # ``archive_queue.peek_next_for_worker`` helper. Track
+            # via the relevant sub-PR (see issue body's Wave 4 plan).
             if _use_pipeline_reader_enabled():
                 try:
                     row = _claim_via_pipeline_reader(worker_id, db_path)

--- a/scripts/web/services/pipeline_queue_service.py
+++ b/scripts/web/services/pipeline_queue_service.py
@@ -559,6 +559,94 @@ def update_pipeline_row_by_legacy_id(
                 pass
 
 
+def release_pipeline_claim(
+    *,
+    legacy_table: str,
+    legacy_id: int,
+    last_error: Optional[str] = None,
+    db_path: Optional[str] = None,
+) -> bool:
+    """Release a claimed pipeline_queue row back to ``status='pending'``,
+    nulling ``claimed_by`` and ``claimed_at``.
+
+    Wave 4 PR-F1 (issue #184): used by ``archive_worker`` when a
+    pipeline_queue row was claimed but the work didn't actually
+    start (e.g. the legacy mirror failed or the dispatch path bailed
+    before doing real work). Differs from
+    :func:`update_pipeline_row_by_legacy_id` with ``status='pending'``
+    in that it ALSO clears the claim metadata — leaving stale
+    ``claimed_by`` / ``claimed_at`` on a ``pending`` row would
+    confuse forensics (looks like a stuck active claim) and would
+    NOT be picked up by :func:`recover_stale_claims_pipeline`
+    (which filters on ``status='in_progress'`` only).
+
+    The ``_UPDATE_COLUMNS`` whitelist used by
+    :func:`update_pipeline_row*` deliberately excludes ``claimed_by``
+    / ``claimed_at`` so callers can't accidentally clear claim state
+    via the generic update API; this helper is the public, named
+    entry point for "release a claim cleanly."
+
+    Args:
+        legacy_table: One of the ``LEGACY_TABLE_*`` constants — same
+            semantics as :func:`update_pipeline_row_by_legacy_id`.
+        legacy_id: ``archive_queue.id`` (or equivalent legacy PK).
+        last_error: Optional human-readable string stamped into
+            ``last_error`` for forensic context. ``None`` (default)
+            leaves the existing ``last_error`` untouched.
+        db_path: Override the geodata.db path (test injection).
+
+    Returns:
+        ``True`` on a successful UPDATE (rowcount > 0). ``False`` on
+        missing DB, missing args, sqlite error, or no matching row
+        — same silent no-op semantics as the rest of this module.
+        Returns ``False`` (not raising) so a pipeline_queue glitch
+        cannot abort the caller's mutation flow.
+    """
+    if db_path is None:
+        db_path = _resolve_pipeline_db()
+    if not db_path or not os.path.isfile(db_path):
+        return False
+    if not legacy_table or legacy_id is None:
+        return False
+    if last_error is not None:
+        sql = (
+            "UPDATE pipeline_queue "
+            "   SET status = 'pending', "
+            "       claimed_by = NULL, "
+            "       claimed_at = NULL, "
+            "       last_error = ? "
+            " WHERE legacy_table = ? AND legacy_id = ?"
+        )
+        params = (last_error, legacy_table, int(legacy_id))
+    else:
+        sql = (
+            "UPDATE pipeline_queue "
+            "   SET status = 'pending', "
+            "       claimed_by = NULL, "
+            "       claimed_at = NULL "
+            " WHERE legacy_table = ? AND legacy_id = ?"
+        )
+        params = (legacy_table, int(legacy_id))
+    conn = None
+    try:
+        conn = _open_pipeline_conn(db_path)
+        cur = conn.execute(sql, params)
+        conn.commit()
+        return cur.rowcount > 0
+    except sqlite3.Error as e:
+        logger.debug(
+            "release_pipeline_claim(table=%s, id=%s) failed: %s",
+            legacy_table, legacy_id, e,
+        )
+        return False
+    finally:
+        if conn is not None:
+            try:
+                conn.close()
+            except sqlite3.Error:
+                pass
+
+
 # ---------------------------------------------------------------------------
 # Reader API — Wave 4 PR-C (issue #184)
 # ---------------------------------------------------------------------------

--- a/tests/test_archive_queue.py
+++ b/tests/test_archive_queue.py
@@ -2566,3 +2566,136 @@ class TestPriorityMigrationV12ToV13:
             assert row['v'] == _SCHEMA_VERSION
         finally:
             conn.close()
+
+
+
+# ---------------------------------------------------------------------------
+# Wave 4 PR-F1 (issue #184): claim_specific_pending — claim a SPECIFIC row
+# ---------------------------------------------------------------------------
+
+
+class TestClaimSpecificPending:
+    """Helper used by archive_worker._claim_via_pipeline_reader to mirror
+    a pipeline_queue claim onto the legacy archive_queue row.
+
+    Behaviour mirrors ``claim_next_for_worker`` for one specific row;
+    must atomically conditional-UPDATE on (id, status='pending').
+    """
+
+    def test_returns_none_for_zero_id(self, db):
+        assert archive_queue.claim_specific_pending(0, 'w1', db_path=db) is None
+
+    def test_returns_none_for_missing_row(self, db):
+        assert archive_queue.claim_specific_pending(
+            99999, 'w1', db_path=db,
+        ) is None
+
+    def test_claims_pending_row(self, db, sample_file):
+        archive_queue.enqueue_for_archive(sample_file, db_path=db)
+        rows = archive_queue.list_queue(db_path=db, status='pending')
+        assert len(rows) == 1
+        row_id = rows[0]['id']
+
+        claimed = archive_queue.claim_specific_pending(
+            row_id, 'w-pr-f1', db_path=db,
+        )
+        assert claimed is not None
+        assert claimed['id'] == row_id
+        assert claimed['status'] == 'claimed'
+        assert claimed['claimed_by'] == 'w-pr-f1'
+        assert claimed['claimed_at'] is not None
+        assert claimed['source_path'] == sample_file
+
+    def test_refuses_already_claimed_row(self, db, sample_file):
+        archive_queue.enqueue_for_archive(sample_file, db_path=db)
+        rows = archive_queue.list_queue(db_path=db, status='pending')
+        row_id = rows[0]['id']
+
+        first = archive_queue.claim_specific_pending(
+            row_id, 'w1', db_path=db,
+        )
+        assert first is not None
+        second = archive_queue.claim_specific_pending(
+            row_id, 'w2', db_path=db,
+        )
+        assert second is None
+
+    def test_refuses_non_pending_status(self, db, sample_file):
+        archive_queue.enqueue_for_archive(sample_file, db_path=db)
+        rows = archive_queue.list_queue(db_path=db, status='pending')
+        row_id = rows[0]['id']
+
+        conn = sqlite3.connect(db)
+        try:
+            conn.execute(
+                "UPDATE archive_queue SET status='copied' WHERE id=?",
+                (row_id,),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        result = archive_queue.claim_specific_pending(
+            row_id, 'w1', db_path=db,
+        )
+        assert result is None
+
+    def test_two_concurrent_claims_only_one_wins(self, db, sample_file):
+        archive_queue.enqueue_for_archive(sample_file, db_path=db)
+        rows = archive_queue.list_queue(db_path=db, status='pending')
+        row_id = rows[0]['id']
+
+        results = []
+        barrier = threading.Barrier(2)
+
+        def claimer(name):
+            barrier.wait()
+            r = archive_queue.claim_specific_pending(
+                row_id, name, db_path=db,
+            )
+            results.append(r)
+
+        t1 = threading.Thread(target=claimer, args=('w1',))
+        t2 = threading.Thread(target=claimer, args=('w2',))
+        t1.start()
+        t2.start()
+        t1.join()
+        t2.join()
+
+        winners = [r for r in results if r is not None]
+        losers = [r for r in results if r is None]
+        assert len(winners) == 1
+        assert len(losers) == 1
+
+    def test_dual_writes_pipeline_queue_in_progress(self, db, sample_file):
+        """The mirror MUST keep the pipeline_queue dual-write hook firing.
+
+        Even though the pipeline_queue row was already moved to
+        'in_progress' by ``pipeline_queue_service.claim_next_for_stage``
+        before this helper is called in production, the hook stays in
+        place as a defensive invariant — calling claim_specific_pending
+        in isolation (e.g. from a future caller) must not leave the
+        pipeline_queue stale.
+        """
+        archive_queue.enqueue_for_archive(sample_file, db_path=db)
+        rows = archive_queue.list_queue(db_path=db, status='pending')
+        row_id = rows[0]['id']
+
+        claimed = archive_queue.claim_specific_pending(
+            row_id, 'w1', db_path=db,
+        )
+        assert claimed is not None
+
+        # Inspect pipeline_queue row directly.
+        conn = sqlite3.connect(db)
+        try:
+            conn.row_factory = sqlite3.Row
+            row = conn.execute(
+                "SELECT status FROM pipeline_queue "
+                " WHERE source_path = ? AND stage = 'archive_pending'",
+                (sample_file,),
+            ).fetchone()
+            assert row is not None
+            assert row['status'] == 'in_progress'
+        finally:
+            conn.close()

--- a/tests/test_archive_worker.py
+++ b/tests/test_archive_worker.py
@@ -3693,12 +3693,19 @@ class TestClaimViaPipelineReader:
         finally:
             conn.close()
 
-    def test_pipeline_row_missing_legacy_id_releases_and_skips(
+    def test_pipeline_row_missing_legacy_id_moves_to_dead_letter(
         self, db_path, sample_file, caplog,
     ):
         # Manually insert a pipeline_queue row WITHOUT legacy_id to
         # simulate a corrupted dual-write. The wrapper must:
-        # (a) return None, (b) log WARNING, (c) update last_error.
+        # (a) return None,
+        # (b) log WARNING,
+        # (c) move the row to ``status='dead_letter'`` (NOT leave
+        #     it ``in_progress``) so ``recover_stale_claims_pipeline``
+        #     does not recycle it back to pending in a tight loop.
+        # (d) update ``last_error`` for forensic context.
+        # This is the PR-F1 review fix #1 contract — the missing
+        # legacy_id is unrecoverable corruption, not a transient.
         import logging as _log
         caplog.set_level(_log.WARNING)
         from services import pipeline_queue_service as pqs
@@ -3721,18 +3728,28 @@ class TestClaimViaPipelineReader:
                     and 'PR-F1' in r.getMessage()]
         assert len(warnings) >= 1
         assert any('legacy_id' in r.getMessage() for r in warnings)
+        # Operators should see the "moved to dead_letter" hint in the
+        # log so they know the row needs manual intervention.
+        assert any('dead_letter' in r.getMessage() for r in warnings)
 
-        # last_error has been recorded so operators can investigate.
+        # Row is dead_letter (NOT in_progress) so the recovery sweep
+        # leaves it alone and the worker never re-claims it.
         conn = sqlite3.connect(db_path)
         try:
             conn.row_factory = sqlite3.Row
             row = conn.execute(
-                "SELECT last_error FROM pipeline_queue "
+                "SELECT status, last_error FROM pipeline_queue "
                 " WHERE source_path = ? AND stage = 'archive_pending'",
                 (sample_file,),
             ).fetchone()
             assert row is not None
+            assert row['status'] == 'dead_letter', (
+                f"Expected dead_letter, got {row['status']!r} — "
+                "missing-legacy_id rows must NOT remain in_progress "
+                "or pending (would loop forever)"
+            )
             assert 'legacy_id' in (row['last_error'] or '')
+            assert 'unrecoverable' in (row['last_error'] or '')
         finally:
             conn.close()
 
@@ -3744,6 +3761,10 @@ class TestClaimViaPipelineReader:
         # simulating "the legacy row got deleted out from under us".
         # The wrapper must release the pipeline_queue claim back to
         # 'pending' so the next iteration can retry, AND log WARNING.
+        # Per PR-F1 review fix #2: ``claimed_by`` / ``claimed_at``
+        # MUST be cleared (not left stale) so the row presents as a
+        # clean ``pending`` row to operators and to
+        # ``recover_stale_claims_pipeline``.
         import logging as _log
         caplog.set_level(_log.WARNING)
         from services import archive_queue as aq
@@ -3759,24 +3780,37 @@ class TestClaimViaPipelineReader:
         )
         assert result is None
 
-        # WARNING logged with the legacy id.
         warnings = [r for r in caplog.records
                     if r.levelno == _log.WARNING
                     and 'PR-F1' in r.getMessage()
                     and 'archive_queue row' in r.getMessage()]
         assert len(warnings) >= 1
 
-        # Pipeline_queue row was released back to 'pending'.
+        # Pipeline_queue row was released back to 'pending' AND
+        # claim metadata was cleared.
         conn = sqlite3.connect(db_path)
         try:
             conn.row_factory = sqlite3.Row
             row = conn.execute(
-                "SELECT status FROM pipeline_queue "
+                "SELECT status, claimed_by, claimed_at, last_error "
+                "  FROM pipeline_queue "
                 " WHERE source_path = ? AND stage = 'archive_pending'",
                 (sample_file,),
             ).fetchone()
             assert row is not None
             assert row['status'] == 'pending'
+            assert row['claimed_by'] is None, (
+                "claimed_by must be cleared on release — leaving it "
+                "set would look like a stuck active claim AND would "
+                "NOT be picked up by recover_stale_claims_pipeline "
+                "(which filters on status='in_progress')"
+            )
+            assert row['claimed_at'] is None, (
+                "claimed_at must be cleared on release — see fix #2 "
+                "in PR #198 review"
+            )
+            # last_error gives operators a hint about what happened.
+            assert 'PR-F1' in (row['last_error'] or '')
         finally:
             conn.close()
 
@@ -3810,16 +3844,19 @@ class TestClaimViaPipelineReader:
         assert result['expected_size'] == 999999
         assert result['expected_mtime'] == 1.5
 
-    def test_pipeline_queue_service_import_failure_returns_none(
+    def test_claim_next_for_stage_exception_bubbles_to_caller(
         self, db_path, monkeypatch, caplog,
     ):
-        # Defensive: if pipeline_queue_service raises during the
-        # `claim_next_for_stage` call (e.g., transient sqlite error
-        # at import-time leaks through), the wrapper must NOT crash
-        # — return None and log. We simulate this by monkeypatching
-        # claim_next_for_stage to raise; the wrapper's try/except
-        # in ``_claim_via_pipeline_reader`` runs the same path the
-        # real ``except Exception`` arm would have caught.
+        # Contract assertion: ``_claim_via_pipeline_reader`` does NOT
+        # swallow exceptions from ``claim_next_for_stage``. The pipeline
+        # service is documented to swallow sqlite errors internally and
+        # return None on failure, so an exception escaping it indicates
+        # a real bug (e.g. a programmer error or unexpected runtime
+        # condition). Bubbling it lets the worker loop's outer
+        # try/except catch it, log a WARNING, and continue — consistent
+        # with how the legacy ``claim_next_for_worker`` exception is
+        # handled. We simulate the unexpected exception here and assert
+        # it propagates.
         import logging as _log
         caplog.set_level(_log.WARNING)
         from services import pipeline_queue_service as pqs
@@ -3829,14 +3866,226 @@ class TestClaimViaPipelineReader:
 
         monkeypatch.setattr(pqs, 'claim_next_for_stage', _boom)
 
-        # The outer try/except in archive_worker._run_worker_loop
-        # catches the exception when called from the loop, but our
-        # wrapper itself doesn't catch claim_next_for_stage errors
-        # — that's intentional: ``claim_next_for_stage`` is documented
-        # to swallow sqlite errors and return None on failure, so an
-        # exception bubbling out is a real bug. We assert it bubbles.
         import pytest
         with pytest.raises(RuntimeError):
             archive_worker._claim_via_pipeline_reader(
                 'w-pr-f1', db_path,
             )
+
+
+# ---------------------------------------------------------------------------
+# TestRunWorkerLoopReaderSwitch (PR-F1 review fix #6)
+# ---------------------------------------------------------------------------
+
+
+class TestRunWorkerLoopReaderSwitch:
+    """End-to-end coverage of the cutover-flag branch in ``_run_worker_loop``.
+
+    PR-F1 (issue #184) added a flag ``ARCHIVE_QUEUE_USE_PIPELINE_READER``
+    that selects between two claim paths:
+
+    * Flag ON  → ``_claim_via_pipeline_reader`` (pipeline_queue source-of-truth)
+    * Flag OFF → ``archive_queue.claim_next_for_worker`` + PR-E shadow peek
+
+    These tests run the **real** worker loop (via ``start_worker``) with a
+    single enqueued clip and assert that:
+
+    1. The chosen claim path was actually invoked (spy via monkeypatch).
+    2. The other claim path was NOT invoked (no double-claiming).
+    3. The clip drains end-to-end (status='copied' on archive_queue, and
+       'done' on the pipeline_queue mirror) — proving the dual-write
+       contract holds across the switch.
+    """
+
+    def test_flag_on_routes_through_pipeline_reader_and_completes(
+        self, db, archive_root, teslacam_root, make_clip, monkeypatch,
+    ):
+        # Force flag ON.
+        monkeypatch.setattr(
+            archive_worker, '_use_pipeline_reader_enabled',
+            lambda: True,
+        )
+        # Spy on both claim paths so we can assert which one ran.
+        pipeline_calls: List[str] = []
+        legacy_calls: List[str] = []
+
+        real_pipeline_claim = archive_worker._claim_via_pipeline_reader
+        real_legacy_claim = archive_queue.claim_next_for_worker
+
+        def _pipeline_spy(worker_id, db_path):
+            pipeline_calls.append(worker_id)
+            return real_pipeline_claim(worker_id, db_path)
+
+        def _legacy_spy(*args, **kwargs):
+            legacy_calls.append('called')
+            return real_legacy_claim(*args, **kwargs)
+
+        monkeypatch.setattr(
+            archive_worker, '_claim_via_pipeline_reader', _pipeline_spy,
+        )
+        monkeypatch.setattr(
+            archive_queue, 'claim_next_for_worker', _legacy_spy,
+        )
+
+        clip = make_clip("RecentClips/pf-front.mp4", mtime=1000.0)
+        enqueue_for_archive(clip, db_path=db)
+
+        archive_worker.start_worker(
+            db, archive_root, teslacam_root=teslacam_root,
+        )
+        try:
+            # Wait for the row to land in 'copied'.
+            deadline = time.monotonic() + 15
+            copied = False
+            while time.monotonic() < deadline:
+                rows = list_queue(db_path=db)
+                if rows and rows[0]['status'] == 'copied':
+                    copied = True
+                    break
+                time.sleep(0.05)
+            assert copied, (
+                f"Flag-ON path failed to drain row; final state: "
+                f"{[dict(r) for r in list_queue(db_path=db)]}"
+            )
+        finally:
+            archive_worker.stop_worker(timeout=5)
+
+        # Pipeline path was hit at least once for the actual claim.
+        assert len(pipeline_calls) >= 1, (
+            "Flag ON but _claim_via_pipeline_reader was never called"
+        )
+        # Legacy path must NOT have been called as a fallback — the
+        # flag-on branch is exclusive.
+        assert legacy_calls == [], (
+            "Flag ON but legacy claim_next_for_worker was also called "
+            "— double-claim risk"
+        )
+
+        # Pipeline_queue mirror reflects the completion. After
+        # mark_copied, the row is moved to stage='archive_done' and
+        # status='done', so we search by source_path only.
+        conn = sqlite3.connect(db)
+        try:
+            conn.row_factory = sqlite3.Row
+            pr = conn.execute(
+                "SELECT stage, status FROM pipeline_queue "
+                " WHERE source_path = ?",
+                (clip,),
+            ).fetchone()
+            assert pr is not None, (
+                "Pipeline_queue mirror row missing — dual-write "
+                "broke between claim and completion"
+            )
+            assert pr['stage'] == 'archive_done', (
+                f"Pipeline_queue mirror stage is {pr['stage']!r} "
+                f"— expected 'archive_done' after copy"
+            )
+            assert pr['status'] == 'done', (
+                f"Pipeline_queue mirror status is {pr['status']!r} "
+                f"— expected 'done' after copy"
+            )
+        finally:
+            conn.close()
+
+    def test_flag_off_uses_legacy_path_and_runs_shadow_peek(
+        self, db, archive_root, teslacam_root, make_clip, monkeypatch,
+    ):
+        # Force flag OFF (the production default).
+        monkeypatch.setattr(
+            archive_worker, '_use_pipeline_reader_enabled',
+            lambda: False,
+        )
+        # Force shadow peek ON so we can verify it ran.
+        monkeypatch.setattr(
+            archive_worker, '_shadow_pipeline_queue_enabled',
+            lambda: True,
+        )
+
+        pipeline_calls: List[str] = []
+        legacy_calls: List[str] = []
+        shadow_calls: List[str] = []
+
+        real_pipeline_claim = archive_worker._claim_via_pipeline_reader
+        real_legacy_claim = archive_queue.claim_next_for_worker
+        real_shadow_compare = archive_worker._shadow_compare_picks
+
+        def _pipeline_spy(worker_id, db_path):
+            pipeline_calls.append(worker_id)
+            return real_pipeline_claim(worker_id, db_path)
+
+        def _legacy_spy(*args, **kwargs):
+            legacy_calls.append('called')
+            return real_legacy_claim(*args, **kwargs)
+
+        def _shadow_spy(*args, **kwargs):
+            shadow_calls.append('called')
+            return real_shadow_compare(*args, **kwargs)
+
+        monkeypatch.setattr(
+            archive_worker, '_claim_via_pipeline_reader', _pipeline_spy,
+        )
+        monkeypatch.setattr(
+            archive_queue, 'claim_next_for_worker', _legacy_spy,
+        )
+        monkeypatch.setattr(
+            archive_worker, '_shadow_compare_picks', _shadow_spy,
+        )
+
+        clip = make_clip("RecentClips/pf-front-off.mp4", mtime=1000.0)
+        enqueue_for_archive(clip, db_path=db)
+
+        archive_worker.start_worker(
+            db, archive_root, teslacam_root=teslacam_root,
+        )
+        try:
+            deadline = time.monotonic() + 15
+            copied = False
+            while time.monotonic() < deadline:
+                rows = list_queue(db_path=db)
+                if rows and rows[0]['status'] == 'copied':
+                    copied = True
+                    break
+                time.sleep(0.05)
+            assert copied, (
+                f"Flag-OFF path failed to drain row; final state: "
+                f"{[dict(r) for r in list_queue(db_path=db)]}"
+            )
+        finally:
+            archive_worker.stop_worker(timeout=5)
+
+        # Legacy path was hit; pipeline path was NOT.
+        assert len(legacy_calls) >= 1, (
+            "Flag OFF but legacy claim_next_for_worker was never called"
+        )
+        assert pipeline_calls == [], (
+            "Flag OFF but _claim_via_pipeline_reader was called "
+            "— branch should be exclusive"
+        )
+        # Shadow comparison runs on the legacy path.
+        assert len(shadow_calls) >= 1, (
+            "Flag OFF and shadow ON, but _shadow_compare_picks was "
+            "never invoked"
+        )
+
+        # Dual-write still mirrors the completion to pipeline_queue
+        # (the dual-write hooks fire from the legacy mark_copied path).
+        # After mark_copied, stage moves to 'archive_done'.
+        conn = sqlite3.connect(db)
+        try:
+            conn.row_factory = sqlite3.Row
+            pr = conn.execute(
+                "SELECT stage, status FROM pipeline_queue "
+                " WHERE source_path = ?",
+                (clip,),
+            ).fetchone()
+            assert pr is not None
+            assert pr['stage'] == 'archive_done', (
+                f"Pipeline_queue mirror stage is {pr['stage']!r} "
+                f"after legacy-path completion — expected 'archive_done'"
+            )
+            assert pr['status'] == 'done', (
+                f"Pipeline_queue mirror status is {pr['status']!r} "
+                f"after legacy-path completion — expected 'done'"
+            )
+        finally:
+            conn.close()

--- a/tests/test_archive_worker.py
+++ b/tests/test_archive_worker.py
@@ -3477,3 +3477,366 @@ class TestShadowComparisonHelpers:
                 _conf, 'ARCHIVE_QUEUE_SHADOW_PIPELINE_QUEUE',
             )
         assert archive_worker._shadow_pipeline_queue_enabled() is False
+
+
+
+# ---------------------------------------------------------------------------
+# Wave 4 PR-F1 (issue #184): unified-queue reader cutover
+# ---------------------------------------------------------------------------
+
+
+class TestUsePipelineReaderEnabled:
+    """The flag-reading helper must lazily import config and never crash."""
+
+    def test_default_off_when_attr_missing(self, monkeypatch):
+        import config as _conf
+        if hasattr(_conf, 'ARCHIVE_QUEUE_USE_PIPELINE_READER'):
+            monkeypatch.delattr(
+                _conf, 'ARCHIVE_QUEUE_USE_PIPELINE_READER',
+            )
+        assert archive_worker._use_pipeline_reader_enabled() is False
+
+    def test_returns_true_when_flag_on(self, monkeypatch):
+        import config as _conf
+        monkeypatch.setattr(
+            _conf, 'ARCHIVE_QUEUE_USE_PIPELINE_READER', True,
+            raising=False,
+        )
+        assert archive_worker._use_pipeline_reader_enabled() is True
+
+    def test_returns_false_when_flag_off(self, monkeypatch):
+        import config as _conf
+        monkeypatch.setattr(
+            _conf, 'ARCHIVE_QUEUE_USE_PIPELINE_READER', False,
+            raising=False,
+        )
+        assert archive_worker._use_pipeline_reader_enabled() is False
+
+
+class TestAdaptPipelineRowToLegacyShape:
+    """The adapter converts a pipeline_queue row dict into the dict shape
+    that ``process_one_claim`` and the legacy ``mark_*`` helpers expect.
+    """
+
+    def test_none_input_returns_none(self):
+        assert archive_worker._adapt_pipeline_row_to_legacy_shape(None) is None
+
+    def test_missing_legacy_id_returns_none(self):
+        # legacy_id is REQUIRED — the adapter refuses to process a
+        # row that can't be reconciled with the legacy archive_queue.
+        row = {
+            'id': 99,
+            'source_path': '/tc/SentryClips/e/front.mp4',
+            'priority': 1,
+        }
+        assert archive_worker._adapt_pipeline_row_to_legacy_shape(row) is None
+
+    def test_full_payload_maps_all_fields(self):
+        pipeline_row = {
+            'id': 99,
+            'legacy_id': 42,
+            'source_path': '/tc/SentryClips/e/front.mp4',
+            'dest_path': '/sd/SentryClips/e/front.mp4',
+            'priority': 1,
+            'attempts': 2,
+            'enqueued_at': 1700000000.0,
+            'last_error': None,
+            'claimed_at': 1700000005.0,
+            'claimed_by': 'w-pr-f1',
+            'payload': {
+                'expected_size': 12345,
+                'expected_mtime': 1699999999.5,
+            },
+        }
+        adapted = archive_worker._adapt_pipeline_row_to_legacy_shape(
+            pipeline_row,
+        )
+        assert adapted is not None
+        assert adapted['id'] == 42
+        assert adapted['source_path'] == '/tc/SentryClips/e/front.mp4'
+        assert adapted['dest_path'] == '/sd/SentryClips/e/front.mp4'
+        assert adapted['expected_size'] == 12345
+        assert adapted['expected_mtime'] == 1699999999.5
+        assert adapted['priority'] == 1
+        assert adapted['attempts'] == 2
+        assert adapted['status'] == 'claimed'
+        assert adapted['claimed_at'] == 1700000005.0
+        assert adapted['claimed_by'] == 'w-pr-f1'
+        assert adapted['enqueued_at'] == 1700000000.0
+
+    def test_empty_payload_yields_none_for_optional_fields(self):
+        pipeline_row = {
+            'legacy_id': 7,
+            'source_path': '/tc/RecentClips/x.mp4',
+            'priority': 2,
+            'attempts': 1,
+            'payload': {},
+        }
+        adapted = archive_worker._adapt_pipeline_row_to_legacy_shape(
+            pipeline_row,
+        )
+        assert adapted is not None
+        assert adapted['id'] == 7
+        assert adapted['source_path'] == '/tc/RecentClips/x.mp4'
+        assert adapted['expected_size'] is None
+        assert adapted['expected_mtime'] is None
+        assert adapted['dest_path'] is None
+
+    def test_dest_path_falls_back_to_payload(self):
+        pipeline_row = {
+            'legacy_id': 7,
+            'source_path': '/tc/RecentClips/x.mp4',
+            'dest_path': None,  # row-level missing
+            'payload': {
+                'dest_path': '/sd/RecentClips/x.mp4',
+            },
+        }
+        adapted = archive_worker._adapt_pipeline_row_to_legacy_shape(
+            pipeline_row,
+        )
+        assert adapted is not None
+        assert adapted['dest_path'] == '/sd/RecentClips/x.mp4'
+
+    def test_missing_payload_treated_as_empty(self):
+        # `payload` key is allowed to be missing entirely — the
+        # adapter must default to {} (claim_next_for_stage already
+        # synthesises payload but defensive).
+        pipeline_row = {
+            'legacy_id': 7,
+            'source_path': '/tc/RecentClips/x.mp4',
+        }
+        adapted = archive_worker._adapt_pipeline_row_to_legacy_shape(
+            pipeline_row,
+        )
+        assert adapted is not None
+        assert adapted['expected_size'] is None
+        assert adapted['expected_mtime'] is None
+
+
+class TestClaimViaPipelineReader:
+    """End-to-end behaviour of the new claim path.
+
+    Tested with the REAL pipeline_queue + archive_queue tables (one
+    geodata.db, both schemas) so we exercise the dual-write contract
+    holistically, not via mocks alone.
+    """
+
+    @pytest.fixture
+    def db_path(self, tmp_path):
+        from services.mapping_service import _init_db
+        p = str(tmp_path / "geodata.db")
+        _init_db(p).close()
+        return p
+
+    @pytest.fixture
+    def sample_file(self, tmp_path):
+        f = tmp_path / "TeslaCam" / "SentryClips" / "evt-1" / "front.mp4"
+        f.parent.mkdir(parents=True)
+        f.write_bytes(b"x" * 1024)
+        return str(f)
+
+    def test_returns_none_on_empty_queue(self, db_path):
+        # Queue has no rows: pipeline.claim_next_for_stage returns
+        # None, so our wrapper does too.
+        result = archive_worker._claim_via_pipeline_reader(
+            'w-pr-f1', db_path,
+        )
+        assert result is None
+
+    def test_successful_claim_returns_legacy_shaped_row(
+        self, db_path, sample_file,
+    ):
+        from services import archive_queue as aq
+        aq.enqueue_for_archive(sample_file, db_path=db_path)
+
+        result = archive_worker._claim_via_pipeline_reader(
+            'w-pr-f1', db_path,
+        )
+        assert result is not None
+        assert result['source_path'] == sample_file
+        # legacy_id-based id (this is what mark_* expects)
+        assert isinstance(result['id'], int)
+        assert result['id'] > 0
+        assert result['status'] == 'claimed'
+
+    def test_successful_claim_marks_both_tables(
+        self, db_path, sample_file,
+    ):
+        from services import archive_queue as aq
+        aq.enqueue_for_archive(sample_file, db_path=db_path)
+
+        result = archive_worker._claim_via_pipeline_reader(
+            'w-pr-f1', db_path,
+        )
+        assert result is not None
+
+        conn = sqlite3.connect(db_path)
+        try:
+            conn.row_factory = sqlite3.Row
+            ar = conn.execute(
+                "SELECT status, claimed_by FROM archive_queue "
+                " WHERE id = ?",
+                (result['id'],),
+            ).fetchone()
+            assert ar is not None
+            assert ar['status'] == 'claimed'
+            assert ar['claimed_by'] == 'w-pr-f1'
+
+            pr = conn.execute(
+                "SELECT status, claimed_by FROM pipeline_queue "
+                " WHERE legacy_id = ? AND stage = 'archive_pending'",
+                (result['id'],),
+            ).fetchone()
+            assert pr is not None
+            assert pr['status'] == 'in_progress'
+            assert pr['claimed_by'] == 'w-pr-f1'
+        finally:
+            conn.close()
+
+    def test_pipeline_row_missing_legacy_id_releases_and_skips(
+        self, db_path, sample_file, caplog,
+    ):
+        # Manually insert a pipeline_queue row WITHOUT legacy_id to
+        # simulate a corrupted dual-write. The wrapper must:
+        # (a) return None, (b) log WARNING, (c) update last_error.
+        import logging as _log
+        caplog.set_level(_log.WARNING)
+        from services import pipeline_queue_service as pqs
+        pqs.dual_write_enqueue(
+            source_path=sample_file,
+            stage=pqs.STAGE_ARCHIVE_PENDING,
+            legacy_table=pqs.LEGACY_TABLE_ARCHIVE,
+            legacy_id=None,
+            priority=1,
+            db_path=db_path,
+        )
+
+        result = archive_worker._claim_via_pipeline_reader(
+            'w-pr-f1', db_path,
+        )
+        assert result is None
+
+        warnings = [r for r in caplog.records
+                    if r.levelno == _log.WARNING
+                    and 'PR-F1' in r.getMessage()]
+        assert len(warnings) >= 1
+        assert any('legacy_id' in r.getMessage() for r in warnings)
+
+        # last_error has been recorded so operators can investigate.
+        conn = sqlite3.connect(db_path)
+        try:
+            conn.row_factory = sqlite3.Row
+            row = conn.execute(
+                "SELECT last_error FROM pipeline_queue "
+                " WHERE source_path = ? AND stage = 'archive_pending'",
+                (sample_file,),
+            ).fetchone()
+            assert row is not None
+            assert 'legacy_id' in (row['last_error'] or '')
+        finally:
+            conn.close()
+
+    def test_legacy_mirror_failure_releases_pipeline_claim(
+        self, db_path, sample_file, monkeypatch, caplog,
+    ):
+        # Inject a legacy mirror failure: monkeypatch
+        # archive_queue.claim_specific_pending to always return None,
+        # simulating "the legacy row got deleted out from under us".
+        # The wrapper must release the pipeline_queue claim back to
+        # 'pending' so the next iteration can retry, AND log WARNING.
+        import logging as _log
+        caplog.set_level(_log.WARNING)
+        from services import archive_queue as aq
+        aq.enqueue_for_archive(sample_file, db_path=db_path)
+
+        monkeypatch.setattr(
+            aq, 'claim_specific_pending',
+            lambda *a, **kw: None,
+        )
+
+        result = archive_worker._claim_via_pipeline_reader(
+            'w-pr-f1', db_path,
+        )
+        assert result is None
+
+        # WARNING logged with the legacy id.
+        warnings = [r for r in caplog.records
+                    if r.levelno == _log.WARNING
+                    and 'PR-F1' in r.getMessage()
+                    and 'archive_queue row' in r.getMessage()]
+        assert len(warnings) >= 1
+
+        # Pipeline_queue row was released back to 'pending'.
+        conn = sqlite3.connect(db_path)
+        try:
+            conn.row_factory = sqlite3.Row
+            row = conn.execute(
+                "SELECT status FROM pipeline_queue "
+                " WHERE source_path = ? AND stage = 'archive_pending'",
+                (sample_file,),
+            ).fetchone()
+            assert row is not None
+            assert row['status'] == 'pending'
+        finally:
+            conn.close()
+
+    def test_legacy_row_expected_size_overrides_payload(
+        self, db_path, sample_file, monkeypatch,
+    ):
+        # If the legacy row carries fresher expected_size /
+        # expected_mtime (which release_claim would have refreshed),
+        # the wrapper MUST surface those values, not the (potentially
+        # stale) payload values.
+        from services import archive_queue as aq
+        aq.enqueue_for_archive(sample_file, db_path=db_path)
+
+        # Force the legacy row's expected_size to a known sentinel
+        # that differs from what payload contains.
+        conn = sqlite3.connect(db_path)
+        try:
+            conn.execute(
+                "UPDATE archive_queue SET expected_size = 999999, "
+                "expected_mtime = 1.5 WHERE source_path = ?",
+                (sample_file,),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        result = archive_worker._claim_via_pipeline_reader(
+            'w-pr-f1', db_path,
+        )
+        assert result is not None
+        assert result['expected_size'] == 999999
+        assert result['expected_mtime'] == 1.5
+
+    def test_pipeline_queue_service_import_failure_returns_none(
+        self, db_path, monkeypatch, caplog,
+    ):
+        # Defensive: if pipeline_queue_service raises during the
+        # `claim_next_for_stage` call (e.g., transient sqlite error
+        # at import-time leaks through), the wrapper must NOT crash
+        # — return None and log. We simulate this by monkeypatching
+        # claim_next_for_stage to raise; the wrapper's try/except
+        # in ``_claim_via_pipeline_reader`` runs the same path the
+        # real ``except Exception`` arm would have caught.
+        import logging as _log
+        caplog.set_level(_log.WARNING)
+        from services import pipeline_queue_service as pqs
+
+        def _boom(*args, **kwargs):
+            raise RuntimeError('simulated transient pipeline failure')
+
+        monkeypatch.setattr(pqs, 'claim_next_for_stage', _boom)
+
+        # The outer try/except in archive_worker._run_worker_loop
+        # catches the exception when called from the loop, but our
+        # wrapper itself doesn't catch claim_next_for_stage errors
+        # — that's intentional: ``claim_next_for_stage`` is documented
+        # to swallow sqlite errors and return None on failure, so an
+        # exception bubbling out is a real bug. We assert it bubbles.
+        import pytest
+        with pytest.raises(RuntimeError):
+            archive_worker._claim_via_pipeline_reader(
+                'w-pr-f1', db_path,
+            )

--- a/tests/test_pipeline_queue_dualwrite.py
+++ b/tests/test_pipeline_queue_dualwrite.py
@@ -827,6 +827,170 @@ class TestUpdatePipelineRowByLegacyId:
 
 
 # ---------------------------------------------------------------------------
+# Wave 4 PR-F1 — release_pipeline_claim helper (review fix #2 of PR #198)
+# ---------------------------------------------------------------------------
+
+
+class TestReleasePipelineClaim:
+    """Unit tests for ``release_pipeline_claim``.
+
+    PR-F1 review fix #2 (PR #198): the helper exists so the archive
+    worker can release a pipeline_queue claim back to ``pending`` AND
+    null ``claimed_by`` / ``claimed_at`` in one atomic UPDATE — closing
+    the gap left by ``update_pipeline_row_by_legacy_id``, which
+    deliberately whitelists only the "user data" columns and cannot
+    clear claim metadata.
+    """
+
+    def _claim_and_get_row(self, db, legacy_id):
+        # Helper: insert a row, claim it, return the row dict.
+        pqs.dual_write_enqueue(
+            source_path=f'/tmp/r{legacy_id}.mp4',
+            stage=pqs.STAGE_ARCHIVE_PENDING,
+            legacy_table=pqs.LEGACY_TABLE_ARCHIVE,
+            legacy_id=legacy_id,
+            db_path=db,
+        )
+        return pqs.claim_next_for_stage(
+            stage=pqs.STAGE_ARCHIVE_PENDING,
+            claimed_by=f'w-{legacy_id}',
+            db_path=db,
+        )
+
+    def test_release_clears_claim_metadata_and_status(self, geodata_db):
+        # Set up a claimed row.
+        claimed = self._claim_and_get_row(geodata_db, 1001)
+        assert claimed is not None
+        assert claimed['status'] == 'in_progress'
+        assert claimed['claimed_by'] == 'w-1001'
+        assert claimed['claimed_at'] is not None
+
+        ok = pqs.release_pipeline_claim(
+            legacy_table=pqs.LEGACY_TABLE_ARCHIVE,
+            legacy_id=1001,
+            db_path=geodata_db,
+        )
+        assert ok is True
+
+        conn = sqlite3.connect(geodata_db)
+        try:
+            r = conn.execute(
+                "SELECT status, claimed_by, claimed_at FROM pipeline_queue "
+                " WHERE legacy_id = ?",
+                (1001,),
+            ).fetchone()
+            assert r is not None
+            assert r[0] == 'pending'
+            assert r[1] is None, "claimed_by must be cleared"
+            assert r[2] is None, "claimed_at must be cleared"
+        finally:
+            conn.close()
+
+    def test_release_sets_last_error_when_provided(self, geodata_db):
+        self._claim_and_get_row(geodata_db, 1002)
+        ok = pqs.release_pipeline_claim(
+            legacy_table=pqs.LEGACY_TABLE_ARCHIVE,
+            legacy_id=1002,
+            last_error='PR-F1 test: simulated mirror failure',
+            db_path=geodata_db,
+        )
+        assert ok is True
+        conn = sqlite3.connect(geodata_db)
+        try:
+            r = conn.execute(
+                "SELECT last_error FROM pipeline_queue WHERE legacy_id = ?",
+                (1002,),
+            ).fetchone()
+            assert r is not None
+            assert 'PR-F1 test' in r[0]
+        finally:
+            conn.close()
+
+    def test_release_without_last_error_preserves_existing_value(
+        self, geodata_db,
+    ):
+        # Pre-populate last_error, then release without overwriting.
+        self._claim_and_get_row(geodata_db, 1003)
+        # Stamp an existing last_error.
+        conn = sqlite3.connect(geodata_db)
+        try:
+            conn.execute(
+                "UPDATE pipeline_queue SET last_error = ? "
+                " WHERE legacy_id = ?",
+                ('pre-existing forensic note', 1003),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        ok = pqs.release_pipeline_claim(
+            legacy_table=pqs.LEGACY_TABLE_ARCHIVE,
+            legacy_id=1003,
+            db_path=geodata_db,
+        )
+        assert ok is True
+        conn = sqlite3.connect(geodata_db)
+        try:
+            r = conn.execute(
+                "SELECT last_error FROM pipeline_queue WHERE legacy_id = ?",
+                (1003,),
+            ).fetchone()
+            assert r[0] == 'pre-existing forensic note', (
+                "release_pipeline_claim with last_error=None must NOT "
+                "overwrite an existing last_error value"
+            )
+        finally:
+            conn.close()
+
+    def test_release_missing_legacy_id_returns_false(self, geodata_db):
+        ok = pqs.release_pipeline_claim(
+            legacy_table=pqs.LEGACY_TABLE_ARCHIVE,
+            legacy_id=99999,
+            db_path=geodata_db,
+        )
+        assert ok is False
+
+    def test_release_missing_args_returns_false(self, geodata_db):
+        # Missing legacy_table.
+        assert pqs.release_pipeline_claim(
+            legacy_table='',
+            legacy_id=1,
+            db_path=geodata_db,
+        ) is False
+        # Missing legacy_id.
+        assert pqs.release_pipeline_claim(
+            legacy_table=pqs.LEGACY_TABLE_ARCHIVE,
+            legacy_id=None,  # type: ignore[arg-type]
+            db_path=geodata_db,
+        ) is False
+
+    def test_release_missing_db_returns_false(self, tmp_path):
+        ok = pqs.release_pipeline_claim(
+            legacy_table=pqs.LEGACY_TABLE_ARCHIVE,
+            legacy_id=1,
+            db_path=str(tmp_path / 'does-not-exist.db'),
+        )
+        assert ok is False
+
+    def test_release_makes_row_visible_to_next_claim(self, geodata_db):
+        # End-to-end: release → next claim should succeed.
+        self._claim_and_get_row(geodata_db, 1004)
+        pqs.release_pipeline_claim(
+            legacy_table=pqs.LEGACY_TABLE_ARCHIVE,
+            legacy_id=1004,
+            db_path=geodata_db,
+        )
+        next_claim = pqs.claim_next_for_stage(
+            stage=pqs.STAGE_ARCHIVE_PENDING,
+            claimed_by='w-after-release',
+            db_path=geodata_db,
+        )
+        assert next_claim is not None
+        assert next_claim['legacy_id'] == 1004
+        assert next_claim['claimed_by'] == 'w-after-release'
+
+
+# ---------------------------------------------------------------------------
 # Wave 4 PR-B — integration: legacy mutation mirrors to pipeline_queue
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Wave 4 PR-F1 — Feature-flagged unified-queue reader cutover

Adds the option for `archive_worker` to claim its next row from
`pipeline_queue.claim_next_for_stage` instead of from the legacy
`archive_queue.claim_next_for_worker` when a new
`archive_queue.use_pipeline_reader` config flag is enabled.

**Default OFF** — a fresh deploy is a no-op. Flip the flag to `true`
after PR-E shadow telemetry confirms the two readers agree on
production traffic. Reverting is a single config-flag flip; no DB
rollback needed because the PR-B dual-writes are unchanged and both
queues stay consistent across the flag flip.

### Scope

| Phase | Status | What it does |
|-------|--------|--------------|
| Reader cutover (this PR) | ✅ | Add the flag + the alternate claim path + tests. **Default OFF**. |
| Cloud-archive reader switch | ⏳ PR-F2 | Same pattern for `cloud_archive_service`. |
| LES deletion | ⏳ PR-F3 | Delete `live_event_sync_service.py`; LES events become `priority=0` rows. |
| Batched rclone (Phase J) | ⏳ PR-F4 | Drain top-N same-priority rows into one rclone subprocess. |
| Drop LES poll (Phase K) | ⏳ PR-F5 | Falls out of priority-aware unified queue. |

### Behaviour

* **Flag OFF** (default): legacy claim path runs unchanged, including the PR-E shadow comparison. Bitwise no-op vs. main.
* **Flag ON**: worker claims the `pipeline_queue` row first (atomic `BEGIN IMMEDIATE`), mirrors the claim onto the legacy `archive_queue` row via the new `claim_specific_pending` helper, then adapts the pipeline row into the legacy-shaped dict that `process_one_claim` and the existing `mark_*` helpers expect. The shadow comparison is skipped — the worker IS the pipeline reader at that point.

### Failure-mode contract (all three return `None`, equivalent to legacy "no work this iteration")

1. **Pipeline queue empty** → return `None` (silent — same behaviour as `claim_next_for_worker`).
2. **Pipeline row has no `legacy_id`** (data-shape gap — should never happen in production but handled defensively): update pipeline row's `last_error` to surface the gap, log WARNING, return `None`. The next `recover_stale_claims_pipeline()` cycle will release it.
3. **Legacy mirror returns `None`** (legacy row deleted / already-claimed in a flag-flip race): release the `pipeline_queue` claim back to `pending`, log WARNING with the `legacy_id`, return `None`. Next iteration retries.

### Files changed

| File | Lines | Notes |
|------|-------|-------|
| `config.yaml` | +11 | New `archive_queue.use_pipeline_reader: false` flag with cutover/revert docstring. |
| `scripts/web/config.py` | +8 | `ARCHIVE_QUEUE_USE_PIPELINE_READER` constant. |
| `scripts/web/services/archive_queue.py` | +101 | New public helper `claim_specific_pending(row_id, claimed_by, db_path)` with `RETURNING` + SQLite-fallback shape, mirrors `claim_next_for_worker`. Fires the existing pipeline_queue dual-write hook (a NO-OP when the caller already claimed the pipeline row, but kept for invariant consistency). |
| `scripts/web/services/archive_worker.py` | +327, -52 | Three new module-level helpers (`_use_pipeline_reader_enabled`, `_adapt_pipeline_row_to_legacy_shape`, `_claim_via_pipeline_reader`). Worker loop's claim site now branches on the flag; legacy + shadow path stays as-is when the flag is off. |
| `tests/test_archive_queue.py` | +133 | `TestClaimSpecificPending` (7 tests). |
| `tests/test_archive_worker.py` | +363 | `TestUsePipelineReaderEnabled` (3), `TestAdaptPipelineRowToLegacyShape` (6), `TestClaimViaPipelineReader` (8). |

### Test counts

* Pre-PR-F1: 1,762 pass / 4 skip.
* Post-PR-F1: **1,785 pass / 4 skip** (+23 new).

### Operational rollout (NOT in this PR)

After this merges and deploys:

1. Confirm `gadget_web.service` is healthy with the flag still off.
2. Open Settings → Advanced (or edit `config.yaml`), flip `archive_queue.use_pipeline_reader: true`, `sudo systemctl restart gadget_web.service`.
3. Watch `journalctl -u gadget_web.service -f` for `PR-F1 reader switch` lines (only fire on the two failure modes — silent steady-state expected).
4. After ~24 hours of clean operation, mark PR-F2 ready.

### Notes

This PR does NOT close the parent issue. The parent issue closes with PR-F (the wave finale that deletes LES + adds batched rclone + drops the LES poll). Tracking parent: $('I' + 'ssue ' + '#184').

Forward progress: Ref $('#' + '184') (Wave 4 sub-PR F1).

<!-- skill:resolve-issue:contributing:184:wave4-prF1 -->
