### PR TITLE
fix(#197): inline SEI parse + sidecar JSON cache during _atomic_copy

### DIFF
--- a/scripts/web/services/archive_worker.py
+++ b/scripts/web/services/archive_worker.py
@@ -1095,6 +1095,72 @@ def _enqueue_indexed(dest_path: str, db_path: str) -> None:
         )
 
 
+# ---------------------------------------------------------------------------
+# Issue #197 — inline SEI parse + sidecar write (Wave 4 PR-E2 / Phase I.3)
+# ---------------------------------------------------------------------------
+# Default indexer sample_rate. Must match
+# ``mapping_service.index_single_file``'s default so the sidecar the
+# archive worker writes is consumable by the indexer without falling
+# back to a fresh mmap parse. If you change one, change the other.
+_INLINE_SEI_SAMPLE_RATE = 30
+
+
+def _write_inline_sei_sidecar(dest_path: str) -> None:
+    """Walk the just-copied file's SEI and persist a sidecar JSON.
+
+    Called once per successful ``_atomic_copy``, BEFORE
+    ``_enqueue_indexed`` adds the file to the indexer queue. The
+    file's pages are still hot in the kernel page cache (we just
+    wrote them), so the SEI walk costs only the protobuf decode
+    work — no extra SD reads. The sidecar lets the indexer's later
+    pass skip both the ``mvhd`` walk and the ``extract_sei_messages``
+    walk, eliminating ~2x file reads per clip and the associated
+    page-cache miss.
+
+    Best-effort: any failure is logged at WARNING and silently
+    swallowed. The downstream indexer's existing fallback path
+    (``read_sei_sidecar`` returning None → mmap parse) handles
+    missing sidecars transparently, so a sidecar-write failure
+    only loses the I/O optimization, never data.
+    """
+    try:
+        from services import sei_parser
+    except Exception as e:  # noqa: BLE001
+        logger.debug(
+            "inline-sei: sei_parser unavailable for %s (%s); "
+            "skipping sidecar write", dest_path, e,
+        )
+        return
+
+    try:
+        sidecar = sei_parser.write_sei_sidecar(
+            dest_path, sample_rate=_INLINE_SEI_SAMPLE_RATE,
+        )
+    except Exception as e:  # noqa: BLE001
+        logger.warning(
+            "inline-sei: sidecar write threw on %s "
+            "(indexer will mmap-parse): %s", dest_path, e,
+        )
+        return
+
+    if sidecar is None:
+        # write_sei_sidecar already logged the failure cause at
+        # DEBUG/WARNING; no need to double-log here.
+        return
+
+    mvhd_repr = (
+        sidecar.mvhd_creation_time_utc.isoformat()
+        if sidecar.mvhd_creation_time_utc is not None
+        else 'unknown'
+    )
+    logger.info(
+        "inline-sei: parsed %d messages (%d GPS, %d no-GPS), "
+        "mvhd=%s for %s",
+        sidecar.sei_count, len(sidecar.messages),
+        sidecar.no_gps_count, mvhd_repr, os.path.basename(dest_path),
+    )
+
+
 def _apply_low_priority() -> None:
     """Drop the calling thread to lowest CPU + I/O priority (Linux only).
 
@@ -1855,6 +1921,25 @@ def process_one_claim(row: Dict[str, Any], db_path: str,
 
     # Success — mark copied AND enqueue into the indexer queue.
     archive_queue.mark_copied(row_id, dest_path, db_path=db_path)
+    # Issue #197: while the just-copied file's pages are still hot
+    # in the kernel page cache, parse SEI + mvhd inline and write
+    # a sidecar JSON. The indexer's later pass reads the sidecar
+    # instead of mmap-parsing the .mp4 a second time.
+    #
+    # Best-effort by contract — wrap in defense-in-depth try/except
+    # so a sidecar bug or unexpected exception never marks the
+    # archive failed. The helper has its own internal try/except,
+    # but a future refactor (or a monkeypatched stub in tests)
+    # could let an exception escape; this outer guard preserves
+    # the "sidecar is an optimization, never a correctness gate"
+    # contract regardless.
+    try:
+        _write_inline_sei_sidecar(dest_path)
+    except Exception as e:  # noqa: BLE001
+        logger.warning(
+            "inline-sei: sidecar write escaped helper for %s "
+            "(indexer will mmap-parse): %s", dest_path, e,
+        )
     _enqueue_indexed(dest_path, db_path)
     return 'copied'
 

--- a/scripts/web/services/archive_worker.py
+++ b/scripts/web/services/archive_worker.py
@@ -1104,6 +1104,17 @@ def _enqueue_indexed(dest_path: str, db_path: str) -> None:
 # back to a fresh mmap parse. If you change one, change the other.
 _INLINE_SEI_SAMPLE_RATE = 30
 
+# Wall-clock soft cap on the inline SEI walk + sidecar write.
+# Reaching or exceeding this elevates the success log to WARNING so
+# operators see "the page-cache hot-path assumption broke for this
+# clip" in journalctl at default verbosity. NOT a hard cap — the
+# walk completes either way; this is purely an observability signal.
+# Calibrated against the 90-second hardware watchdog timeout: 5s
+# leaves plenty of headroom for the rest of ``process_one_claim``
+# and the worker's outer guards (``per_file_time_budget_seconds``
+# defaults to 60s for the copy itself).
+_SIDECAR_WRITE_WARN_SECONDS = 5.0
+
 
 def _write_inline_sei_sidecar(dest_path: str) -> None:
     """Walk the just-copied file's SEI and persist a sidecar JSON.
@@ -1117,12 +1128,39 @@ def _write_inline_sei_sidecar(dest_path: str) -> None:
     walk, eliminating ~2x file reads per clip and the associated
     page-cache miss.
 
+    **Time-budget context (issue #104 + review of PR #205).** This
+    helper runs OUTSIDE the per-file ``chunk_pause_seconds`` /
+    ``per_file_time_budget_seconds`` guards that ``_atomic_copy``
+    enforces. That is intentional and safe because:
+
+    * The work here is CPU-bound (protobuf decode on small NAL
+      buffers), not I/O-bound — the SD card is not the bottleneck,
+      so the SDIO-bus-saturation failure mode the time-budget
+      guards exist for does not apply.
+    * The file's pages are already resident in the page cache from
+      the immediately-prior ``_atomic_copy``, so no fresh SD reads
+      occur during the walk.
+    * The walk samples every ``_INLINE_SEI_SAMPLE_RATE`` (30) SEI
+      NAL — total work is O(file_size / 30), which on a worst-case
+      80 MB Tesla clip is well under a second on the Pi Zero 2 W.
+    * The downstream `_enqueue_indexed` call is a single SQLite
+      INSERT — sub-millisecond.
+
+    To keep that contract observable in production, we measure the
+    wall-clock and emit a WARNING if the helper exceeds
+    ``_SIDECAR_WRITE_WARN_SECONDS``. That gives operators an early
+    signal if the assumption above breaks (e.g. a future change
+    drops the sample-rate, or a corrupt clip causes pathological
+    parser behaviour) without forcing a hard cap that would silently
+    drop the optimization on every slow clip.
+
     Best-effort: any failure is logged at WARNING and silently
     swallowed. The downstream indexer's existing fallback path
     (``read_sei_sidecar`` returning None → mmap parse) handles
     missing sidecars transparently, so a sidecar-write failure
     only loses the I/O optimization, never data.
     """
+    start = time.monotonic()
     try:
         from services import sei_parser
     except Exception as e:  # noqa: BLE001
@@ -1143,6 +1181,7 @@ def _write_inline_sei_sidecar(dest_path: str) -> None:
         )
         return
 
+    elapsed = time.monotonic() - start
     if sidecar is None:
         # write_sei_sidecar already logged the failure cause at
         # DEBUG/WARNING; no need to double-log here.
@@ -1153,12 +1192,27 @@ def _write_inline_sei_sidecar(dest_path: str) -> None:
         if sidecar.mvhd_creation_time_utc is not None
         else 'unknown'
     )
-    logger.info(
-        "inline-sei: parsed %d messages (%d GPS, %d no-GPS), "
-        "mvhd=%s for %s",
-        sidecar.sei_count, len(sidecar.messages),
-        sidecar.no_gps_count, mvhd_repr, os.path.basename(dest_path),
-    )
+    if elapsed >= _SIDECAR_WRITE_WARN_SECONDS:
+        # Near-miss against the watchdog timeout — the page-cache
+        # hot-path assumption above appears to no longer hold for
+        # this clip. Surface at WARNING so it shows up in journalctl
+        # at the default verbosity.
+        logger.warning(
+            "inline-sei: sidecar write took %.2fs (>= %.1fs warn "
+            "threshold) for %s — page-cache fast-path may have "
+            "missed; %d messages, mvhd=%s",
+            elapsed, _SIDECAR_WRITE_WARN_SECONDS,
+            os.path.basename(dest_path),
+            sidecar.sei_count, mvhd_repr,
+        )
+    else:
+        logger.info(
+            "inline-sei: parsed %d messages (%d GPS, %d no-GPS), "
+            "mvhd=%s, elapsed=%.2fs for %s",
+            sidecar.sei_count, len(sidecar.messages),
+            sidecar.no_gps_count, mvhd_repr, elapsed,
+            os.path.basename(dest_path),
+        )
 
 
 def _apply_low_priority() -> None:

--- a/scripts/web/services/mapping_service.py
+++ b/scripts/web/services/mapping_service.py
@@ -672,7 +672,10 @@ def _timestamp_from_filename(filename: str) -> Optional[str]:
 _CLOCK_SKEW_WARN_SECONDS = 300
 
 
-def _resolve_recording_time(video_path: str) -> Optional[str]:
+def _resolve_recording_time(
+    video_path: str,
+    sidecar=None,
+) -> Optional[str]:
     """Return the authoritative ISO start-of-recording timestamp for a clip.
 
     Strategy (in priority order):
@@ -699,17 +702,28 @@ def _resolve_recording_time(video_path: str) -> Optional[str]:
     that pattern indicates a Tesla onboard-clock glitch worth knowing
     about. The indexer always uses the mvhd value regardless of gap
     size — mvhd is the truth.
+
+    ``sidecar`` is an optional pre-loaded ``SeiSidecar`` from
+    ``read_sei_sidecar``. When provided, we use its cached
+    ``mvhd_creation_time_utc`` and skip ALL parser I/O. Pass it from
+    callers (e.g. ``_index_video``) that are already going to read
+    the sidecar themselves — it eliminates the duplicate sidecar
+    JSON read that issue #197's review flagged. mvhd is
+    sample-rate-independent so the caller MAY pass a sidecar even if
+    its ``sample_rate`` doesn't match the indexer's request.
     """
     filename_ts = _timestamp_from_filename(video_path)
     parser = _get_sei_parser()
     mvhd_dt: Optional[datetime] = None
-    sidecar = None
     # Issue #197: prefer the sidecar's cached mvhd if present —
     # avoids one full mmap walk of the .mp4. The sidecar is
     # written by archive_worker right after _atomic_copy while
     # the file's pages are still hot in the page cache; reading
     # it back is a 5-50 KB JSON load instead of a 30-80 MB mmap.
-    if hasattr(parser, 'read_sei_sidecar'):
+    # Caller may have already loaded the sidecar (via
+    # ``read_sei_sidecar``) and passed it in to avoid a second
+    # JSON read on the same file.
+    if sidecar is None and hasattr(parser, 'read_sei_sidecar'):
         try:
             sidecar = parser.read_sei_sidecar(video_path)
         except Exception as e:  # noqa: BLE001
@@ -1213,7 +1227,33 @@ def _index_video(
             rel_path = os.path.relpath(video_path, teslacam_root)
     except ImportError:
         rel_path = os.path.relpath(video_path, teslacam_root)
-    file_timestamp = _resolve_recording_time(video_path)
+    # Issue #197: read the sidecar exactly once — first to extract
+    # the cached mvhd (sample-rate-independent) for
+    # ``_resolve_recording_time``, then to consume the cached
+    # messages if the sample_rate matches what we want. Doing this
+    # ONCE here (instead of letting both _resolve_recording_time and
+    # the message-extraction below each fire their own
+    # ``read_sei_sidecar`` call) saves one JSON read + one ``stat``
+    # per indexed clip — the duplicate read PR #205's review
+    # flagged.
+    sidecar = None
+    if hasattr(parser, 'read_sei_sidecar'):
+        try:
+            # Don't pin to required_sample_rate yet — the mvhd
+            # branch needs the sidecar even on a sample_rate
+            # mismatch. We re-check sample_rate at the
+            # message-consumption point below.
+            sidecar = parser.read_sei_sidecar(video_path)
+        except Exception as e:  # noqa: BLE001
+            logger.debug(
+                "sidecar read failed for %s (%s); "
+                "falling back to mmap parse", video_path, e,
+            )
+            sidecar = None
+
+    file_timestamp = _resolve_recording_time(
+        video_path, sidecar=sidecar,
+    )
 
     # --- Cross-folder dedup (fast path) ---
     # Tesla videos can exist in both RecentClips and ArchivedClips with the
@@ -1317,36 +1357,47 @@ def _index_video(
     waypoint_dicts = []
     sei_count = 0
     no_gps_count = 0
-    sidecar = None
-    if hasattr(parser, 'read_sei_sidecar'):
-        try:
-            sidecar = parser.read_sei_sidecar(
-                video_path, required_sample_rate=sample_rate,
-            )
-        except Exception as e:  # noqa: BLE001
-            logger.debug(
-                "sidecar read failed for %s (%s); "
-                "falling back to mmap parse", rel_path, e,
-            )
-            sidecar = None
+    # We already loaded ``sidecar`` above for _resolve_recording_time.
+    # Apply the sample_rate check here: if the cached sidecar was
+    # written at a different sampling than the indexer wants, we
+    # cannot reuse its messages — fall back to a mmap walk at the
+    # requested rate. (mvhd was sample-rate-independent so the call
+    # above was still useful.)
+    if sidecar is not None and sidecar.sample_rate != sample_rate:
+        logger.debug(
+            "sidecar sample_rate mismatch for %s "
+            "(cached %d, requested %d); using sidecar mvhd but "
+            "mmap-parsing for messages",
+            rel_path, sidecar.sample_rate, sample_rate,
+        )
+        sidecar_for_messages = None
+    else:
+        sidecar_for_messages = sidecar
 
     try:
-        if sidecar is not None:
+        if sidecar_for_messages is not None:
             logger.info(
                 "loaded sidecar parse for %s "
-                "(%d GPS messages, sample_rate=%d, cached path)",
-                rel_path, len(sidecar.messages), sidecar.sample_rate,
+                "(%d GPS messages, sample_rate=%d)",
+                rel_path,
+                len(sidecar_for_messages.messages),
+                sidecar_for_messages.sample_rate,
             )
-            sei_count = sidecar.sei_count
-            no_gps_count = sidecar.no_gps_count
-            msg_iter = sidecar.messages
+            sei_count = sidecar_for_messages.sei_count
+            no_gps_count = sidecar_for_messages.no_gps_count
+            msg_iter = sidecar_for_messages.messages
         else:
+            logger.info(
+                "parsed SEI messages for %s via mmap "
+                "(no sidecar, sample_rate=%d)",
+                rel_path, sample_rate,
+            )
             msg_iter = parser.extract_sei_messages(
                 video_path, sample_rate=sample_rate,
             )
 
         for msg in msg_iter:
-            if sidecar is None:
+            if sidecar_for_messages is None:
                 # Sidecar path already accounted for sei_count /
                 # no_gps_count + filtered out no-GPS messages, so the
                 # tally is only meaningful on the mmap fallback path.
@@ -1354,9 +1405,10 @@ def _index_video(
                 if not msg.has_gps:
                     no_gps_count += 1
                     continue
-            # NOTE: sidecar.messages is pre-filtered to GPS-bearing
-            # only (see ``write_sei_sidecar``), so the ``has_gps``
-            # check above is redundant when ``sidecar is not None``.
+            # NOTE: sidecar_for_messages.messages is pre-filtered to
+            # GPS-bearing only (see ``write_sei_sidecar``), so the
+            # ``has_gps`` check above is redundant when
+            # ``sidecar_for_messages is not None``.
 
             # Compute absolute timestamp from file timestamp + frame offset
             if file_timestamp:

--- a/scripts/web/services/mapping_service.py
+++ b/scripts/web/services/mapping_service.py
@@ -701,11 +701,32 @@ def _resolve_recording_time(video_path: str) -> Optional[str]:
     size — mvhd is the truth.
     """
     filename_ts = _timestamp_from_filename(video_path)
-    try:
-        mvhd_dt = _get_sei_parser().extract_mvhd_creation_time(video_path)
-    except Exception as e:  # defensive: mvhd reader is best-effort
-        logger.debug("mvhd read failed for %s: %s", video_path, e)
-        mvhd_dt = None
+    parser = _get_sei_parser()
+    mvhd_dt: Optional[datetime] = None
+    sidecar = None
+    # Issue #197: prefer the sidecar's cached mvhd if present —
+    # avoids one full mmap walk of the .mp4. The sidecar is
+    # written by archive_worker right after _atomic_copy while
+    # the file's pages are still hot in the page cache; reading
+    # it back is a 5-50 KB JSON load instead of a 30-80 MB mmap.
+    if hasattr(parser, 'read_sei_sidecar'):
+        try:
+            sidecar = parser.read_sei_sidecar(video_path)
+        except Exception as e:  # noqa: BLE001
+            logger.debug(
+                "sidecar read failed for %s (%s); "
+                "falling back to mmap mvhd parse",
+                video_path, e,
+            )
+            sidecar = None
+    if sidecar is not None and sidecar.mvhd_creation_time_utc is not None:
+        mvhd_dt = sidecar.mvhd_creation_time_utc
+    else:
+        try:
+            mvhd_dt = parser.extract_mvhd_creation_time(video_path)
+        except Exception as e:  # defensive: mvhd reader is best-effort
+            logger.debug("mvhd read failed for %s: %s", video_path, e)
+            mvhd_dt = None
 
     if mvhd_dt is None:
         return filename_ts
@@ -1287,16 +1308,55 @@ def _index_video(
             )
             return IndexResult(IndexOutcome.ALREADY_INDEXED)
 
-    # Extract SEI messages
+    # Extract SEI messages — prefer the issue #197 sidecar JSON cache
+    # over a fresh mmap walk when available. The sidecar is written by
+    # archive_worker right after _atomic_copy while the file's pages
+    # are still hot in the page cache; reading it back is a 5-50 KB
+    # JSON load instead of a 30-80 MB mmap (the .mp4 has likely been
+    # evicted from cache by the time the indexer runs minutes later).
     waypoint_dicts = []
     sei_count = 0
     no_gps_count = 0
+    sidecar = None
+    if hasattr(parser, 'read_sei_sidecar'):
+        try:
+            sidecar = parser.read_sei_sidecar(
+                video_path, required_sample_rate=sample_rate,
+            )
+        except Exception as e:  # noqa: BLE001
+            logger.debug(
+                "sidecar read failed for %s (%s); "
+                "falling back to mmap parse", rel_path, e,
+            )
+            sidecar = None
+
     try:
-        for msg in parser.extract_sei_messages(video_path, sample_rate=sample_rate):
-            sei_count += 1
-            if not msg.has_gps:
-                no_gps_count += 1
-                continue
+        if sidecar is not None:
+            logger.info(
+                "loaded sidecar parse for %s "
+                "(%d GPS messages, sample_rate=%d, cached path)",
+                rel_path, len(sidecar.messages), sidecar.sample_rate,
+            )
+            sei_count = sidecar.sei_count
+            no_gps_count = sidecar.no_gps_count
+            msg_iter = sidecar.messages
+        else:
+            msg_iter = parser.extract_sei_messages(
+                video_path, sample_rate=sample_rate,
+            )
+
+        for msg in msg_iter:
+            if sidecar is None:
+                # Sidecar path already accounted for sei_count /
+                # no_gps_count + filtered out no-GPS messages, so the
+                # tally is only meaningful on the mmap fallback path.
+                sei_count += 1
+                if not msg.has_gps:
+                    no_gps_count += 1
+                    continue
+            # NOTE: sidecar.messages is pre-filtered to GPS-bearing
+            # only (see ``write_sei_sidecar``), so the ``has_gps``
+            # check above is redundant when ``sidecar is not None``.
 
             # Compute absolute timestamp from file timestamp + frame offset
             if file_timestamp:
@@ -1843,6 +1903,21 @@ def purge_deleted_videos(db_path: str, teslacam_path: Optional[str] = None,
                     (path,),
                 )
                 purged_files += cur.rowcount
+
+                # 1a) Issue #197: delete the SEI sidecar JSON if any.
+                #     The sidecar is no longer useful (the .mp4 it
+                #     describes is gone) and would otherwise become
+                #     dead weight in the directory listing. Best-
+                #     effort; failure is logged at DEBUG inside the
+                #     helper.
+                try:
+                    from services import sei_parser as _sei
+                    _sei.delete_sei_sidecar(path)
+                except Exception as e:  # noqa: BLE001
+                    logger.debug(
+                        "purge: sidecar delete failed for %s: %s",
+                        path, e,
+                    )
 
                 # 2) waypoints / detected_events: NULL out video_path
                 #    instead of deleting the row. The GPS coordinates,

--- a/scripts/web/services/sei_parser.py
+++ b/scripts/web/services/sei_parser.py
@@ -34,6 +34,7 @@ Usage:
     messages = parse_video_sei('/path/to/video.mp4')
 """
 
+import json
 import logging
 import mmap
 import os
@@ -717,6 +718,18 @@ def sidecar_path_for(video_path: str) -> str:
     """Return the canonical sidecar path for ``video_path``.
 
     Format: ``<video_path>.sei.json`` (sibling to the .mp4).
+
+    **Trusted-input contract:** ``video_path`` is always a path
+    that the archive worker just wrote (see
+    ``archive_worker._atomic_copy``) or that the indexer found via
+    a directory walk under ``ArchivedClips`` / the RO USB mount.
+    No user-supplied input ever reaches this function — the path
+    has already been normalized and validated by upstream code
+    (``video_archive_service`` for the producer side,
+    ``mapping_service`` for the consumer side). For that reason
+    this function performs NO independent traversal validation;
+    it is purely a string-suffix operation. Callers MUST NOT pass
+    untrusted external input directly to this function.
     """
     return video_path + SIDECAR_SUFFIX
 
@@ -857,11 +870,11 @@ def write_sei_sidecar(
         'messages': [_message_to_dict(m) for m in gps_messages],
     }
 
-    import json as _json
     tmp_path = sidecar_path + '.tmp'
+    wrote_replace = False
     try:
         with open(tmp_path, 'w', encoding='utf-8') as f:
-            _json.dump(payload, f, separators=(',', ':'))
+            json.dump(payload, f, separators=(',', ':'))
             f.flush()
             try:
                 os.fsync(f.fileno())
@@ -871,16 +884,30 @@ def write_sei_sidecar(
                 # atomicity guarantee.
                 pass
         os.replace(tmp_path, sidecar_path)
+        wrote_replace = True
     except OSError as e:
         logger.warning(
             "sei sidecar: write failed for %s (indexer will "
             "mmap-parse): %s", sidecar_path, e,
         )
-        try:
-            os.unlink(tmp_path)
-        except OSError:
-            pass
         return None
+    except Exception as e:  # noqa: BLE001
+        logger.warning(
+            "sei sidecar: unexpected write failure for %s "
+            "(indexer will mmap-parse): %s", sidecar_path, e,
+        )
+        return None
+    finally:
+        # Belt-and-suspenders: any failure path that didn't reach
+        # ``os.replace`` (json serialization error, surprise
+        # exception type, abnormal exit from the with-block) leaves
+        # the .tmp behind. Sweep it up unconditionally; harmless
+        # when the replace succeeded (file already moved away).
+        if not wrote_replace:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
 
     return SeiSidecar(
         schema_version=SIDECAR_SCHEMA_VERSION,
@@ -928,10 +955,9 @@ def read_sei_sidecar(
     if not os.path.isfile(sidecar_path):
         return None
 
-    import json as _json
     try:
         with open(sidecar_path, 'r', encoding='utf-8') as f:
-            payload = _json.load(f)
+            payload = json.load(f)
     except (OSError, ValueError) as e:
         logger.debug(
             "sei sidecar: read/parse failed for %s (%s); "

--- a/scripts/web/services/sei_parser.py
+++ b/scripts/web/services/sei_parser.py
@@ -647,6 +647,421 @@ def parse_video_sei(
     return list(extract_sei_messages(video_path, sample_rate))
 
 
+# ---------------------------------------------------------------------------
+# Issue #197 — inline-SEI sidecar JSON cache (Wave 4 PR-E2 / Phase I.3)
+# ---------------------------------------------------------------------------
+# When ``archive_worker._atomic_copy`` finishes copying a clip, the file's
+# pages are still hot in the kernel page cache. Walking the SEI parser
+# right then is a near-zero-I/O operation. We persist the result as a
+# small sidecar JSON next to the ``.mp4`` so the indexer (which runs
+# minutes later, after the page cache has likely evicted the clip) can
+# consume the parsed result with a single 5-50 KB read instead of a
+# second full mmap walk of the 30-80 MB file.
+#
+# Net effect: the indexer's per-clip SD I/O drops by roughly 2x — one
+# walk for ``mvhd``, one walk for ``extract_sei_messages``, both
+# eliminated when a sidecar is present. See issue #197 for the full
+# motivation and acceptance criteria.
+#
+# Schema versioning lets us evolve the format without breaking the
+# fallback path: any reader sees a mismatched ``schema_version`` and
+# returns None, the caller falls back to mmap parse, and the next
+# archive run rewrites the sidecar in the new format. The schema
+# version is bumped any time field semantics change in a way the old
+# reader can't safely interpret.
+#
+# Only GPS-bearing messages are stored (the indexer drops no-GPS
+# messages anyway). For diagnostic visibility we ALSO store
+# ``sei_count`` (total messages walked) and ``no_gps_count`` (how many
+# were dropped) so the indexer's per-clip log lines are unchanged.
+#
+# Sample-rate is recorded explicitly so a reader that wants a finer
+# rate than what's cached can detect the mismatch and fall back to
+# mmap parse. The archive worker writes at the indexer's default
+# (``sample_rate=30``) — finer-grained tools (the diagnostic
+# ``sample_rate=1`` walk) fall back transparently.
+SIDECAR_SUFFIX = '.sei.json'
+SIDECAR_SCHEMA_VERSION = 1
+
+
+@dataclass
+class SeiSidecar:
+    """Cached SEI parse result loaded from a sidecar JSON.
+
+    ``messages`` contains only GPS-bearing messages (the same filter
+    the indexer applies inline). ``sei_count`` and ``no_gps_count``
+    preserve diagnostic visibility for the stationary-clip case.
+
+    ``mvhd_creation_time_utc`` is the timezone-aware UTC datetime
+    parsed from the MP4's ``mvhd`` atom (or None if the atom was
+    missing / unparseable). Same semantics as
+    ``extract_mvhd_creation_time``.
+
+    ``video_size_bytes`` and ``video_mtime_unix`` are integrity
+    guards — the reader compares them to the live file's stat() and
+    invalidates the sidecar (returns None) on drift. This catches
+    the case where the .mp4 was overwritten but the sidecar was
+    not.
+    """
+    schema_version: int
+    sample_rate: int
+    sei_count: int
+    no_gps_count: int
+    mvhd_creation_time_utc: Optional[datetime]
+    messages: List[SeiMessage]
+    video_size_bytes: int
+    video_mtime_unix: float
+
+
+def sidecar_path_for(video_path: str) -> str:
+    """Return the canonical sidecar path for ``video_path``.
+
+    Format: ``<video_path>.sei.json`` (sibling to the .mp4).
+    """
+    return video_path + SIDECAR_SUFFIX
+
+
+def _message_to_dict(msg: SeiMessage) -> dict:
+    """Serialize a ``SeiMessage`` for the sidecar JSON.
+
+    Field names match the dataclass attributes for readability.
+    The ``video_path`` field is intentionally OMITTED — it would
+    otherwise pin the sidecar to a specific filesystem location
+    and break if the .mp4 is renamed (e.g. moved between
+    RecentClips and ArchivedClips). The reader re-injects the
+    current ``video_path`` from the load call.
+    """
+    return {
+        'frame_index': msg.frame_index,
+        'timestamp_ms': msg.timestamp_ms,
+        'latitude_deg': msg.latitude_deg,
+        'longitude_deg': msg.longitude_deg,
+        'heading_deg': msg.heading_deg,
+        'vehicle_speed_mps': msg.vehicle_speed_mps,
+        'linear_acceleration_x': msg.linear_acceleration_x,
+        'linear_acceleration_y': msg.linear_acceleration_y,
+        'linear_acceleration_z': msg.linear_acceleration_z,
+        'steering_wheel_angle': msg.steering_wheel_angle,
+        'accelerator_pedal_position': msg.accelerator_pedal_position,
+        'brake_applied': msg.brake_applied,
+        'gear_state': msg.gear_state,
+        'autopilot_state': msg.autopilot_state,
+        'blinker_on_left': msg.blinker_on_left,
+        'blinker_on_right': msg.blinker_on_right,
+        'frame_seq_no': msg.frame_seq_no,
+    }
+
+
+def _dict_to_message(d: dict, video_path: str) -> SeiMessage:
+    """Reconstruct a ``SeiMessage`` from its sidecar-dict form."""
+    return SeiMessage(
+        frame_index=int(d['frame_index']),
+        timestamp_ms=float(d['timestamp_ms']),
+        latitude_deg=float(d['latitude_deg']),
+        longitude_deg=float(d['longitude_deg']),
+        heading_deg=float(d['heading_deg']),
+        vehicle_speed_mps=float(d['vehicle_speed_mps']),
+        linear_acceleration_x=float(d['linear_acceleration_x']),
+        linear_acceleration_y=float(d['linear_acceleration_y']),
+        linear_acceleration_z=float(d['linear_acceleration_z']),
+        steering_wheel_angle=float(d['steering_wheel_angle']),
+        accelerator_pedal_position=float(d['accelerator_pedal_position']),
+        brake_applied=bool(d['brake_applied']),
+        gear_state=str(d['gear_state']),
+        autopilot_state=str(d['autopilot_state']),
+        blinker_on_left=bool(d['blinker_on_left']),
+        blinker_on_right=bool(d['blinker_on_right']),
+        frame_seq_no=int(d['frame_seq_no']),
+        video_path=video_path,
+    )
+
+
+def write_sei_sidecar(
+    video_path: str,
+    sample_rate: int = 30,
+    sidecar_path: Optional[str] = None,
+) -> Optional[SeiSidecar]:
+    """Walk ``video_path`` once (mvhd + SEI) and persist the result
+    as a sidecar JSON next to the .mp4.
+
+    Best-effort: returns ``None`` on any failure (file missing,
+    parse error, write error). Callers MUST treat ``None`` as "no
+    sidecar; downstream consumers will mmap-parse the file
+    themselves". This is the issue #197 hot-path call: the file's
+    pages are hot in the kernel page cache (we just wrote them),
+    so the SEI walk costs only the protobuf decode work.
+
+    Atomic write: tempfile + ``os.fsync`` + ``os.rename`` so a
+    crash mid-write never leaves a half-written sidecar that the
+    reader would then accept as authoritative.
+
+    The default ``sample_rate=30`` matches the indexer's default
+    (``mapping_service._index_video``). A reader that requests a
+    finer rate must fall back to mmap parse — see
+    ``read_sei_sidecar``.
+    """
+    if sidecar_path is None:
+        sidecar_path = sidecar_path_for(video_path)
+
+    try:
+        st = os.stat(video_path)
+    except OSError as e:
+        logger.debug(
+            "sei sidecar: cannot stat %s for sidecar write: %s",
+            video_path, e,
+        )
+        return None
+
+    try:
+        mvhd_dt = extract_mvhd_creation_time(video_path)
+    except Exception as e:  # noqa: BLE001
+        logger.debug(
+            "sei sidecar: mvhd parse failed for %s: %s", video_path, e,
+        )
+        mvhd_dt = None
+
+    sei_count = 0
+    no_gps_count = 0
+    gps_messages: List[SeiMessage] = []
+    try:
+        for msg in extract_sei_messages(
+                video_path, sample_rate=sample_rate):
+            sei_count += 1
+            if not msg.has_gps:
+                no_gps_count += 1
+                continue
+            gps_messages.append(msg)
+    except (FileNotFoundError, ValueError) as e:
+        logger.debug(
+            "sei sidecar: SEI walk failed for %s: %s", video_path, e,
+        )
+        return None
+    except Exception as e:  # noqa: BLE001
+        logger.warning(
+            "sei sidecar: unexpected SEI walk failure on %s "
+            "(no sidecar written, indexer will mmap-parse): %s",
+            video_path, e,
+        )
+        return None
+
+    payload = {
+        'schema_version': SIDECAR_SCHEMA_VERSION,
+        'sample_rate': sample_rate,
+        'sei_count': sei_count,
+        'no_gps_count': no_gps_count,
+        'mvhd_creation_time_utc': (
+            mvhd_dt.isoformat() if mvhd_dt is not None else None
+        ),
+        'video_size_bytes': st.st_size,
+        'video_mtime_unix': st.st_mtime,
+        'messages': [_message_to_dict(m) for m in gps_messages],
+    }
+
+    import json as _json
+    tmp_path = sidecar_path + '.tmp'
+    try:
+        with open(tmp_path, 'w', encoding='utf-8') as f:
+            _json.dump(payload, f, separators=(',', ':'))
+            f.flush()
+            try:
+                os.fsync(f.fileno())
+            except OSError:
+                # Some filesystems (tmpfs in tests) don't support
+                # fsync — non-fatal; the rename below is the
+                # atomicity guarantee.
+                pass
+        os.replace(tmp_path, sidecar_path)
+    except OSError as e:
+        logger.warning(
+            "sei sidecar: write failed for %s (indexer will "
+            "mmap-parse): %s", sidecar_path, e,
+        )
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        return None
+
+    return SeiSidecar(
+        schema_version=SIDECAR_SCHEMA_VERSION,
+        sample_rate=sample_rate,
+        sei_count=sei_count,
+        no_gps_count=no_gps_count,
+        mvhd_creation_time_utc=mvhd_dt,
+        messages=gps_messages,
+        video_size_bytes=st.st_size,
+        video_mtime_unix=st.st_mtime,
+    )
+
+
+def read_sei_sidecar(
+    video_path: str,
+    sidecar_path: Optional[str] = None,
+    *,
+    required_sample_rate: Optional[int] = None,
+) -> Optional[SeiSidecar]:
+    """Load and validate the sidecar JSON for ``video_path``.
+
+    Returns ``None`` (and the caller falls back to mmap parse) when
+    ANY of the following holds:
+
+    * The sidecar file does not exist.
+    * The sidecar JSON is malformed or missing required keys.
+    * ``schema_version`` does not match ``SIDECAR_SCHEMA_VERSION``.
+    * The recorded ``video_size_bytes`` / ``video_mtime_unix`` do
+      not match the live file's stat — the .mp4 was overwritten or
+      replaced after the sidecar was written, so the cached parse
+      is no longer authoritative.
+    * ``required_sample_rate`` is set and does not match the
+      recorded ``sample_rate`` (the consumer needs a finer or
+      different sampling than was cached).
+
+    The integrity guards (size, mtime) are intentionally
+    permissive — they catch obvious overwrites without requiring a
+    cryptographic checksum. A user who manually re-encodes a clip
+    will produce a different mtime and the sidecar will correctly
+    invalidate.
+    """
+    if sidecar_path is None:
+        sidecar_path = sidecar_path_for(video_path)
+
+    if not os.path.isfile(sidecar_path):
+        return None
+
+    import json as _json
+    try:
+        with open(sidecar_path, 'r', encoding='utf-8') as f:
+            payload = _json.load(f)
+    except (OSError, ValueError) as e:
+        logger.debug(
+            "sei sidecar: read/parse failed for %s (%s); "
+            "falling back to mmap parse",
+            sidecar_path, e,
+        )
+        return None
+
+    if not isinstance(payload, dict):
+        return None
+
+    try:
+        schema_v = int(payload['schema_version'])
+        sample_rate = int(payload['sample_rate'])
+        sei_count = int(payload['sei_count'])
+        no_gps_count = int(payload['no_gps_count'])
+        size_bytes = int(payload['video_size_bytes'])
+        mtime_unix = float(payload['video_mtime_unix'])
+        msgs_payload = payload['messages']
+        mvhd_iso = payload.get('mvhd_creation_time_utc')
+    except (KeyError, TypeError, ValueError) as e:
+        logger.debug(
+            "sei sidecar: required key missing or bad type in %s "
+            "(%s); falling back to mmap parse", sidecar_path, e,
+        )
+        return None
+
+    if schema_v != SIDECAR_SCHEMA_VERSION:
+        logger.debug(
+            "sei sidecar: schema mismatch for %s (have v%d, "
+            "expected v%d); falling back to mmap parse",
+            sidecar_path, schema_v, SIDECAR_SCHEMA_VERSION,
+        )
+        return None
+
+    if (required_sample_rate is not None
+            and required_sample_rate != sample_rate):
+        logger.debug(
+            "sei sidecar: sample_rate mismatch for %s "
+            "(cached %d, requested %d); falling back to mmap parse",
+            sidecar_path, sample_rate, required_sample_rate,
+        )
+        return None
+
+    # Integrity guard: the .mp4 must still match what we cached.
+    try:
+        st = os.stat(video_path)
+    except OSError as e:
+        logger.debug(
+            "sei sidecar: video missing for %s (%s); cannot "
+            "validate; falling back to mmap parse",
+            video_path, e,
+        )
+        return None
+    if st.st_size != size_bytes:
+        logger.info(
+            "sei sidecar: video size drift for %s "
+            "(cached %d, now %d); invalidating sidecar",
+            os.path.basename(video_path), size_bytes, st.st_size,
+        )
+        return None
+    # mtime is float; tolerate sub-millisecond rounding from JSON
+    # round-trip but reject any meaningful drift.
+    if abs(st.st_mtime - mtime_unix) > 0.001:
+        logger.info(
+            "sei sidecar: video mtime drift for %s "
+            "(cached %s, now %s); invalidating sidecar",
+            os.path.basename(video_path), mtime_unix, st.st_mtime,
+        )
+        return None
+
+    mvhd_dt: Optional[datetime] = None
+    if mvhd_iso is not None:
+        try:
+            mvhd_dt = datetime.fromisoformat(mvhd_iso)
+        except (ValueError, TypeError):
+            logger.debug(
+                "sei sidecar: malformed mvhd timestamp %r in %s; "
+                "treating as None",
+                mvhd_iso, sidecar_path,
+            )
+            mvhd_dt = None
+
+    if not isinstance(msgs_payload, list):
+        return None
+    try:
+        messages = [_dict_to_message(m, video_path) for m in msgs_payload]
+    except (KeyError, TypeError, ValueError) as e:
+        logger.debug(
+            "sei sidecar: malformed message in %s (%s); "
+            "falling back to mmap parse", sidecar_path, e,
+        )
+        return None
+
+    return SeiSidecar(
+        schema_version=schema_v,
+        sample_rate=sample_rate,
+        sei_count=sei_count,
+        no_gps_count=no_gps_count,
+        mvhd_creation_time_utc=mvhd_dt,
+        messages=messages,
+        video_size_bytes=size_bytes,
+        video_mtime_unix=mtime_unix,
+    )
+
+
+def delete_sei_sidecar(video_path: str) -> bool:
+    """Delete the sidecar for ``video_path`` if it exists.
+
+    Returns ``True`` if a file was removed, ``False`` if there was
+    no sidecar to delete (or the unlink failed). Best-effort —
+    failure is logged at DEBUG and never propagated, since a
+    leftover sidecar pointing at a deleted .mp4 just becomes dead
+    weight that the next sweep will skip (the integrity guard in
+    ``read_sei_sidecar`` correctly invalidates a sidecar whose
+    .mp4 is missing).
+    """
+    sidecar_path = sidecar_path_for(video_path)
+    try:
+        os.unlink(sidecar_path)
+        return True
+    except FileNotFoundError:
+        return False
+    except OSError as e:
+        logger.debug(
+            "sei sidecar: delete failed for %s: %s", sidecar_path, e,
+        )
+        return False
+
+
 def get_video_gps_summary(video_path: str) -> Optional[dict]:
     """Get a quick GPS summary from a video file (first and last GPS points).
 

--- a/tests/test_archive_worker.py
+++ b/tests/test_archive_worker.py
@@ -320,6 +320,62 @@ class TestArchiveWorkerCopy:
         )
         assert indexer_db == db
 
+    def test_copy_calls_inline_sei_sidecar_write(
+        self, db, archive_root, teslacam_root, make_clip, monkeypatch,
+    ):
+        """Issue #197: every successful copy must invoke the inline-
+        SEI sidecar writer on the destination path. The sidecar
+        write itself is best-effort and may produce zero messages
+        on a non-Tesla MP4 — what matters is that the call happens."""
+        clip = make_clip("SentryClips/evt1/2025-01-01_10-00-00-front.mp4")
+        enqueue_for_archive(clip, db_path=db)
+        row = claim_next_for_worker('w', db_path=db)
+
+        called_with: List[str] = []
+        monkeypatch.setattr(
+            archive_worker, '_write_inline_sei_sidecar',
+            lambda dest: called_with.append(dest),
+        )
+        outcome = archive_worker.process_one_claim(
+            row, db, archive_root, teslacam_root,
+            chunk_size=4096, max_attempts=3,
+        )
+        assert outcome == 'copied'
+        assert len(called_with) == 1, (
+            "_write_inline_sei_sidecar was not called exactly once on "
+            "the success path (issue #197 hot-path optimization)."
+        )
+        assert called_with[0].endswith(
+            os.path.join(
+                "SentryClips", "evt1", "2025-01-01_10-00-00-front.mp4",
+            ),
+        )
+
+    def test_copy_succeeds_when_sidecar_write_raises(
+        self, db, archive_root, teslacam_root, make_clip, monkeypatch,
+    ):
+        """Sidecar write is BEST-EFFORT — a thrown exception inside
+        the sidecar path must NOT mark the archive failed. The
+        downstream indexer's mmap fallback handles the missing
+        sidecar transparently."""
+        clip = make_clip("SentryClips/evt1/2025-01-01_10-00-00-front.mp4")
+        enqueue_for_archive(clip, db_path=db)
+        row = claim_next_for_worker('w', db_path=db)
+
+        def _bad_sidecar(dest):
+            raise RuntimeError("simulated sidecar disk-full")
+        monkeypatch.setattr(
+            archive_worker, '_write_inline_sei_sidecar', _bad_sidecar,
+        )
+        outcome = archive_worker.process_one_claim(
+            row, db, archive_root, teslacam_root,
+            chunk_size=4096, max_attempts=3,
+        )
+        # Archive STILL succeeds despite sidecar exception. This is
+        # the contract: sidecar is an optimization, never a
+        # correctness gate.
+        assert outcome == 'copied'
+
     def test_copy_creates_intermediate_dirs(
         self, db, archive_root, teslacam_root, make_clip,
     ):

--- a/tests/test_mapping_service.py
+++ b/tests/test_mapping_service.py
@@ -2342,6 +2342,301 @@ class TestIndexSingleFileOutcomes:
             assert not result.terminal
 
 
+class TestIndexSingleFileSidecarConsumption:
+    """Issue #197: ``_index_video`` (via ``index_single_file``) must
+    prefer a sidecar JSON over a fresh mmap walk when one exists.
+    """
+
+    def _make_sidecar_with_messages(
+        self, video_path, sample_rate=30, messages=None, mvhd=None,
+    ):
+        """Hand-build a sidecar JSON the indexer should consume
+        without calling the real SEI parser. Lets us isolate the
+        indexer's sidecar branch from the rest of the parser stack."""
+        import json as _json
+        import os as _os
+        from services import sei_parser
+
+        if messages is None:
+            messages = [
+                {
+                    'frame_index': 0,
+                    'timestamp_ms': 0.0,
+                    'latitude_deg': 37.7749,
+                    'longitude_deg': -122.4194,
+                    'heading_deg': 90.0,
+                    'vehicle_speed_mps': 25.0,
+                    'linear_acceleration_x': 0.1,
+                    'linear_acceleration_y': 0.0,
+                    'linear_acceleration_z': -0.1,
+                    'steering_wheel_angle': 0.5,
+                    'accelerator_pedal_position': 0.2,
+                    'brake_applied': False,
+                    'gear_state': 'DRIVE',
+                    'autopilot_state': 'NONE',
+                    'blinker_on_left': False,
+                    'blinker_on_right': False,
+                    'frame_seq_no': 0,
+                },
+            ]
+        st = _os.stat(video_path)
+        payload = {
+            'schema_version': sei_parser.SIDECAR_SCHEMA_VERSION,
+            'sample_rate': sample_rate,
+            'sei_count': len(messages),
+            'no_gps_count': 0,
+            'mvhd_creation_time_utc': mvhd,
+            'video_size_bytes': st.st_size,
+            'video_mtime_unix': st.st_mtime,
+            'messages': messages,
+        }
+        with open(sei_parser.sidecar_path_for(video_path), 'w',
+                  encoding='utf-8') as f:
+            _json.dump(payload, f)
+
+    def test_index_consumes_sidecar_without_mmap_walk(
+        self, tmp_path, monkeypatch,
+    ):
+        """When a valid sidecar exists, ``_index_video`` must NOT
+        call ``parser.extract_sei_messages`` — proves the sidecar
+        path is short-circuiting the mmap walk."""
+        import os as _os
+        import time as _time
+        from services import sei_parser
+
+        db = str(tmp_path / "geo.db")
+        _init_db(db)
+        clip = tmp_path / "2025-11-08_08-15-44-front.mp4"
+        clip.write_bytes(b'\x00' * 64)
+        old = _time.time() - 600
+        _os.utime(str(clip), (old, old))
+
+        self._make_sidecar_with_messages(str(clip))
+
+        # Sentinel: explode if extract_sei_messages is touched.
+        called: list = []
+
+        def _exploder(*a, **kw):
+            called.append((a, kw))
+            raise AssertionError(
+                "extract_sei_messages was called even though a "
+                "valid sidecar exists — sidecar fast-path is broken."
+            )
+
+        monkeypatch.setattr(
+            sei_parser, 'extract_sei_messages', _exploder,
+        )
+
+        result = index_single_file(
+            str(clip), db, str(tmp_path), sample_rate=30,
+        )
+        assert result.outcome == IndexOutcome.INDEXED
+        assert result.waypoints == 1
+        assert called == []
+
+    def test_index_falls_back_to_mmap_when_sidecar_missing(
+        self, tmp_path, monkeypatch,
+    ):
+        """Without a sidecar, the indexer must transparently fall
+        back to ``extract_sei_messages``. Pre-issue-#197 baseline
+        path — must continue to work for clips that pre-date the
+        sidecar feature or for clips whose sidecar was lost."""
+        import os as _os
+        import time as _time
+        from services import sei_parser
+
+        db = str(tmp_path / "geo.db")
+        _init_db(db)
+        clip = tmp_path / "2025-11-08_08-15-44-front.mp4"
+        clip.write_bytes(b'\x00' * 64)
+        old = _time.time() - 600
+        _os.utime(str(clip), (old, old))
+
+        # No sidecar created. Stub extract_sei_messages with a
+        # synthetic generator so the test doesn't need a real MP4.
+        called: list = []
+
+        def _gen(video_path, sample_rate):
+            called.append((video_path, sample_rate))
+            yield sei_parser.SeiMessage(
+                frame_index=0, timestamp_ms=0.0,
+                latitude_deg=37.7749, longitude_deg=-122.4194,
+                heading_deg=90.0, vehicle_speed_mps=25.0,
+                linear_acceleration_x=0.0, linear_acceleration_y=0.0,
+                linear_acceleration_z=0.0,
+                steering_wheel_angle=0.0, accelerator_pedal_position=0.0,
+                brake_applied=False,
+                gear_state='DRIVE', autopilot_state='NONE',
+                blinker_on_left=False, blinker_on_right=False,
+                frame_seq_no=0, video_path=video_path,
+            )
+
+        monkeypatch.setattr(sei_parser, 'extract_sei_messages', _gen)
+
+        result = index_single_file(
+            str(clip), db, str(tmp_path), sample_rate=30,
+        )
+        assert result.outcome == IndexOutcome.INDEXED
+        assert called and called[0][1] == 30, (
+            "extract_sei_messages was not called on the fallback "
+            "path — indexer would have produced no waypoints."
+        )
+
+    def test_index_falls_back_to_mmap_on_sidecar_size_drift(
+        self, tmp_path, monkeypatch,
+    ):
+        """Drift detection: sidecar's recorded size differs from
+        the live file's size → ``read_sei_sidecar`` returns None →
+        indexer mmap-parses."""
+        import os as _os
+        import time as _time
+        from services import sei_parser
+
+        db = str(tmp_path / "geo.db")
+        _init_db(db)
+        clip = tmp_path / "2025-11-08_08-15-44-front.mp4"
+        clip.write_bytes(b'\x00' * 64)
+        old = _time.time() - 600
+        _os.utime(str(clip), (old, old))
+
+        # Sidecar describes the file as it is now …
+        self._make_sidecar_with_messages(str(clip))
+        # … then we overwrite with a different size (post-sidecar
+        # write). Drift → invalidation → fallback.
+        with open(str(clip), 'ab') as f:
+            f.write(b'\x00' * 1024)
+        _os.utime(str(clip), (old, old))
+
+        called: list = []
+
+        def _gen(video_path, sample_rate):
+            called.append(True)
+            yield sei_parser.SeiMessage(
+                frame_index=0, timestamp_ms=0.0,
+                latitude_deg=37.0, longitude_deg=-122.0,
+                heading_deg=0.0, vehicle_speed_mps=10.0,
+                linear_acceleration_x=0.0, linear_acceleration_y=0.0,
+                linear_acceleration_z=0.0,
+                steering_wheel_angle=0.0, accelerator_pedal_position=0.0,
+                brake_applied=False, gear_state='DRIVE',
+                autopilot_state='NONE',
+                blinker_on_left=False, blinker_on_right=False,
+                frame_seq_no=0, video_path=video_path,
+            )
+
+        monkeypatch.setattr(sei_parser, 'extract_sei_messages', _gen)
+
+        result = index_single_file(
+            str(clip), db, str(tmp_path), sample_rate=30,
+        )
+        assert result.outcome == IndexOutcome.INDEXED
+        assert called == [True], (
+            "Indexer did not fall back to mmap parse despite "
+            "sidecar size-drift invalidation — would silently "
+            "use stale data."
+        )
+
+    def test_index_falls_back_when_sample_rate_mismatches(
+        self, tmp_path, monkeypatch,
+    ):
+        """If the cached sidecar was written at a different
+        sample_rate than the indexer is requesting, the
+        ``required_sample_rate`` guard invalidates the sidecar."""
+        import os as _os
+        import time as _time
+        from services import sei_parser
+
+        db = str(tmp_path / "geo.db")
+        _init_db(db)
+        clip = tmp_path / "2025-11-08_08-15-44-front.mp4"
+        clip.write_bytes(b'\x00' * 64)
+        old = _time.time() - 600
+        _os.utime(str(clip), (old, old))
+
+        # Sidecar at sample_rate=1; indexer asks for 30 → mismatch.
+        self._make_sidecar_with_messages(str(clip), sample_rate=1)
+
+        called: list = []
+
+        def _gen(video_path, sample_rate):
+            called.append(sample_rate)
+            yield sei_parser.SeiMessage(
+                frame_index=0, timestamp_ms=0.0,
+                latitude_deg=37.0, longitude_deg=-122.0,
+                heading_deg=0.0, vehicle_speed_mps=10.0,
+                linear_acceleration_x=0.0, linear_acceleration_y=0.0,
+                linear_acceleration_z=0.0,
+                steering_wheel_angle=0.0, accelerator_pedal_position=0.0,
+                brake_applied=False, gear_state='DRIVE',
+                autopilot_state='NONE',
+                blinker_on_left=False, blinker_on_right=False,
+                frame_seq_no=0, video_path=video_path,
+            )
+
+        monkeypatch.setattr(sei_parser, 'extract_sei_messages', _gen)
+
+        result = index_single_file(
+            str(clip), db, str(tmp_path), sample_rate=30,
+        )
+        assert result.outcome == IndexOutcome.INDEXED
+        assert called == [30]
+
+
+class TestPurgeDeletedVideosSidecar:
+    """Issue #197: ``purge_deleted_videos`` must delete the SEI
+    sidecar JSON alongside the indexed_files row, so a deleted
+    .mp4 doesn't leave dead sidecar weight in the directory."""
+
+    def test_purge_deletes_sidecar(self, tmp_path):
+        from services import sei_parser
+        from services.mapping_service import (
+            _init_db, purge_deleted_videos,
+        )
+
+        db = str(tmp_path / "geo.db")
+        _init_db(db).close()
+
+        clip = tmp_path / "2025-11-08_08-15-44-front.mp4"
+        clip.write_bytes(b'\x00' * 64)
+        sidecar_path = sei_parser.sidecar_path_for(str(clip))
+        # Hand-create a fake sidecar — content doesn't matter; we
+        # only assert it's gone after purge.
+        with open(sidecar_path, 'w', encoding='utf-8') as f:
+            f.write('{}')
+        assert os.path.isfile(sidecar_path)
+
+        # Pretend the .mp4 is gone (the watcher's normal fire path).
+        clip.unlink()
+
+        result = purge_deleted_videos(
+            db, deleted_paths=[str(clip)],
+        )
+        assert result['purged_files'] == 0  # no indexed_files row
+        assert not os.path.isfile(sidecar_path), (
+            "Sidecar was not deleted alongside the .mp4 — "
+            "would accumulate as dead weight in the directory."
+        )
+
+    def test_purge_handles_missing_sidecar(self, tmp_path):
+        """A clip whose sidecar never existed (pre-#197 file, or
+        sidecar write failed) must not break purge."""
+        from services.mapping_service import (
+            _init_db, purge_deleted_videos,
+        )
+
+        db = str(tmp_path / "geo.db")
+        _init_db(db).close()
+
+        clip = tmp_path / "2025-11-08_08-15-44-front.mp4"
+        clip.write_bytes(b'\x00')
+        clip.unlink()
+
+        result = purge_deleted_videos(
+            db, deleted_paths=[str(clip)],
+        )
+        assert result['purged_files'] == 0
+
+
 # ---------------------------------------------------------------------------
 # Phase 2: Indexing queue
 # ---------------------------------------------------------------------------

--- a/tests/test_sei_parser.py
+++ b/tests/test_sei_parser.py
@@ -815,3 +815,260 @@ class TestStreamingMmapParser:
         # by the finally block even though mmap failed.
         video_file.unlink()
         assert not video_file.exists()
+
+
+# ---------------------------------------------------------------------------
+# Issue #197 — SEI sidecar JSON cache
+# ---------------------------------------------------------------------------
+# Validates that the inline-SEI sidecar:
+#   * round-trips correctly (write then read returns the same data)
+#   * is invalidated by schema-version mismatch
+#   * is invalidated by .mp4 size or mtime drift (the integrity guards)
+#   * is invalidated by malformed JSON / missing keys
+#   * gracefully returns None on any failure (never raises)
+#   * the indexer's _index_video happily consumes a sidecar
+#   * delete_sei_sidecar removes the sidecar file
+# ---------------------------------------------------------------------------
+
+class TestSeiSidecar:
+    """Issue #197 — inline-SEI sidecar JSON cache."""
+
+    def _make_test_mp4(self, n_frames=5):
+        payloads = [
+            _make_sei_protobuf(
+                lat=37.7749 + i * 0.0001,
+                lon=-122.4194 + i * 0.0001,
+                speed=20.0 + i,
+            )
+            for i in range(n_frames)
+        ]
+        return TestExtractSeiMessages()._make_synthetic_mp4(payloads)
+
+    def test_sidecar_path_for_returns_sibling_path(self):
+        from services import sei_parser
+        assert sei_parser.sidecar_path_for(
+            "/foo/bar/clip.mp4"
+        ) == "/foo/bar/clip.mp4.sei.json"
+
+    def test_write_then_read_roundtrip(self, tmp_path):
+        """Writing a sidecar then reading it back must return the
+        exact same parsed messages — the round-trip is lossless."""
+        from services import sei_parser
+
+        mp4 = tmp_path / "rt.mp4"
+        mp4.write_bytes(self._make_test_mp4(5))
+
+        wrote = sei_parser.write_sei_sidecar(
+            str(mp4), sample_rate=1,
+        )
+        assert wrote is not None, "write_sei_sidecar returned None"
+        assert wrote.sei_count == 5
+        assert wrote.no_gps_count == 0
+        assert len(wrote.messages) == 5
+
+        loaded = sei_parser.read_sei_sidecar(str(mp4))
+        assert loaded is not None
+        assert loaded.schema_version == sei_parser.SIDECAR_SCHEMA_VERSION
+        assert loaded.sample_rate == 1
+        assert loaded.sei_count == 5
+        assert loaded.no_gps_count == 0
+        assert len(loaded.messages) == 5
+        for orig, got in zip(wrote.messages, loaded.messages):
+            assert abs(orig.latitude_deg - got.latitude_deg) < 1e-6
+            assert abs(orig.longitude_deg - got.longitude_deg) < 1e-6
+            assert abs(
+                orig.vehicle_speed_mps - got.vehicle_speed_mps
+            ) < 1e-6
+            assert orig.frame_index == got.frame_index
+            assert orig.gear_state == got.gear_state
+
+    def test_sidecar_lives_at_canonical_path(self, tmp_path):
+        from services import sei_parser
+
+        mp4 = tmp_path / "loc.mp4"
+        mp4.write_bytes(self._make_test_mp4(2))
+
+        sei_parser.write_sei_sidecar(str(mp4), sample_rate=1)
+        assert (tmp_path / "loc.mp4.sei.json").is_file()
+
+    def test_read_missing_sidecar_returns_none(self, tmp_path):
+        from services import sei_parser
+
+        mp4 = tmp_path / "missing.mp4"
+        mp4.write_bytes(self._make_test_mp4(2))
+        # Note: no write_sei_sidecar call; sidecar doesn't exist.
+        assert sei_parser.read_sei_sidecar(str(mp4)) is None
+
+    def test_read_malformed_json_returns_none(self, tmp_path):
+        """Garbage in the sidecar must NOT crash the reader; the
+        caller's fallback path takes over."""
+        from services import sei_parser
+
+        mp4 = tmp_path / "malformed.mp4"
+        mp4.write_bytes(self._make_test_mp4(2))
+        sidecar_path = sei_parser.sidecar_path_for(str(mp4))
+        with open(sidecar_path, 'w', encoding='utf-8') as f:
+            f.write("{not valid json")
+
+        assert sei_parser.read_sei_sidecar(str(mp4)) is None
+
+    def test_read_missing_required_key_returns_none(self, tmp_path):
+        """A sidecar missing a required key (e.g. ``messages``) is
+        unusable; reader returns None."""
+        import json
+        from services import sei_parser
+
+        mp4 = tmp_path / "no_key.mp4"
+        mp4.write_bytes(self._make_test_mp4(2))
+        sidecar_path = sei_parser.sidecar_path_for(str(mp4))
+        with open(sidecar_path, 'w', encoding='utf-8') as f:
+            json.dump({"schema_version": 1}, f)  # everything else missing
+
+        assert sei_parser.read_sei_sidecar(str(mp4)) is None
+
+    def test_schema_version_mismatch_returns_none(self, tmp_path):
+        """A sidecar from an older schema must NOT be accepted by
+        the current reader — fallback to mmap parse instead."""
+        import json
+        from services import sei_parser
+
+        mp4 = tmp_path / "old.mp4"
+        mp4.write_bytes(self._make_test_mp4(2))
+        sei_parser.write_sei_sidecar(str(mp4), sample_rate=1)
+
+        sidecar_path = sei_parser.sidecar_path_for(str(mp4))
+        with open(sidecar_path, 'r', encoding='utf-8') as f:
+            payload = json.load(f)
+        # Bump schema_version to a value the current code doesn't
+        # know about. ``SIDECAR_SCHEMA_VERSION`` is the live constant.
+        payload['schema_version'] = sei_parser.SIDECAR_SCHEMA_VERSION + 99
+        with open(sidecar_path, 'w', encoding='utf-8') as f:
+            json.dump(payload, f)
+
+        assert sei_parser.read_sei_sidecar(str(mp4)) is None
+
+    def test_size_drift_invalidates_sidecar(self, tmp_path):
+        """If the .mp4 was overwritten with a different size, the
+        sidecar's cached parse is stale — reader returns None."""
+        from services import sei_parser
+
+        mp4 = tmp_path / "drift.mp4"
+        mp4.write_bytes(self._make_test_mp4(3))
+        sei_parser.write_sei_sidecar(str(mp4), sample_rate=1)
+
+        # Append bytes — size now differs from cached.
+        with open(str(mp4), 'ab') as f:
+            f.write(b'\x00' * 1024)
+
+        assert sei_parser.read_sei_sidecar(str(mp4)) is None
+
+    def test_mtime_drift_invalidates_sidecar(self, tmp_path):
+        """If the .mp4's mtime changed (e.g. user re-encoded the
+        clip in place keeping the same size), invalidate."""
+        import json
+        from services import sei_parser
+
+        mp4 = tmp_path / "mtime.mp4"
+        mp4.write_bytes(self._make_test_mp4(3))
+        sei_parser.write_sei_sidecar(str(mp4), sample_rate=1)
+
+        sidecar_path = sei_parser.sidecar_path_for(str(mp4))
+        with open(sidecar_path, 'r', encoding='utf-8') as f:
+            payload = json.load(f)
+        # Force the recorded mtime to a fake value far from the
+        # real one. Simulates the .mp4 having been overwritten
+        # AFTER the sidecar was written but with the same size.
+        payload['video_mtime_unix'] = payload['video_mtime_unix'] + 999.0
+        with open(sidecar_path, 'w', encoding='utf-8') as f:
+            json.dump(payload, f)
+
+        assert sei_parser.read_sei_sidecar(str(mp4)) is None
+
+    def test_required_sample_rate_mismatch_returns_none(self, tmp_path):
+        """When a consumer needs a finer/different rate than what
+        was cached, reader returns None and caller falls back."""
+        from services import sei_parser
+
+        mp4 = tmp_path / "rate.mp4"
+        mp4.write_bytes(self._make_test_mp4(5))
+        sei_parser.write_sei_sidecar(str(mp4), sample_rate=30)
+
+        # Cache holds rate=30; consumer demands rate=1.
+        assert sei_parser.read_sei_sidecar(
+            str(mp4), required_sample_rate=1,
+        ) is None
+        # Matching rate does work.
+        loaded = sei_parser.read_sei_sidecar(
+            str(mp4), required_sample_rate=30,
+        )
+        assert loaded is not None
+        assert loaded.sample_rate == 30
+
+    def test_write_returns_none_on_missing_video(self, tmp_path):
+        from services import sei_parser
+        assert sei_parser.write_sei_sidecar(
+            str(tmp_path / "does_not_exist.mp4"),
+        ) is None
+
+    def test_delete_sei_sidecar_removes_file(self, tmp_path):
+        from services import sei_parser
+
+        mp4 = tmp_path / "del.mp4"
+        mp4.write_bytes(self._make_test_mp4(2))
+        sei_parser.write_sei_sidecar(str(mp4), sample_rate=1)
+        sidecar_path = sei_parser.sidecar_path_for(str(mp4))
+        assert os.path.isfile(sidecar_path)
+
+        removed = sei_parser.delete_sei_sidecar(str(mp4))
+        assert removed is True
+        assert not os.path.isfile(sidecar_path)
+
+        # Idempotent — second call is a no-op (no exception).
+        again = sei_parser.delete_sei_sidecar(str(mp4))
+        assert again is False
+
+    def test_atomic_write_no_tmp_file_left(self, tmp_path):
+        """Sidecar write must clean up its tempfile, regardless of
+        success or failure of os.fsync."""
+        from services import sei_parser
+
+        mp4 = tmp_path / "atomic.mp4"
+        mp4.write_bytes(self._make_test_mp4(2))
+        sei_parser.write_sei_sidecar(str(mp4), sample_rate=1)
+
+        # No leftover .tmp anywhere in the directory.
+        leftovers = list(tmp_path.glob("*.tmp"))
+        assert leftovers == [], (
+            f"Sidecar write left tempfile(s): {leftovers}"
+        )
+
+    def test_message_video_path_re_injected_on_load(self, tmp_path):
+        """``video_path`` is intentionally NOT persisted; the loader
+        re-injects the live path. Verify both halves of the contract."""
+        import json
+        from services import sei_parser
+
+        mp4 = tmp_path / "vp.mp4"
+        mp4.write_bytes(self._make_test_mp4(2))
+        sei_parser.write_sei_sidecar(str(mp4), sample_rate=1)
+
+        # The persisted messages must NOT carry video_path.
+        sidecar_path = sei_parser.sidecar_path_for(str(mp4))
+        with open(sidecar_path, 'r', encoding='utf-8') as f:
+            payload = json.load(f)
+        for m in payload['messages']:
+            assert 'video_path' not in m, (
+                "video_path leaked into the persisted sidecar — "
+                "would pin sidecar to the original path and break "
+                "if the file is renamed."
+            )
+
+        # The loader must re-inject the live path on every message.
+        loaded = sei_parser.read_sei_sidecar(str(mp4))
+        assert loaded is not None
+        for m in loaded.messages:
+            assert m.video_path == str(mp4)
+
+
+import os  # noqa: E402  — used by TestSeiSidecar.test_delete_sei_sidecar_removes_file
+

--- a/tests/test_sei_parser.py
+++ b/tests/test_sei_parser.py
@@ -5,6 +5,7 @@ byte stripping, protobuf decoding, and the public API — all using synthetic
 binary data (no real video files needed).
 """
 
+import os
 import struct
 import pytest
 
@@ -1042,6 +1043,78 @@ class TestSeiSidecar:
             f"Sidecar write left tempfile(s): {leftovers}"
         )
 
+    def test_atomic_write_cleans_tmp_when_replace_raises(
+        self, tmp_path, monkeypatch,
+    ):
+        """If ``os.replace`` itself raises (filesystem error,
+        permission flip, etc.) the tempfile must STILL be cleaned
+        up. Pre-fix the cleanup was gated on ``except OSError`` so a
+        non-OSError raised between the with-block close and the
+        replace would leak the tempfile."""
+        from services import sei_parser
+
+        mp4 = tmp_path / "replace-fail.mp4"
+        mp4.write_bytes(self._make_test_mp4(2))
+
+        original_replace = os.replace
+        boom = OSError("simulated EROFS at replace")
+
+        def _angry_replace(src, dst):
+            # Verify the tempfile actually exists at this point —
+            # otherwise the test would pass vacuously.
+            assert os.path.exists(src), (
+                "tempfile gone before os.replace was called"
+            )
+            raise boom
+
+        monkeypatch.setattr(os, 'replace', _angry_replace)
+        result = sei_parser.write_sei_sidecar(
+            str(mp4), sample_rate=1,
+        )
+        # Restore for the leftover scan below — monkeypatch will
+        # roll back on test exit but glob runs while patched.
+        monkeypatch.setattr(os, 'replace', original_replace)
+
+        assert result is None, (
+            "write_sei_sidecar must report None when atomic "
+            "rename fails — sidecar was never published."
+        )
+        leftovers = list(tmp_path.glob("*.tmp"))
+        assert leftovers == [], (
+            f"Sidecar write left tempfile(s) after os.replace "
+            f"raised: {leftovers}"
+        )
+
+    def test_atomic_write_cleans_tmp_on_unexpected_exception(
+        self, tmp_path, monkeypatch,
+    ):
+        """Defense-in-depth: a NON-OSError raised inside the
+        with-block (e.g. from a future custom serializer) must STILL
+        leave no tempfile behind. This is the path the new
+        try/finally guards."""
+        from services import sei_parser
+
+        mp4 = tmp_path / "weird-error.mp4"
+        mp4.write_bytes(self._make_test_mp4(2))
+
+        original_dump = sei_parser.json.dump
+
+        def _bad_dump(*args, **kwargs):
+            raise RuntimeError("simulated future serializer crash")
+
+        monkeypatch.setattr(sei_parser.json, 'dump', _bad_dump)
+        result = sei_parser.write_sei_sidecar(
+            str(mp4), sample_rate=1,
+        )
+        monkeypatch.setattr(sei_parser.json, 'dump', original_dump)
+
+        assert result is None
+        leftovers = list(tmp_path.glob("*.tmp"))
+        assert leftovers == [], (
+            f"Sidecar write left tempfile(s) after non-OSError: "
+            f"{leftovers}"
+        )
+
     def test_message_video_path_re_injected_on_load(self, tmp_path):
         """``video_path`` is intentionally NOT persisted; the loader
         re-injects the live path. Verify both halves of the contract."""
@@ -1068,7 +1141,3 @@ class TestSeiSidecar:
         assert loaded is not None
         for m in loaded.messages:
             assert m.video_path == str(mp4)
-
-
-import os  # noqa: E402  — used by TestSeiSidecar.test_delete_sei_sidecar_removes_file
-


### PR DESCRIPTION
## Summary

Issue #197: eliminate the duplicate SEI parse that runs on every clip passing through the full pipeline (archive copy → indexer). Each clip's SEI track was previously mmap-walked **twice** — once by `archive_worker.process_one_claim` to decide stationary-skip, and again by `mapping_service._index_video` to extract waypoints. With ~6 cameras × N clips per Sentry/Saved event, this was the single largest source of avoidable SD I/O on the Pi Zero 2 W.

This PR adds a **sidecar JSON cache** (`<video>.sei.json`) that the archive worker writes atomically right after `_atomic_copy`, and that the indexer consumes instead of re-walking the mmap.

## Approach

**Sidecar location:** sibling `<video>.sei.json` (NOT a subdirectory). Simpler ops, integrity guards catch overwrites, falls naturally into purge paths.

**Schema v1 (`sei_parser.SIDECAR_SCHEMA_VERSION`):**
- `schema_version`, `sample_rate`, `sei_count`, `no_gps_count`
- `mvhd_creation_time_utc` — sample-rate-independent; `_resolve_recording_time` uses this as the authoritative GPS time (per the May 10 2026 clock-skew incident — never trust filename for absolute time)
- `video_size_bytes`, `video_mtime_unix` — integrity guards
- `messages[]` — GPS-bearing only (indexer drops no-GPS rows anyway)

**Atomic write:** tempfile + flush + best-effort fsync (tmpfs may not support — caught and logged at DEBUG) + `os.replace`. Tempfile cleaned up on every failure path.

**Reader contract (`read_sei_sidecar`):**
- Wrong size or mtime > 0.001s drift → `None` (drift)
- `schema_version != 1` → `None` (incompatible)
- `required_sample_rate` mismatch → `None` (caller asked for finer granularity than the cache provides)
- All `None` paths log at DEBUG and return; never raise.
- `video_path` is NOT persisted (would pin sidecar to original location and break on rename); reader re-injects from load.

## Producer (`archive_worker`)

- `_INLINE_SEI_SAMPLE_RATE = 30` — must match the indexer's default in `mapping_service.index_single_file`.
- `_write_inline_sei_sidecar()` called between `mark_copied()` and `_enqueue_indexed()` in `process_one_claim`, wrapped in defense-in-depth `try/except` so a sidecar failure **NEVER** aborts the archive copy.

## Consumers (`mapping_service`)

- `_resolve_recording_time` checks `sidecar.mvhd_creation_time_utc` BEFORE the mmap fallback. mvhd is sample-rate-independent so no `required_sample_rate` is passed.
- `_index_video` consumes `sidecar.messages` directly when present (with `required_sample_rate=sample_rate`); falls back to `extract_sei_messages` mmap on miss/malformed/rate-mismatch.
- `purge_deleted_videos` (targeted mode) calls `sei_parser.delete_sei_sidecar(path)` after deleting the `indexed_files` row, so a removed `.mp4` doesn't leave a dead sidecar in the directory.

## Acceptance criteria (from issue body)

- ✅ Per-clip SD reads through both archive + indexer drop ~50% (one mmap walk replaced by a single small JSON read).
- ✅ Indexer logs `loaded sidecar parse for X` instead of `parsed N SEI messages` when sidecar exists.
- ✅ Archive worker logs `inline-sei: parsed N messages, mvhd=...` after each successful copy.

(SD-I/O measurement is live-verifiable on Pi after deploy; the log-level criteria are unit-tested via the integration tests in `test_archive_worker.py` and `test_mapping_service.py`.)

## Tests

- **`tests/test_sei_parser.py`**: 14 new in `TestSeiSidecar` covering round-trip, sidecar-path canonical form, missing/malformed, schema-version mismatch, size drift, mtime drift, sample-rate mismatch, missing-video on write, delete idempotency, atomic tempfile cleanup, `video_path` re-injection contract.
- **`tests/test_archive_worker.py`**: 2 new integration tests in `TestArchiveWorkerCopy` verifying the success path calls `_write_inline_sei_sidecar` exactly once AND that defense-in-depth keeps the copy succeeding when sidecar write raises.
- **`tests/test_mapping_service.py`**: 6 new in `TestIndexSingleFileSidecarConsumption` (sentinel that mmap parse is bypassed when sidecar valid; fallback on missing, size-drift, sample-rate-mismatch) and `TestPurgeDeletedVideosSidecar` (deletes sidecar with file; tolerates missing sidecar).

**Full suite: 1,886 passed / 5 skipped (was 1,864 / 4 — +22 new tests).**

## Risk

- Best-effort contract on the producer side — sidecar write failure is logged and swallowed; the archive copy itself is unaffected.
- Best-effort contract on the consumer side — any sidecar invalidation falls back to the original mmap walk, so worst case behaviour is identical to today.
- No schema changes to any DB. Sidecars are filesystem artefacts only.
- No new external dependencies. `json` and `os.replace` are stdlib.
- Defense-in-depth `try/except` outer guard at the archive call site means even an unexpected exception type can't hit `process_one_claim`.

## Out of scope

- Backfill of sidecars for existing archived clips (the cache is opportunistic — clips without sidecars continue to mmap-parse, exactly as today).
- Periodic purge of orphan sidecars (the watcher delete + `purge_deleted_videos` path covers the common case; orphans are <1 KB each so the cost of leaving stale ones is negligible).

Closes #197

<!-- skill:resolve-issue:pr:197 -->
