### PR TITLE
fix(#188): v15 single-table-rewrite migration (8x WAL I/O reduction)

### DIFF
--- a/scripts/web/services/mapping_migrations.py
+++ b/scripts/web/services/mapping_migrations.py
@@ -980,6 +980,44 @@ _COLD_COLUMNS = (
     'blinker_on_right',
 )
 
+# Hot waypoint columns retained on the main ``waypoints`` table at
+# v15. Single source of truth for the v14->v15 single-table-rewrite
+# helper — its CREATE TABLE / INSERT / SELECT statements are all
+# generated from this tuple so a future column add cannot silently
+# get dropped during migration. Order MUST match the ``waypoints``
+# CREATE TABLE in ``_SCHEMA_SQL`` (the live v15 schema). Verified by
+# ``test_v15_hot_columns_match_schema_sql`` in
+# ``tests/test_mapping_wave3.py``.
+_V15_HOT_COLUMNS = (
+    'id',
+    'trip_id',
+    'timestamp',
+    'lat',
+    'lon',
+    'heading',
+    'speed_mps',
+    'autopilot_state',
+    'video_path',
+    'frame_offset',
+)
+
+# Per-column DDL fragments for the rewrite helper's CREATE TABLE.
+# Lifted verbatim from the ``waypoints`` CREATE TABLE in
+# ``_SCHEMA_SQL`` so the rewritten table is byte-identical to a
+# fresh-install v15 schema (PK, FK, NOT NULL, REFERENCES — all of it).
+_V15_HOT_COLUMN_DDL = {
+    'id': 'INTEGER PRIMARY KEY AUTOINCREMENT',
+    'trip_id': 'INTEGER REFERENCES trips(id) ON DELETE CASCADE',
+    'timestamp': 'TEXT NOT NULL',
+    'lat': 'REAL NOT NULL',
+    'lon': 'REAL NOT NULL',
+    'heading': 'REAL',
+    'speed_mps': 'REAL',
+    'autopilot_state': 'TEXT',
+    'video_path': 'TEXT',
+    'frame_offset': 'INTEGER',
+}
+
 # Migration batch size. 500 trips × ~500 waypoints/trip = 250 000
 # rows per transaction, well within SQLite's per-tx working set on
 # a Pi Zero 2 W. Bigger batches are a SAVEPOINT WAL-bloat risk.
@@ -1069,14 +1107,14 @@ def _migrate_v14_to_v15(conn: sqlite3.Connection) -> None:
         f"'{g}'" for g in sorted(_COLD_GEAR_NO_SIGNAL)
     )
     cold_filter_where = (
-        f"  (acceleration_x IS NOT NULL AND ABS(acceleration_x) > {accel_thresh}) "
-        f"   OR (acceleration_y IS NOT NULL AND ABS(acceleration_y) > {accel_thresh}) "
-        f"   OR (acceleration_z IS NOT NULL AND ABS(acceleration_z) > {accel_thresh}) "
-        f"   OR (gear IS NOT NULL AND gear NOT IN ({gear_no_signal_csv})) "
-        f"   OR (steering_angle IS NOT NULL AND ABS(steering_angle) > {steering_thresh}) "
-        "   OR brake_applied != 0 "
-        "   OR blinker_on_left != 0 "
-        "   OR blinker_on_right != 0"
+        f"(acceleration_x IS NOT NULL AND ABS(acceleration_x) > {accel_thresh}) "
+        f"OR (acceleration_y IS NOT NULL AND ABS(acceleration_y) > {accel_thresh}) "
+        f"OR (acceleration_z IS NOT NULL AND ABS(acceleration_z) > {accel_thresh}) "
+        f"OR (gear IS NOT NULL AND gear NOT IN ({gear_no_signal_csv})) "
+        f"OR (steering_angle IS NOT NULL AND ABS(steering_angle) > {steering_thresh}) "
+        "OR brake_applied != 0 "
+        "OR blinker_on_left != 0 "
+        "OR blinker_on_right != 0"
     )
 
     # 1. Capture cold-eligible rows BEFORE the rewrite. The temp
@@ -1165,20 +1203,33 @@ def _migrate_v14_to_v15(conn: sqlite3.Connection) -> None:
     # FK integrity check — defensive verification that the
     # rewrite preserved waypoints_cold.id -> waypoints(id).
     # PRAGMA foreign_key_check returns one row per violation.
-    # Empty result = clean.
+    # Empty result = clean. Raise inside the v15 SAVEPOINT on
+    # violation so the SAVEPOINT rolls back deterministically
+    # to v14 (the outer ``except sqlite3.Error`` in ``_init_db``
+    # catches this and ROLLBACKs cleanly). Letting it slide here
+    # would defer the failure to ``conn.commit()`` at the
+    # outermost transaction, which propagates a bare
+    # ``sqlite3.IntegrityError`` and crashes ``gadget_web`` at
+    # boot — bypassing the SAVEPOINT-rollback path entirely on a
+    # power-loss-prone device.
     violations = conn.execute("PRAGMA foreign_key_check").fetchall()
     if violations:
-        logger.warning(
+        violation_summary = [tuple(v) for v in violations]
+        logger.error(
             "v14->v15: PRAGMA foreign_key_check returned %d "
-            "violations after rewrite — outermost commit will "
-            "abort. Rows: %r",
-            len(violations), [tuple(v) for v in violations],
+            "violations after rewrite; raising IntegrityError "
+            "to force SAVEPOINT rollback to v14. Rows: %r",
+            len(violations), violation_summary,
         )
-    else:
-        logger.info(
-            "v14->v15: foreign_key_check clean (waypoints_cold "
-            "FK preserved across single-rewrite)",
+        raise sqlite3.IntegrityError(
+            f"v14->v15: foreign_key_check returned "
+            f"{len(violations)} violations after rewrite: "
+            f"{violation_summary!r}"
         )
+    logger.info(
+        "v14->v15: foreign_key_check clean (waypoints_cold "
+        "FK preserved across single-rewrite)",
+    )
 
 
 def _drop_cold_cols_via_rewrite(conn: sqlite3.Connection) -> None:
@@ -1198,42 +1249,60 @@ def _drop_cold_cols_via_rewrite(conn: sqlite3.Connection) -> None:
 
     This helper replaces the eight rewrites with one:
 
-    1. ``PRAGMA defer_foreign_keys = ON`` — settable inside a tx
+    1. ``DROP TABLE IF EXISTS waypoints_new`` — clears any zombie
+       table from a previous-boot crash that landed between
+       ``CREATE TABLE waypoints_new`` (step 4) and
+       ``DROP TABLE waypoints`` (step 6). Without this clear, the
+       rewrite would fail forever ("table waypoints_new already
+       exists") and force the fallback path on every subsequent
+       boot.
+    2. ``PRAGMA defer_foreign_keys = ON`` — settable inside a tx
        (unlike ``PRAGMA foreign_keys`` which is a no-op inside a
        tx). With deferred FKs, the FK checks fire only at the
        outermost-transaction commit.
-    2. Capture the current ``sqlite_sequence`` value for
+    3. Capture the current ``sqlite_sequence`` value for
        ``waypoints`` so AUTOINCREMENT semantics survive the rewrite.
        Without this, deleting the highest-id row pre-migration
        would let the next INSERT recycle that id (a real
        AUTOINCREMENT correctness bug — AUTOINCREMENT explicitly
        guarantees no recycling).
-    3. ``CREATE TABLE waypoints_new`` with hot columns only — the
-       schema mirrors the v15 ``executescript`` definition exactly.
-    4. ``INSERT INTO waypoints_new SELECT <hot_cols> FROM waypoints``
+    4. ``CREATE TABLE waypoints_new`` with hot columns only — the
+       schema is generated from ``_V15_HOT_COLUMNS`` +
+       ``_V15_HOT_COLUMN_DDL`` so it tracks ``_SCHEMA_SQL`` (the
+       live v15 ``waypoints`` definition) automatically. A future
+       column add in ``_SCHEMA_SQL`` that's forgotten here would
+       blow up an assertion test
+       (``test_v15_hot_columns_match_schema_sql``) before it could
+       silently drop the column from every install during migration.
+    5. ``INSERT INTO waypoints_new SELECT <hot_cols> FROM waypoints``
        — one read pass, one write pass.
-    5. ``DROP TABLE waypoints`` — also removes its
+    6. ``DROP TABLE waypoints`` — also removes its
        ``sqlite_sequence`` entry. **Caller MUST ensure
        ``waypoints_cold`` is empty at this point** (DROP TABLE
        cascades through ``ON DELETE CASCADE`` even with
        ``defer_foreign_keys=ON``). The v14→v15 caller satisfies
        this by snapshotting cold-eligible rows into a TEMP TABLE
        BEFORE this helper runs and backfilling AFTER.
-    6. ``ALTER TABLE waypoints_new RENAME TO waypoints`` — SQLite
+    7. ``ALTER TABLE waypoints_new RENAME TO waypoints`` — SQLite
        evaluates FKs by name at check time; the renamed table
        satisfies ``waypoints_cold.id REFERENCES waypoints(id)`` for
        the post-backfill rows the caller will insert.
-    7. Restore the captured ``sqlite_sequence`` value so
+    8. Restore the captured ``sqlite_sequence`` value so
        AUTOINCREMENT picks up where it left off.
 
     Raises ``sqlite3.Error`` on any failure; the caller falls back
     to the per-column ALTER path.
     """
-    # 1. Defer FK enforcement. Settable inside the surrounding
+    # 1. Clear any zombie waypoints_new from a previous-boot crash
+    #    between steps 4 and 6 (CREATE TABLE waypoints_new
+    #    succeeded; DROP TABLE waypoints did not). Idempotent.
+    conn.execute("DROP TABLE IF EXISTS waypoints_new")
+
+    # 2. Defer FK enforcement. Settable inside the surrounding
     #    savepoint; auto-resets at outermost-tx commit.
     conn.execute("PRAGMA defer_foreign_keys = ON")
 
-    # 2. Capture sqlite_sequence high-water for waypoints. The
+    # 3. Capture sqlite_sequence high-water for waypoints. The
     #    table is created on first AUTOINCREMENT INSERT, so it may
     #    or may not exist on a fresh-ish DB. ``MAX(seq, MAX(id))``
     #    handles two corner cases:
@@ -1253,70 +1322,72 @@ def _drop_cold_cols_via_rewrite(conn: sqlite3.Connection) -> None:
     ).fetchone()
     seq_high_water = max(seq_row['seq'], max_id_row['m'])
 
-    # 3. CREATE TABLE waypoints_new with HOT columns only. Must
-    #    match the v15 executescript schema exactly (lines 79-90).
+    # 4. CREATE TABLE waypoints_new with HOT columns only. Schema
+    #    is built from the single-source-of-truth tuple +
+    #    DDL-fragment map so any future column add in
+    #    ``_SCHEMA_SQL``'s ``waypoints`` definition that's missed
+    #    here is caught by ``test_v15_hot_columns_match_schema_sql``
+    #    rather than silently dropped during migration.
+    create_cols_sql = ",\n    ".join(
+        f"{col} {_V15_HOT_COLUMN_DDL[col]}"
+        for col in _V15_HOT_COLUMNS
+    )
     conn.execute(
-        "CREATE TABLE waypoints_new ("
-        "    id INTEGER PRIMARY KEY AUTOINCREMENT, "
-        "    trip_id INTEGER REFERENCES trips(id) ON DELETE CASCADE, "
-        "    timestamp TEXT NOT NULL, "
-        "    lat REAL NOT NULL, "
-        "    lon REAL NOT NULL, "
-        "    heading REAL, "
-        "    speed_mps REAL, "
-        "    autopilot_state TEXT, "
-        "    video_path TEXT, "
-        "    frame_offset INTEGER"
-        ")"
+        f"CREATE TABLE waypoints_new (\n    {create_cols_sql}\n)"
     )
 
-    # 4. Single-pass copy. Explicit column list on both sides so
-    #    the SELECT order survives a future column-add to the
-    #    executescript.
+    # 5. Single-pass copy. Explicit column list on both sides so
+    #    the SELECT order survives a future column-add.
+    hot_cols_csv = ", ".join(_V15_HOT_COLUMNS)
     conn.execute(
-        "INSERT INTO waypoints_new "
-        "(id, trip_id, timestamp, lat, lon, heading, speed_mps, "
-        "autopilot_state, video_path, frame_offset) "
-        "SELECT id, trip_id, timestamp, lat, lon, heading, speed_mps, "
-        "autopilot_state, video_path, frame_offset "
-        "FROM waypoints"
+        f"INSERT INTO waypoints_new ({hot_cols_csv}) "
+        f"SELECT {hot_cols_csv} FROM waypoints"
     )
 
-    # 5. Drop the old table. Caller has snapshotted cold rows into
+    # 6. Drop the old table. Caller has snapshotted cold rows into
     #    a TEMP TABLE so the cascade-emptying of waypoints_cold is
     #    a no-op (it's already empty).
     conn.execute("DROP TABLE waypoints")
 
-    # 6. Atomic rename — at this point queries against ``waypoints``
+    # 7. Atomic rename — at this point queries against ``waypoints``
     #    return the new (hot-cols-only) table. SQLite preserves
     #    the per-table sqlite_sequence row across rename, but the
     #    DROP+RENAME sequence loses the high-water mark from the
     #    deleted-rows-above-MAX(id) case (e.g., insert ids 1..5,
     #    delete id=5 → sqlite_sequence.seq=5 but MAX(id)=4 →
     #    after rewrite seq=4 → next AUTOINCREMENT recycles id=5).
-    #    Step 7 restores it.
+    #    Step 8 restores it.
     conn.execute("ALTER TABLE waypoints_new RENAME TO waypoints")
 
-    # 7. Restore the captured high-water so AUTOINCREMENT
-    #    semantics are preserved (no id recycling). ``sqlite_sequence``
-    #    has no UNIQUE constraint on ``name``, so ``INSERT OR REPLACE``
-    #    silently appends a duplicate row instead of replacing —
-    #    we must ``INSERT OR IGNORE`` (creates the row if missing)
-    #    then ``UPDATE`` (sets the value if present). This pattern
-    #    is the documented SQLite-correct way to manipulate
-    #    sqlite_sequence safely. Use ``MAX(seq, ?)`` in the UPDATE
-    #    so we never DECREASE the value (which would itself recycle
-    #    ids).
+    # 8. Restore the captured high-water so AUTOINCREMENT
+    #    semantics are preserved (no id recycling).
+    #
+    #    Critical correctness note: ``sqlite_sequence`` has NO
+    #    UNIQUE constraint on ``name``. That means BOTH
+    #    ``INSERT OR REPLACE`` (no row to replace → silently
+    #    appends a duplicate) AND ``INSERT OR IGNORE`` (no
+    #    constraint to violate → silently appends a duplicate)
+    #    leave the table with two rows for ``'waypoints'``.
+    #    The safe pattern is **UPDATE first, INSERT only on
+    #    rowcount == 0** — UPDATE on a non-existent row is a no-op
+    #    (rowcount=0), then we INSERT exactly once. Use
+    #    ``MAX(seq, ?)`` in the UPDATE so we never DECREASE the
+    #    value (which would itself recycle ids). The post-condition
+    #    ``COUNT(*) FROM sqlite_sequence WHERE name='waypoints'
+    #    <= 1`` is asserted by the
+    #    ``test_migration_sqlite_sequence_is_single_row`` test.
     if seq_high_water > 0:
-        conn.execute(
-            "INSERT OR IGNORE INTO sqlite_sequence (name, seq) "
-            "VALUES ('waypoints', 0)"
-        )
-        conn.execute(
+        cur = conn.execute(
             "UPDATE sqlite_sequence SET seq = MAX(seq, ?) "
             "WHERE name = 'waypoints'",
             (seq_high_water,),
         )
+        if cur.rowcount == 0:
+            conn.execute(
+                "INSERT INTO sqlite_sequence (name, seq) "
+                "VALUES ('waypoints', ?)",
+                (seq_high_water,),
+            )
 
     logger.info(
         "v14->v15: single-table-rewrite complete (1 read+write "
@@ -1339,9 +1410,18 @@ def _drop_cold_cols_via_per_column_alter(conn: sqlite3.Connection) -> None:
     "8 slow rewrites" is strictly better than "schema stuck at
     v14 with cold columns still present."
     """
+    # Clear any partial-rewrite leftover from this same migration
+    # call (rewrite raised AFTER ``CREATE TABLE waypoints_new``).
+    # Idempotent — DROP TABLE IF EXISTS is a no-op when the table
+    # isn't there.
+    conn.execute("DROP TABLE IF EXISTS waypoints_new")
+
+    dropped = 0
+    failures: list[tuple[str, str]] = []
     for col in _COLD_COLUMNS:
         try:
             conn.execute(f"ALTER TABLE waypoints DROP COLUMN {col}")
+            dropped += 1
         except sqlite3.OperationalError as e:
             # Already dropped (idempotent retry) or older SQLite —
             # log once at WARNING; the runtime INSERT path handles
@@ -1350,3 +1430,22 @@ def _drop_cold_cols_via_per_column_alter(conn: sqlite3.Connection) -> None:
                 "v14->v15 fallback: could not drop %s from "
                 "waypoints: %s (continuing)", col, e,
             )
+            failures.append((col, str(e)))
+
+    # Aggregate summary so a single ``journalctl`` line tells the
+    # operator whether the fallback succeeded. Without this they
+    # have to count 8 lines and cross-reference against
+    # ``_COLD_COLUMNS`` themselves.
+    if not failures:
+        logger.info(
+            "v14->v15 fallback complete: dropped %d of %d cold "
+            "columns via per-column ALTER",
+            dropped, len(_COLD_COLUMNS),
+        )
+    else:
+        logger.error(
+            "v14->v15 fallback partial: dropped %d of %d cold "
+            "columns; %d failure(s) — remaining: %r",
+            dropped, len(_COLD_COLUMNS), len(failures),
+            [c for c, _ in failures],
+        )

--- a/scripts/web/services/mapping_migrations.py
+++ b/scripts/web/services/mapping_migrations.py
@@ -1008,16 +1008,29 @@ def _migrate_v14_to_v15(conn: sqlite3.Connection) -> None:
 
     Steps (run inside the v15 SAVEPOINT in :func:`_init_db`):
 
-    1. If ``waypoints`` still has the cold columns, copy each row
-       with at least one non-default cold field into
-       ``waypoints_cold`` (the table itself is created idempotently
-       by the executescript). Insert is one batched ``INSERT ... SELECT``
-       — fastest and exhibits a single WAL frame.
-    2. Drop the cold columns from ``waypoints`` via repeated
-       ``ALTER TABLE waypoints DROP COLUMN`` (SQLite ≥ 3.35, present
-       on Bookworm). Each drop is idempotent — duplicate-column
-       ``OperationalError`` is caught and ignored, so re-runs after
-       a partial migration are safe.
+    1. **Capture cold data in a TEMP TABLE first** — required because
+       step 2's table rewrite would otherwise lose any rows the
+       backfill INSERT'd. ``DROP TABLE waypoints`` cascades through
+       the ``waypoints_cold.id REFERENCES waypoints(id) ON DELETE
+       CASCADE`` foreign key and empties ``waypoints_cold`` (verified
+       experimentally), so we MUST take a snapshot before the
+       rewrite, do the rewrite while ``waypoints_cold`` is empty
+       (cascade is a no-op), then re-insert from the snapshot.
+    2. Drop the cold columns from ``waypoints`` via a SINGLE
+       table-rewrite (CREATE waypoints_new + INSERT + DROP +
+       RENAME), bounded by ``PRAGMA defer_foreign_keys=ON``.
+       Issue #188: replaces 8x ``ALTER TABLE DROP COLUMN`` (each of
+       which rewrote the entire table) with one CREATE+INSERT+DROP+
+       RENAME pass. On a 1M-row waypoints table this drops WAL
+       spike from ~800 MB to ~100 MB and slashes SDIO contention
+       with the archive worker during boot.
+    3. Backfill ``waypoints_cold`` from the snapshot. The WHERE
+       clause filters out rows whose cold telemetry is entirely at
+       sensor noise / no-signal defaults — thresholds mirror
+       ``mapping_service._index_video`` exactly so a v14→v15
+       upgrade and a fresh v15 install populate ``waypoints_cold``
+       with the same row set.
+    4. Drop the temp snapshot table.
 
     After completion, the runtime INSERT path (in
     ``mapping_service._insert_waypoints``) writes hot columns to
@@ -1026,97 +1039,314 @@ def _migrate_v14_to_v15(conn: sqlite3.Connection) -> None:
     payload they did before. Hot-only readers (``query_trip_route``,
     ``query_day_routes``) skip the join and pay only for the hot
     pages.
+
+    Idempotent: a re-run after a partial completion (cold cols
+    already dropped) is a no-op via the ``_waypoints_has_cold_columns``
+    guard. The single-rewrite is itself wrapped in a try/except that
+    falls back to the legacy 8x DROP COLUMN if the rewrite path
+    fails for any reason — defensive belt-and-suspenders so a
+    pathological row payload can't strand the schema mid-rewrite.
     """
-    # 1. Backfill waypoints_cold from any remaining inline cold data
-    if _waypoints_has_cold_columns(conn):
-        col_list = ", ".join(_COLD_COLUMNS)
-        # ``INSERT OR IGNORE`` so a partially-completed prior run
-        # (where ``waypoints_cold`` already has some rows) doesn't
-        # collide on PRIMARY KEY ``id``.
-        #
-        # The WHERE clause filters out rows whose cold telemetry is
-        # entirely at sensor noise / no-signal defaults. The thresholds
-        # mirror ``mapping_service._index_video`` exactly so a v14→v15
-        # upgrade and a fresh v15 install populate ``waypoints_cold``
-        # with the same row set. Without absolute-tolerance thresholds
-        # the cold table would get one row per waypoint (Tesla's IMU
-        # noise floor of ±0.001–±0.05 m/s² makes ``acceleration_x != 0``
-        # true on virtually every parked-car waypoint), defeating the
-        # split's purpose.
-        from services.mapping_service import (
-            _COLD_ACCEL_THRESHOLD_MPS2,
-            _COLD_STEERING_THRESHOLD_DEG,
-            _COLD_GEAR_NO_SIGNAL,
-        )
-        accel_thresh = float(_COLD_ACCEL_THRESHOLD_MPS2)
-        steering_thresh = float(_COLD_STEERING_THRESHOLD_DEG)
-        gear_no_signal_csv = ", ".join(
-            f"'{g}'" for g in sorted(_COLD_GEAR_NO_SIGNAL)
-        )
-        conn.execute(
-            f"INSERT OR IGNORE INTO waypoints_cold (id, {col_list}) "
-            f"SELECT id, {col_list} FROM waypoints "
-            f"WHERE (acceleration_x IS NOT NULL AND ABS(acceleration_x) > {accel_thresh}) "
-            f"   OR (acceleration_y IS NOT NULL AND ABS(acceleration_y) > {accel_thresh}) "
-            f"   OR (acceleration_z IS NOT NULL AND ABS(acceleration_z) > {accel_thresh}) "
-            f"   OR (gear IS NOT NULL AND gear NOT IN ({gear_no_signal_csv})) "
-            f"   OR (steering_angle IS NOT NULL AND ABS(steering_angle) > {steering_thresh}) "
-            "   OR brake_applied != 0 "
-            "   OR blinker_on_left != 0 "
-            "   OR blinker_on_right != 0"
-        )
-        backfilled = conn.execute(
-            "SELECT COUNT(*) AS n FROM waypoints_cold"
-        ).fetchone()['n']
-        logger.info(
-            "v14->v15: backfilled %d row(s) into waypoints_cold",
-            backfilled,
-        )
-
-        # 2. Drop the cold columns from waypoints. Each ALTER is its
-        #    own statement so a duplicate-column failure on retry is
-        #    isolated to one column. SQLite rebuilds the table once
-        #    per drop, but an empty rewrite on a table with hot
-        #    columns only is fast. Total cost: ~50 ms on a 100k-row
-        #    waypoints table.
-        for col in _COLD_COLUMNS:
-            try:
-                conn.execute(f"ALTER TABLE waypoints DROP COLUMN {col}")
-            except sqlite3.OperationalError as e:
-                # Already dropped (idempotent retry) or older SQLite —
-                # log once at WARNING; the runtime INSERT path handles
-                # the cold half via waypoints_cold either way.
-                logger.warning(
-                    "v14->v15: could not drop %s from waypoints: %s "
-                    "(continuing)", col, e,
-                )
-
-        # Re-create the small waypoints indexes; SQLite preserves
-        # them across DROP COLUMN, but a defensive idempotent CREATE
-        # IF NOT EXISTS covers the corner case where ALTER's table
-        # rebuild lost them.
-        conn.execute(
-            "CREATE INDEX IF NOT EXISTS idx_waypoints_trip "
-            "ON waypoints(trip_id)"
-        )
-        conn.execute(
-            "CREATE INDEX IF NOT EXISTS idx_waypoints_coords "
-            "ON waypoints(lat, lon)"
-        )
-        conn.execute(
-            "CREATE INDEX IF NOT EXISTS idx_waypoints_timestamp "
-            "ON waypoints(timestamp)"
-        )
-        conn.execute(
-            "CREATE INDEX IF NOT EXISTS idx_waypoints_video_path "
-            "ON waypoints(video_path)"
-        )
-        conn.execute(
-            "CREATE INDEX IF NOT EXISTS idx_waypoints_trip_video "
-            "ON waypoints(trip_id, video_path)"
-        )
-    else:
+    if not _waypoints_has_cold_columns(conn):
         logger.info(
             "v14->v15: waypoints already lacks cold columns — "
             "no migration work needed",
         )
+        return
+
+    col_list = ", ".join(_COLD_COLUMNS)
+
+    # The thresholds & no-signal set are owned by mapping_service
+    # so the runtime path and the migration backfill stay in sync.
+    from services.mapping_service import (
+        _COLD_ACCEL_THRESHOLD_MPS2,
+        _COLD_STEERING_THRESHOLD_DEG,
+        _COLD_GEAR_NO_SIGNAL,
+    )
+    accel_thresh = float(_COLD_ACCEL_THRESHOLD_MPS2)
+    steering_thresh = float(_COLD_STEERING_THRESHOLD_DEG)
+    gear_no_signal_csv = ", ".join(
+        f"'{g}'" for g in sorted(_COLD_GEAR_NO_SIGNAL)
+    )
+    cold_filter_where = (
+        f"  (acceleration_x IS NOT NULL AND ABS(acceleration_x) > {accel_thresh}) "
+        f"   OR (acceleration_y IS NOT NULL AND ABS(acceleration_y) > {accel_thresh}) "
+        f"   OR (acceleration_z IS NOT NULL AND ABS(acceleration_z) > {accel_thresh}) "
+        f"   OR (gear IS NOT NULL AND gear NOT IN ({gear_no_signal_csv})) "
+        f"   OR (steering_angle IS NOT NULL AND ABS(steering_angle) > {steering_thresh}) "
+        "   OR brake_applied != 0 "
+        "   OR blinker_on_left != 0 "
+        "   OR blinker_on_right != 0"
+    )
+
+    # 1. Capture cold-eligible rows BEFORE the rewrite. The temp
+    #    table sits in TEMPDB so it doesn't pollute the WAL of the
+    #    main DB (TEMPDB uses MEMORY journal mode under our
+    #    PRAGMA temp_store=MEMORY config). It survives DROP TABLE
+    #    waypoints because temp tables aren't subject to the main
+    #    DB's FK enforcement.
+    conn.execute("DROP TABLE IF EXISTS temp._migrate_v15_cold_snap")
+    conn.execute(
+        f"CREATE TEMP TABLE _migrate_v15_cold_snap AS "
+        f"SELECT id, {col_list} FROM waypoints "
+        f"WHERE {cold_filter_where}"
+    )
+    snap_rows = conn.execute(
+        "SELECT COUNT(*) AS n FROM temp._migrate_v15_cold_snap"
+    ).fetchone()['n']
+    logger.info(
+        "v14->v15: snapshotted %d cold-eligible row(s) before rewrite",
+        snap_rows,
+    )
+
+    # 2. Rewrite waypoints to drop cold cols. Safe to do now because
+    #    waypoints_cold is empty (just created by executescript) so
+    #    the DROP TABLE waypoints cascade is a no-op.
+    try:
+        _drop_cold_cols_via_rewrite(conn)
+    except sqlite3.Error as e:
+        # Defensive fallback: if the single-rewrite fails for any
+        # reason, fall back to the legacy 8x DROP COLUMN path.
+        # ALTER TABLE DROP COLUMN does NOT cascade through FKs
+        # (verified experimentally — only DROP TABLE does), so the
+        # fallback path is also safe to run after the snapshot.
+        logger.warning(
+            "v14->v15: single-table-rewrite failed (%s); "
+            "falling back to per-column DROP COLUMN", e,
+        )
+        _drop_cold_cols_via_per_column_alter(conn)
+
+    # 3. Backfill waypoints_cold from the snapshot. INSERT OR IGNORE
+    #    so a re-run after a partial completion (where some rows
+    #    already exist) doesn't collide on PRIMARY KEY.
+    conn.execute(
+        f"INSERT OR IGNORE INTO waypoints_cold (id, {col_list}) "
+        f"SELECT id, {col_list} FROM temp._migrate_v15_cold_snap"
+    )
+    backfilled = conn.execute(
+        "SELECT COUNT(*) AS n FROM waypoints_cold"
+    ).fetchone()['n']
+    logger.info(
+        "v14->v15: backfilled %d row(s) into waypoints_cold",
+        backfilled,
+    )
+
+    # 4. Clean up the snapshot. Temp tables vanish at connection
+    #    close anyway, but explicit drop keeps the connection's
+    #    TEMPDB footprint small for the rest of the session.
+    conn.execute("DROP TABLE temp._migrate_v15_cold_snap")
+
+    # Re-create the small waypoints indexes; the table-rewrite
+    # path drops them (DROP TABLE removes attached indexes), and
+    # the per-column-ALTER fallback path may have lost them too
+    # under some SQLite builds. Idempotent CREATE IF NOT EXISTS
+    # keeps both code paths uniform.
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_waypoints_trip "
+        "ON waypoints(trip_id)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_waypoints_coords "
+        "ON waypoints(lat, lon)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_waypoints_timestamp "
+        "ON waypoints(timestamp)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_waypoints_video_path "
+        "ON waypoints(video_path)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_waypoints_trip_video "
+        "ON waypoints(trip_id, video_path)"
+    )
+
+    # FK integrity check — defensive verification that the
+    # rewrite preserved waypoints_cold.id -> waypoints(id).
+    # PRAGMA foreign_key_check returns one row per violation.
+    # Empty result = clean.
+    violations = conn.execute("PRAGMA foreign_key_check").fetchall()
+    if violations:
+        logger.warning(
+            "v14->v15: PRAGMA foreign_key_check returned %d "
+            "violations after rewrite — outermost commit will "
+            "abort. Rows: %r",
+            len(violations), [tuple(v) for v in violations],
+        )
+    else:
+        logger.info(
+            "v14->v15: foreign_key_check clean (waypoints_cold "
+            "FK preserved across single-rewrite)",
+        )
+
+
+def _drop_cold_cols_via_rewrite(conn: sqlite3.Connection) -> None:
+    """Drop the cold telemetry columns from ``waypoints`` in ONE
+    table rewrite using the standard SQLite "12-step ALTER TABLE"
+    pattern, adapted to run inside an existing SAVEPOINT.
+
+    Issue #188 (PR #187 review finding #5): the prior implementation
+    issued eight ``ALTER TABLE waypoints DROP COLUMN`` statements
+    inside the v15 SAVEPOINT. SQLite ≥ 3.35 implements DROP COLUMN
+    as an in-place table rewrite, so 8 drops = 8 rewrites = 8x
+    read+write of the entire ``waypoints`` table into the WAL. On a
+    Pi Zero 2 W with a 1M-row waypoints table (~100 MB), that's
+    ~800 MB of WAL I/O competing with the archive worker on the
+    same SDIO bus — a documented contributor to boot-time bus
+    saturation.
+
+    This helper replaces the eight rewrites with one:
+
+    1. ``PRAGMA defer_foreign_keys = ON`` — settable inside a tx
+       (unlike ``PRAGMA foreign_keys`` which is a no-op inside a
+       tx). With deferred FKs, the FK checks fire only at the
+       outermost-transaction commit.
+    2. Capture the current ``sqlite_sequence`` value for
+       ``waypoints`` so AUTOINCREMENT semantics survive the rewrite.
+       Without this, deleting the highest-id row pre-migration
+       would let the next INSERT recycle that id (a real
+       AUTOINCREMENT correctness bug — AUTOINCREMENT explicitly
+       guarantees no recycling).
+    3. ``CREATE TABLE waypoints_new`` with hot columns only — the
+       schema mirrors the v15 ``executescript`` definition exactly.
+    4. ``INSERT INTO waypoints_new SELECT <hot_cols> FROM waypoints``
+       — one read pass, one write pass.
+    5. ``DROP TABLE waypoints`` — also removes its
+       ``sqlite_sequence`` entry. **Caller MUST ensure
+       ``waypoints_cold`` is empty at this point** (DROP TABLE
+       cascades through ``ON DELETE CASCADE`` even with
+       ``defer_foreign_keys=ON``). The v14→v15 caller satisfies
+       this by snapshotting cold-eligible rows into a TEMP TABLE
+       BEFORE this helper runs and backfilling AFTER.
+    6. ``ALTER TABLE waypoints_new RENAME TO waypoints`` — SQLite
+       evaluates FKs by name at check time; the renamed table
+       satisfies ``waypoints_cold.id REFERENCES waypoints(id)`` for
+       the post-backfill rows the caller will insert.
+    7. Restore the captured ``sqlite_sequence`` value so
+       AUTOINCREMENT picks up where it left off.
+
+    Raises ``sqlite3.Error`` on any failure; the caller falls back
+    to the per-column ALTER path.
+    """
+    # 1. Defer FK enforcement. Settable inside the surrounding
+    #    savepoint; auto-resets at outermost-tx commit.
+    conn.execute("PRAGMA defer_foreign_keys = ON")
+
+    # 2. Capture sqlite_sequence high-water for waypoints. The
+    #    table is created on first AUTOINCREMENT INSERT, so it may
+    #    or may not exist on a fresh-ish DB. ``MAX(seq, MAX(id))``
+    #    handles two corner cases:
+    #      * sqlite_sequence row exists but the highest id was
+    #        deleted post-INSERT — sqlite_sequence.seq is the right
+    #        value (already higher than current MAX(id)).
+    #      * sqlite_sequence row missing entirely (no AUTOINCREMENT
+    #        INSERT ever happened on this DB) — fall back to
+    #        MAX(id) which is the highest explicit id used.
+    seq_row = conn.execute(
+        "SELECT COALESCE("
+        "  (SELECT seq FROM sqlite_sequence WHERE name='waypoints'), "
+        "  0) AS seq"
+    ).fetchone()
+    max_id_row = conn.execute(
+        "SELECT COALESCE(MAX(id), 0) AS m FROM waypoints"
+    ).fetchone()
+    seq_high_water = max(seq_row['seq'], max_id_row['m'])
+
+    # 3. CREATE TABLE waypoints_new with HOT columns only. Must
+    #    match the v15 executescript schema exactly (lines 79-90).
+    conn.execute(
+        "CREATE TABLE waypoints_new ("
+        "    id INTEGER PRIMARY KEY AUTOINCREMENT, "
+        "    trip_id INTEGER REFERENCES trips(id) ON DELETE CASCADE, "
+        "    timestamp TEXT NOT NULL, "
+        "    lat REAL NOT NULL, "
+        "    lon REAL NOT NULL, "
+        "    heading REAL, "
+        "    speed_mps REAL, "
+        "    autopilot_state TEXT, "
+        "    video_path TEXT, "
+        "    frame_offset INTEGER"
+        ")"
+    )
+
+    # 4. Single-pass copy. Explicit column list on both sides so
+    #    the SELECT order survives a future column-add to the
+    #    executescript.
+    conn.execute(
+        "INSERT INTO waypoints_new "
+        "(id, trip_id, timestamp, lat, lon, heading, speed_mps, "
+        "autopilot_state, video_path, frame_offset) "
+        "SELECT id, trip_id, timestamp, lat, lon, heading, speed_mps, "
+        "autopilot_state, video_path, frame_offset "
+        "FROM waypoints"
+    )
+
+    # 5. Drop the old table. Caller has snapshotted cold rows into
+    #    a TEMP TABLE so the cascade-emptying of waypoints_cold is
+    #    a no-op (it's already empty).
+    conn.execute("DROP TABLE waypoints")
+
+    # 6. Atomic rename — at this point queries against ``waypoints``
+    #    return the new (hot-cols-only) table. SQLite preserves
+    #    the per-table sqlite_sequence row across rename, but the
+    #    DROP+RENAME sequence loses the high-water mark from the
+    #    deleted-rows-above-MAX(id) case (e.g., insert ids 1..5,
+    #    delete id=5 → sqlite_sequence.seq=5 but MAX(id)=4 →
+    #    after rewrite seq=4 → next AUTOINCREMENT recycles id=5).
+    #    Step 7 restores it.
+    conn.execute("ALTER TABLE waypoints_new RENAME TO waypoints")
+
+    # 7. Restore the captured high-water so AUTOINCREMENT
+    #    semantics are preserved (no id recycling). ``sqlite_sequence``
+    #    has no UNIQUE constraint on ``name``, so ``INSERT OR REPLACE``
+    #    silently appends a duplicate row instead of replacing —
+    #    we must ``INSERT OR IGNORE`` (creates the row if missing)
+    #    then ``UPDATE`` (sets the value if present). This pattern
+    #    is the documented SQLite-correct way to manipulate
+    #    sqlite_sequence safely. Use ``MAX(seq, ?)`` in the UPDATE
+    #    so we never DECREASE the value (which would itself recycle
+    #    ids).
+    if seq_high_water > 0:
+        conn.execute(
+            "INSERT OR IGNORE INTO sqlite_sequence (name, seq) "
+            "VALUES ('waypoints', 0)"
+        )
+        conn.execute(
+            "UPDATE sqlite_sequence SET seq = MAX(seq, ?) "
+            "WHERE name = 'waypoints'",
+            (seq_high_water,),
+        )
+
+    logger.info(
+        "v14->v15: single-table-rewrite complete (1 read+write "
+        "pass instead of 8x DROP COLUMN); AUTOINCREMENT high-water "
+        "restored to %d", seq_high_water,
+    )
+
+
+def _drop_cold_cols_via_per_column_alter(conn: sqlite3.Connection) -> None:
+    """Legacy fallback: drop cold columns via 8x ALTER TABLE DROP COLUMN.
+
+    Used only when :func:`_drop_cold_cols_via_rewrite` raises a
+    ``sqlite3.Error`` (corrupt row, FK weirdness, disk pressure
+    mid-rewrite). Each ALTER is its own statement so a
+    duplicate-column failure on retry is isolated to one column.
+
+    SQLite ≥ 3.35 implements DROP COLUMN as a table rewrite, so
+    this path costs 8 rewrites — the exact behaviour issue #188 was
+    filed to eliminate. Keeping it as a fallback is intentional:
+    "8 slow rewrites" is strictly better than "schema stuck at
+    v14 with cold columns still present."
+    """
+    for col in _COLD_COLUMNS:
+        try:
+            conn.execute(f"ALTER TABLE waypoints DROP COLUMN {col}")
+        except sqlite3.OperationalError as e:
+            # Already dropped (idempotent retry) or older SQLite —
+            # log once at WARNING; the runtime INSERT path handles
+            # the cold half via waypoints_cold either way.
+            logger.warning(
+                "v14->v15 fallback: could not drop %s from "
+                "waypoints: %s (continuing)", col, e,
+            )

--- a/tests/test_mapping_wave3.py
+++ b/tests/test_mapping_wave3.py
@@ -390,6 +390,283 @@ class TestV14ToV15Migration:
         }
         assert set(_COLD_COLUMNS) == expected
 
+    def test_migration_uses_single_table_rewrite_path(self, tmp_path,
+                                                       caplog):
+        """Issue #188: the v14→v15 migration MUST drop the cold columns
+        via a single table-rewrite, not 8x ``ALTER TABLE DROP COLUMN``.
+
+        We assert the new path by checking the dedicated log message
+        the rewrite helper emits. The legacy fallback path also runs
+        through ``_drop_cold_cols_via_per_column_alter`` but emits a
+        different message — so a future regression that ditches the
+        rewrite for the legacy path will fail this test.
+        """
+        import logging
+        db_path = str(tmp_path / "geodata.db")
+        _build_v14_db(db_path)
+        _seed_waypoints(db_path, trip_id=1, count=3, cold_data=True)
+
+        with caplog.at_level(logging.INFO,
+                             logger='services.mapping_migrations'):
+            _init_db(db_path).close()
+
+        rewrite_msgs = [r for r in caplog.records
+                        if 'single-table-rewrite complete' in r.message]
+        fallback_msgs = [r for r in caplog.records
+                         if 'falling back to per-column DROP COLUMN' in r.message]
+        assert rewrite_msgs, (
+            "Expected the single-rewrite path to fire and emit its "
+            "completion log line. Got records: "
+            f"{[r.message for r in caplog.records]}"
+        )
+        assert not fallback_msgs, (
+            "Fallback path should not fire on a clean v14 DB. Records: "
+            f"{[r.message for r in caplog.records]}"
+        )
+
+    def test_migration_preserves_waypoints_cold_fk(self, tmp_path):
+        """Issue #188: the single-rewrite must preserve the
+        ``waypoints_cold.id REFERENCES waypoints(id) ON DELETE CASCADE``
+        foreign key. Verify via ``PRAGMA foreign_key_check`` (no rows
+        means clean) AND by checking ``PRAGMA foreign_key_list`` on
+        ``waypoints_cold`` after the migration.
+        """
+        db_path = str(tmp_path / "geodata.db")
+        _build_v14_db(db_path)
+        _seed_waypoints(db_path, trip_id=1, count=3, cold_data=True)
+
+        conn = _init_db(db_path)
+        try:
+            # FK enforcement is on at connection-open in _init_db.
+            # Any violation would manifest here.
+            violations = conn.execute("PRAGMA foreign_key_check").fetchall()
+            assert violations == [], (
+                f"Migration left FK violations: "
+                f"{[tuple(v) for v in violations]}"
+            )
+
+            # Verify the FK is still defined on waypoints_cold
+            # pointing at waypoints(id) with CASCADE.
+            fk_list = conn.execute(
+                "PRAGMA foreign_key_list(waypoints_cold)"
+            ).fetchall()
+            assert len(fk_list) == 1, (
+                f"waypoints_cold should have exactly one FK; got: "
+                f"{[dict(r) for r in fk_list]}"
+            )
+            fk = dict(fk_list[0])
+            assert fk['table'] == 'waypoints'
+            assert fk['from'] == 'id'
+            assert fk['to'] == 'id'
+            assert fk['on_delete'] == 'CASCADE'
+        finally:
+            conn.close()
+
+    def test_migration_preserves_waypoints_data_after_rewrite(self,
+                                                               tmp_path):
+        """Issue #188: the single-rewrite MUST preserve every
+        ``waypoints`` row's hot data — id, trip_id, timestamp, lat,
+        lon, heading, speed_mps, autopilot_state, video_path,
+        frame_offset. A bug in the INSERT INTO ... SELECT column
+        list would silently drop or rearrange data.
+        """
+        db_path = str(tmp_path / "geodata.db")
+        _build_v14_db(db_path)
+        # Seed 5 waypoints so we get coverage of multiple ids /
+        # offsets.
+        _seed_waypoints(db_path, trip_id=1, count=5, cold_data=True)
+
+        # Snapshot hot-column values BEFORE the migration.
+        c = sqlite3.connect(db_path)
+        c.row_factory = sqlite3.Row
+        try:
+            before = {r['id']: dict(r) for r in c.execute(
+                "SELECT id, trip_id, timestamp, lat, lon, heading, "
+                "speed_mps, autopilot_state, video_path, frame_offset "
+                "FROM waypoints ORDER BY id"
+            )}
+        finally:
+            c.close()
+        assert len(before) == 5
+
+        # Migrate.
+        _init_db(db_path).close()
+
+        # Snapshot hot-column values AFTER the migration.
+        c = sqlite3.connect(db_path)
+        c.row_factory = sqlite3.Row
+        try:
+            after = {r['id']: dict(r) for r in c.execute(
+                "SELECT id, trip_id, timestamp, lat, lon, heading, "
+                "speed_mps, autopilot_state, video_path, frame_offset "
+                "FROM waypoints ORDER BY id"
+            )}
+        finally:
+            c.close()
+
+        assert before == after, (
+            f"Single-rewrite changed hot-column values. "
+            f"Before: {before}\nAfter: {after}"
+        )
+
+    def test_migration_cascade_delete_still_fires_after_rewrite(
+        self, tmp_path,
+    ):
+        """Issue #188: the FK ``waypoints_cold.id REFERENCES
+        waypoints(id) ON DELETE CASCADE`` must still trigger a
+        cascade after the rewrite. If the rewrite somehow lost the
+        ``ON DELETE CASCADE`` clause, deleting a waypoint would
+        leave an orphan in waypoints_cold (silent data corruption).
+        """
+        db_path = str(tmp_path / "geodata.db")
+        _build_v14_db(db_path)
+        _seed_waypoints(db_path, trip_id=1, count=3, cold_data=True)
+
+        conn = _init_db(db_path)
+        try:
+            # All 3 cold rows backfilled from the seed.
+            assert conn.execute(
+                "SELECT COUNT(*) AS c FROM waypoints_cold"
+            ).fetchone()['c'] == 3
+
+            # Delete waypoint id=2 — cascade should remove the
+            # matching cold row.
+            conn.execute("DELETE FROM waypoints WHERE id = 2")
+            conn.commit()
+
+            remaining = conn.execute(
+                "SELECT id FROM waypoints_cold ORDER BY id"
+            ).fetchall()
+            ids = [r['id'] for r in remaining]
+            assert 2 not in ids, (
+                f"Expected ON DELETE CASCADE to remove waypoints_cold "
+                f"row for id=2; ids remaining: {ids}"
+            )
+            assert ids == [1, 3]
+        finally:
+            conn.close()
+
+    def test_migration_recreates_all_waypoints_indexes(self, tmp_path):
+        """Issue #188: the rewrite drops the table (and its indexes);
+        the caller MUST recreate every index. Verify all 5 indexes
+        the v15 schema declares are present after the migration.
+        """
+        db_path = str(tmp_path / "geodata.db")
+        _build_v14_db(db_path)
+        _seed_waypoints(db_path, trip_id=1, count=2, cold_data=True)
+
+        conn = _init_db(db_path)
+        try:
+            indexes = {
+                r['name'] for r in conn.execute(
+                    "SELECT name FROM sqlite_master "
+                    "WHERE type='index' AND tbl_name='waypoints' "
+                    "AND name NOT LIKE 'sqlite_%'"
+                )
+            }
+            expected = {
+                'idx_waypoints_trip',
+                'idx_waypoints_coords',
+                'idx_waypoints_timestamp',
+                'idx_waypoints_video_path',
+                'idx_waypoints_trip_video',
+            }
+            missing = expected - indexes
+            assert not missing, (
+                f"Missing indexes after rewrite: {missing}. "
+                f"Present: {indexes}"
+            )
+        finally:
+            conn.close()
+
+    def test_migration_preserves_autoincrement_state(self, tmp_path):
+        """Issue #188: the rewrite preserves ``INTEGER PRIMARY KEY
+        AUTOINCREMENT`` semantics, including ``sqlite_sequence``
+        state. A new INSERT after the migration must allocate an id
+        strictly greater than the highest pre-migration id (not
+        recycle a deleted-row id, which AUTOINCREMENT explicitly
+        prevents).
+        """
+        db_path = str(tmp_path / "geodata.db")
+        _build_v14_db(db_path)
+        _seed_waypoints(db_path, trip_id=1, count=5, cold_data=True)
+
+        # Delete the last waypoint pre-migration so the id is gone.
+        c = sqlite3.connect(db_path)
+        try:
+            c.execute("DELETE FROM waypoints WHERE id = 5")
+            c.commit()
+        finally:
+            c.close()
+
+        # Run the migration.
+        conn = _init_db(db_path)
+        try:
+            # AUTOINCREMENT must NOT recycle id=5; the next insert
+            # gets id=6 (if sqlite_sequence is preserved across the
+            # rewrite).
+            conn.execute(
+                "INSERT INTO waypoints (trip_id, timestamp, lat, lon) "
+                "VALUES (1, '2026-05-04T08:00:99', 37.0, -122.0)"
+            )
+            new_id = conn.execute(
+                "SELECT last_insert_rowid() AS i"
+            ).fetchone()['i']
+            assert new_id >= 6, (
+                f"AUTOINCREMENT recycled an id (got {new_id}, "
+                f"expected >= 6) — sqlite_sequence was lost across "
+                f"the rewrite."
+            )
+        finally:
+            conn.close()
+
+    def test_migration_fallback_path_runs_when_rewrite_raises(
+        self, tmp_path, monkeypatch, caplog,
+    ):
+        """Issue #188: the defensive try/except around the rewrite
+        must fall back to the legacy 8x DROP COLUMN path when the
+        rewrite raises. Patch the rewrite helper to raise an
+        ``OperationalError`` and verify the legacy path runs.
+        """
+        import logging
+        from services import mapping_migrations as mm
+
+        db_path = str(tmp_path / "geodata.db")
+        _build_v14_db(db_path)
+        _seed_waypoints(db_path, trip_id=1, count=2, cold_data=True)
+
+        def boom(_conn):
+            raise sqlite3.OperationalError(
+                "synthetic rewrite failure for fallback test"
+            )
+
+        monkeypatch.setattr(mm, '_drop_cold_cols_via_rewrite', boom)
+
+        with caplog.at_level(logging.WARNING,
+                             logger='services.mapping_migrations'):
+            _init_db(db_path).close()
+
+        fallback_msgs = [r for r in caplog.records
+                         if 'falling back to per-column DROP COLUMN'
+                         in r.message]
+        assert fallback_msgs, (
+            "Fallback path did not run despite the rewrite raising. "
+            f"Records: {[r.message for r in caplog.records]}"
+        )
+
+        # Schema must have ended up at v15 (the fallback path
+        # successfully dropped the cold cols, so no rollback).
+        c = sqlite3.connect(db_path)
+        c.row_factory = sqlite3.Row
+        try:
+            assert _waypoints_has_cold_columns(c) is False
+            ver = c.execute(
+                "SELECT MAX(version) AS v FROM schema_version"
+            ).fetchone()['v']
+            assert ver == _SCHEMA_VERSION
+        finally:
+            c.close()
+
 
 # ---------------------------------------------------------------------------
 # query_trip_route — must return ONLY hot columns (and ``id`` for

--- a/tests/test_mapping_wave3.py
+++ b/tests/test_mapping_wave3.py
@@ -667,6 +667,257 @@ class TestV14ToV15Migration:
         finally:
             c.close()
 
+    def test_migration_sqlite_sequence_is_single_row(self, tmp_path):
+        """Issue #188 (PR #203 Critical #1 regression): the
+        AUTOINCREMENT-restoration step must NEVER leave more than
+        one ``sqlite_sequence`` row for ``'waypoints'``. The
+        original fix used ``INSERT OR IGNORE``, which silently
+        appends a duplicate row because ``sqlite_sequence`` has no
+        UNIQUE constraint on ``name``. This regression test pins
+        the post-condition.
+        """
+        db_path = str(tmp_path / "geodata.db")
+        _build_v14_db(db_path)
+        _seed_waypoints(db_path, trip_id=1, count=5, cold_data=True)
+
+        # Delete the highest-id row pre-migration so MAX(id) <
+        # sqlite_sequence.seq — exercises the restoration path.
+        c = sqlite3.connect(db_path)
+        try:
+            c.execute("DELETE FROM waypoints WHERE id = 5")
+            c.commit()
+        finally:
+            c.close()
+
+        _init_db(db_path).close()
+
+        c = sqlite3.connect(db_path)
+        c.row_factory = sqlite3.Row
+        try:
+            seq_rows = c.execute(
+                "SELECT name, seq FROM sqlite_sequence "
+                "WHERE name = 'waypoints'"
+            ).fetchall()
+            assert len(seq_rows) == 1, (
+                f"sqlite_sequence has {len(seq_rows)} rows for "
+                f"'waypoints'; expected exactly 1. Rows: "
+                f"{[tuple(r) for r in seq_rows]}. The IGNORE-then-"
+                "UPDATE pattern silently appends duplicates "
+                "because sqlite_sequence has no UNIQUE constraint "
+                "on name."
+            )
+            assert seq_rows[0]['seq'] >= 5, (
+                f"sqlite_sequence.seq dropped below the pre-"
+                f"migration high-water (got {seq_rows[0]['seq']}, "
+                f"expected >= 5)."
+            )
+        finally:
+            c.close()
+
+    def test_migration_partial_rerun_with_existing_waypoints_cold_rows(
+        self, tmp_path,
+    ):
+        """Issue #188 (PR #203 Info #8 regression): simulate a
+        partial-rerun scenario where the OLD pre-PR-#203 code's
+        BACKFILL succeeded (waypoints_cold has rows) but the OLD
+        DROP COLUMN loop crashed mid-way (waypoints still has cold
+        cols). The new snapshot-then-rewrite-then-backfill code
+        must handle this without losing data: snapshot rebuilds
+        the same row set from waypoints, the cascade-empties
+        waypoints_cold, then the backfill restores it identically.
+        Net: data preserved, schema at v15.
+        """
+        db_path = str(tmp_path / "geodata.db")
+        _build_v14_db(db_path)
+        _seed_waypoints(db_path, trip_id=1, count=4, cold_data=True)
+
+        # Pre-create the v15 waypoints_cold table and pre-populate
+        # it as the OLD code's BACKFILL would have. Use the same
+        # cold-eligible row set (rows where any cold col is non-
+        # default) so the post-migration row count matches.
+        c = sqlite3.connect(db_path)
+        try:
+            c.execute("PRAGMA foreign_keys = ON")
+            c.execute(
+                "CREATE TABLE waypoints_cold ("
+                " id INTEGER PRIMARY KEY, "
+                " acceleration_x REAL, acceleration_y REAL, "
+                " acceleration_z REAL, gear TEXT, "
+                " steering_angle REAL, brake_applied INTEGER, "
+                " blinker_on_left INTEGER, blinker_on_right INTEGER, "
+                " FOREIGN KEY (id) REFERENCES waypoints(id) "
+                "  ON DELETE CASCADE"
+                ")"
+            )
+            c.execute(
+                "INSERT INTO waypoints_cold (id, acceleration_x, "
+                " acceleration_y, acceleration_z, gear, steering_angle, "
+                " brake_applied, blinker_on_left, blinker_on_right) "
+                "SELECT id, acceleration_x, acceleration_y, "
+                " acceleration_z, gear, steering_angle, brake_applied, "
+                " blinker_on_left, blinker_on_right "
+                "FROM waypoints"
+            )
+            pre_cold_count = c.execute(
+                "SELECT COUNT(*) AS n FROM waypoints_cold"
+            ).fetchone()[0]
+            c.commit()
+        finally:
+            c.close()
+
+        assert pre_cold_count == 4, "fixture sanity check"
+
+        _init_db(db_path).close()
+
+        c = sqlite3.connect(db_path)
+        c.row_factory = sqlite3.Row
+        try:
+            # Hot data preserved (4 rows, all original ids).
+            wps = c.execute(
+                "SELECT id, lat, lon FROM waypoints ORDER BY id"
+            ).fetchall()
+            assert len(wps) == 4
+            assert [w['id'] for w in wps] == [1, 2, 3, 4]
+            # Cold data preserved (same row count post-migration as
+            # pre-migration; the snapshot-then-restore is a no-op
+            # for the data even though waypoints_cold was
+            # cascade-emptied mid-flight).
+            post_cold_count = c.execute(
+                "SELECT COUNT(*) AS n FROM waypoints_cold"
+            ).fetchone()['n']
+            assert post_cold_count == 4
+            # Schema at v15.
+            ver = c.execute(
+                "SELECT MAX(version) AS v FROM schema_version"
+            ).fetchone()['v']
+            assert ver == _SCHEMA_VERSION
+        finally:
+            c.close()
+
+    def test_migration_fallback_runs_when_waypoints_new_zombie_exists(
+        self, tmp_path, caplog,
+    ):
+        """Issue #188 (PR #203 Warning #3 regression): a
+        previous-boot crash that landed between ``CREATE TABLE
+        waypoints_new`` and ``DROP TABLE waypoints`` leaves a
+        zombie ``waypoints_new`` table. The new ``DROP TABLE IF
+        EXISTS waypoints_new`` at the top of the rewrite helper
+        must clear the zombie so the rewrite can succeed on the
+        next boot — without it, every subsequent boot would
+        force the fallback path.
+
+        This is also a 'natural failure' regression for the prior
+        gap (Info #9): exercises the cleanup path without
+        monkeypatching.
+        """
+        import logging
+        db_path = str(tmp_path / "geodata.db")
+        _build_v14_db(db_path)
+        _seed_waypoints(db_path, trip_id=1, count=3, cold_data=True)
+
+        # Pre-create the zombie table to simulate a crash between
+        # CREATE waypoints_new and DROP waypoints.
+        c = sqlite3.connect(db_path)
+        try:
+            c.execute(
+                "CREATE TABLE waypoints_new ("
+                " id INTEGER PRIMARY KEY, garbage TEXT)"
+            )
+            c.execute(
+                "INSERT INTO waypoints_new VALUES (999, 'leftover')"
+            )
+            c.commit()
+        finally:
+            c.close()
+
+        with caplog.at_level(logging.WARNING,
+                             logger='services.mapping_migrations'):
+            _init_db(db_path).close()
+
+        # The migration must NOT have fallen back — the rewrite
+        # cleared the zombie at step 1 and proceeded normally.
+        fallback_msgs = [r for r in caplog.records
+                         if 'falling back to per-column DROP COLUMN'
+                         in r.message]
+        assert not fallback_msgs, (
+            "Migration unexpectedly fell back instead of clearing "
+            "the zombie waypoints_new and proceeding with the "
+            f"rewrite. Records: {[r.message for r in caplog.records]}"
+        )
+
+        c = sqlite3.connect(db_path)
+        c.row_factory = sqlite3.Row
+        try:
+            # Schema at v15, hot data preserved, no zombie.
+            assert _waypoints_has_cold_columns(c) is False
+            wps = c.execute(
+                "SELECT id, lat, lon FROM waypoints ORDER BY id"
+            ).fetchall()
+            assert len(wps) == 3
+            zombie = c.execute(
+                "SELECT name FROM sqlite_master "
+                "WHERE type = 'table' AND name = 'waypoints_new'"
+            ).fetchone()
+            assert zombie is None, (
+                "waypoints_new zombie table was not cleaned up"
+            )
+        finally:
+            c.close()
+
+
+# ---------------------------------------------------------------------------
+# v15 hot-column constants — single source of truth pinned to schema.
+# ---------------------------------------------------------------------------
+
+
+def test_v15_hot_columns_match_schema_sql():
+    """Issue #188 (PR #203 Info #5 regression): the
+    ``_V15_HOT_COLUMNS`` tuple drives the rewrite helper's CREATE
+    / INSERT / SELECT statements. If a future column is added to
+    ``_SCHEMA_SQL``'s ``waypoints`` definition but forgotten in
+    ``_V15_HOT_COLUMNS``, the migration would silently DROP that
+    column from every existing v14 install. Pin the equivalence
+    here so the test fails loudly instead.
+    """
+    import re
+    from services.mapping_migrations import (
+        _SCHEMA_SQL, _V15_HOT_COLUMNS, _V15_HOT_COLUMN_DDL,
+    )
+
+    # Extract the column list from the live ``waypoints`` CREATE
+    # TABLE in _SCHEMA_SQL (not waypoints_cold — different table).
+    match = re.search(
+        r"CREATE TABLE IF NOT EXISTS waypoints \((.*?)\);",
+        _SCHEMA_SQL, re.DOTALL,
+    )
+    assert match, "Could not locate waypoints CREATE TABLE in _SCHEMA_SQL"
+
+    schema_cols = []
+    for line in match.group(1).strip().split('\n'):
+        line = line.strip().rstrip(',')
+        if not line:
+            continue
+        # Column name is the first whitespace-delimited token.
+        col_name = line.split()[0]
+        schema_cols.append(col_name)
+
+    assert tuple(schema_cols) == _V15_HOT_COLUMNS, (
+        f"_V15_HOT_COLUMNS drift detected!\n"
+        f"  _SCHEMA_SQL has:        {schema_cols}\n"
+        f"  _V15_HOT_COLUMNS has:   {list(_V15_HOT_COLUMNS)}\n"
+        "If you added a column to the live waypoints schema, also "
+        "add it to _V15_HOT_COLUMNS and _V15_HOT_COLUMN_DDL in "
+        "mapping_migrations.py — otherwise the v14->v15 rewrite "
+        "will silently drop it from every existing install."
+    )
+
+    # Every hot column must have a DDL fragment registered too.
+    missing_ddl = [c for c in _V15_HOT_COLUMNS
+                   if c not in _V15_HOT_COLUMN_DDL]
+    assert not missing_ddl, (
+        f"_V15_HOT_COLUMN_DDL missing entries for: {missing_ddl}"
+    )
+
 
 # ---------------------------------------------------------------------------
 # query_trip_route — must return ONLY hot columns (and ``id`` for


### PR DESCRIPTION
## Summary

Replace the v14->v15 migration's eight serial `ALTER TABLE waypoints DROP COLUMN` calls with a single full-table rewrite. On a Pi Zero 2 W with ~20K waypoints this collapses 8 WAL-amplifying internal table rewrites into 1.

Closes #188.

## Why it matters

Each `ALTER TABLE DROP COLUMN` in SQLite is an internal full-table rewrite. The v14->v15 migration drops 8 cold telemetry columns sequentially, which means the migration was paying 8x the WAL/page-churn cost during a boot-time path. Issue #188 calls this out specifically.

## What changed

- `_migrate_v14_to_v15` (`mapping_migrations.py`): restructured to **snapshot -> rewrite -> backfill** order. Capture cold-eligible rows BEFORE the rewrite (when `waypoints_cold` is empty so the FK cascade is a no-op), do one rewrite, then backfill the cold rows from the snapshot.
- New helper `_drop_cold_cols_via_rewrite(conn)`: standard SQLite rewrite (`CREATE NEW; INSERT FROM OLD; DROP OLD; RENAME NEW`) with cascade-safety + AUTOINCREMENT preservation built in.
- New helper `_drop_cold_cols_via_per_column_alter(conn)`: legacy 8x DROP COLUMN path retained as a safety fallback. If the rewrite raises for any reason, the migration falls back to it inside the same outer SAVEPOINT so the entire migration remains atomic.

## Two SQLite gotchas surfaced (and pinned by tests)

### 1. `DROP TABLE` cascades through `ON DELETE CASCADE` even with `defer_foreign_keys=ON`

`waypoints_cold.id REFERENCES waypoints(id) ON DELETE CASCADE` -> a naive `DROP TABLE waypoints` empties `waypoints_cold`. `defer_foreign_keys=ON` only defers FK *constraint checks*, not CASCADE *actions*. Verified with a tempfile reproducer.

**Fix:** snapshot cold rows into a TEMP TABLE BEFORE the rewrite (when `waypoints_cold` is empty so cascade is a no-op), backfill AFTER. The legacy `ALTER TABLE DROP COLUMN` path was safe by accident -- DROP COLUMN is an internal rewrite that does NOT trigger the cascade.

### 2. `sqlite_sequence` is lost across DROP+RENAME when `MAX(id) < seq`

If the highest-id row was deleted pre-migration (seq=5, MAX(id)=4), the rewrite copies max id 4 into the new table; after the rename, `sqlite_sequence.seq` is 4 -- recycling id 5 on the next AUTOINCREMENT INSERT, violating AUTOINCREMENT's no-recycling guarantee.

**Fix:** capture `MAX(sqlite_sequence.seq, MAX(waypoints.id))` before the rewrite. Restore via `INSERT OR IGNORE + UPDATE`. `INSERT OR REPLACE` is **unsafe** here -- `sqlite_sequence` has no UNIQUE constraint on `name`, so REPLACE silently appends a duplicate row instead of replacing the existing one.

## Test additions (7 new in `TestV14ToV15Migration`)

- `test_migration_uses_single_table_rewrite_path` -- log assertion that the rewrite path fired (not the fallback).
- `test_migration_preserves_waypoints_cold_fk` -- the `waypoints_cold -> waypoints(id)` FK with `ON DELETE CASCADE` survives.
- `test_migration_preserves_waypoints_data_after_rewrite` -- hot data round-trips with no loss.
- `test_migration_cascade_delete_still_fires_after_rewrite` -- post-migration `DELETE FROM waypoints WHERE id=?` still cascades into `waypoints_cold`.
- `test_migration_recreates_all_waypoints_indexes` -- all 5 indexes on `waypoints` are present.
- `test_migration_preserves_autoincrement_state` -- the AUTOINCREMENT high-water survives even when MAX(id) < seq pre-migration.
- `test_migration_fallback_path_runs_when_rewrite_raises` -- monkeypatched failure of the rewrite triggers the legacy 8x DROP COLUMN path; data is preserved either way.

## Test results

Full suite: **1,854 passed / 4 skipped** (was 1,847, +7 new).

Ref #184 (Wave 4 follow-up).
