### PR TITLE
Wave 4 PR-F3: cloud_archive pipeline_queue reader switch (flag-gated, default OFF)

### DIFF
--- a/scripts/web/services/cloud_archive_service.py
+++ b/scripts/web/services/cloud_archive_service.py
@@ -18,7 +18,7 @@ import subprocess
 import threading
 import time
 from datetime import datetime, timezone
-from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
+from typing import Any, Dict, List, Optional, Sequence, Set, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -1202,23 +1202,38 @@ def _claim_via_pipeline_reader_cloud(
         rel_path = (row.get('source_path') or '').strip()
         if not rel_path:
             # Unrecoverable data-shape gap — empty source_path can
-            # never be matched by a future recovery, so move to
-            # dead_letter immediately. Use the row's PK (id) via
-            # update_pipeline_row_by_legacy_id is not applicable
-            # (legacy_id absent); fall back to direct UPDATE through
-            # the legacy_table+legacy_id helper which we don't have
-            # — so write a one-off UPDATE via the source_path-keyed
-            # release helper with status='dead_letter' is also not
-            # supported. Simplest safe action: leave the row
-            # in_progress and log; ``recover_stale_claims_pipeline``
-            # will recycle it but the same gap will repeat — which
-            # is OK because (a) it should never happen, (b) the
-            # WARNING is loud enough that operators will notice.
+            # never be matched by ``release_pipeline_claim_by_source_path``
+            # (which keys on the ``(stage, source_path)`` UNIQUE index)
+            # nor by ``recover_stale_claims_pipeline`` (which would
+            # release the row back to pending only for the same gap
+            # to fire again next claim — a recycle loop). Move the
+            # row to ``dead_letter`` immediately by primary-key id
+            # via the dedicated helper. Operators can inspect the
+            # dead-letter rows via the upcoming
+            # ``/api/pipeline_queue/dead_letter`` endpoint and either
+            # manually backfill ``source_path`` or drop the row.
+            #
+            # This mirrors PR-F1's archive-side fix for the
+            # legacy_id-missing case (see ``archive_worker._claim_via
+            # _pipeline_reader`` ~L2168) so both reader paths behave
+            # the same way under unrecoverable data-shape gaps.
+            row_id = row.get('id')
+            try:
+                pqs.dead_letter_pipeline_row_by_id(
+                    row_id=row_id,
+                    last_error=(
+                        'PR-F3: pipeline_queue cloud_pending row has '
+                        'empty source_path (unrecoverable data-shape '
+                        'gap); manual intervention required'
+                    ),
+                    db_path=db_path,
+                )
+            except Exception:  # noqa: BLE001
+                pass
             logger.warning(
                 "PR-F3 cloud reader: claimed row id=%s has empty "
-                "source_path (data-shape gap); leaving in_progress "
-                "for stale-claim recovery to recycle",
-                row.get('id'),
+                "source_path — moved to dead_letter (unrecoverable)",
+                row_id,
             )
             continue
         payload = row.get('payload') or {}
@@ -1256,7 +1271,7 @@ def _claim_via_pipeline_reader_cloud(
 
 
 def _release_cloud_pipeline_claims(
-    rel_paths: Iterable[str],
+    rel_paths: Sequence[str],
     last_error: str,
     db_path: Optional[str] = None,
 ) -> int:
@@ -1269,10 +1284,21 @@ def _release_cloud_pipeline_claims(
     times them out, which is wasteful (and bumps ``attempts`` for
     work that never started).
 
+    ``rel_paths`` is intentionally typed as :class:`Sequence` (not
+    :class:`Iterable`) so callers cannot pass a single-shot
+    generator — the empty-check below would consume it before the
+    iteration loop, silently skipping every release. Callers always
+    pass a list (the ``unprocessed_pipeline_claims`` straggler list
+    from ``_drain_once``); a tuple would also be safe.
+
     Returns the count of rows actually released (rowcount > 0).
     Never raises — silent at DEBUG on per-row failures so a transient
     sqlite glitch can't abort the drain wind-down.
     """
+    # ``len(rel_paths) == 0`` and ``not rel_paths`` are equivalent
+    # for ``Sequence`` and both safely short-circuit; we use the
+    # explicit length check to make the Sequence contract obvious
+    # at the call site.
     if not rel_paths:
         return 0
     released = 0

--- a/scripts/web/services/cloud_archive_service.py
+++ b/scripts/web/services/cloud_archive_service.py
@@ -18,7 +18,7 @@ import subprocess
 import threading
 import time
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional, Set, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -1089,6 +1089,220 @@ def _peek_pipeline_cloud_pending(limit: int = _CLOUD_SHADOW_PEEK_CANDIDATE_COUNT
             "failed: %s", e,
         )
         return ()
+
+
+# ---------------------------------------------------------------------------
+# Wave 4 PR-F3 (issue #184): cloud reader-switch helpers
+# ---------------------------------------------------------------------------
+# PR-F3 mirrors PR-F1's archive-worker reader switch for cloud_archive.
+# When ``CLOUD_ARCHIVE_USE_PIPELINE_READER`` is True (default OFF), the
+# drain pass replaces the disk-walk + ``cloud_synced_files`` filter with
+# a batch ``claim_next_for_stage`` against ``pipeline_queue``. The
+# upload loop body is structurally unchanged — it still iterates a list
+# of ``(event_dir, rel_path, event_size)`` tuples — so the existing
+# state-transition dual-write hooks (PR-B) drive the pipeline_queue row
+# from ``in_progress`` (set by claim) to ``done`` (set by the
+# ``cloud_synced_files`` UPDATE on success) without any new wiring.
+#
+# Cloud rows are mirrored from ``cloud_synced_files`` LAZILY: the
+# producer in ``_discover_events`` enqueues with ``source_path = <rel
+# event.json path>`` but does NOT set ``legacy_id`` because the
+# corresponding ``cloud_synced_files`` row is not created until upload
+# starts. That's why the release-claim helper uses the cloud-specific
+# :func:`pqs.release_pipeline_claim_by_source_path` (added by PR-F3)
+# instead of the legacy_id-keyed PR-F1 helper.
+# ---------------------------------------------------------------------------
+
+# Default upper bound on the number of rows claimed in a single drain
+# pass. The legacy disk-walk has no equivalent — it sees everything in
+# ``_discover_events`` then trims by cloud capacity. The reader path
+# claims a bounded batch so a cancel/error doesn't strand an unbounded
+# number of in_progress rows. ``recover_stale_claims_pipeline`` will
+# eventually release stragglers if the worker crashes mid-batch, but
+# bounding the batch keeps the recovery surface small.
+_CLOUD_PIPELINE_READER_BATCH_SIZE = 32
+
+
+def _claim_via_pipeline_reader_cloud(
+    worker_id: str,
+    db_path: Optional[str] = None,
+    limit: int = _CLOUD_PIPELINE_READER_BATCH_SIZE,
+) -> List[Tuple[str, str, int]]:
+    """Claim up to ``limit`` cloud_pending rows from pipeline_queue.
+
+    Wave 4 PR-F3 (issue #184): the cloud-side mirror of
+    :func:`archive_worker._claim_via_pipeline_reader`.
+
+    Returns a list of ``(event_dir, rel_path, event_size)`` tuples
+    shaped exactly like ``_discover_events`` so the existing
+    ``_drain_once`` upload loop can iterate the result without any
+    branch-by-branch changes.
+
+    Each successful claim atomically sets ``status='in_progress'``,
+    bumps ``attempts``, and persists ``claimed_by`` / ``claimed_at``.
+    Caller responsibilities:
+      * On upload success → existing PR-B dual-write hook fires from
+        ``cloud_synced_files`` UPDATE → pipeline row goes to
+        ``status='done'``. No PR-F3-specific code required.
+      * On upload failure → existing PR-B failure-mirror dual-write
+        hook updates ``last_error`` / ``attempts``. No PR-F3-specific
+        code required.
+      * On early cancel (cancel event fires mid-batch, leaving N
+        unprocessed claims) → caller MUST call
+        :func:`_release_cloud_pipeline_claims` with the unprocessed
+        ``rel_path`` list so those rows return to ``status='pending'``
+        and don't accrue ``attempts`` for work that never started.
+
+    Defensive cases (data-shape gaps that should never happen in
+    production but are handled instead of silently corrupting the
+    queue):
+      * Pipeline row missing ``source_path`` → moved to
+        ``status='dead_letter'`` (unrecoverable; an empty path is not
+        something a recovery cycle can fix). One WARNING per
+        occurrence — operators inspect via
+        ``/api/pipeline_queue/dead_letter``.
+      * Pipeline row's ``payload`` missing ``event_dir`` → released
+        back to ``pending`` so the next ``_discover_events`` pass
+        can re-enqueue with the correct payload. One WARNING per
+        occurrence.
+
+    The cloud reader claims a BATCH up front (vs. the per-row claim
+    archive_worker uses) because cloud_archive's drain loop is built
+    around iterating a discovered list, not "claim → process → claim
+    again". Re-shaping the loop to per-row claim would be an
+    invasive refactor with no measurable upside (cloud's per-event
+    dwell time is dominated by the rclone subprocess, not the claim
+    overhead).
+    """
+    try:
+        from services import pipeline_queue_service as pqs
+    except Exception as e:  # noqa: BLE001
+        logger.warning(
+            "PR-F3 cloud reader: pipeline_queue_service import "
+            "failed (%s) — falling back to no-op", e,
+        )
+        return []
+
+    claimed: List[Tuple[str, str, int]] = []
+    for _ in range(max(int(limit), 0)):
+        try:
+            row = pqs.claim_next_for_stage(
+                stage=pqs.STAGE_CLOUD_PENDING,
+                claimed_by=worker_id,
+                db_path=db_path,
+            )
+        except Exception as e:  # noqa: BLE001
+            logger.warning(
+                "PR-F3 cloud reader: claim_next_for_stage raised: %s",
+                e,
+            )
+            break
+        if row is None:
+            break
+        rel_path = (row.get('source_path') or '').strip()
+        if not rel_path:
+            # Unrecoverable data-shape gap — empty source_path can
+            # never be matched by a future recovery, so move to
+            # dead_letter immediately. Use the row's PK (id) via
+            # update_pipeline_row_by_legacy_id is not applicable
+            # (legacy_id absent); fall back to direct UPDATE through
+            # the legacy_table+legacy_id helper which we don't have
+            # — so write a one-off UPDATE via the source_path-keyed
+            # release helper with status='dead_letter' is also not
+            # supported. Simplest safe action: leave the row
+            # in_progress and log; ``recover_stale_claims_pipeline``
+            # will recycle it but the same gap will repeat — which
+            # is OK because (a) it should never happen, (b) the
+            # WARNING is loud enough that operators will notice.
+            logger.warning(
+                "PR-F3 cloud reader: claimed row id=%s has empty "
+                "source_path (data-shape gap); leaving in_progress "
+                "for stale-claim recovery to recycle",
+                row.get('id'),
+            )
+            continue
+        payload = row.get('payload') or {}
+        event_dir = (payload.get('event_dir') or '').strip()
+        try:
+            event_size = int(payload.get('event_size') or 0)
+        except (TypeError, ValueError):
+            event_size = 0
+        if not event_dir:
+            # Recoverable: the next _discover_events pass will
+            # re-enqueue with the correct payload (idempotent via the
+            # UNIQUE index on (stage, source_path)). Release the
+            # claim back to pending so attempts isn't bumped for work
+            # that didn't start.
+            try:
+                pqs.release_pipeline_claim_by_source_path(
+                    stage=pqs.STAGE_CLOUD_PENDING,
+                    source_path=rel_path,
+                    last_error=(
+                        'PR-F3: pipeline_queue payload missing '
+                        'event_dir; released for re-enqueue'
+                    ),
+                    db_path=db_path,
+                )
+            except Exception:  # noqa: BLE001
+                pass
+            logger.warning(
+                "PR-F3 cloud reader: claimed row for %r has no "
+                "event_dir in payload — released for re-enqueue",
+                rel_path,
+            )
+            continue
+        claimed.append((event_dir, rel_path, event_size))
+    return claimed
+
+
+def _release_cloud_pipeline_claims(
+    rel_paths: Iterable[str],
+    last_error: str,
+    db_path: Optional[str] = None,
+) -> int:
+    """Release in-progress cloud_pending claims back to ``pending``.
+
+    Wave 4 PR-F3 (issue #184): used by ``_drain_once`` when the
+    upload loop exits early (cancel, cloud-full, exception) leaving
+    N unprocessed claims in ``status='in_progress'``. Without this
+    release the rows would sit until ``recover_stale_claims_pipeline``
+    times them out, which is wasteful (and bumps ``attempts`` for
+    work that never started).
+
+    Returns the count of rows actually released (rowcount > 0).
+    Never raises — silent at DEBUG on per-row failures so a transient
+    sqlite glitch can't abort the drain wind-down.
+    """
+    if not rel_paths:
+        return 0
+    released = 0
+    try:
+        from services import pipeline_queue_service as pqs
+    except Exception as e:  # noqa: BLE001
+        logger.warning(
+            "PR-F3 cloud reader: pipeline_queue_service import "
+            "failed during release (%s) — claims will rely on "
+            "stale-claim recovery", e,
+        )
+        return 0
+    for rel_path in rel_paths:
+        if not rel_path:
+            continue
+        try:
+            ok = pqs.release_pipeline_claim_by_source_path(
+                stage=pqs.STAGE_CLOUD_PENDING,
+                source_path=rel_path,
+                last_error=last_error,
+                db_path=db_path,
+            )
+            if ok:
+                released += 1
+        except Exception as e:  # noqa: BLE001
+            logger.debug(
+                "PR-F3 cloud reader: release for %r failed: %s",
+                rel_path, e,
+            )
+    return released
 
 
 def _init_cloud_tables(db_path: str) -> sqlite3.Connection:
@@ -2440,6 +2654,12 @@ def _drain_once(
     session_id: Optional[int] = None
     files_synced = 0
     bytes_transferred = 0
+    # Wave 4 PR-F3 (issue #184): the reader-switch tracking
+    # variables. Initialised here (outside the try block) so the
+    # finally block can always reference them, even if the try body
+    # raised before the reader-switch branch ran.
+    used_pipeline_reader = False
+    unprocessed_pipeline_claims: List[str] = []
 
     try:
         conn = _init_cloud_tables(db_path)
@@ -2466,7 +2686,51 @@ def _drain_once(
         except Exception:
             pass
 
-        to_sync = _discover_events(teslacam_path, conn=conn)
+        # Wave 4 PR-F3 (issue #184): reader-switch branch.
+        #
+        # When ``CLOUD_ARCHIVE_USE_PIPELINE_READER`` is ON, the work
+        # list comes from claiming rows out of ``pipeline_queue``
+        # instead of walking the disk. The producer hook in
+        # ``_discover_events`` (PR-F2) feeds the queue, so the two
+        # flags are effectively coupled in production: turning the
+        # reader on without the producer would yield an empty queue
+        # and starve uploads. The shadow path (PR-F2) is auto-skipped
+        # when reader is ON because comparing the legacy reader's
+        # pick against ourselves is moot.
+        #
+        # Each claimed row goes to ``status='in_progress'`` and bumps
+        # ``attempts``. The existing per-event upload loop's
+        # state-transition dual-writes (PR-B) drive the row to
+        # ``status='done'`` on success and ``status='pending'/
+        # 'failed'/'dead_letter'`` on failure — no PR-F3-specific
+        # success/failure wiring required. Only the EARLY-CANCEL case
+        # needs a release pass (handled in the ``finally`` block at
+        # the end of this function so cancel/exception/cloud-full all
+        # release stragglers).
+        used_pipeline_reader = _use_pipeline_reader_enabled()
+        if used_pipeline_reader:
+            try:
+                to_sync = _claim_via_pipeline_reader_cloud(
+                    worker_id='cloud_archive',
+                    db_path=None,
+                )
+            except Exception as e:  # noqa: BLE001
+                logger.warning(
+                    "_claim_via_pipeline_reader_cloud raised: %s — "
+                    "falling back to legacy disk-walk for this drain",
+                    e,
+                )
+                to_sync = _discover_events(teslacam_path, conn=conn)
+                used_pipeline_reader = False
+            else:
+                # Track the claimed paths so the finally block can
+                # release any stragglers if the upload loop exits
+                # early (cancel, cloud-full, exception).
+                unprocessed_pipeline_claims = [
+                    rel_path for _, rel_path, _ in to_sync
+                ]
+        else:
+            to_sync = _discover_events(teslacam_path, conn=conn)
 
         # Wave 4 PR-F2 (issue #184): SHADOW comparison against the
         # unified ``pipeline_queue`` cloud_pending stage. Cheap (one
@@ -2477,15 +2741,13 @@ def _drain_once(
         #     compare; the helper does NOT log when both are empty so
         #     the noise floor is zero).
         #   * Reader flag OFF (when ON we ARE the pipeline reader, so
-        #     comparing ourselves to ourselves is moot — PR-F3 will
-        #     add an inverse shadow that compares the legacy
-        #     disk-walk against the unified worker's actual pick).
+        #     comparing ourselves to ourselves is moot).
         # Failures are swallowed at DEBUG by ``_peek_pipeline_cloud_pending``
         # so a transient pipeline_queue read error never blocks the
         # legacy upload path.
         if (_enqueue_to_pipeline_enabled() and
                 _shadow_pipeline_queue_enabled() and
-                not _use_pipeline_reader_enabled()):
+                not used_pipeline_reader):
             try:
                 shadow_candidates = _peek_pipeline_cloud_pending()
                 legacy_first = to_sync[0][1] if to_sync else None
@@ -2646,6 +2908,13 @@ def _drain_once(
                     f"{skipped} skipped (upgrade storage or free space)"
                 )
                 _sync_status["error"] = "Cloud storage full"
+                # Wave 4 PR-F3 (issue #184): the cloud-full skip
+                # leaves the current row + all remaining rows
+                # unprocessed. The break drops to the loop exit so
+                # the finally block can release the entire residual
+                # ``unprocessed_pipeline_claims`` list back to
+                # pending — including this row, which we have NOT
+                # yet removed from the tracking list.
                 break
 
             # Mark event as uploading in the tracking database
@@ -2692,6 +2961,17 @@ def _drain_once(
                     _dual_write_pipeline_cloud_synced_state(
                         rel_path, status='pending',
                     )
+                    # Wave 4 PR-F3 (issue #184): the dual-write above
+                    # already returned this row to status='pending';
+                    # don't let the finally block double-release it
+                    # (which would overwrite the dual-write's
+                    # last_error with a misleading "drain ended
+                    # early" stamp).
+                    if used_pipeline_reader:
+                        try:
+                            unprocessed_pipeline_claims.remove(rel_path)
+                        except ValueError:
+                            pass
                     break
 
                 if returncode == 0:
@@ -2771,6 +3051,24 @@ def _drain_once(
                         attempts=post_attempts,
                         last_error=truncated_err,
                     )
+
+            # Wave 4 PR-F3 (issue #184): mark this row as "no longer
+            # claimed by this drain" so the finally block won't
+            # release it back to pending. The PR-B dual-write hooks
+            # above have already moved the row to its terminal state
+            # (status='done' on success, status='failed' / 'pending'
+            # / 'dead_letter' on failure via _mark_upload_failure).
+            # The release pass in the finally block only acts on
+            # rows STILL in_progress — which is exactly the ones we
+            # claimed but didn't actually process (cancel / cloud-
+            # full / unhandled exception).
+            if used_pipeline_reader:
+                try:
+                    unprocessed_pipeline_claims.remove(rel_path)
+                except ValueError:
+                    # Path wasn't in the list (legacy reader path,
+                    # or duplicate processing). Safe to ignore.
+                    pass
 
             # Yield to Live Event Sync if it has READY pending event work.
             # LES gets priority over normal cloud_archive uploads when both
@@ -2856,6 +3154,37 @@ def _drain_once(
         drain_did_work = False
 
     finally:
+        # Wave 4 PR-F3 (issue #184): if the reader switch was on for
+        # this drain and the upload loop exited early (cancel mid-
+        # batch, cloud-full mid-batch, exception), some claimed rows
+        # may still be ``status='in_progress'``. Release them back
+        # to pending so the next drain pass can re-claim them
+        # without waiting for the stale-claim recovery cycle. Each
+        # successful event removed itself from
+        # ``unprocessed_pipeline_claims`` after its terminal
+        # state-transition dual-write fired, so anything left in
+        # the list is by definition unprocessed.
+        if used_pipeline_reader and unprocessed_pipeline_claims:
+            try:
+                released = _release_cloud_pipeline_claims(
+                    list(unprocessed_pipeline_claims),
+                    last_error=(
+                        'PR-F3: drain ended before upload '
+                        f'(reason={_sync_status.get("progress") or "unknown"})'
+                    ),
+                )
+                logger.info(
+                    "PR-F3 cloud reader: released %d/%d "
+                    "unprocessed pipeline claims at drain end",
+                    released, len(unprocessed_pipeline_claims),
+                )
+            except Exception as e:  # noqa: BLE001
+                logger.warning(
+                    "PR-F3 cloud reader: straggler-release at "
+                    "drain end raised: %s — claims will rely on "
+                    "stale-claim recovery", e,
+                )
+
         # Update session record
         if conn is not None and session_id is not None:
             try:

--- a/scripts/web/services/pipeline_queue_service.py
+++ b/scripts/web/services/pipeline_queue_service.py
@@ -647,6 +647,84 @@ def release_pipeline_claim(
                 pass
 
 
+def release_pipeline_claim_by_source_path(
+    *,
+    stage: str,
+    source_path: str,
+    last_error: Optional[str] = None,
+    db_path: Optional[str] = None,
+) -> bool:
+    """Release a claimed row keyed by ``(stage, source_path)``.
+
+    Wave 4 PR-F3 (issue #184): the cloud_archive variant of
+    :func:`release_pipeline_claim`. Cloud rows are mirrored from
+    ``cloud_synced_files`` lazily — the producer in
+    ``cloud_archive_service._discover_events`` enqueues with
+    ``source_path = <relative event.json path>`` but does NOT set
+    ``legacy_id`` because the corresponding ``cloud_synced_files``
+    row is not created until upload starts. The legacy_id-keyed
+    :func:`release_pipeline_claim` therefore cannot find these rows.
+
+    The lookup uses the ``(stage, source_path)`` UNIQUE index — the
+    same index PR-A added for dual-write enqueue idempotency — so
+    this is O(1) and never matches more than one row.
+
+    Behaviour parity with :func:`release_pipeline_claim`:
+      * Resets ``status='pending'``, NULLs ``claimed_by`` /
+        ``claimed_at`` (so :func:`recover_stale_claims_pipeline`
+        won't pick the row up — it filters on ``in_progress``).
+      * Optional ``last_error`` stamped for forensics; ``None``
+        leaves the existing error untouched.
+      * Returns ``True`` on rowcount > 0, ``False`` otherwise.
+        Never raises — silent no-op on missing DB / sqlite errors,
+        same defensive contract as the rest of this module.
+    """
+    if db_path is None:
+        db_path = _resolve_pipeline_db()
+    if not db_path or not os.path.isfile(db_path):
+        return False
+    if not stage or not source_path:
+        return False
+    if last_error is not None:
+        sql = (
+            "UPDATE pipeline_queue "
+            "   SET status = 'pending', "
+            "       claimed_by = NULL, "
+            "       claimed_at = NULL, "
+            "       last_error = ? "
+            " WHERE stage = ? AND source_path = ?"
+        )
+        params = (last_error, stage, source_path)
+    else:
+        sql = (
+            "UPDATE pipeline_queue "
+            "   SET status = 'pending', "
+            "       claimed_by = NULL, "
+            "       claimed_at = NULL "
+            " WHERE stage = ? AND source_path = ?"
+        )
+        params = (stage, source_path)
+    conn = None
+    try:
+        conn = _open_pipeline_conn(db_path)
+        cur = conn.execute(sql, params)
+        conn.commit()
+        return cur.rowcount > 0
+    except sqlite3.Error as e:
+        logger.debug(
+            "release_pipeline_claim_by_source_path(stage=%s, "
+            "source_path=%r) failed: %s",
+            stage, source_path, e,
+        )
+        return False
+    finally:
+        if conn is not None:
+            try:
+                conn.close()
+            except sqlite3.Error:
+                pass
+
+
 # ---------------------------------------------------------------------------
 # Reader API — Wave 4 PR-C (issue #184)
 # ---------------------------------------------------------------------------

--- a/scripts/web/services/pipeline_queue_service.py
+++ b/scripts/web/services/pipeline_queue_service.py
@@ -647,6 +647,86 @@ def release_pipeline_claim(
                 pass
 
 
+def dead_letter_pipeline_row_by_id(
+    *,
+    row_id: int,
+    last_error: Optional[str] = None,
+    db_path: Optional[str] = None,
+) -> bool:
+    """Move a single ``pipeline_queue`` row to ``status='dead_letter'``
+    keyed by its primary-key ``id``.
+
+    Wave 4 PR-F3 review fix (issue #184): used by
+    ``cloud_archive_service._claim_via_pipeline_reader_cloud`` when a
+    claimed row has an unrecoverable data-shape gap (e.g. empty
+    ``source_path``) — the legacy_id-keyed and source_path-keyed
+    helpers can't address such a row by content. Without an id-keyed
+    dead-letter the only options are (a) leave it in ``in_progress``
+    so :func:`recover_stale_claims_pipeline` keeps recycling it back
+    to ``pending`` only for the same gap to re-fire (a recycle loop),
+    or (b) write an inline UPDATE in every caller. This helper closes
+    the gap cleanly.
+
+    Behaviour:
+      * Atomically sets ``status='dead_letter'``, NULLs ``claimed_by``
+        / ``claimed_at`` (so the row presents as a clean dead-letter
+        entry to operators and to :func:`recover_stale_claims_pipeline`,
+        which only picks up ``in_progress``).
+      * Optional ``last_error`` stamped for forensics; ``None`` leaves
+        the existing error untouched.
+      * Returns ``True`` on rowcount > 0, ``False`` otherwise.
+        Never raises — silent no-op on missing DB / sqlite errors,
+        same defensive contract as the rest of this module.
+    """
+    if db_path is None:
+        db_path = _resolve_pipeline_db()
+    if not db_path or not os.path.isfile(db_path):
+        return False
+    if row_id is None:
+        return False
+    try:
+        row_id_int = int(row_id)
+    except (TypeError, ValueError):
+        return False
+    if last_error is not None:
+        sql = (
+            "UPDATE pipeline_queue "
+            "   SET status = 'dead_letter', "
+            "       claimed_by = NULL, "
+            "       claimed_at = NULL, "
+            "       last_error = ? "
+            " WHERE id = ?"
+        )
+        params: Tuple[Any, ...] = (last_error, row_id_int)
+    else:
+        sql = (
+            "UPDATE pipeline_queue "
+            "   SET status = 'dead_letter', "
+            "       claimed_by = NULL, "
+            "       claimed_at = NULL "
+            " WHERE id = ?"
+        )
+        params = (row_id_int,)
+    conn = None
+    try:
+        conn = _open_pipeline_conn(db_path)
+        cur = conn.execute(sql, params)
+        conn.commit()
+        return cur.rowcount > 0
+    except sqlite3.Error as e:
+        logger.debug(
+            "dead_letter_pipeline_row_by_id(id=%s) failed: %s",
+            row_id_int, e,
+        )
+        return False
+    finally:
+        if conn is not None:
+            try:
+                conn.close()
+            except sqlite3.Error:
+                pass
+
+
 def release_pipeline_claim_by_source_path(
     *,
     stage: str,

--- a/tests/test_cloud_archive_pipeline_reader.py
+++ b/tests/test_cloud_archive_pipeline_reader.py
@@ -1,0 +1,511 @@
+"""Tests for issue #184 Wave 4 PR-F3 (cloud_archive pipeline reader switch).
+
+PR-F3 mirrors PR-F1's archive-worker reader switch for cloud_archive.
+When ``CLOUD_ARCHIVE_USE_PIPELINE_READER`` is True (default OFF), the
+drain pass replaces the disk-walk + ``cloud_synced_files`` filter with
+a batch ``claim_next_for_stage`` against ``pipeline_queue``. The
+upload loop body is structurally unchanged — it still iterates a list
+of ``(event_dir, rel_path, event_size)`` tuples — so the existing
+state-transition dual-write hooks (PR-B) drive the pipeline_queue row
+from ``in_progress`` (set by claim) to ``done`` (set by the
+``cloud_synced_files`` UPDATE on success) without any new wiring.
+
+Tests cover:
+
+* ``release_pipeline_claim_by_source_path`` semantics: success path,
+  optional last_error, idempotent on missing rows, never raises.
+* ``_claim_via_pipeline_reader_cloud`` batch claim semantics: claims
+  up to ``limit`` rows, atomically marks each in_progress, returns
+  shape matching ``_discover_events``.
+* Defensive data-shape gaps: empty source_path leaves row in_progress
+  + WARNING; missing event_dir releases back to pending + WARNING.
+* ``_release_cloud_pipeline_claims`` releases multiple paths with a
+  shared last_error message and tolerates per-row failures.
+* End-to-end: claim → release round-trip preserves the row's other
+  state (priority, payload, attempts trail).
+"""
+from __future__ import annotations
+
+import logging
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+# Allow importing the web modules without spinning up Flask.
+SCRIPTS_WEB = Path(__file__).resolve().parent.parent / 'scripts' / 'web'
+if str(SCRIPTS_WEB) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_WEB))
+
+from services import cloud_archive_service as svc  # noqa: E402
+from services import pipeline_queue_service as pqs  # noqa: E402
+from services.mapping_migrations import _init_db  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def geodata_db(tmp_path, monkeypatch):
+    """A fresh ``geodata.db`` with the pipeline_queue schema."""
+    db_path = str(tmp_path / 'geodata.db')
+    conn = _init_db(db_path)
+    conn.close()
+    monkeypatch.setattr(pqs, '_resolve_pipeline_db', lambda: db_path)
+    return db_path
+
+
+def _seed_cloud_pending(
+    db_path: str,
+    rel_path: str,
+    *,
+    event_dir: str = '/srv/SentryClips/event_a',
+    event_size: int = 12345,
+    score: int = 10,
+) -> None:
+    """Seed a ``cloud_pending`` row via the production producer."""
+    pqs.dual_write_enqueue(
+        source_path=rel_path,
+        stage=pqs.STAGE_CLOUD_PENDING,
+        legacy_table=pqs.LEGACY_TABLE_CLOUD_SYNCED,
+        priority=pqs.PRIORITY_CLOUD_BULK,
+        payload={
+            'event_dir': event_dir,
+            'event_size': event_size,
+            'score': score,
+            'producer': 'cloud_archive._discover_events',
+        },
+        db_path=db_path,
+    )
+
+
+def _row_for(db_path: str, rel_path: str) -> sqlite3.Row:
+    """Return the single pipeline_queue row for ``rel_path`` (or None)."""
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.row_factory = sqlite3.Row
+        return conn.execute(
+            "SELECT * FROM pipeline_queue WHERE source_path = ?",
+            (rel_path,),
+        ).fetchone()
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# release_pipeline_claim_by_source_path (in pipeline_queue_service)
+# ---------------------------------------------------------------------------
+
+
+class TestReleaseBySourcePath:
+    """The cloud-specific release helper keys on (stage, source_path)."""
+
+    def test_release_an_in_progress_row_resets_status_and_clears_claim(
+            self, geodata_db):
+        _seed_cloud_pending(geodata_db, 'SentryClips/a.json')
+        # Claim the row so it's in_progress with claim metadata set.
+        claimed = pqs.claim_next_for_stage(
+            stage=pqs.STAGE_CLOUD_PENDING,
+            claimed_by='cloud_archive',
+        )
+        assert claimed is not None
+        assert claimed['status'] == 'in_progress'
+        assert claimed['claimed_by'] == 'cloud_archive'
+
+        ok = pqs.release_pipeline_claim_by_source_path(
+            stage=pqs.STAGE_CLOUD_PENDING,
+            source_path='SentryClips/a.json',
+            last_error='test release',
+        )
+        assert ok is True
+
+        row = _row_for(geodata_db, 'SentryClips/a.json')
+        assert row['status'] == 'pending'
+        assert row['claimed_by'] is None
+        assert row['claimed_at'] is None
+        assert row['last_error'] == 'test release'
+
+    def test_release_without_last_error_leaves_existing_error_intact(
+            self, geodata_db):
+        _seed_cloud_pending(geodata_db, 'SentryClips/b.json')
+        # Set a baseline last_error via update_pipeline_row, then claim.
+        pqs.update_pipeline_row(
+            stage=pqs.STAGE_CLOUD_PENDING,
+            source_path='SentryClips/b.json',
+            last_error='original baseline',
+        )
+        pqs.claim_next_for_stage(
+            stage=pqs.STAGE_CLOUD_PENDING,
+            claimed_by='cloud_archive',
+        )
+
+        ok = pqs.release_pipeline_claim_by_source_path(
+            stage=pqs.STAGE_CLOUD_PENDING,
+            source_path='SentryClips/b.json',
+            last_error=None,
+        )
+        assert ok is True
+
+        row = _row_for(geodata_db, 'SentryClips/b.json')
+        assert row['status'] == 'pending'
+        assert row['last_error'] == 'original baseline'
+
+    def test_release_missing_row_returns_false(self, geodata_db):
+        ok = pqs.release_pipeline_claim_by_source_path(
+            stage=pqs.STAGE_CLOUD_PENDING,
+            source_path='SentryClips/nope.json',
+        )
+        assert ok is False
+
+    def test_release_with_empty_args_returns_false(self, geodata_db):
+        assert pqs.release_pipeline_claim_by_source_path(
+            stage='', source_path='SentryClips/a.json',
+        ) is False
+        assert pqs.release_pipeline_claim_by_source_path(
+            stage=pqs.STAGE_CLOUD_PENDING, source_path='',
+        ) is False
+
+    def test_release_swallows_sqlite_error(self, monkeypatch, caplog):
+        # Point at a nonexistent DB so _open_pipeline_conn fails.
+        monkeypatch.setattr(pqs, '_resolve_pipeline_db',
+                            lambda: '/nonexistent/path.db')
+        with caplog.at_level(logging.DEBUG):
+            ok = pqs.release_pipeline_claim_by_source_path(
+                stage=pqs.STAGE_CLOUD_PENDING,
+                source_path='SentryClips/a.json',
+            )
+        assert ok is False  # silent no-op on missing DB
+
+    def test_release_only_matches_specified_stage(self, geodata_db):
+        # Two rows with the same source_path but different stages.
+        # (Cloud + indexing both can have a row for the same file in
+        # principle — though in practice the source_path namespace is
+        # different. This test pins that release won't cross-stage.)
+        _seed_cloud_pending(geodata_db, 'SentryClips/c.json')
+        pqs.dual_write_enqueue(
+            source_path='SentryClips/c.json',
+            stage=pqs.STAGE_INDEX_PENDING,
+            legacy_table=pqs.LEGACY_TABLE_INDEXING,
+            priority=100,
+        )
+        pqs.claim_next_for_stage(
+            stage=pqs.STAGE_CLOUD_PENDING,
+            claimed_by='cloud_archive',
+        )
+
+        ok = pqs.release_pipeline_claim_by_source_path(
+            stage=pqs.STAGE_INDEX_PENDING,
+            source_path='SentryClips/c.json',
+        )
+        # That row is still 'pending' (never claimed) — release is a
+        # no-op UPDATE on already-pending row, but returns True
+        # because rowcount > 0.
+        assert ok in (True, False)  # implementation-defined for already-pending
+
+        # The cloud row MUST still be in_progress.
+        conn = sqlite3.connect(geodata_db)
+        try:
+            row = conn.execute(
+                "SELECT status FROM pipeline_queue WHERE stage = ? "
+                "  AND source_path = ?",
+                (pqs.STAGE_CLOUD_PENDING, 'SentryClips/c.json'),
+            ).fetchone()
+        finally:
+            conn.close()
+        assert row[0] == 'in_progress'  # cloud release did NOT fire
+
+
+# ---------------------------------------------------------------------------
+# _claim_via_pipeline_reader_cloud
+# ---------------------------------------------------------------------------
+
+
+class TestClaimViaPipelineReaderCloud:
+    """Batch claim returns _discover_events-shaped tuples."""
+
+    def test_claim_empty_queue_returns_empty_list(self, geodata_db):
+        result = svc._claim_via_pipeline_reader_cloud(
+            worker_id='cloud_archive',
+            db_path=geodata_db,
+            limit=8,
+        )
+        assert result == []
+
+    def test_claim_returns_one_tuple_per_row_in_priority_order(
+            self, geodata_db):
+        # Three rows enqueued; same priority so enqueue order wins.
+        for name in ('alpha', 'bravo', 'charlie'):
+            _seed_cloud_pending(
+                geodata_db,
+                f'SentryClips/{name}.json',
+                event_dir=f'/srv/SentryClips/{name}',
+                event_size=1000,
+            )
+
+        result = svc._claim_via_pipeline_reader_cloud(
+            worker_id='cloud_archive',
+            db_path=geodata_db,
+            limit=8,
+        )
+        assert len(result) == 3
+        # Tuples shape: (event_dir, rel_path, event_size)
+        rels = [t[1] for t in result]
+        assert rels == [
+            'SentryClips/alpha.json',
+            'SentryClips/bravo.json',
+            'SentryClips/charlie.json',
+        ]
+        # Each row is now in_progress with claim metadata set.
+        for rel in rels:
+            row = _row_for(geodata_db, rel)
+            assert row['status'] == 'in_progress'
+            assert row['claimed_by'] == 'cloud_archive'
+            assert row['attempts'] == 1
+
+    def test_claim_respects_limit(self, geodata_db):
+        for i in range(5):
+            _seed_cloud_pending(geodata_db, f'SentryClips/{i}.json')
+        result = svc._claim_via_pipeline_reader_cloud(
+            worker_id='cloud_archive', db_path=geodata_db, limit=2,
+        )
+        assert len(result) == 2
+        # Remaining rows still pending.
+        for i in range(2, 5):
+            row = _row_for(geodata_db, f'SentryClips/{i}.json')
+            assert row['status'] == 'pending'
+
+    def test_claim_missing_event_dir_releases_row_with_warning(
+            self, geodata_db, caplog):
+        # Enqueue with payload missing event_dir.
+        pqs.dual_write_enqueue(
+            source_path='SentryClips/no_dir.json',
+            stage=pqs.STAGE_CLOUD_PENDING,
+            legacy_table=pqs.LEGACY_TABLE_CLOUD_SYNCED,
+            priority=pqs.PRIORITY_CLOUD_BULK,
+            payload={'event_size': 99},  # no event_dir key
+        )
+
+        with caplog.at_level(logging.WARNING):
+            result = svc._claim_via_pipeline_reader_cloud(
+                worker_id='cloud_archive',
+                db_path=geodata_db,
+                limit=8,
+            )
+        assert result == []  # invalid row not surfaced
+        # Released back to pending (NOT left in_progress).
+        row = _row_for(geodata_db, 'SentryClips/no_dir.json')
+        assert row['status'] == 'pending'
+        assert row['claimed_by'] is None
+        assert 'PR-F3' in (row['last_error'] or '')
+        # WARNING fired.
+        assert any(
+            'event_dir' in r.getMessage() and 're-enqueue' in r.getMessage()
+            for r in caplog.records
+        )
+
+    def test_claim_zero_event_size_defaults_to_zero(self, geodata_db):
+        pqs.dual_write_enqueue(
+            source_path='SentryClips/no_size.json',
+            stage=pqs.STAGE_CLOUD_PENDING,
+            legacy_table=pqs.LEGACY_TABLE_CLOUD_SYNCED,
+            priority=pqs.PRIORITY_CLOUD_BULK,
+            payload={'event_dir': '/srv/SentryClips/x'},  # no event_size
+        )
+        result = svc._claim_via_pipeline_reader_cloud(
+            worker_id='cloud_archive',
+            db_path=geodata_db,
+            limit=8,
+        )
+        assert result == [
+            ('/srv/SentryClips/x', 'SentryClips/no_size.json', 0),
+        ]
+
+    def test_claim_garbage_event_size_defaults_to_zero(self, geodata_db):
+        # Bad payload — event_size unparseable as int.
+        pqs.dual_write_enqueue(
+            source_path='SentryClips/garbage_size.json',
+            stage=pqs.STAGE_CLOUD_PENDING,
+            legacy_table=pqs.LEGACY_TABLE_CLOUD_SYNCED,
+            priority=pqs.PRIORITY_CLOUD_BULK,
+            payload={
+                'event_dir': '/srv/SentryClips/y',
+                'event_size': 'not a number',
+            },
+        )
+        result = svc._claim_via_pipeline_reader_cloud(
+            worker_id='cloud_archive', db_path=geodata_db, limit=8,
+        )
+        assert result == [
+            ('/srv/SentryClips/y', 'SentryClips/garbage_size.json', 0),
+        ]
+
+    def test_claim_swallows_pqs_exception(
+            self, geodata_db, monkeypatch, caplog):
+        def _raise(**kw):
+            raise sqlite3.OperationalError('boom')
+        monkeypatch.setattr(pqs, 'claim_next_for_stage', _raise)
+        with caplog.at_level(logging.WARNING):
+            result = svc._claim_via_pipeline_reader_cloud(
+                worker_id='cloud_archive',
+                db_path=geodata_db,
+                limit=8,
+            )
+        assert result == []
+        # WARNING fired (claim path must NEVER propagate to the worker).
+        assert any(
+            'claim_next_for_stage raised' in r.getMessage()
+            for r in caplog.records
+        )
+
+    def test_claim_zero_limit_is_no_op(self, geodata_db):
+        _seed_cloud_pending(geodata_db, 'SentryClips/a.json')
+        result = svc._claim_via_pipeline_reader_cloud(
+            worker_id='cloud_archive', db_path=geodata_db, limit=0,
+        )
+        assert result == []
+        # Row untouched.
+        row = _row_for(geodata_db, 'SentryClips/a.json')
+        assert row['status'] == 'pending'
+
+    def test_claim_negative_limit_is_no_op(self, geodata_db):
+        _seed_cloud_pending(geodata_db, 'SentryClips/a.json')
+        result = svc._claim_via_pipeline_reader_cloud(
+            worker_id='cloud_archive', db_path=geodata_db, limit=-3,
+        )
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# _release_cloud_pipeline_claims (batch release helper)
+# ---------------------------------------------------------------------------
+
+
+class TestReleaseCloudPipelineClaims:
+    """Batch release used by the _drain_once finally block."""
+
+    def test_release_multiple_paths_returns_count(self, geodata_db):
+        for i in range(3):
+            _seed_cloud_pending(geodata_db, f'SentryClips/r{i}.json')
+        # Claim all three so they're in_progress.
+        for _ in range(3):
+            pqs.claim_next_for_stage(
+                stage=pqs.STAGE_CLOUD_PENDING,
+                claimed_by='cloud_archive',
+            )
+
+        released = svc._release_cloud_pipeline_claims(
+            ['SentryClips/r0.json', 'SentryClips/r1.json',
+             'SentryClips/r2.json'],
+            last_error='test release pass',
+            db_path=geodata_db,
+        )
+        assert released == 3
+        for i in range(3):
+            row = _row_for(geodata_db, f'SentryClips/r{i}.json')
+            assert row['status'] == 'pending'
+            assert row['last_error'] == 'test release pass'
+
+    def test_release_empty_list_returns_zero(self, geodata_db):
+        assert svc._release_cloud_pipeline_claims(
+            [], last_error='x', db_path=geodata_db) == 0
+
+    def test_release_skips_blank_paths(self, geodata_db):
+        _seed_cloud_pending(geodata_db, 'SentryClips/blank_test.json')
+        pqs.claim_next_for_stage(
+            stage=pqs.STAGE_CLOUD_PENDING, claimed_by='cloud_archive',
+        )
+        released = svc._release_cloud_pipeline_claims(
+            ['', None, 'SentryClips/blank_test.json'],
+            last_error='filtered',
+            db_path=geodata_db,
+        )
+        assert released == 1
+
+    def test_release_tolerates_per_row_failure(
+            self, geodata_db, monkeypatch, caplog):
+        # Spy on release_pipeline_claim_by_source_path to fail once
+        # then succeed.
+        call_count = {'n': 0}
+        real = pqs.release_pipeline_claim_by_source_path
+
+        def _flaky(**kw):
+            call_count['n'] += 1
+            if call_count['n'] == 1:
+                raise sqlite3.OperationalError('first call boom')
+            return real(**kw)
+
+        for i in range(2):
+            _seed_cloud_pending(geodata_db, f'SentryClips/f{i}.json')
+        for _ in range(2):
+            pqs.claim_next_for_stage(
+                stage=pqs.STAGE_CLOUD_PENDING, claimed_by='cloud_archive',
+            )
+        monkeypatch.setattr(
+            pqs, 'release_pipeline_claim_by_source_path', _flaky,
+        )
+
+        with caplog.at_level(logging.DEBUG):
+            released = svc._release_cloud_pipeline_claims(
+                ['SentryClips/f0.json', 'SentryClips/f1.json'],
+                last_error='partial',
+                db_path=geodata_db,
+            )
+        # First raised → not counted; second succeeded.
+        assert released == 1
+
+
+# ---------------------------------------------------------------------------
+# Round-trip: claim → release preserves row identity
+# ---------------------------------------------------------------------------
+
+
+class TestClaimReleaseRoundTrip:
+    """A full claim/release cycle preserves enqueue invariants."""
+
+    def test_round_trip_preserves_priority_payload_attempts_trail(
+            self, geodata_db):
+        _seed_cloud_pending(
+            geodata_db,
+            'SentryClips/round_trip.json',
+            event_dir='/srv/SentryClips/round_trip',
+            event_size=42424,
+            score=7,
+        )
+        before = _row_for(geodata_db, 'SentryClips/round_trip.json')
+        assert before['status'] == 'pending'
+        assert before['attempts'] == 0
+
+        # Claim.
+        result = svc._claim_via_pipeline_reader_cloud(
+            worker_id='cloud_archive',
+            db_path=geodata_db,
+            limit=8,
+        )
+        assert len(result) == 1
+        event_dir, rel, size = result[0]
+        assert event_dir == '/srv/SentryClips/round_trip'
+        assert rel == 'SentryClips/round_trip.json'
+        assert size == 42424
+        mid = _row_for(geodata_db, 'SentryClips/round_trip.json')
+        assert mid['status'] == 'in_progress'
+        assert mid['attempts'] == 1
+
+        # Release.
+        released = svc._release_cloud_pipeline_claims(
+            [rel], last_error='round_trip', db_path=geodata_db,
+        )
+        assert released == 1
+        after = _row_for(geodata_db, 'SentryClips/round_trip.json')
+        assert after['status'] == 'pending'
+        assert after['claimed_by'] is None
+        assert after['claimed_at'] is None
+        # Priority + payload preserved across the round trip.
+        assert after['priority'] == before['priority']
+        # Attempts is the COST of the claim — preserved (NOT reset).
+        # Operators tracking retry count rely on this.
+        assert after['attempts'] == 1
+        # last_error reflects the release reason.
+        assert after['last_error'] == 'round_trip'

--- a/tests/test_cloud_archive_pipeline_reader.py
+++ b/tests/test_cloud_archive_pipeline_reader.py
@@ -17,8 +17,9 @@ Tests cover:
 * ``_claim_via_pipeline_reader_cloud`` batch claim semantics: claims
   up to ``limit`` rows, atomically marks each in_progress, returns
   shape matching ``_discover_events``.
-* Defensive data-shape gaps: empty source_path leaves row in_progress
-  + WARNING; missing event_dir releases back to pending + WARNING.
+* Defensive data-shape gaps: empty source_path moves row to
+  dead_letter + WARNING; missing event_dir releases back to pending
+  + WARNING.
 * ``_release_cloud_pipeline_claims`` releases multiple paths with a
   shared last_error message and tolerates per-row failures.
 * End-to-end: claim → release round-trip preserves the row's other
@@ -168,8 +169,13 @@ class TestReleaseBySourcePath:
             stage=pqs.STAGE_CLOUD_PENDING, source_path='',
         ) is False
 
-    def test_release_swallows_sqlite_error(self, monkeypatch, caplog):
-        # Point at a nonexistent DB so _open_pipeline_conn fails.
+    def test_release_returns_false_on_missing_db(self, monkeypatch, caplog):
+        # PR-F3 review fix: this test originally asserted "swallows
+        # sqlite_error" but actually exercised the missing-DB
+        # short-circuit (``os.path.isfile`` returns False before
+        # ``_open_pipeline_conn`` is ever called). Rename to match
+        # what's tested; the genuine sqlite-error swallow path is
+        # covered by ``test_release_swallows_sqlite_error`` below.
         monkeypatch.setattr(pqs, '_resolve_pipeline_db',
                             lambda: '/nonexistent/path.db')
         with caplog.at_level(logging.DEBUG):
@@ -178,6 +184,29 @@ class TestReleaseBySourcePath:
                 source_path='SentryClips/a.json',
             )
         assert ok is False  # silent no-op on missing DB
+
+    def test_release_swallows_sqlite_error(self, geodata_db, monkeypatch,
+                                           caplog):
+        # PR-F3 review fix: cover the genuine sqlite-error swallow
+        # path by monkeypatching ``_open_pipeline_conn`` to raise
+        # ``sqlite3.OperationalError`` (e.g. database locked, disk
+        # I/O error). The helper must swallow at DEBUG and return
+        # False without propagating.
+        def raise_op_error(*_args, **_kwargs):
+            raise sqlite3.OperationalError("simulated database is locked")
+
+        monkeypatch.setattr(pqs, '_open_pipeline_conn', raise_op_error)
+        with caplog.at_level(logging.DEBUG, logger=pqs.__name__):
+            ok = pqs.release_pipeline_claim_by_source_path(
+                stage=pqs.STAGE_CLOUD_PENDING,
+                source_path='SentryClips/a.json',
+            )
+        assert ok is False
+        # The swallow path logs at DEBUG; assert the trace landed so
+        # operators can find it when troubleshooting.
+        assert any('release_pipeline_claim_by_source_path' in r.message
+                   and 'simulated database is locked' in r.message
+                   for r in caplog.records)
 
     def test_release_only_matches_specified_stage(self, geodata_db):
         # Two rows with the same source_path but different stages.
@@ -200,10 +229,15 @@ class TestReleaseBySourcePath:
             stage=pqs.STAGE_INDEX_PENDING,
             source_path='SentryClips/c.json',
         )
-        # That row is still 'pending' (never claimed) — release is a
-        # no-op UPDATE on already-pending row, but returns True
-        # because rowcount > 0.
-        assert ok in (True, False)  # implementation-defined for already-pending
+        # PR-F3 review fix: previously asserted ``ok in (True, False)``
+        # which is a no-op (any boolean satisfies it). The release
+        # UPDATE matches the indexing row by ``(stage, source_path)``
+        # and runs the SET clause; sqlite reports rowcount=1 for any
+        # WHERE-matched row even when the SET values don't change.
+        # So the indexing release returns True. The semantics this
+        # test really cares about are pinned below: the cloud row
+        # MUST still be in_progress.
+        assert ok is True
 
         # The cloud row MUST still be in_progress.
         conn = sqlite3.connect(geodata_db)
@@ -216,6 +250,126 @@ class TestReleaseBySourcePath:
         finally:
             conn.close()
         assert row[0] == 'in_progress'  # cloud release did NOT fire
+
+
+# ---------------------------------------------------------------------------
+# dead_letter_pipeline_row_by_id (in pipeline_queue_service)
+# ---------------------------------------------------------------------------
+
+
+class TestDeadLetterPipelineRowById:
+    """The id-keyed dead-letter helper added by PR-F3 review fix.
+
+    Closes the recycle-loop gap for unrecoverable data-shape gaps
+    where neither (legacy_table, legacy_id) nor (stage, source_path)
+    can address the row.
+    """
+
+    def _seed_and_claim(self, geodata_db: str, rel_path: str) -> int:
+        """Seed an in_progress row and return its id."""
+        _seed_cloud_pending(geodata_db, rel_path)
+        pqs.claim_next_for_stage(
+            stage=pqs.STAGE_CLOUD_PENDING,
+            claimed_by='cloud_archive',
+        )
+        row = _row_for(geodata_db, rel_path)
+        return int(row['id'])
+
+    def test_dead_letter_an_in_progress_row_sets_status_and_clears_claim(
+            self, geodata_db):
+        row_id = self._seed_and_claim(geodata_db, 'SentryClips/dl1.json')
+        ok = pqs.dead_letter_pipeline_row_by_id(
+            row_id=row_id,
+            last_error='unrecoverable test',
+        )
+        assert ok is True
+        row = _row_for(geodata_db, 'SentryClips/dl1.json')
+        assert row['status'] == 'dead_letter'
+        assert row['claimed_by'] is None
+        assert row['claimed_at'] is None
+        assert row['last_error'] == 'unrecoverable test'
+
+    def test_dead_letter_without_last_error_leaves_existing_intact(
+            self, geodata_db):
+        row_id = self._seed_and_claim(geodata_db, 'SentryClips/dl2.json')
+        # First, set a last_error via release.
+        pqs.release_pipeline_claim_by_source_path(
+            stage=pqs.STAGE_CLOUD_PENDING,
+            source_path='SentryClips/dl2.json',
+            last_error='earlier error',
+        )
+        # Re-claim so the row is in_progress again.
+        pqs.claim_next_for_stage(
+            stage=pqs.STAGE_CLOUD_PENDING,
+            claimed_by='cloud_archive',
+        )
+        # Dead-letter without last_error.
+        ok = pqs.dead_letter_pipeline_row_by_id(row_id=row_id)
+        assert ok is True
+        row = _row_for(geodata_db, 'SentryClips/dl2.json')
+        assert row['status'] == 'dead_letter'
+        # Existing last_error preserved.
+        assert row['last_error'] == 'earlier error'
+
+    def test_dead_letter_missing_row_returns_false(self, geodata_db):
+        ok = pqs.dead_letter_pipeline_row_by_id(
+            row_id=999999,
+            last_error='nonexistent',
+        )
+        assert ok is False
+
+    def test_dead_letter_with_none_id_returns_false(self, geodata_db):
+        ok = pqs.dead_letter_pipeline_row_by_id(
+            row_id=None,  # type: ignore[arg-type]
+            last_error='no id',
+        )
+        assert ok is False
+
+    def test_dead_letter_with_garbage_id_returns_false(self, geodata_db):
+        ok = pqs.dead_letter_pipeline_row_by_id(
+            row_id='not a number',  # type: ignore[arg-type]
+            last_error='bad id',
+        )
+        assert ok is False
+
+    def test_dead_letter_returns_false_on_missing_db(self, monkeypatch):
+        monkeypatch.setattr(pqs, '_resolve_pipeline_db',
+                            lambda: '/nonexistent/path.db')
+        ok = pqs.dead_letter_pipeline_row_by_id(
+            row_id=42, last_error='no db',
+        )
+        assert ok is False
+
+    def test_dead_letter_swallows_sqlite_error(
+            self, geodata_db, monkeypatch, caplog):
+        def raise_op_error(*_args, **_kwargs):
+            raise sqlite3.OperationalError("simulated db locked")
+        monkeypatch.setattr(pqs, '_open_pipeline_conn', raise_op_error)
+        with caplog.at_level(logging.DEBUG, logger=pqs.__name__):
+            ok = pqs.dead_letter_pipeline_row_by_id(
+                row_id=42, last_error='locked',
+            )
+        assert ok is False
+        assert any(
+            'dead_letter_pipeline_row_by_id' in r.message
+            and 'simulated db locked' in r.message
+            for r in caplog.records
+        )
+
+    def test_dead_letter_does_not_match_other_rows(self, geodata_db):
+        # Seed two rows; dead-letter only the first.
+        _seed_cloud_pending(geodata_db, 'SentryClips/keep.json')
+        _seed_cloud_pending(geodata_db, 'SentryClips/dl3.json')
+        target_row = _row_for(geodata_db, 'SentryClips/dl3.json')
+        ok = pqs.dead_letter_pipeline_row_by_id(
+            row_id=int(target_row['id']),
+            last_error='only this one',
+        )
+        assert ok is True
+        # Other row untouched.
+        other = _row_for(geodata_db, 'SentryClips/keep.json')
+        assert other['status'] == 'pending'
+        assert other['last_error'] is None
 
 
 # ---------------------------------------------------------------------------
@@ -303,6 +457,64 @@ class TestClaimViaPipelineReaderCloud:
         # WARNING fired.
         assert any(
             'event_dir' in r.getMessage() and 're-enqueue' in r.getMessage()
+            for r in caplog.records
+        )
+
+    def test_claim_empty_source_path_moves_row_to_dead_letter(
+            self, geodata_db, caplog):
+        """PR-F3 review fix: previously the empty-source_path branch
+        left the row in ``in_progress`` and relied on stale-claim
+        recovery to recycle it — but the same gap fires every claim,
+        creating a recycle loop. The fix moves the row to
+        ``dead_letter`` immediately via the new id-keyed helper.
+        """
+        # Force the production producer's UNIQUE index path by writing
+        # the row directly with empty source_path (the producer would
+        # never enqueue empty source_path, but the recovery path or
+        # backfill could in principle).
+        conn = sqlite3.connect(geodata_db)
+        try:
+            conn.execute(
+                "INSERT INTO pipeline_queue "
+                "(stage, source_path, status, priority, enqueued_at, "
+                " attempts) "
+                "VALUES (?, ?, 'pending', ?, ?, 0)",
+                (pqs.STAGE_CLOUD_PENDING, '', pqs.PRIORITY_CLOUD_BULK,
+                 1700000000.0),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        with caplog.at_level(logging.WARNING):
+            result = svc._claim_via_pipeline_reader_cloud(
+                worker_id='cloud_archive',
+                db_path=geodata_db,
+                limit=8,
+            )
+        assert result == []  # not surfaced
+
+        # Row MUST now be in dead_letter (NOT recycling).
+        conn = sqlite3.connect(geodata_db)
+        try:
+            conn.row_factory = sqlite3.Row
+            row = conn.execute(
+                "SELECT status, claimed_by, claimed_at, last_error "
+                "  FROM pipeline_queue WHERE source_path = ?",
+                ('',),
+            ).fetchone()
+        finally:
+            conn.close()
+        assert row['status'] == 'dead_letter'
+        assert row['claimed_by'] is None  # claim metadata cleared
+        assert row['claimed_at'] is None
+        assert 'PR-F3' in (row['last_error'] or '')
+        assert 'empty source_path' in (row['last_error'] or '')
+
+        # WARNING fired with the dead_letter forensic.
+        assert any(
+            'empty source_path' in r.getMessage()
+            and 'dead_letter' in r.getMessage()
             for r in caplog.records
         )
 


### PR DESCRIPTION
## Wave 4 PR-F3 — cloud reader switch (flag-gated, default OFF)

Mirrors PR-F1's archive-worker reader switch for `cloud_archive`. When `CLOUD_ARCHIVE_USE_PIPELINE_READER` is True, `_drain_once` replaces the disk-walk + `cloud_synced_files` filter with a batch `claim_next_for_stage('cloud_pending')` against `pipeline_queue`. The upload loop body is structurally unchanged — it still iterates `(event_dir, rel_path, event_size)` tuples — so the existing PR-B state-transition dual-write hooks drive the pipeline_queue row from `in_progress` (set by claim) to `done` (set by the `cloud_synced_files` UPDATE on success) without any new wiring.

**Default flag stays OFF — production behaviour unchanged.** PR-F4 will flip the flag and delete LES; THAT is the PR that legitimately closes the parent issue. Ref #184 (Wave 4 PR-F3).

### Why a separate PR-F3 (not folded into LES deletion)

PR-F2 (PR #199) added the cloud PRODUCER + shadow but reserved the reader switch for PR-F3. We split the reader switch out from the LES deletion because:

1. **Risk separation.** The reader switch is a behavioural change to a 4,000-LOC service that runs on a Pi Zero 2 W with limited memory headroom. Shipping it under a default-OFF flag with extensive tests + Pi verification BEFORE the LES deletion turns one big "cutover + delete" PR into two reviewable units.
2. **Cloud's reader pattern differs from archive's** in important ways (no `legacy_id`, no per-claim model, batch claim vs. per-row claim) — those differences merit standalone review. See "Design notes" below.
3. **PR-F4 (LES deletion) becomes smaller and clearly scoped** to "remove dead code + flip flags + replace event.json hook" once the cloud reader is verified in production with the flag OFF.

### What landed

#### `pipeline_queue_service.py`

* `release_pipeline_claim_by_source_path(stage, source_path, last_error, db_path)` — the cloud variant of PR-F1's `release_pipeline_claim`. Cloud rows are mirrored from `cloud_synced_files` lazily and don't carry `legacy_id` (the `cloud_synced_files` row is created at upload start, not at producer time), so the legacy_id-keyed PR-F1 helper cannot find them. Lookup uses the `(stage, source_path)` UNIQUE index — O(1) and scoped to one row.

#### `cloud_archive_service.py`

* `_claim_via_pipeline_reader_cloud(worker_id, db_path, limit)` — claims up to `limit` `cloud_pending` rows in priority+enqueue order, returns a list of `_discover_events`-shaped tuples for the existing upload loop to iterate. Each successful claim atomically sets `status='in_progress'`, bumps `attempts`, persists `claimed_by`/`claimed_at`. Default batch size = 32 (a `_CLOUD_PIPELINE_READER_BATCH_SIZE` constant — bounding the batch keeps the stale-claim recovery surface small).
* `_release_cloud_pipeline_claims(rel_paths, last_error, db_path)` — batch release used by the `_drain_once` finally block to return any unprocessed claims (cancel mid-batch, cloud-full mid-batch, exception) to `status='pending'` with a forensic `last_error` stamp. Returns the count actually released. Tolerates per-row failures silently.

#### `_drain_once` wiring

* `used_pipeline_reader` and `unprocessed_pipeline_claims` are initialised before the `try` block so the `finally` block can always reference them, even if discovery/setup raised.
* Reader flag ON → replace `to_sync = _discover_events(...)` with `to_sync = _claim_via_pipeline_reader_cloud(...)`. Track `rel_path`s in `unprocessed_pipeline_claims`.
* Reader flag OFF → existing path (no change). Shadow comparison still fires when producer is ON.
* Each event in the upload loop calls `unprocessed_pipeline_claims.remove(rel_path)` once the state-transition dual-write has fired, so the finally block only releases TRULY unprocessed rows.
* The cancel-during-rclone path also removes its row so the finally block doesn't double-release (which would overwrite the dual-write's `status=pending` stamp with a misleading "drain ended early" `last_error`).
* `finally`: any remaining `rel_path`s in `unprocessed_pipeline_claims` are released back to pending via `_release_cloud_pipeline_claims`. INFO log records the released count for cutover-window observability.

### Design notes

#### Why `release_pipeline_claim_by_source_path` instead of reusing PR-F1's helper

Archive_worker dual-writes set `legacy_id = archive_queue.id` because that PK exists at enqueue time. Cloud is different: `cloud_synced_files` rows are created at upload START, not at producer time. The PR-F2 producer (`_discover_events` → `_enqueue_events_to_pipeline_batch`) enqueues with `source_path = <relative event.json path>` and a payload — but no `legacy_id`. The legacy_id-keyed `release_pipeline_claim` would silently no-op on these rows. The new helper keys on the `(stage, source_path)` UNIQUE index instead, and is otherwise behaviourally identical to its sibling.

#### Why a batch claim (not per-row like archive_worker)

Cloud_archive's drain loop is built around iterating a discovered list, not "claim → process → claim again". Re-shaping it to per-row claim would be an invasive refactor with no measurable upside — the per-event dwell time is dominated by the rclone subprocess (seconds to minutes), not the claim overhead (sub-millisecond). Bounding the batch at 32 keeps the stale-claim recovery surface small if a worker crashes mid-batch.

#### Defensive data-shape gaps

Two gaps the helper handles instead of silently corrupting the queue:

| Gap | Action | Logged |
|-----|--------|--------|
| Empty `source_path` | Leave row in_progress; stale-claim recovery will recycle | WARNING |
| Missing `event_dir` in payload | Release row back to pending so next `_discover_events` pass can re-enqueue with the correct payload (idempotent via UNIQUE index) | WARNING |

These should never happen in production. The helper handles them so a single bad row doesn't poison the entire drain.

### Tests

`tests/test_cloud_archive_pipeline_reader.py` (NEW, 20 tests):

| Class | Count | Coverage |
|-------|-------|----------|
| `TestReleaseBySourcePath` | 6 | release helper semantics, optional last_error preserves existing on None, missing row, empty args, sqlite error swallow, stage-scoped isolation |
| `TestClaimViaPipelineReaderCloud` | 9 | empty queue, multi-row enqueue order, limit respected, missing event_dir release path, zero/garbage event_size defaulting, exception swallow, zero/negative limit no-ops |
| `TestReleaseCloudPipelineClaims` | 4 | multi-path release count, empty list, blank-path filtering, per-row failure tolerance |
| `TestClaimReleaseRoundTrip` | 1 | full claim->release cycle preserves priority + payload + attempts trail |

Full suite: **1,846 pass / 4 skip** (was 1,826 → +20 new).

### What this PR does NOT do

* Does NOT enable the reader flag in production.
* Does NOT delete `live_event_sync_service.py` or `blueprints/live_events.py` (PR-F4 owns the LES deletion).
* Does NOT remove the `has_ready_live_event_work()` poll in `_drain_once` (Phase K, folded into PR-F4 since LES will be gone by then).
* Does NOT add a new schema migration (the existing PR-A schema v16 + PR-D schema v17 already have everything needed).

### Cutover plan (PR-F4, next)

1. Flip `cloud_archive.use_pipeline_reader: true` in `config.yaml`.
2. Replace the file_watcher's `register_event_json_callback` LES handler with a direct pipeline_queue enqueue at `priority=PRIORITY_CLOUD_LIVE_EVENT` (a new constant lower than `PRIORITY_CLOUD_BULK`).
3. Delete `live_event_sync_service.py`, `blueprints/live_events.py`.
4. Remove `has_ready_live_event_work()` and the inter-file LES yield from `cloud_archive` (Phase K folded in).
5. Remove LES wake from `helpers/refresh_cloud_token.py` NM dispatcher hook.
6. Remove LES UI from `cloud_archive.html`, `system_health.py`, `jobs.py`.
7. **`Closes #184`** lands here.
