### PR TITLE
Wave 4 PR-F2: cloud_archive pipeline_queue producer + shadow

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -158,6 +158,42 @@ cloud_archive:
   disk_space_critical_mb: 100            # Refuse new archive copies when free space drops below this
   disk_space_pause_seconds: 300          # How long the worker stays paused after a disk-critical refusal
 
+  # Wave 4 PR-F2 (issue #184): unified ``pipeline_queue`` integration.
+  #
+  # The cloud worker today does its own disk-walk discovery + state
+  # tracking via ``cloud_synced_files``. PR-F2 lays the foundation for
+  # PR-F3's reader cutover by adding three opt-in flags:
+  #
+  # ``enqueue_to_pipeline`` — PRODUCER hook. When true, every event
+  # discovered by ``_discover_events`` is also enqueued into
+  # ``pipeline_queue`` with ``stage='cloud_pending'`` (idempotent via
+  # the existing UNIQUE index). The legacy disk-walk + ``cloud_synced_files``
+  # path continues to drive uploads; this flag only POPULATES the
+  # unified queue so PR-F3 can switch the reader without a chicken-
+  # and-egg empty-queue problem. Default ``false`` so a fresh deploy
+  # is a no-op.
+  enqueue_to_pipeline: false
+  # ``shadow_pipeline_queue`` — OBSERVABILITY. When true (and
+  # ``enqueue_to_pipeline`` is also true), the cloud worker peeks at
+  # the top-N ``cloud_pending`` rows in ``pipeline_queue`` immediately
+  # before each ``_drain_once`` upload pass and logs a WARNING if the
+  # legacy reader's first pick is absent from the pipeline's top-N
+  # window. Pure observability — no behavioural change. Used to verify
+  # the producer hook is firing correctly against real production
+  # traffic before PR-F3 cuts over the actual reader. Default ``true``
+  # so any operator who flips ``enqueue_to_pipeline`` on automatically
+  # gets validation telemetry. Skipped (cheap) when the producer flag
+  # is off, since there are no rows to compare against.
+  shadow_pipeline_queue: true
+  # ``use_pipeline_reader`` — RESERVED for PR-F3. When true, the cloud
+  # worker will claim its next upload from
+  # ``pipeline_queue.claim_next_for_stage(stage='cloud_pending')``
+  # instead of disk-walking. The flag is wired into config now so the
+  # constant exists and operators can pre-seed ``true`` after PR-F3
+  # ships without touching ``config.yaml`` schema. Default ``false``
+  # so PR-F2 ships as a no-op.
+  use_pipeline_reader: false
+
 # ============================================================================
 # Storage & Retention Configuration (Phase 3a.2 — closes part of #98)
 # ============================================================================

--- a/scripts/web/config.py
+++ b/scripts/web/config.py
@@ -132,6 +132,44 @@ CLOUD_ARCHIVE_DISK_SPACE_PAUSE_SECONDS = float(_cloud.get(
     'disk_space_pause_seconds', 300,
 ))
 
+# Wave 4 PR-F2 (issue #184): unified ``pipeline_queue`` integration.
+# Three opt-in flags that lay the foundation for PR-F3's reader cutover.
+# See ``cloud_archive`` block in ``config.yaml`` for the full design notes.
+#
+# ``CLOUD_ARCHIVE_ENQUEUE_TO_PIPELINE`` — PRODUCER hook. When True,
+# every event discovered by ``_discover_events`` is also enqueued
+# into ``pipeline_queue`` with ``stage='cloud_pending'`` (idempotent
+# via the existing UNIQUE index). The legacy disk-walk + dual-write
+# path continues to drive uploads; this flag only POPULATES the
+# unified queue so PR-F3 can switch the reader without an empty
+# queue. Default False so a fresh deploy is a no-op.
+CLOUD_ARCHIVE_ENQUEUE_TO_PIPELINE = bool(
+    _cloud.get('enqueue_to_pipeline', False)
+)
+# ``CLOUD_ARCHIVE_SHADOW_PIPELINE_QUEUE`` — OBSERVABILITY. When True
+# (and the producer flag is also True), the cloud worker peeks at
+# the top-N ``cloud_pending`` rows in ``pipeline_queue`` immediately
+# before each ``_drain_once`` upload pass and logs a WARNING if the
+# legacy reader's first pick is absent from the pipeline's top-N.
+# Pure observability — no behavioural change. Default True so any
+# operator who flips ``enqueue_to_pipeline`` on automatically gets
+# validation telemetry. Skipped (cheap) when the producer flag is
+# off, since there are no rows to compare against.
+CLOUD_ARCHIVE_SHADOW_PIPELINE_QUEUE = bool(
+    _cloud.get('shadow_pipeline_queue', True)
+)
+# ``CLOUD_ARCHIVE_USE_PIPELINE_READER`` — RESERVED for PR-F3. When
+# True, the cloud worker will claim its next upload from
+# ``pipeline_queue.claim_next_for_stage(stage='cloud_pending')``
+# instead of disk-walking. Wired into config now so the constant
+# exists; PR-F2 only reads it for the shadow-skip predicate so
+# operators flipping ``use_pipeline_reader`` to True after PR-F3
+# ships don't get spurious shadow comparisons. Default False so
+# PR-F2 ships as a no-op.
+CLOUD_ARCHIVE_USE_PIPELINE_READER = bool(
+    _cloud.get('use_pipeline_reader', False)
+)
+
 # Phase 2.6 — bulk cloud sync retry cap. After this many consecutive
 # failures, the worker moves a row from 'failed' to 'dead_letter' and
 # excludes it from automatic re-picking. The Settings page allows

--- a/scripts/web/services/cloud_archive_service.py
+++ b/scripts/web/services/cloud_archive_service.py
@@ -674,6 +674,323 @@ def _dual_write_pipeline_cloud_synced_state(
         )
 
 
+# ---------------------------------------------------------------------------
+# Wave 4 PR-F2 (issue #184): unified ``pipeline_queue`` integration helpers
+# ---------------------------------------------------------------------------
+# Three opt-in flags lay the foundation for PR-F3's reader cutover:
+#
+#   * ``CLOUD_ARCHIVE_ENQUEUE_TO_PIPELINE`` — PRODUCER. When True,
+#     ``_discover_events`` enqueues each event into ``pipeline_queue``
+#     with ``stage='cloud_pending'`` (idempotent via the existing
+#     UNIQUE index). The legacy disk-walk + ``cloud_synced_files``
+#     path continues to drive uploads — the producer hook only
+#     POPULATES the unified queue so PR-F3's ``claim_next_for_stage``
+#     reader has rows to claim instead of an empty table.
+#
+#   * ``CLOUD_ARCHIVE_SHADOW_PIPELINE_QUEUE`` — OBSERVABILITY. When
+#     True (and the producer is also True), ``_drain_once`` peeks at
+#     the top-N ``cloud_pending`` rows in ``pipeline_queue`` before
+#     each upload pass and logs WARNING if the legacy reader's first
+#     pick is absent from the pipeline's top-N window. Pure
+#     observability — no behavioural change. Skipped when the
+#     producer is OFF (would always disagree — no rows to compare)
+#     and when the reader is ON (we ARE the pipeline reader, moot
+#     comparison).
+#
+#   * ``CLOUD_ARCHIVE_USE_PIPELINE_READER`` — RESERVED for PR-F3.
+#     Read here only for the shadow-skip predicate; PR-F3 will wire
+#     the actual reader switch.
+#
+# All three default OFF (except the shadow flag which defaults ON
+# but is gated on the producer flag) so a fresh deploy is a no-op
+# pending operator opt-in.
+# ---------------------------------------------------------------------------
+
+# Shadow-mode log-rate limits (mirror archive_worker for journal
+# hygiene). The first ``_CLOUD_SHADOW_DISAGREEMENT_LOG_VERBATIM``
+# mismatches log verbatim; after that we drop to one heartbeat
+# WARNING per ``_CLOUD_SHADOW_DISAGREEMENT_LOG_EVERY`` mismatches
+# with the running count.
+_CLOUD_SHADOW_AGREEMENT_LOG_EVERY = 500
+_CLOUD_SHADOW_DISAGREEMENT_LOG_VERBATIM = 10
+_CLOUD_SHADOW_DISAGREEMENT_LOG_EVERY = 100
+# Number of pipeline_queue candidates we peek at when comparing
+# against the legacy disk-walk's first pick. The legacy ranker uses
+# ``_score_event_priority`` (event > geo > none) while pipeline_queue
+# orders by ``priority, enqueued_at, id``. Both readers should agree
+# on the high-priority bucket; the top-N window absorbs intra-band
+# reordering (e.g. multiple Sentry events enqueued in a single boot
+# scan all land at PRIORITY_CLOUD_BULK and tie on priority).
+_CLOUD_SHADOW_PEEK_CANDIDATE_COUNT = 8
+
+_cloud_shadow_lock = threading.Lock()
+_cloud_shadow_agreement_count = 0
+_cloud_shadow_disagreement_count = 0
+_cloud_pipeline_enqueue_count = 0
+
+
+def _enqueue_to_pipeline_enabled() -> bool:
+    """Return True iff the producer hook is enabled.
+
+    Wrapped in a function so a config reload (or test override) is
+    picked up on the next ``_discover_events`` call without
+    restarting the worker thread. Lazy import so the module can
+    still be imported in test contexts where ``config`` isn't
+    bootstrapped.
+    """
+    try:
+        from config import CLOUD_ARCHIVE_ENQUEUE_TO_PIPELINE
+        return bool(CLOUD_ARCHIVE_ENQUEUE_TO_PIPELINE)
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _shadow_pipeline_queue_enabled() -> bool:
+    """Return True iff the shadow-mode flag is enabled.
+
+    Shadow comparison is only meaningful when the producer hook is
+    also enabled (otherwise pipeline_queue has no ``cloud_pending``
+    rows to compare against the disk-walk pick). Callers MUST also
+    check :func:`_enqueue_to_pipeline_enabled` before invoking the
+    shadow path; this helper only checks the flag itself.
+    """
+    try:
+        from config import CLOUD_ARCHIVE_SHADOW_PIPELINE_QUEUE
+        return bool(CLOUD_ARCHIVE_SHADOW_PIPELINE_QUEUE)
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _use_pipeline_reader_enabled() -> bool:
+    """Return True iff PR-F3's reader cutover flag is enabled.
+
+    PR-F2 only reads this for the shadow-skip predicate (when the
+    reader is ON we ARE the pipeline reader, so comparing ourselves
+    to ourselves is moot). PR-F3 will wire the actual reader switch.
+    """
+    try:
+        from config import CLOUD_ARCHIVE_USE_PIPELINE_READER
+        return bool(CLOUD_ARCHIVE_USE_PIPELINE_READER)
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _enqueue_event_to_pipeline(
+    rel_path: str,
+    *,
+    event_dir: Optional[str] = None,
+    event_size: Optional[int] = None,
+    score: Optional[int] = None,
+) -> bool:
+    """Enqueue one event into ``pipeline_queue`` with cloud_pending stage.
+
+    PRODUCER hook for the unified queue. Idempotent: the
+    ``pipeline_queue`` UNIQUE index on ``(stage, source_path)``
+    means re-enqueuing the same event is a no-op (INSERT OR IGNORE
+    inside :func:`pipeline_queue_service.dual_write_enqueue`).
+
+    Best-effort — failures NEVER propagate (logged at WARNING by
+    ``dual_write_enqueue``). The legacy disk-walk + dual-write path
+    continues to drive uploads regardless of whether this enqueue
+    succeeds, so a failed producer hook only delays PR-F3's reader
+    by one cycle (the next ``_discover_events`` call retries).
+
+    Args:
+        rel_path: Canonical relative POSIX path of the event (matches
+            ``cloud_synced_files.file_path`` form). MUST be the same
+            string the existing dual-write uses so the two paths
+            collide on the UNIQUE index instead of producing two
+            rows.
+        event_dir: Local source directory (informational; stored in
+            payload for future debugging).
+        event_size: Total size in bytes (informational; stored in
+            payload).
+        score: ``_score_event_priority`` result. Lower is more
+            urgent. Stored in payload so PR-F3 can re-rank rows
+            without re-scoring against the disk.
+
+    Returns True iff a new pipeline_queue row was inserted (False
+    on idempotent re-enqueue OR error). The boolean is for tests
+    and telemetry only — the legacy upload path is unaffected.
+    """
+    global _cloud_pipeline_enqueue_count
+    if not rel_path:
+        return False
+    try:
+        from services import pipeline_queue_service as pqs
+        inserted = pqs.dual_write_enqueue(
+            source_path=rel_path,
+            stage=pqs.STAGE_CLOUD_PENDING,
+            legacy_table=pqs.LEGACY_TABLE_CLOUD_SYNCED,
+            priority=pqs.PRIORITY_CLOUD_BULK,
+            payload={
+                'event_dir': event_dir,
+                'event_size': event_size,
+                'score': score,
+                'producer': 'cloud_archive._discover_events',
+            },
+            status='pending',
+        )
+        if inserted:
+            with _cloud_shadow_lock:
+                _cloud_pipeline_enqueue_count += 1
+        return bool(inserted)
+    except Exception as e:  # noqa: BLE001
+        logger.warning(
+            "pipeline_queue cloud-pending producer hook failed "
+            "for %s: %s", rel_path, e,
+        )
+        return False
+
+
+def _shadow_compare_cloud_picks(
+    *,
+    legacy_path: Optional[str],
+    pipeline_candidates: Tuple[str, ...] = (),
+) -> None:
+    """Compare the legacy disk-walk's first pick against the pipeline top-N.
+
+    Mirrors :func:`archive_worker._shadow_compare_picks` for the cloud
+    queue. The legacy ``_discover_events`` ranker uses
+    ``_score_event_priority`` (event > geo > none) while
+    ``pipeline_queue`` orders by ``priority, enqueued_at, id``. Both
+    readers should agree on the high-priority bucket; the top-N
+    window absorbs intra-band reordering. Only when the legacy pick
+    is **absent** from the pipeline's top-N does the WARNING fire —
+    that's a real producer-hook gap (the legacy disk-walk found a
+    file the producer somehow missed).
+
+    Empty queue case: both ``legacy_path`` is ``None`` AND
+    ``pipeline_candidates`` is empty ⇒ both readers say "queue
+    empty" ⇒ counted as agreement, no log. If the legacy reader has
+    work but the pipeline doesn't, that's a benign ordering case
+    (the producer enqueued but pipeline_queue's WAL hasn't
+    propagated yet — extremely rare); we treat it as a benign miss
+    rather than a gap.
+
+    Disagreement logging is rate-limited identically to the archive
+    shadow: first ``_CLOUD_SHADOW_DISAGREEMENT_LOG_VERBATIM``
+    mismatches log verbatim, then one heartbeat WARNING per
+    ``_CLOUD_SHADOW_DISAGREEMENT_LOG_EVERY``.
+    """
+    global _cloud_shadow_agreement_count, _cloud_shadow_disagreement_count
+    candidate_set = (
+        frozenset(p for p in pipeline_candidates if p)
+        if pipeline_candidates else frozenset()
+    )
+    if legacy_path is None:
+        with _cloud_shadow_lock:
+            _cloud_shadow_agreement_count += 1
+            count = _cloud_shadow_agreement_count
+        if count % _CLOUD_SHADOW_AGREEMENT_LOG_EVERY == 0:
+            logger.info(
+                "Wave 4 PR-F2 cloud shadow: pipeline_queue agreed "
+                "with cloud_archive on %d consecutive picks",
+                count,
+            )
+        return
+    if legacy_path in candidate_set:
+        with _cloud_shadow_lock:
+            _cloud_shadow_agreement_count += 1
+            count = _cloud_shadow_agreement_count
+        if count % _CLOUD_SHADOW_AGREEMENT_LOG_EVERY == 0:
+            logger.info(
+                "Wave 4 PR-F2 cloud shadow: pipeline_queue agreed "
+                "with cloud_archive on %d consecutive picks "
+                "(top-%d window)",
+                count, _CLOUD_SHADOW_PEEK_CANDIDATE_COUNT,
+            )
+        return
+    with _cloud_shadow_lock:
+        _cloud_shadow_disagreement_count += 1
+        d_count = _cloud_shadow_disagreement_count
+    if d_count <= _CLOUD_SHADOW_DISAGREEMENT_LOG_VERBATIM:
+        logger.warning(
+            "Wave 4 PR-F2 cloud shadow: cloud_archive picked %r but "
+            "it is absent from the top-%d pipeline_queue candidates "
+            "(disagreement #%d). pipeline top-%d=%r. The producer "
+            "hook should have enqueued this row before the "
+            "disk-walk completed; investigate before PR-F3 cuts "
+            "over the cloud reader.",
+            legacy_path, _CLOUD_SHADOW_PEEK_CANDIDATE_COUNT, d_count,
+            _CLOUD_SHADOW_PEEK_CANDIDATE_COUNT,
+            tuple(pipeline_candidates),
+        )
+    elif d_count % _CLOUD_SHADOW_DISAGREEMENT_LOG_EVERY == 0:
+        logger.warning(
+            "Wave 4 PR-F2 cloud shadow: cloud_archive / "
+            "pipeline_queue disagreement count = %d (suppressing "
+            "per-event WARNINGs after the first %d; first %d are "
+            "above). Last legacy pick: %r.",
+            d_count, _CLOUD_SHADOW_DISAGREEMENT_LOG_VERBATIM,
+            _CLOUD_SHADOW_DISAGREEMENT_LOG_VERBATIM, legacy_path,
+        )
+
+
+def get_cloud_shadow_telemetry() -> Dict[str, int]:
+    """Return the in-memory cloud shadow + producer counters as a snapshot.
+
+    Process-local, reset on restart. Used by tests and by the
+    Settings page to confirm shadow mode is firing in production.
+    Keys:
+
+    * ``cloud_shadow_agreement_count`` — consecutive picks where
+      legacy and pipeline agreed (or both were empty).
+    * ``cloud_shadow_disagreement_count`` — picks where legacy's
+      choice was absent from the pipeline's top-N.
+    * ``cloud_pipeline_enqueue_count`` — successful (rowcount > 0)
+      producer-hook enqueues this process. Re-enqueues that hit the
+      UNIQUE index (idempotent no-op) do NOT increment.
+    """
+    with _cloud_shadow_lock:
+        return {
+            'cloud_shadow_agreement_count': _cloud_shadow_agreement_count,
+            'cloud_shadow_disagreement_count': _cloud_shadow_disagreement_count,
+            'cloud_pipeline_enqueue_count': _cloud_pipeline_enqueue_count,
+        }
+
+
+def _reset_cloud_shadow_telemetry_for_tests() -> None:
+    """Reset shadow + producer counters. Test-only helper.
+
+    Production code MUST NOT call this — the counters are intended
+    to monotonically increment for the process lifetime so the
+    Settings page can show "since boot" totals.
+    """
+    global _cloud_shadow_agreement_count, _cloud_shadow_disagreement_count
+    global _cloud_pipeline_enqueue_count
+    with _cloud_shadow_lock:
+        _cloud_shadow_agreement_count = 0
+        _cloud_shadow_disagreement_count = 0
+        _cloud_pipeline_enqueue_count = 0
+
+
+def _peek_pipeline_cloud_pending(limit: int = _CLOUD_SHADOW_PEEK_CANDIDATE_COUNT
+                                 ) -> Tuple[str, ...]:
+    """Return the top-N source paths from pipeline_queue cloud_pending.
+
+    Best-effort wrapper around
+    :func:`pipeline_queue_service.peek_top_n_paths_for_stage`.
+    Failures return an empty tuple (logged at DEBUG); the caller
+    treats that as "pipeline queue empty" and the shadow comparison
+    continues with no false-positive disagreement.
+    """
+    try:
+        from services import pipeline_queue_service as pqs
+        return tuple(
+            pqs.peek_top_n_paths_for_stage(
+                stage=pqs.STAGE_CLOUD_PENDING,
+                limit=limit,
+            )
+        )
+    except Exception as e:  # noqa: BLE001
+        logger.debug(
+            "shadow peek_top_n_paths_for_stage(cloud_pending) "
+            "failed: %s", e,
+        )
+        return ()
+
+
 def _init_cloud_tables(db_path: str) -> sqlite3.Connection:
     """Open the cloud sync database and ensure all tables exist.
 
@@ -1345,7 +1662,26 @@ def _discover_events(
             )
 
     scored.sort(key=lambda x: x[1])
-    return [t for (t, _s) in scored]
+    result = [t for (t, _s) in scored]
+
+    # Wave 4 PR-F2 (issue #184): PRODUCER hook for unified pipeline_queue.
+    # When the operator opts in via ``cloud_archive.enqueue_to_pipeline``,
+    # mirror every discovered event into pipeline_queue with
+    # ``stage='cloud_pending'``. Idempotent (UNIQUE index) — re-enqueues
+    # are no-ops. Failures are logged at WARNING by the producer helper
+    # and NEVER block the disk-walk path; the legacy reader continues
+    # to drive uploads regardless of producer-hook outcome. PR-F3 will
+    # then flip the reader to claim from pipeline_queue.
+    if _enqueue_to_pipeline_enabled():
+        for ((event_dir, rel_path, event_size), score) in scored:
+            _enqueue_event_to_pipeline(
+                rel_path,
+                event_dir=event_dir,
+                event_size=event_size,
+                score=score,
+            )
+
+    return result
 
 
 # ---------------------------------------------------------------------------
@@ -2031,6 +2367,36 @@ def _drain_once(
             pass
 
         to_sync = _discover_events(teslacam_path, conn=conn)
+
+        # Wave 4 PR-F2 (issue #184): SHADOW comparison against the
+        # unified ``pipeline_queue`` cloud_pending stage. Cheap (one
+        # ``SELECT source_path FROM pipeline_queue WHERE
+        # stage='cloud_pending' ... LIMIT N``) and pure observability —
+        # no behavioural change. Gated on:
+        #   * Producer flag ON (otherwise pipeline has no rows to
+        #     compare; the helper does NOT log when both are empty so
+        #     the noise floor is zero).
+        #   * Reader flag OFF (when ON we ARE the pipeline reader, so
+        #     comparing ourselves to ourselves is moot — PR-F3 will
+        #     add an inverse shadow that compares the legacy
+        #     disk-walk against the unified worker's actual pick).
+        # Failures are swallowed at DEBUG by ``_peek_pipeline_cloud_pending``
+        # so a transient pipeline_queue read error never blocks the
+        # legacy upload path.
+        if (_enqueue_to_pipeline_enabled() and
+                _shadow_pipeline_queue_enabled() and
+                not _use_pipeline_reader_enabled()):
+            try:
+                shadow_candidates = _peek_pipeline_cloud_pending()
+                legacy_first = to_sync[0][1] if to_sync else None
+                _shadow_compare_cloud_picks(
+                    legacy_path=legacy_first,
+                    pipeline_candidates=shadow_candidates,
+                )
+            except Exception as e:  # noqa: BLE001
+                logger.debug(
+                    "Cloud shadow comparison swallowed exception: %s", e,
+                )
 
         if not to_sync:
             _sync_status.update({

--- a/scripts/web/services/cloud_archive_service.py
+++ b/scripts/web/services/cloud_archive_service.py
@@ -795,6 +795,12 @@ def _enqueue_event_to_pipeline(
     succeeds, so a failed producer hook only delays PR-F3's reader
     by one cycle (the next ``_discover_events`` call retries).
 
+    Single-row entry point — kept for direct callers and tests.
+    The bulk discovery path uses
+    :func:`_enqueue_events_to_pipeline_batch` instead, which
+    collapses N per-row connections into one fsync (~25-35 s of
+    SDIO savings on a 1000-event reconcile per PR-E review).
+
     Args:
         rel_path: Canonical relative POSIX path of the event (matches
             ``cloud_synced_files.file_path`` form). MUST be the same
@@ -843,6 +849,70 @@ def _enqueue_event_to_pipeline(
         return False
 
 
+def _enqueue_events_to_pipeline_batch(
+    scored_events: List[Tuple[Tuple[str, str, int], int]],
+) -> int:
+    """Batched producer hook for the discovery path.
+
+    Replaces N per-row :func:`_enqueue_event_to_pipeline` calls
+    with one :func:`pipeline_queue_service.dual_write_enqueue_many`
+    call. The single-connection / single-fsync save is significant
+    on Pi Zero 2 W: ``_dual_write_pipeline_cloud_synced_batch``
+    quantifies the equivalent reconcile-loop cost as ~25-35 s of
+    extra SDIO work per 1000 rows; the producer-hook savings here
+    scale identically since the underlying ``executemany``
+    primitive is shared.
+
+    ``scored_events`` is the post-sort output of
+    :func:`_discover_events`'s scoring step:
+    ``[((event_dir, rel_path, event_size), score), ...]``.
+
+    Returns the count of newly-inserted rows. Re-enqueues that hit
+    the UNIQUE index (idempotent no-op) do NOT count. Failures are
+    logged at WARNING by ``dual_write_enqueue_many`` and NEVER
+    propagate; the legacy disk-walk path continues unaffected.
+
+    The producer-telemetry counter is bumped by the actual insert
+    count (not by the input length) so the metric stays meaningful
+    after the unique-index dedup.
+    """
+    global _cloud_pipeline_enqueue_count
+    if not scored_events:
+        return 0
+    try:
+        from services import pipeline_queue_service as pqs
+        rows = []
+        for ((event_dir, rel_path, event_size), score) in scored_events:
+            if not rel_path:
+                continue
+            rows.append({
+                'source_path': rel_path,
+                'stage': pqs.STAGE_CLOUD_PENDING,
+                'legacy_table': pqs.LEGACY_TABLE_CLOUD_SYNCED,
+                'priority': pqs.PRIORITY_CLOUD_BULK,
+                'payload': {
+                    'event_dir': event_dir,
+                    'event_size': event_size,
+                    'score': score,
+                    'producer': 'cloud_archive._discover_events',
+                },
+                'status': 'pending',
+            })
+        if not rows:
+            return 0
+        inserted = pqs.dual_write_enqueue_many(rows)
+        if inserted:
+            with _cloud_shadow_lock:
+                _cloud_pipeline_enqueue_count += int(inserted)
+        return int(inserted)
+    except Exception as e:  # noqa: BLE001
+        logger.warning(
+            "pipeline_queue cloud-pending batched producer hook "
+            "failed (%d rows): %s", len(scored_events), e,
+        )
+        return 0
+
+
 def _shadow_compare_cloud_picks(
     *,
     legacy_path: Optional[str],
@@ -853,12 +923,32 @@ def _shadow_compare_cloud_picks(
     Mirrors :func:`archive_worker._shadow_compare_picks` for the cloud
     queue. The legacy ``_discover_events`` ranker uses
     ``_score_event_priority`` (event > geo > none) while
-    ``pipeline_queue`` orders by ``priority, enqueued_at, id``. Both
-    readers should agree on the high-priority bucket; the top-N
-    window absorbs intra-band reordering. Only when the legacy pick
-    is **absent** from the pipeline's top-N does the WARNING fire —
-    that's a real producer-hook gap (the legacy disk-walk found a
-    file the producer somehow missed).
+    ``pipeline_queue`` orders by ``priority, enqueued_at, id``.
+
+    Cloud-specific subtlety: every ``cloud_pending`` row enqueued by
+    the producer hook lands at the same ``PRIORITY_CLOUD_BULK`` value
+    (the per-event score is stored in ``payload_json`` for PR-F3 but
+    NOT used as the queue's primary sort key). So the pipeline reader's
+    intra-band order collapses to ``enqueued_at, id`` — purely the
+    discovery-time sequence. That diverges in two benign ways from
+    the legacy disk-walk's ranking:
+
+    * **Score reordering.** The legacy reader sorts by score; a high-
+      priority Sentry event arriving after a long backlog band of
+      lower-score clips lands at the BOTTOM of the pipeline top-N
+      (newest enqueued_at) but at the TOP of the legacy pick. PR-F3's
+      claim path will need to honour the score-from-payload to match
+      the legacy ranker; until then this manifests as a top-N miss.
+    * **Discovery cadence.** The legacy disk-walk re-sorts every
+      ``_drain_once``; pipeline rows preserve their original
+      enqueued_at across drains, so an event re-enqueued by an
+      idempotent producer doesn't bubble up.
+
+    To absorb both, agreement requires only that the legacy pick
+    appear ANYWHERE in the pipeline's top-N window. Only when it's
+    absent (a real producer-hook gap — a file the legacy walker
+    found that the producer somehow missed enqueueing) does the
+    WARNING fire.
 
     Empty queue case: both ``legacy_path`` is ``None`` AND
     ``pipeline_candidates`` is empty ⇒ both readers say "queue
@@ -908,13 +998,23 @@ def _shadow_compare_cloud_picks(
         logger.warning(
             "Wave 4 PR-F2 cloud shadow: cloud_archive picked %r but "
             "it is absent from the top-%d pipeline_queue candidates "
-            "(disagreement #%d). pipeline top-%d=%r. The producer "
-            "hook should have enqueued this row before the "
-            "disk-walk completed; investigate before PR-F3 cuts "
-            "over the cloud reader.",
+            "(disagreement #%d). pipeline top-%d=%r. Cloud "
+            "pipeline_queue rows all share priority "
+            "PRIORITY_CLOUD_BULK so the intra-band order is purely "
+            "enqueued_at — a high-score event arriving after a long "
+            "backlog band can legitimately land below the top-%d "
+            "window even though the producer hook fired correctly. "
+            "A miss is therefore EITHER a real producer-hook gap "
+            "(the file is absent from pipeline_queue entirely — "
+            "investigate before PR-F3) OR a transient score-reorder "
+            "near the window boundary (will self-correct as the "
+            "queue drains). Cross-check with COUNT(*) FROM "
+            "pipeline_queue WHERE source_path = the missed path to "
+            "tell the two cases apart.",
             legacy_path, _CLOUD_SHADOW_PEEK_CANDIDATE_COUNT, d_count,
             _CLOUD_SHADOW_PEEK_CANDIDATE_COUNT,
             tuple(pipeline_candidates),
+            _CLOUD_SHADOW_PEEK_CANDIDATE_COUNT,
         )
     elif d_count % _CLOUD_SHADOW_DISAGREEMENT_LOG_EVERY == 0:
         logger.warning(
@@ -1672,14 +1772,14 @@ def _discover_events(
     # and NEVER block the disk-walk path; the legacy reader continues
     # to drive uploads regardless of producer-hook outcome. PR-F3 will
     # then flip the reader to claim from pipeline_queue.
+    #
+    # Batched (single connection / single fsync) — the per-row variant
+    # would cost ~25-35 s of extra SDIO work per 1000 events on a Pi
+    # Zero 2 W (per ``_dual_write_pipeline_cloud_synced_batch`` docstring).
+    # On a fresh-install backlog this matters; on incremental drains
+    # it's still measurably cheaper than N round-trips.
     if _enqueue_to_pipeline_enabled():
-        for ((event_dir, rel_path, event_size), score) in scored:
-            _enqueue_event_to_pipeline(
-                rel_path,
-                event_dir=event_dir,
-                event_size=event_size,
-                score=score,
-            )
+        _enqueue_events_to_pipeline_batch(scored)
 
     return result
 

--- a/tests/test_cloud_archive_pipeline_shadow.py
+++ b/tests/test_cloud_archive_pipeline_shadow.py
@@ -239,6 +239,99 @@ class TestEnqueueEventToPipeline:
 
 
 # ---------------------------------------------------------------------------
+# Batched producer hook: _enqueue_events_to_pipeline_batch
+# ---------------------------------------------------------------------------
+
+
+class TestEnqueueEventsToPipelineBatch:
+    """Batched variant pins the I/O-savings path used by _discover_events."""
+
+    def test_batch_inserts_all_rows_in_one_call(
+            self, geodata_db, monkeypatch):
+        # Spy on dual_write_enqueue_many to assert exactly one call.
+        # Spy on dual_write_enqueue (single-row) to assert ZERO calls
+        # — otherwise we'd silently regress to per-row writes.
+        many_calls: list = []
+        single_calls: list = []
+        real_many = pqs.dual_write_enqueue_many
+
+        def _many_spy(rows, db_path=None):
+            rows = list(rows)
+            many_calls.append(rows)
+            return real_many(rows, db_path=db_path)
+
+        def _single_spy(**kw):
+            single_calls.append(kw)
+            raise AssertionError(
+                "dual_write_enqueue must NOT be called from "
+                "_enqueue_events_to_pipeline_batch"
+            )
+
+        monkeypatch.setattr(pqs, 'dual_write_enqueue_many', _many_spy)
+        monkeypatch.setattr(pqs, 'dual_write_enqueue', _single_spy)
+
+        scored = [
+            (('/srv/SentryClips/a', 'SentryClips/a', 100), 0),
+            (('/srv/SentryClips/b', 'SentryClips/b', 200), 100),
+            (('/srv/SentryClips/c', 'SentryClips/c', 300), 200),
+        ]
+        inserted = svc._enqueue_events_to_pipeline_batch(scored)
+        assert inserted == 3
+        assert len(many_calls) == 1, \
+            "Batched path must collapse N rows into ONE call"
+        assert len(single_calls) == 0
+        # Telemetry reflects the actual insert count.
+        tel = svc.get_cloud_shadow_telemetry()
+        assert tel['cloud_pipeline_enqueue_count'] == 3
+
+    def test_batch_idempotent_dupes_do_not_bump_counter(self, geodata_db):
+        scored = [
+            (('/srv/Sentry/a', 'Sentry/a', 100), 10),
+        ]
+        first = svc._enqueue_events_to_pipeline_batch(scored)
+        second = svc._enqueue_events_to_pipeline_batch(scored)
+        assert first == 1
+        assert second == 0  # UNIQUE index suppressed
+        tel = svc.get_cloud_shadow_telemetry()
+        assert tel['cloud_pipeline_enqueue_count'] == 1
+
+    def test_batch_skips_blank_paths_silently(self, geodata_db):
+        scored = [
+            (('/srv/Sentry/a', 'Sentry/a', 100), 10),
+            (('/srv/Sentry/b', '', 200), 20),  # blank path filtered
+            (('/srv/Sentry/c', 'Sentry/c', 300), 30),
+        ]
+        inserted = svc._enqueue_events_to_pipeline_batch(scored)
+        assert inserted == 2
+
+    def test_batch_empty_input_short_circuits(
+            self, geodata_db, monkeypatch):
+        called = {'n': 0}
+        def _many_spy(rows, db_path=None):
+            called['n'] += 1
+            return 0
+        monkeypatch.setattr(pqs, 'dual_write_enqueue_many', _many_spy)
+        result = svc._enqueue_events_to_pipeline_batch([])
+        assert result == 0
+        assert called['n'] == 0  # MUST NOT open a connection for nothing
+
+    def test_batch_swallows_pqs_exception(
+            self, geodata_db, monkeypatch, caplog):
+        def _raises(rows, db_path=None):
+            raise RuntimeError('boom')
+        monkeypatch.setattr(pqs, 'dual_write_enqueue_many', _raises)
+        scored = [(('/srv/Sentry/a', 'Sentry/a', 100), 10)]
+        with caplog.at_level(logging.WARNING):
+            result = svc._enqueue_events_to_pipeline_batch(scored)
+        assert result == 0
+        # Batched hook MUST NEVER propagate exceptions to the disk-walk.
+        assert any(
+            'batched producer hook' in r.getMessage()
+            for r in caplog.records
+        )
+
+
+# ---------------------------------------------------------------------------
 # Shadow comparator: _shadow_compare_cloud_picks
 # ---------------------------------------------------------------------------
 
@@ -504,4 +597,141 @@ class TestDiscoverEventsProducerIntegration:
         assert count == 0  # producer hook stayed quiet
         tel = svc.get_cloud_shadow_telemetry()
         assert tel['cloud_pipeline_enqueue_count'] == 0
+
+
+# ---------------------------------------------------------------------------
+# Priority-collapse / score-mismatch shadow scenarios
+# ---------------------------------------------------------------------------
+
+
+class TestShadowScoreCollapseScenarios:
+    """All cloud_pending rows share priority PRIORITY_CLOUD_BULK; the
+    intra-band order collapses to enqueued_at. Pin the resulting
+    legitimate disagreement scenarios so PR-F3 can re-rank by payload
+    score without breaking the shadow contract."""
+
+    def test_legacy_picks_high_score_event_arriving_after_backlog(
+            self, geodata_db):
+        """A late-arriving high-priority event lands at bottom of pipeline.
+
+        Scenario:
+        1. Producer enqueues 12 low-score (geo) events first (oldest
+           enqueued_at). All sit in pipeline at PRIORITY_CLOUD_BULK.
+        2. Producer enqueues 1 high-score Sentry event last.
+        3. Legacy disk-walk reorders by score and picks the Sentry
+           event first.
+        4. Pipeline's top-8 (peek window) is dominated by the older
+           backlog rows; the Sentry event ranks #13 by enqueued_at.
+        5. Shadow comparator sees legacy_pick='Sentry/...' is ABSENT
+           from the pipeline top-8 → disagreement counter increments.
+
+        This is the documented "score-collapse near the window
+        boundary" case from the WARNING text. PR-F3 must use
+        payload['score'] for re-ranking to eliminate it.
+        """
+        # Enqueue 12 backlog rows first.
+        for i in range(12):
+            pqs.dual_write_enqueue(
+                source_path=f'SentryClips/backlog_{i:03d}',
+                stage=pqs.STAGE_CLOUD_PENDING,
+                legacy_table=pqs.LEGACY_TABLE_CLOUD_SYNCED,
+                priority=pqs.PRIORITY_CLOUD_BULK,
+                payload={'score': 200},  # geo-only score
+            )
+        # Enqueue the late high-score Sentry event.
+        pqs.dual_write_enqueue(
+            source_path='SentryClips/late_sentry',
+            stage=pqs.STAGE_CLOUD_PENDING,
+            legacy_table=pqs.LEGACY_TABLE_CLOUD_SYNCED,
+            priority=pqs.PRIORITY_CLOUD_BULK,
+            payload={'score': 0},  # event score
+        )
+
+        # Pipeline peek returns top-8 ordered by enqueued_at.
+        top_n = svc._peek_pipeline_cloud_pending(limit=8)
+        assert 'SentryClips/late_sentry' not in top_n, \
+            "test premise — late-enqueued row must be outside top-8"
+
+        # Legacy reader picks the Sentry event (lowest score wins).
+        before = svc.get_cloud_shadow_telemetry()
+        svc._shadow_compare_cloud_picks(
+            legacy_path='SentryClips/late_sentry',
+            pipeline_candidates=top_n,
+        )
+        after = svc.get_cloud_shadow_telemetry()
+        # This is the disagreement that PR-F3 will address.
+        assert after['cloud_shadow_disagreement_count'] == \
+            before['cloud_shadow_disagreement_count'] + 1
+        assert after['cloud_shadow_agreement_count'] == \
+            before['cloud_shadow_agreement_count']
+
+    def test_legacy_pick_within_top_n_window_when_band_is_small(
+            self, geodata_db):
+        """When backlog fits in the top-N window, no disagreement fires.
+
+        With ≤ 8 rows total in cloud_pending, the legacy pick is
+        guaranteed to be in the peek window regardless of score
+        ranking. Pins the absence of false-positive disagreements
+        on a typical (small) drain.
+        """
+        # Enqueue 5 events in arbitrary order with mixed scores.
+        events_and_scores = [
+            ('SentryClips/c', 200),
+            ('SentryClips/a', 0),
+            ('SentryClips/e', 100),
+            ('SentryClips/b', 50),
+            ('SentryClips/d', 150),
+        ]
+        for path, score in events_and_scores:
+            pqs.dual_write_enqueue(
+                source_path=path,
+                stage=pqs.STAGE_CLOUD_PENDING,
+                legacy_table=pqs.LEGACY_TABLE_CLOUD_SYNCED,
+                priority=pqs.PRIORITY_CLOUD_BULK,
+                payload={'score': score},
+            )
+
+        # Legacy picks the lowest-score event.
+        legacy_pick = 'SentryClips/a'
+        top_n = svc._peek_pipeline_cloud_pending(limit=8)
+        assert legacy_pick in top_n  # band fits in window
+
+        before = svc.get_cloud_shadow_telemetry()
+        svc._shadow_compare_cloud_picks(
+            legacy_path=legacy_pick,
+            pipeline_candidates=top_n,
+        )
+        after = svc.get_cloud_shadow_telemetry()
+        # Agreement: small backlog never produces false positives.
+        assert after['cloud_shadow_agreement_count'] == \
+            before['cloud_shadow_agreement_count'] + 1
+        assert after['cloud_shadow_disagreement_count'] == \
+            before['cloud_shadow_disagreement_count']
+
+    def test_warning_text_mentions_priority_collapse(
+            self, geodata_db, caplog):
+        """The disagreement WARNING explicitly cites the score-collapse
+        cause so an operator reading the journal can immediately tell
+        whether the miss is benign (transient reorder) or real
+        (producer-hook gap).
+        """
+        svc._reset_cloud_shadow_telemetry_for_tests()
+        with caplog.at_level(logging.WARNING):
+            svc._shadow_compare_cloud_picks(
+                legacy_path='SentryClips/missed',
+                pipeline_candidates=('SentryClips/other',),
+            )
+        # The first verbatim WARNING must include the priority-collapse
+        # explanation so operators can self-diagnose without reading
+        # source.
+        verbatim = [
+            r.getMessage() for r in caplog.records
+            if 'absent from the top-' in r.getMessage()
+        ]
+        assert len(verbatim) == 1
+        msg = verbatim[0]
+        assert 'PRIORITY_CLOUD_BULK' in msg
+        assert 'enqueued_at' in msg
+        assert ('producer-hook gap' in msg
+                or 'producer hook gap' in msg)
 

--- a/tests/test_cloud_archive_pipeline_shadow.py
+++ b/tests/test_cloud_archive_pipeline_shadow.py
@@ -1,0 +1,507 @@
+"""Tests for issue #184 Wave 4 PR-F2 (cloud_archive pipeline_queue integration).
+
+PR-F2 lays the foundation for PR-F3's reader cutover by adding three
+opt-in flags to ``cloud_archive_service``:
+
+* ``CLOUD_ARCHIVE_ENQUEUE_TO_PIPELINE`` — PRODUCER hook in
+  ``_discover_events``: every discovered event is also enqueued into
+  ``pipeline_queue`` with ``stage='cloud_pending'`` (idempotent via
+  the existing UNIQUE index).
+* ``CLOUD_ARCHIVE_SHADOW_PIPELINE_QUEUE`` — OBSERVABILITY: when the
+  producer is also on, ``_drain_once`` peeks the top-N
+  ``cloud_pending`` rows and logs WARNING if the legacy disk-walk's
+  first pick is absent from the pipeline window.
+* ``CLOUD_ARCHIVE_USE_PIPELINE_READER`` — RESERVED for PR-F3, read
+  here only for the shadow-skip predicate.
+
+These tests verify:
+
+* Each flag predicate (``_enqueue_to_pipeline_enabled`` etc.) reads
+  the live config constant and returns False on import failure.
+* ``_enqueue_event_to_pipeline`` produces a ``cloud_pending`` row in
+  ``pipeline_queue`` with the expected priority + payload, is
+  idempotent, swallows errors, and bumps the producer telemetry
+  counter only on first insert.
+* ``_shadow_compare_cloud_picks`` agreement / disagreement counters
+  and rate-limited WARNING logging.
+* ``_peek_pipeline_cloud_pending`` returns top-N from pipeline_queue
+  and gracefully handles peek failures.
+* ``_discover_events`` invokes the producer hook for each scored
+  event when the flag is on, and is a complete no-op when the flag
+  is off.
+* ``get_cloud_shadow_telemetry`` snapshot keys.
+"""
+from __future__ import annotations
+
+import logging
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+# Allow importing the web modules without spinning up Flask.
+SCRIPTS_WEB = Path(__file__).resolve().parent.parent / 'scripts' / 'web'
+if str(SCRIPTS_WEB) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_WEB))
+
+from services import cloud_archive_service as svc  # noqa: E402
+from services import pipeline_queue_service as pqs  # noqa: E402
+from services.mapping_migrations import _init_db  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def geodata_db(tmp_path, monkeypatch):
+    """A fresh ``geodata.db`` with the pipeline_queue schema."""
+    db_path = str(tmp_path / 'geodata.db')
+    conn = _init_db(db_path)
+    conn.close()
+    # Ensure pqs._resolve_pipeline_db points at our temp DB so the
+    # producer hook lands rows in the same DB tests inspect.
+    monkeypatch.setattr(pqs, '_resolve_pipeline_db', lambda: db_path)
+    return db_path
+
+
+@pytest.fixture(autouse=True)
+def _reset_cloud_telemetry():
+    """Reset shadow + producer counters between tests."""
+    svc._reset_cloud_shadow_telemetry_for_tests()
+    yield
+    svc._reset_cloud_shadow_telemetry_for_tests()
+
+
+@pytest.fixture
+def enable_producer(monkeypatch):
+    """Turn the producer flag ON for the duration of the test."""
+    import config as cfg
+    monkeypatch.setattr(cfg, 'CLOUD_ARCHIVE_ENQUEUE_TO_PIPELINE', True)
+
+
+@pytest.fixture
+def disable_producer(monkeypatch):
+    """Force the producer flag OFF (default)."""
+    import config as cfg
+    monkeypatch.setattr(cfg, 'CLOUD_ARCHIVE_ENQUEUE_TO_PIPELINE', False)
+
+
+@pytest.fixture
+def enable_shadow(monkeypatch):
+    import config as cfg
+    monkeypatch.setattr(cfg, 'CLOUD_ARCHIVE_SHADOW_PIPELINE_QUEUE', True)
+
+
+@pytest.fixture
+def disable_shadow(monkeypatch):
+    import config as cfg
+    monkeypatch.setattr(cfg, 'CLOUD_ARCHIVE_SHADOW_PIPELINE_QUEUE', False)
+
+
+@pytest.fixture
+def enable_reader(monkeypatch):
+    import config as cfg
+    monkeypatch.setattr(cfg, 'CLOUD_ARCHIVE_USE_PIPELINE_READER', True)
+
+
+@pytest.fixture
+def disable_reader(monkeypatch):
+    import config as cfg
+    monkeypatch.setattr(cfg, 'CLOUD_ARCHIVE_USE_PIPELINE_READER', False)
+
+
+# ---------------------------------------------------------------------------
+# Flag predicates
+# ---------------------------------------------------------------------------
+
+
+class TestFlagPredicates:
+    """Each flag predicate reads the live config and is import-safe."""
+
+    def test_enqueue_to_pipeline_off_by_default(self, disable_producer):
+        assert svc._enqueue_to_pipeline_enabled() is False
+
+    def test_enqueue_to_pipeline_on(self, enable_producer):
+        assert svc._enqueue_to_pipeline_enabled() is True
+
+    def test_shadow_on_by_default(self, enable_shadow):
+        assert svc._shadow_pipeline_queue_enabled() is True
+
+    def test_shadow_off(self, disable_shadow):
+        assert svc._shadow_pipeline_queue_enabled() is False
+
+    def test_reader_off_by_default(self, disable_reader):
+        assert svc._use_pipeline_reader_enabled() is False
+
+    def test_reader_on(self, enable_reader):
+        assert svc._use_pipeline_reader_enabled() is True
+
+    def test_predicates_swallow_import_errors(self, monkeypatch):
+        """If config attribute is missing the predicate returns False."""
+        import config as cfg
+        for attr in (
+            'CLOUD_ARCHIVE_ENQUEUE_TO_PIPELINE',
+            'CLOUD_ARCHIVE_SHADOW_PIPELINE_QUEUE',
+            'CLOUD_ARCHIVE_USE_PIPELINE_READER',
+        ):
+            if hasattr(cfg, attr):
+                monkeypatch.delattr(cfg, attr, raising=False)
+        assert svc._enqueue_to_pipeline_enabled() is False
+        assert svc._shadow_pipeline_queue_enabled() is False
+        assert svc._use_pipeline_reader_enabled() is False
+
+
+# ---------------------------------------------------------------------------
+# Producer hook: _enqueue_event_to_pipeline
+# ---------------------------------------------------------------------------
+
+
+class TestEnqueueEventToPipeline:
+    """Producer hook semantics."""
+
+    def test_inserts_cloud_pending_row(self, geodata_db):
+        ok = svc._enqueue_event_to_pipeline(
+            'SentryClips/2024-01-01_event.json',
+            event_dir='/srv/SentryClips/2024-01-01_event',
+            event_size=12345,
+            score=10,
+        )
+        assert ok is True
+        conn = sqlite3.connect(geodata_db)
+        try:
+            row = conn.execute(
+                "SELECT stage, status, priority, source_path, "
+                "       payload_json, legacy_table "
+                "  FROM pipeline_queue WHERE source_path = ?",
+                ('SentryClips/2024-01-01_event.json',),
+            ).fetchone()
+        finally:
+            conn.close()
+        assert row is not None
+        stage, status, priority, source_path, payload, legacy_tbl = row
+        assert stage == pqs.STAGE_CLOUD_PENDING
+        assert status == 'pending'
+        assert priority == pqs.PRIORITY_CLOUD_BULK
+        assert source_path == 'SentryClips/2024-01-01_event.json'
+        assert legacy_tbl == pqs.LEGACY_TABLE_CLOUD_SYNCED
+        # Payload carries the producer metadata for PR-F3 + debugging.
+        import json as _json
+        decoded = _json.loads(payload)
+        assert decoded['event_size'] == 12345
+        assert decoded['score'] == 10
+        assert decoded['producer'] == 'cloud_archive._discover_events'
+
+    def test_idempotent_re_enqueue_returns_false(self, geodata_db):
+        first = svc._enqueue_event_to_pipeline('Sentry/foo.json')
+        second = svc._enqueue_event_to_pipeline('Sentry/foo.json')
+        assert first is True
+        assert second is False  # UNIQUE index suppresses the second insert
+
+    def test_telemetry_counter_only_bumps_on_first_insert(self, geodata_db):
+        before = svc.get_cloud_shadow_telemetry()['cloud_pipeline_enqueue_count']
+        svc._enqueue_event_to_pipeline('Sentry/a.json')
+        after_one = svc.get_cloud_shadow_telemetry()['cloud_pipeline_enqueue_count']
+        svc._enqueue_event_to_pipeline('Sentry/a.json')  # dupe
+        after_two = svc.get_cloud_shadow_telemetry()['cloud_pipeline_enqueue_count']
+        svc._enqueue_event_to_pipeline('Sentry/b.json')  # new
+        after_three = svc.get_cloud_shadow_telemetry()['cloud_pipeline_enqueue_count']
+        assert after_one == before + 1
+        assert after_two == after_one  # dupe must not bump
+        assert after_three == after_one + 1
+
+    def test_empty_path_returns_false_without_calling_pqs(
+            self, monkeypatch):
+        # Patch dual_write_enqueue to detect any call.
+        called = {'n': 0}
+
+        def _spy(**kw):
+            called['n'] += 1
+            return True
+        monkeypatch.setattr(pqs, 'dual_write_enqueue', _spy)
+        assert svc._enqueue_event_to_pipeline('') is False
+        assert called['n'] == 0
+
+    def test_swallows_pqs_exception(self, monkeypatch, caplog):
+        def _raises(**kw):
+            raise RuntimeError('boom')
+        monkeypatch.setattr(pqs, 'dual_write_enqueue', _raises)
+        with caplog.at_level(logging.WARNING):
+            ok = svc._enqueue_event_to_pipeline('Sentry/foo.json')
+        assert ok is False
+        # Producer hook MUST NEVER propagate exceptions to the disk-walk.
+        assert any(
+            'producer hook failed' in r.getMessage()
+            for r in caplog.records
+        )
+
+
+# ---------------------------------------------------------------------------
+# Shadow comparator: _shadow_compare_cloud_picks
+# ---------------------------------------------------------------------------
+
+
+class TestShadowComparePicks:
+    """Shadow-mode counters and rate-limited logging."""
+
+    def test_both_empty_counts_as_agreement(self):
+        before = svc.get_cloud_shadow_telemetry()
+        svc._shadow_compare_cloud_picks(
+            legacy_path=None, pipeline_candidates=(),
+        )
+        after = svc.get_cloud_shadow_telemetry()
+        assert after['cloud_shadow_agreement_count'] == \
+            before['cloud_shadow_agreement_count'] + 1
+        assert after['cloud_shadow_disagreement_count'] == \
+            before['cloud_shadow_disagreement_count']
+
+    def test_legacy_pick_in_top_n_counts_as_agreement(self):
+        svc._shadow_compare_cloud_picks(
+            legacy_path='Sentry/x.json',
+            pipeline_candidates=('Sentry/x.json', 'Sentry/y.json'),
+        )
+        tel = svc.get_cloud_shadow_telemetry()
+        assert tel['cloud_shadow_agreement_count'] == 1
+        assert tel['cloud_shadow_disagreement_count'] == 0
+
+    def test_legacy_pick_absent_from_top_n_counts_as_disagreement(
+            self, caplog):
+        with caplog.at_level(logging.WARNING):
+            svc._shadow_compare_cloud_picks(
+                legacy_path='Sentry/missing.json',
+                pipeline_candidates=('Sentry/y.json', 'Sentry/z.json'),
+            )
+        tel = svc.get_cloud_shadow_telemetry()
+        assert tel['cloud_shadow_agreement_count'] == 0
+        assert tel['cloud_shadow_disagreement_count'] == 1
+        # First N disagreements log verbatim.
+        msgs = [r.getMessage() for r in caplog.records]
+        assert any('cloud shadow' in m for m in msgs)
+        assert any('absent from the top-' in m for m in msgs)
+
+    def test_disagreement_log_is_rate_limited_after_verbatim_threshold(
+            self, caplog):
+        svc._reset_cloud_shadow_telemetry_for_tests()
+        with caplog.at_level(logging.WARNING):
+            for i in range(svc._CLOUD_SHADOW_DISAGREEMENT_LOG_VERBATIM + 1):
+                svc._shadow_compare_cloud_picks(
+                    legacy_path=f'Sentry/{i}.json',
+                    pipeline_candidates=('Sentry/other.json',),
+                )
+        # Exactly _CLOUD_SHADOW_DISAGREEMENT_LOG_VERBATIM verbatim WARNINGs.
+        verbatim = [
+            r for r in caplog.records
+            if 'absent from the top-' in r.getMessage()
+        ]
+        assert len(verbatim) == svc._CLOUD_SHADOW_DISAGREEMENT_LOG_VERBATIM
+        # The (LOG_VERBATIM + 1)-th call doesn't emit a heartbeat (heartbeat
+        # fires only when count is a multiple of LOG_EVERY).
+        heartbeats = [
+            r for r in caplog.records
+            if 'disagreement count =' in r.getMessage()
+        ]
+        assert len(heartbeats) == 0
+
+    def test_heartbeat_fires_at_log_every_threshold(self, caplog):
+        svc._reset_cloud_shadow_telemetry_for_tests()
+        every = svc._CLOUD_SHADOW_DISAGREEMENT_LOG_EVERY
+        verbatim = svc._CLOUD_SHADOW_DISAGREEMENT_LOG_VERBATIM
+        # Drive the counter to the next heartbeat boundary.
+        # We need enough disagreements to reach `every` cumulative.
+        with caplog.at_level(logging.WARNING):
+            for i in range(every):
+                svc._shadow_compare_cloud_picks(
+                    legacy_path=f'Sentry/{i}.json',
+                    pipeline_candidates=('Sentry/other.json',),
+                )
+        verbatim_logs = [
+            r for r in caplog.records
+            if 'absent from the top-' in r.getMessage()
+        ]
+        heartbeats = [
+            r for r in caplog.records
+            if 'disagreement count =' in r.getMessage()
+        ]
+        assert len(verbatim_logs) == verbatim
+        # When LOG_EVERY > LOG_VERBATIM, exactly one heartbeat fires
+        # at the LOG_EVERY mark.
+        assert len(heartbeats) == 1
+
+    def test_agreement_log_fires_at_log_every_threshold(self, caplog):
+        svc._reset_cloud_shadow_telemetry_for_tests()
+        every = svc._CLOUD_SHADOW_AGREEMENT_LOG_EVERY
+        with caplog.at_level(logging.INFO):
+            for _ in range(every):
+                svc._shadow_compare_cloud_picks(
+                    legacy_path=None, pipeline_candidates=(),
+                )
+        agreement_logs = [
+            r for r in caplog.records
+            if 'agreed with cloud_archive' in r.getMessage()
+        ]
+        assert len(agreement_logs) == 1
+
+    def test_telemetry_snapshot_keys(self):
+        snap = svc.get_cloud_shadow_telemetry()
+        assert set(snap.keys()) == {
+            'cloud_shadow_agreement_count',
+            'cloud_shadow_disagreement_count',
+            'cloud_pipeline_enqueue_count',
+        }
+
+
+# ---------------------------------------------------------------------------
+# Peek wrapper: _peek_pipeline_cloud_pending
+# ---------------------------------------------------------------------------
+
+
+class TestPeekPipelineCloudPending:
+    def test_returns_top_n_paths_in_priority_order(self, geodata_db):
+        # Enqueue three rows; pipeline_queue orders by priority, enqueued_at.
+        for path in ('Sentry/a.json', 'Sentry/b.json', 'Sentry/c.json'):
+            pqs.dual_write_enqueue(
+                source_path=path,
+                stage=pqs.STAGE_CLOUD_PENDING,
+                legacy_table=pqs.LEGACY_TABLE_CLOUD_SYNCED,
+                priority=pqs.PRIORITY_CLOUD_BULK,
+            )
+        result = svc._peek_pipeline_cloud_pending(limit=3)
+        assert isinstance(result, tuple)
+        assert set(result) == {
+            'Sentry/a.json', 'Sentry/b.json', 'Sentry/c.json',
+        }
+
+    def test_returns_empty_tuple_when_no_rows(self, geodata_db):
+        assert svc._peek_pipeline_cloud_pending() == ()
+
+    def test_swallows_peek_exception(self, monkeypatch, caplog):
+        def _raises(**kw):
+            raise sqlite3.OperationalError('database is locked')
+        monkeypatch.setattr(pqs, 'peek_top_n_paths_for_stage', _raises)
+        with caplog.at_level(logging.DEBUG):
+            result = svc._peek_pipeline_cloud_pending()
+        assert result == ()
+
+
+# ---------------------------------------------------------------------------
+# _discover_events producer integration
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoverEventsProducerIntegration:
+    """The producer hook fires only when the flag is ON.
+
+    Uses real temp directories (small files only) since the disk-walk
+    is inline in ``_discover_events``; mocking would require patching
+    ``os.listdir`` / ``os.path.isfile`` / ``os.path.getsize`` which
+    is more brittle than just creating two small fake event dirs.
+    """
+
+    @pytest.fixture
+    def teslacam_root(self, tmp_path):
+        """Build a TeslaCam-shaped tree with two SentryClips events."""
+        sentry = tmp_path / 'SentryClips'
+        for entry in ('2024-01-01_event_a', '2024-01-02_event_b'):
+            event_dir = sentry / entry
+            event_dir.mkdir(parents=True)
+            (event_dir / 'event.json').write_text(
+                '{"timestamp": "2024-01-01T00:00:00", "reason": "sentry_aware_object_detection"}'
+            )
+            (event_dir / 'front.mp4').write_bytes(b'fake')
+        return str(tmp_path)
+
+    @pytest.fixture
+    def cloud_conn(self, tmp_path):
+        """Empty cloud_synced_files connection so nothing is filtered."""
+        cloud_db = str(tmp_path / 'cloud_sync.db')
+        conn = sqlite3.connect(cloud_db)
+        conn.executescript(
+            """
+            CREATE TABLE cloud_synced_files (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                file_path TEXT NOT NULL UNIQUE,
+                file_size INTEGER, file_mtime REAL, remote_path TEXT,
+                status TEXT DEFAULT 'pending',
+                synced_at TEXT, retry_count INTEGER DEFAULT 0,
+                last_error TEXT
+            );
+            """
+        )
+        conn.commit()
+        yield conn
+        conn.close()
+
+    def test_hook_fires_for_each_event_when_flag_on(
+            self, geodata_db, enable_producer, monkeypatch,
+            teslacam_root, cloud_conn):
+        # Restrict to SentryClips so the test tree matches.
+        monkeypatch.setattr(
+            svc, 'CLOUD_ARCHIVE_SYNC_FOLDERS', ['SentryClips'],
+        )
+        # Skip the geo-hit DB lookup and the live YAML re-read to keep
+        # the test hermetic.
+        monkeypatch.setattr(svc, '_load_geo_hits', lambda: None)
+        monkeypatch.setattr(
+            svc, '_read_sync_non_event_setting', lambda: True,
+        )
+        # Force a low score so all events pass the < 200 filter.
+        monkeypatch.setattr(
+            svc, '_score_event_priority',
+            lambda dir_path, **kw: 10,
+        )
+
+        result = svc._discover_events(teslacam_root, conn=cloud_conn)
+
+        # Both fake events should be in the result.
+        assert len(result) == 2
+        # And both should be in pipeline_queue under cloud_pending.
+        gconn = sqlite3.connect(geodata_db)
+        try:
+            rows = gconn.execute(
+                "SELECT source_path FROM pipeline_queue "
+                " WHERE stage = ? ORDER BY source_path",
+                (pqs.STAGE_CLOUD_PENDING,),
+            ).fetchall()
+        finally:
+            gconn.close()
+        paths = [r[0] for r in rows]
+        assert paths == [
+            'SentryClips/2024-01-01_event_a',
+            'SentryClips/2024-01-02_event_b',
+        ]
+        # Telemetry should reflect 2 inserts.
+        tel = svc.get_cloud_shadow_telemetry()
+        assert tel['cloud_pipeline_enqueue_count'] == 2
+
+    def test_hook_does_not_fire_when_flag_off(
+            self, geodata_db, disable_producer, monkeypatch,
+            teslacam_root, cloud_conn):
+        monkeypatch.setattr(
+            svc, 'CLOUD_ARCHIVE_SYNC_FOLDERS', ['SentryClips'],
+        )
+        monkeypatch.setattr(svc, '_load_geo_hits', lambda: None)
+        monkeypatch.setattr(
+            svc, '_read_sync_non_event_setting', lambda: True,
+        )
+        monkeypatch.setattr(
+            svc, '_score_event_priority', lambda d, **kw: 10,
+        )
+
+        result = svc._discover_events(teslacam_root, conn=cloud_conn)
+        # Discovery still works.
+        assert len(result) == 2
+
+        gconn = sqlite3.connect(geodata_db)
+        try:
+            count = gconn.execute(
+                "SELECT COUNT(*) FROM pipeline_queue WHERE stage = ?",
+                (pqs.STAGE_CLOUD_PENDING,),
+            ).fetchone()[0]
+        finally:
+            gconn.close()
+        assert count == 0  # producer hook stayed quiet
+        tel = svc.get_cloud_shadow_telemetry()
+        assert tel['cloud_pipeline_enqueue_count'] == 0
+


### PR DESCRIPTION
## Summary

Wave 4 PR-F2 ships the cloud-side foundation for PR-F3's reader cutover.

Three opt-in flags are added to ``cloud_archive``:

| Flag | Default | Role |
|------|---------|------|
| ``enqueue_to_pipeline`` | `false` | **PRODUCER** — `_discover_events` mirrors every scored event into `pipeline_queue` with `stage='cloud_pending'` |
| ``shadow_pipeline_queue`` | `true` | **OBSERVABILITY** — gated on the producer flag; peeks pipeline top-N before each `_drain_once` and logs WARNING on disagreement |
| ``use_pipeline_reader`` | `false` | **RESERVED for PR-F3** — read here only for the shadow-skip predicate |

The legacy disk-walk + `cloud_synced_files` state-tracking continue to drive uploads. This PR is **pure additive** — a fresh deploy is a no-op.

## Why a producer hook (not a direct reader switch like PR-F1)

PR-F1 had a clean lift-and-shift target — `archive_queue.claim_next_for_worker` ↔ `pipeline_queue.claim_next_for_stage`. Cloud is fundamentally different:

* `cloud_archive` doesn't have a "claim" pattern today; `_drain_once` walks disk, filters by `cloud_synced_files` state, and uploads in a loop.
* The existing dual-write only fires when `cloud_synced_files` rows are written (`status='uploading'`/`'synced'`/`'queued'`). It NEVER fires for the moment of discovery.
* So `pipeline_queue` cloud_pending rows lag behind discovery — at the moment PR-F3 would `claim_next_for_stage('cloud_pending')`, the queue could legitimately be empty even though `_discover_events` found 50 events.

The producer hook closes that gap: `_discover_events` itself enqueues every candidate into the unified queue (idempotent). Once the operator flips `enqueue_to_pipeline: true`, the queue starts populating. PR-F3 can then switch the reader without an empty-queue chicken-and-egg.

## Files changed

### `config.yaml` + `scripts/web/config.py`
* Three flags added with full docstrings explaining the producer/shadow/reader division.
* All defaults preserve current behaviour.

### `scripts/web/services/cloud_archive_service.py`
* Three lazy-import flag predicates — config reload is picked up next iteration without restarting the worker thread.
* `_enqueue_event_to_pipeline(rel_path, event_dir, event_size, score)` — wraps `pqs.dual_write_enqueue` with `stage='cloud_pending'`, `priority=PRIORITY_CLOUD_BULK`. Idempotent via UNIQUE index. NEVER propagates errors.
* `_shadow_compare_cloud_picks(legacy_path, pipeline_candidates)` — mirrors `archive_worker._shadow_compare_picks` exactly:
  * Both empty → silent agreement.
  * Legacy pick in pipeline top-N → silent agreement (heartbeat INFO every 500).
  * Legacy pick absent → WARNING (first 10 verbatim, then heartbeat per 100).
* `_peek_pipeline_cloud_pending()` — best-effort wrapper; failures return `()`.
* `get_cloud_shadow_telemetry()` — process-local snapshot of three counters (agreement, disagreement, enqueues).
* `_discover_events`: when producer ON, mirror every scored event after the priority sort.
* `_drain_once`: when producer + shadow ON and reader OFF, peek pipeline top-N and call shadow comparator.

### `tests/test_cloud_archive_pipeline_shadow.py` (new — 24 tests)
* **Flag predicates** (7 tests): defaults, on/off, import-failure swallowing.
* **Producer hook** (5 tests): row contents, idempotency, telemetry counter only on first insert, empty-path fast-fail, swallowed pqs exceptions.
* **Shadow comparator** (7 tests): both-empty agreement, top-N agreement, disagreement WARNING, verbatim-then-heartbeat throttle, agreement-INFO threshold, telemetry snapshot keys.
* **Peek wrapper** (3 tests): top-N return, empty when no rows, swallows pqs errors.
* **`_discover_events` integration** (2 tests): real temp dirs prove producer fires per scored event when flag ON, complete no-op when flag OFF.

## Test results

```
1,818 pass / 4 skip
```

(was 1,794 — +24 new from this PR.)

## Operator rollout (post-merge, future PR-F3 prep)

1. Deploy this PR — no behaviour change (all flags default OFF/no-op).
2. Operator flips `cloud_archive.enqueue_to_pipeline: true` in `config.yaml` and restarts `gadget_web.service`.
3. After ~24h of normal cloud sync activity, check `get_cloud_shadow_telemetry()` via the Settings page (or `python -c "from services import cloud_archive_service as s; print(s.get_cloud_shadow_telemetry())"`).
4. If `cloud_shadow_disagreement_count == 0` (or near-zero) and `cloud_pipeline_enqueue_count > 0`, the producer is healthy — PR-F3 can safely flip `use_pipeline_reader: true` to cut the reader over.
5. If disagreements appear, journalctl WARNINGs name the missed paths so the producer-hook gap is investigable before PR-F3 ships.

Ref #184 (Wave 4 PR-F2)
