### PR TITLE
chore(#202): drop legacy live_event_queue table (cloud_sync.db v3->v4)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -67,7 +67,7 @@ flowchart TB
 
     subgraph FlaskApp["Flask application (gadget_web)"]
         BLUEPRINTS[Blueprints<br/>HTTP routes]
-        WORKERS[Background workers<br/>archive / indexer / cloud / LES]
+        WORKERS[Background workers<br/>archive / indexer / cloud]
         WATCHER[file_watcher_service<br/>inotify]
         COORDINATOR[task_coordinator<br/>fairness lock]
     end
@@ -169,9 +169,9 @@ The Pi-side services that drive everything:
 | `teslausb-safe-mode.service`         | Detects 3+ reboots in 10 minutes; skips TeslaUSB services if so    |
 
 Notice that **`gadget_web.service` owns every background worker**.
-The archive worker, indexing worker, cloud-archive worker, LES
-worker, file watcher, and chime scheduler ticker are all threads
-inside the Flask process. There is no separate worker daemon.
+The archive worker, indexing worker, cloud-archive worker, file
+watcher, and chime scheduler ticker are all threads inside the
+Flask process. There is no separate worker daemon.
 
 ### The Flask application (`gadget_web`)
 
@@ -237,21 +237,27 @@ detection. Writes `indexed_files`, `waypoints`, `detected_events`
 rows. Updates / merges `trips`. Returns a typed `IndexResult` with
 an `IndexOutcome` enum value.
 
-### 4. Cloud upload (two cooperating workers)
+### 4. Cloud upload (single unified worker)
 
-- **`cloud_archive_service.py`** — bulk catch-up uploader. Drains
-  `cloud_synced_files` (status `pending`). Priority order: events
-  first → geolocated → non-event (opt-in). One rclone subprocess
-  at a time.
-- **`live_event_sync_service.py`** (LES) — opt-in real-time
-  uploader. Triggered by `event.json` arrival. Drains
-  `live_event_queue`. Has its own thread, idle on
-  `threading.Event.wait()`. **Disabled by default.**
+- **`cloud_archive_service.py`** — the only cloud worker. Drains
+  `cloud_synced_files` (status `pending`) and reads from
+  `pipeline_queue` (priority-ordered: live events at
+  `PRIORITY_LIVE_EVENT = 0`, geolocated event clips at
+  `PRIORITY_ARCHIVE_EVENT = 1`, RecentClips at
+  `PRIORITY_ARCHIVE_RECENT = 2`, etc.). One rclone subprocess
+  at a time, `nice -n 19` + `ionice -c 3`.
 
-The two cloud subsystems coordinate via `task_coordinator`. When
-LES has work, `cloud_archive` yields between files. The NM WiFi
-dispatcher (`refresh_cloud_token.py`) wakes LES first, waits up
-to 10 minutes for it to drain, then triggers `cloud_archive`.
+The standalone Live Event Sync subsystem
+(`live_event_sync_service.py`) was deleted in Wave 4 PR-F4 / issue
+#184. Live-event uploads are now first-class rows in
+`pipeline_queue` distinguished by `priority` — the unified worker's
+natural priority ordering means a live event always leapfrogs bulk
+catch-up rows on the next claim. The orphaned `live_event_queue`
+table itself was dropped in cloud_sync.db v4 / issue #202.
+
+The NM WiFi dispatcher (`refresh_cloud_token.py`) refreshes the RO
+mount → waits for the archive timer → waits for the indexing queue
+→ triggers `cloud_archive`.
 
 ---
 
@@ -262,7 +268,7 @@ flowchart LR
     Tesla -->|writes mp4 + event.json| GadgetIMG[usb_cam.img]
     GadgetIMG -->|inotify on RO mount| Watcher
     Watcher -->|new mp4| ArchiveProducer
-    Watcher -->|event.json| LES
+    Watcher -->|event.json| CloudArchive
     ArchiveProducer --> ArchiveQueue[(archive_queue)]
     ArchiveQueue --> ArchiveWorker
     ArchiveWorker -->|copy| ArchivedClips[(~/ArchivedClips)]
@@ -273,13 +279,11 @@ flowchart LR
     ArchivedClips --> CloudArchive
     CloudArchive --> CloudDB[(cloud_synced_files)]
     CloudArchive -->|rclone| CloudProvider[Cloud provider]
-    LES --> LESQueue[(live_event_queue)]
-    LES -->|rclone| CloudProvider
 ```
 
-That diagram is the **video lifecycle** in 14 nodes. Every node has
-its own dedicated subsystem doc. The full narrative — including
-every branch, decision point, retry, and failure mode — is in
+That diagram is the **video lifecycle**. Every node has its own
+dedicated subsystem doc. The full narrative — including every
+branch, decision point, retry, and failure mode — is in
 [`VIDEO_LIFECYCLE.md`](VIDEO_LIFECYCLE.md).
 
 ---
@@ -308,8 +312,8 @@ delete code path.
 
 | File             | Owns                                                                          |
 |------------------|-------------------------------------------------------------------------------|
-| `geodata.db`     | Trips, waypoints, detected events, indexed file records, the indexing queue   |
-| `cloud_sync.db`  | Cloud-upload state, the archive queue, the LES queue, sync sessions           |
+| `geodata.db`     | Trips, waypoints, detected events, indexed file records, the indexing queue, the unified `pipeline_queue` |
+| `cloud_sync.db`  | Cloud-upload state, sync sessions                                              |
 
 Schemas are documented in
 [`contributor/core/DATABASES.md`](contributor/core/DATABASES.md).
@@ -371,7 +375,7 @@ trashes throughput and can starve the watchdog. The
 `task_coordinator` is the single mutex point.
 
 Tasks are named: `'indexer'`, `'archive'`, `'cloud_sync'`,
-`'live_event_sync'`, `'retention'`. Workers call
+`'retention'`. Workers call
 `acquire_task('<name>', wait_seconds=N, yield_to_waiters=True)` to
 get exclusive access. The fairness model lets a tight cyclic
 worker (the indexer) yield to a less-frequent priority task
@@ -445,8 +449,8 @@ behavior, update this doc.
 - `scripts/web/services/file_watcher_service.py` — inotify + polling
 - `scripts/web/services/archive_*.py` — archive subsystem
 - `scripts/web/services/indexing_*.py`, `mapping_*.py` — indexing
-- `scripts/web/services/cloud_archive_service.py` — bulk cloud sync
-- `scripts/web/services/live_event_sync_service.py` — LES
+- `scripts/web/services/cloud_archive_service.py` — bulk cloud sync + live-event uploads (post-PR-F4)
+- `scripts/web/services/pipeline_queue_service.py` — unified queue API (post-Wave-4)
 - `scripts/web/services/task_coordinator.py` — fairness lock
 - `scripts/web/services/partition_*.py`, `mode_service.py` — modes/mounts
 - `scripts/web/helpers/refresh_cloud_token.py` — NM dispatcher entry point

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -170,18 +170,25 @@ typed via the `IndexOutcome` enum.
 events first, then geolocated, then non-event clips (opt-in).
 
 ### Live Event Sync (LES)
-`live_event_sync_service.py`. Opt-in real-time uploader that fires
-on `event.json` arrivals. Has its own queue (`live_event_queue` in
-`cloud_sync.db`), its own worker thread, and a strict 25 MB
-steady-state RSS budget. **Disabled by default.**
+**Removed (Wave 4 PR-F4 / issue #184).** LES used to be a separate
+opt-in subsystem (`live_event_sync_service.py`) with its own queue
+(`live_event_queue` in `cloud_sync.db`), its own worker thread, and
+a 25 MB RSS budget. PR-F4 deleted it; live-event uploads are now
+first-class rows in `pipeline_queue` (geodata.db) at
+`PRIORITY_LIVE_EVENT = 0` (vs. `PRIORITY_CLOUD_BULK = 4`). The
+unified cloud worker's natural priority ordering means a live event
+always leapfrogs bulk catch-up rows on the very next claim — no
+separate worker, no separate queue, no inter-file yield dance. The
+orphaned `live_event_queue` table itself was dropped in
+cloud_sync.db v4 / issue #202.
 
 ### Task coordinator
 `task_coordinator.py`. The single mutual-exclusion point for the
 heavy background workers (`indexer`, `archive`, `cloud_sync`,
-`live_event_sync`, `retention`). Provides fairness so a tight cyclic
-worker (the indexer) cannot starve a less-frequent priority task
-(archive). `WATCHDOG_NEAR_MISS_THRESHOLD_SECONDS = 60.0` seconds —
-any worker holding the lock longer logs a WARNING.
+`retention`). Provides fairness so a tight cyclic worker (the
+indexer) cannot starve a less-frequent priority task (archive).
+`WATCHDOG_NEAR_MISS_THRESHOLD_SECONDS = 60.0` seconds — any worker
+holding the lock longer logs a WARNING.
 
 ---
 
@@ -291,11 +298,11 @@ detection if the file is absent or stale.
 
 ### Failed jobs
 The `/jobs` page surfaces every queue row across `archive_queue`,
-`indexing_queue`, `cloud_synced_files` (with status `failed` or
-`dead_letter`), and `live_event_queue`. Each row is enriched with a
-**clip value** badge ("Event clip" / "Rolling buffer" / "Already on
-SD card" / etc.) and a **recommendation chip** ("Retry" / "Delete" /
-"Either is safe") classified from the error message.
+`indexing_queue`, and `cloud_synced_files` (with status `failed` or
+`dead_letter`). Each row is enriched with a **clip value** badge
+("Event clip" / "Rolling buffer" / "Already on SD card" / etc.) and
+a **recommendation chip** ("Retry" / "Delete" / "Either is safe")
+classified from the error message.
 
 ### System Health
 The `/api/system/health` endpoint and the matching UI card. Reports

--- a/docs/contributor/core/DATABASES.md
+++ b/docs/contributor/core/DATABASES.md
@@ -134,7 +134,13 @@ captures the entire transient queue state.
 | `archive_queue`      | Files queued for copy from RO USB mount → `~/ArchivedClips/`          |
 | `cloud_synced_files` | Per-file cloud-upload state                                           |
 | `cloud_sync_sessions`| Audit log of sync runs                                                |
-| `live_event_queue`   | Per-event LES upload queue (only used when LES is enabled)            |
+
+(The `live_event_queue` table existed for the standalone Live Event
+Sync subsystem before Wave 4 PR-F4 / issue #184. PR-F4 deleted the
+LES code and folded live-event uploads into the unified cloud worker
+as `priority=PRIORITY_LIVE_EVENT` (0) rows in `geodata.db`'s
+`pipeline_queue`. The orphaned table was dropped in cloud_sync.db
+v4 / issue #202.)
 
 ### `archive_queue`
 
@@ -183,28 +189,6 @@ Audit-log table tracking each sync session: when it started, what
 triggered it, how many files moved, total bytes, errors. Used by
 the cloud sync UI to show "last sync" history.
 
-### `live_event_queue`
-
-LES-only. Populated by the file watcher's `event.json` callback
-firing `live_event_sync_service.enqueue_event_json()`.
-
-Approximate columns: `id, event_dir, event_json_path,
-event_timestamp, event_reason, upload_scope, status, enqueued_at,
-uploaded_at, next_retry_at, attempts, last_error,
-previous_last_error, bytes_uploaded`. **Unique on `event_dir`** —
-duplicate enqueues of the same event are no-ops.
-
-`status` enum: `pending`, `uploading`, `uploaded`, `failed`.
-`upload_scope` is one of `event_minute` (default — event.json plus
-the 6 cameras matching the timestamp's `YYYY-MM-DD_HH-MM` prefix)
-or `event_folder` (every `.mp4` in the event dir).
-
-Retry backoff is the constant
-`LIVE_EVENT_RETRY_BACKOFF_SECONDS = [30, 120, 300, 900, 3600]` —
-five attempts, growing from 30 seconds to 1 hour. After the last
-attempt, the row moves to `failed` and stays there until a manual
-retry via `/api/live_events/retry/<id>`.
-
 ---
 
 ## Module split
@@ -218,8 +202,8 @@ The schema and queue API are intentionally split across modules:
 | `services/mapping_service.py`                         | Indexing core (`index_single_file`, `IndexResult`, trip merge, …)     |
 | `services/mapping_queries.py`                         | Read-only query helpers for the map UI (route polylines, RDP, …)     |
 | `services/archive_queue.py`                           | Archive-queue API + status enum                                       |
-| `services/cloud_archive_service.py`                   | Cloud upload state mutations                                          |
-| `services/live_event_sync_service.py`                 | LES queue mutations                                                   |
+| `services/cloud_archive_service.py`                   | Cloud upload state mutations + live-event uploads (post-PR-F4)        |
+| `services/pipeline_queue_service.py`                  | Unified `pipeline_queue` API (post-Wave-4 PR-F4)                      |
 
 Backward compatibility: `mapping_service` re-exports many of the
 schema/migration symbols so existing imports keep working. **New
@@ -323,5 +307,5 @@ acknowledging completion to producers.
 - `scripts/web/services/mapping_queries.py` — read-only query helpers
   for the map UI
 - `scripts/web/services/archive_queue.py` — archive queue + status enum
-- `scripts/web/services/cloud_archive_service.py` — cloud upload state
-- `scripts/web/services/live_event_sync_service.py` — LES queue
+- `scripts/web/services/cloud_archive_service.py` — cloud upload state + live-event uploads (post-PR-F4)
+- `scripts/web/services/pipeline_queue_service.py` — unified `pipeline_queue` API (post-Wave-4)

--- a/scripts/web/services/cloud_archive_service.py
+++ b/scripts/web/services/cloud_archive_service.py
@@ -158,7 +158,7 @@ def canonical_cloud_path(file_path: str) -> str:
 # ---------------------------------------------------------------------------
 
 _CLOUD_MODULE = "cloud_archive"
-_CLOUD_SCHEMA_VERSION = 3
+_CLOUD_SCHEMA_VERSION = 4
 
 _CLOUD_TABLES_SQL = """\
 CREATE TABLE IF NOT EXISTS module_versions (
@@ -523,6 +523,215 @@ def _migrate_canonicalize_paths_v2(
             rewrites, merges,
         )
     return (rewrites, merges)
+
+
+def _migrate_drop_live_event_queue_v4(
+    conn: sqlite3.Connection, db_path: str,
+) -> None:
+    """Drop the orphaned ``live_event_queue`` table from cloud_sync.db.
+
+    Issue #202 — Wave 4 PR-F4 (issue #184 / PR #201) deleted the
+    standalone Live Event Sync subsystem (the service, blueprints,
+    routes, and config block). The ``live_event_queue`` table created
+    by that subsystem was deliberately left behind so any rows still
+    pending at deploy time could survive a rollback. After at least
+    one stable release post-PR-F4, the table is now safe to drop:
+    every install has had time to either (a) drain the table to zero
+    via the cloud worker (which now reads from ``pipeline_queue``
+    priority-0 rows), or (b) leave it untouched at zero rows because
+    LES was never enabled on that install.
+
+    Defensive cross-DB check (the issue body explicitly asks for this):
+    if the table contains any rows, verify each row is mirrored into
+    ``pipeline_queue.legacy_table='live_event_queue'`` in geodata.db.
+    For any unmirrored rows, log a WARNING with the row IDs and
+    backfill them via :func:`pipeline_queue_service.dual_write_enqueue`
+    BEFORE the DROP, so no live-event upload work is lost. This is a
+    safety net — the canonical install verified pre-merge had 0 rows
+    on both sides — but it remains the correct shape because some
+    third-party install may have captured rows between PR-F4 deploy
+    and this PR's deploy.
+
+    Order:
+      1. Existence check (no-op if table already absent).
+      2. Defensive zero-row check + cross-DB mirror reconciliation.
+      3. Drop secondary indexes (``idx_les_status``,
+         ``idx_les_next_retry``).
+      4. Drop the table itself (autoindex from UNIQUE drops with it).
+
+    All work runs in a single transaction (the caller owns the
+    connection and gates the version bump on this function returning
+    cleanly). On any exception the caller calls ``conn.rollback()``
+    and leaves the schema at v3 for retry on next start.
+    """
+    if not _table_exists_local(conn, 'live_event_queue'):
+        return
+
+    row_count = conn.execute(
+        "SELECT COUNT(*) FROM live_event_queue"
+    ).fetchone()[0]
+
+    if row_count > 0:
+        logger.warning(
+            "Cloud archive v4 migration: live_event_queue contains "
+            "%d row(s); reconciling against pipeline_queue before DROP.",
+            row_count,
+        )
+        _reconcile_live_event_queue_into_pipeline(conn, db_path)
+
+    # Drop secondary indexes first. The autoindex from the UNIQUE
+    # constraint drops automatically with the table itself.
+    conn.execute("DROP INDEX IF EXISTS idx_les_status")
+    conn.execute("DROP INDEX IF EXISTS idx_les_next_retry")
+    conn.execute("DROP TABLE IF EXISTS live_event_queue")
+    logger.info(
+        "Cloud archive v4 migration: dropped live_event_queue table "
+        "and indexes from %s",
+        db_path,
+    )
+
+
+def _table_exists_local(conn: sqlite3.Connection, table: str) -> bool:
+    """Return True if ``table`` exists in the connected DB.
+
+    Local copy (cloud_archive_service is not allowed to import from
+    pipeline_queue_service at module load — pipeline_queue_service
+    is a leaf module that lives in the same package). Tiny helper,
+    no need to share.
+    """
+    row = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+        (table,),
+    ).fetchone()
+    return row is not None
+
+
+def _reconcile_live_event_queue_into_pipeline(
+    conn: sqlite3.Connection, db_path: str,
+) -> None:
+    """Cross-DB reconciliation: ensure every ``live_event_queue`` row
+    has a matching ``pipeline_queue`` row before the DROP.
+
+    Reads the LES rows from the connected cloud_sync.db, opens a
+    short-lived geodata.db connection via
+    :func:`pipeline_queue_service.dual_write_enqueue`, and writes any
+    missing mirrors at ``priority=PRIORITY_LIVE_EVENT, stage='cloud_pending'``
+    so the unified cloud worker picks them up on its next claim.
+
+    Status mapping mirrors the deleted ``_backfill_live_event_queue``:
+    legacy ``uploaded`` → unified ``done`` at ``stage='cloud_done'``;
+    legacy ``uploading`` → unified ``in_progress``; legacy ``failed``
+    → unified ``failed``; everything else → ``pending``.
+
+    A failure here re-raises so the caller can rollback and leave
+    the schema at v3 for retry.
+    """
+    rows = conn.execute(
+        "SELECT id, event_dir, event_json_path, event_timestamp, "
+        "event_reason, upload_scope, status FROM live_event_queue"
+    ).fetchall()
+    if not rows:
+        return
+
+    # Lazy import to avoid a load-time dependency cycle and to keep
+    # cloud_archive importable even if pipeline_queue_service is
+    # somehow unavailable (a corrupt install or deferred package
+    # initialisation during early gadget_web boot).
+    from services import pipeline_queue_service as pqs
+
+    pipeline_db = pqs._resolve_pipeline_db()  # noqa: SLF001
+    if not pipeline_db or not os.path.exists(pipeline_db):
+        logger.warning(
+            "Cloud archive v4 migration: pipeline_queue DB not "
+            "available (%s); cannot mirror %d live_event_queue row(s) "
+            "before DROP. The DROP is aborted to preserve the rows.",
+            pipeline_db, len(rows),
+        )
+        raise RuntimeError(
+            "pipeline_queue DB unavailable; cannot mirror "
+            "live_event_queue rows before DROP"
+        )
+
+    # Open a single short-lived geodata.db connection to look up
+    # existing mirrors in one query, instead of one per legacy row.
+    pipeline_conn = sqlite3.connect(pipeline_db, timeout=10.0)
+    try:
+        legacy_ids = tuple(r[0] for r in rows)  # row[0] = id
+        placeholders = ','.join('?' * len(legacy_ids))
+        existing = {
+            r[0] for r in pipeline_conn.execute(
+                f"SELECT legacy_id FROM pipeline_queue "
+                f"WHERE legacy_table='live_event_queue' "
+                f"AND legacy_id IN ({placeholders})",
+                legacy_ids,
+            ).fetchall()
+        }
+    finally:
+        try:
+            pipeline_conn.close()
+        except sqlite3.Error:
+            pass
+
+    unmirrored = [r for r in rows if r[0] not in existing]
+    if not unmirrored:
+        logger.info(
+            "Cloud archive v4 migration: all %d live_event_queue "
+            "row(s) already mirrored into pipeline_queue; safe to DROP.",
+            len(rows),
+        )
+        return
+
+    logger.warning(
+        "Cloud archive v4 migration: %d unmirrored live_event_queue "
+        "row(s) found (ids=%s); backfilling into pipeline_queue at "
+        "PRIORITY_LIVE_EVENT before DROP.",
+        len(unmirrored), [r[0] for r in unmirrored],
+    )
+
+    status_map = {
+        'pending': 'pending',
+        'uploading': 'in_progress',
+        'uploaded': 'done',
+        'failed': 'failed',
+    }
+    for r in unmirrored:
+        legacy_id, event_dir, event_json_path, event_timestamp, \
+            event_reason, upload_scope, legacy_status = r
+        unified_status = status_map.get(legacy_status, 'pending')
+        # Mirror as a cloud_pending/cloud_done row at PRIORITY_LIVE_EVENT
+        # so the unified cloud worker picks it up on its next claim.
+        # The ``stage='cloud_done'`` mapping for already-uploaded rows
+        # ensures we don't re-upload completed work.
+        stage = (
+            pqs.STAGE_CLOUD_DONE if legacy_status == 'uploaded'
+            else pqs.STAGE_CLOUD_PENDING
+        )
+        ok = pqs.dual_write_enqueue(
+            source_path=event_json_path,
+            stage=stage,
+            legacy_table='live_event_queue',
+            legacy_id=legacy_id,
+            priority=pqs.PRIORITY_LIVE_EVENT,
+            payload={
+                'event_dir': event_dir,
+                'event_timestamp': event_timestamp,
+                'event_reason': event_reason,
+                'upload_scope': upload_scope,
+            },
+            status=unified_status,
+            db_path=pipeline_db,
+        )
+        if not ok:
+            # Idempotency note: a False return from dual_write_enqueue
+            # typically means the (source_path, stage, legacy_table)
+            # composite already exists — i.e. there IS a mirror, just
+            # under a different legacy_id. Don't treat as fatal.
+            logger.info(
+                "Cloud archive v4 migration: mirror skipped for "
+                "live_event_queue.id=%d (%r) — likely a pre-existing "
+                "pipeline_queue row with the same source_path.",
+                legacy_id, event_json_path,
+            )
 
 
 def _dual_write_pipeline_cloud_synced(file_path: str,
@@ -1648,6 +1857,28 @@ def _init_cloud_tables(db_path: str) -> sqlite3.Connection:
                 )
             except sqlite3.OperationalError:
                 pass
+
+        # v4 (#202): drop the orphaned ``live_event_queue`` table left
+        # behind when the standalone Live Event Sync subsystem was
+        # deleted in Wave 4 PR-F4 (issue #184). The DROP is gated on
+        # the same ``migration_ok`` flag as v2; if the cross-DB
+        # mirroring sanity check raises, we leave the table in place
+        # and retry on the next service start.
+        if current < 4:
+            try:
+                _migrate_drop_live_event_queue_v4(conn, db_path)
+            except Exception as e:  # noqa: BLE001
+                migration_ok = False
+                try:
+                    conn.rollback()
+                except Exception:  # noqa: BLE001
+                    pass
+                logger.error(
+                    "Cloud archive v4 migration failed (%s); rolled "
+                    "back partial work and leaving schema at v%d. "
+                    "Migration will retry on next service start.",
+                    e, current,
+                )
 
         if migration_ok:
             conn.execute(

--- a/scripts/web/services/cloud_archive_service.py
+++ b/scripts/web/services/cloud_archive_service.py
@@ -603,17 +603,21 @@ def _migrate_drop_live_event_queue_v4(
 def _table_exists_local(conn: sqlite3.Connection, table: str) -> bool:
     """Return True if ``table`` exists in the connected DB.
 
-    Thin wrapper around :func:`pipeline_queue_service._table_exists`
+    Thin wrapper around :func:`pipeline_queue_service.table_exists`
     via lazy import — the lazy-import pattern is already used inside
     :func:`_backfill_missing_live_event_mirrors`, so the no-cycle
     constraint is satisfied. Falls back to an inline ``sqlite_master``
     lookup if the import fails (corrupt install / deferred package
     init during early gadget_web boot — same scenarios as the lazy
     import below).
+
+    Public ``table_exists`` was promoted from ``_table_exists`` per
+    review-pr finding N1; this wrapper now uses the public name and
+    drops the prior ``# noqa: SLF001``.
     """
     try:
         from services import pipeline_queue_service as pqs
-        return pqs._table_exists(conn, table)  # noqa: SLF001
+        return pqs.table_exists(conn, table)
     except Exception:  # noqa: BLE001
         try:
             row = conn.execute(
@@ -694,27 +698,40 @@ def _backfill_missing_live_event_mirrors(
         )
 
     legacy_ids = [r[0] for r in rows]
-    existing_mirrors = _query_existing_mirrors(pipeline_db, legacy_ids)
+    source_paths = [r[2] for r in rows if r[2]]
+    existing_ids, existing_paths = _query_existing_mirrors(
+        pipeline_db, legacy_ids, source_paths,
+    )
+
+    def _is_mirrored(row) -> bool:
+        # A row is mirrored if EITHER its legacy_id is present OR its
+        # event_json_path matches an existing pipeline_queue row's
+        # source_path. The path-based fallback (originally filed as
+        # #207, fixed inline) catches dev-branch installs where a
+        # residual mirror row has NULL legacy_id but the right path.
+        return row[0] in existing_ids or (row[2] and row[2] in existing_paths)
 
     # ------------------------------------------------------------------
     # Stale-mirror UPDATE (finding #5): for rows that ARE mirrored but
     # whose legacy status has advanced past the mirror's stage/status,
     # update the mirror so the worker doesn't re-upload completed work.
+    # Carry just the legacy_id (re-review N3 — the row is unused below).
     # ------------------------------------------------------------------
-    stale_updates = [
-        (r[0], r) for r in rows
-        if r[0] in existing_mirrors and r[6] == 'uploaded'
+    stale_updates: List[int] = [
+        r[0] for r in rows
+        if _is_mirrored(r) and r[6] == 'uploaded'
     ]
+    refreshed = 0
     if stale_updates:
-        _refresh_stale_mirrors_to_done(pipeline_db, stale_updates)
+        refreshed = _refresh_stale_mirrors_to_done(pipeline_db, stale_updates)
 
-    unmirrored = [r for r in rows if r[0] not in existing_mirrors]
+    unmirrored = [r for r in rows if not _is_mirrored(r)]
     if not unmirrored:
         logger.info(
             "Cloud archive v4 migration: all %d live_event_queue "
             "row(s) already mirrored into pipeline_queue (%d stale "
             "mirror(s) refreshed); safe to DROP.",
-            len(rows), len(stale_updates),
+            len(rows), refreshed,
         )
         return
 
@@ -781,17 +798,25 @@ def _backfill_missing_live_event_mirrors(
 
     # --------------------------------------------------------------
     # Post-loop verification (review-pr finding #1): re-query the
-    # pipeline_queue for every unmirrored legacy_id. Anything still
-    # missing means dual_write_enqueue silently returned False on a
-    # sqlite3.Error and the row would be lost on DROP. Raise so the
-    # caller rolls back and the DROP is skipped — the LES table and
-    # its rows remain intact for the next migration attempt.
+    # pipeline_queue for every unmirrored legacy_id AND source_path.
+    # Anything still missing on BOTH keys means dual_write_enqueue
+    # silently returned False on a sqlite3.Error (not a UNIQUE
+    # idempotency match) and the row would be lost on DROP. Raise
+    # so the caller rolls back and the DROP is skipped — the LES
+    # table and its rows remain intact for the next migration
+    # attempt. Using both keys lets the orphan-mirror edge (#207
+    # fix) be recognised as "already mirrored" instead of triggering
+    # an abort loop.
     # --------------------------------------------------------------
-    after_backfill_mirrors = _query_existing_mirrors(
-        pipeline_db, [r[0] for r in unmirrored]
+    after_ids, after_paths = _query_existing_mirrors(
+        pipeline_db,
+        [r[0] for r in unmirrored],
+        [r[2] for r in unmirrored if r[2]],
     )
     still_missing = [
-        r[0] for r in unmirrored if r[0] not in after_backfill_mirrors
+        r[0] for r in unmirrored
+        if r[0] not in after_ids
+        and not (r[2] and r[2] in after_paths)
     ]
     if still_missing:
         logger.error(
@@ -816,34 +841,74 @@ _LIVE_EVENT_BACKFILL_CHUNK = 500
 
 
 def _query_existing_mirrors(
-    pipeline_db: str, legacy_ids: List[int],
-) -> set:
-    """Return the set of ``legacy_id`` values that already have a
-    ``pipeline_queue`` row with ``legacy_table='live_event_queue'``.
+    pipeline_db: str,
+    legacy_ids: List[int],
+    source_paths: Optional[List[str]] = None,
+) -> Tuple[set, set]:
+    """Return ``(existing_legacy_ids, existing_source_paths)`` — the set
+    of ``legacy_id`` values AND the set of ``source_path`` values that
+    already have a ``pipeline_queue`` row with
+    ``legacy_table='live_event_queue'``.
+
+    Looking up by both keys is defensive against an edge case observed
+    on dev-branch installs (originally filed as #207, fixed inline
+    here): a pre-existing mirror row that has the right
+    ``source_path`` but a NULL ``legacy_id`` would otherwise be
+    invisible to the legacy-id ``IN (...)`` lookup, causing the
+    backfill INSERT to hit the
+    ``(source_path, stage, legacy_table)`` UNIQUE constraint, the
+    post-loop verification to keep failing, and the migration to
+    abort-loop on every service start. SQLite NULL never matches
+    ``IN (...)``, so we widen the query to OR-match on
+    ``source_path`` for the same ``legacy_table``. Canonical installs
+    (0 LES rows or all-mirrored-by-id) are unaffected.
 
     Chunks the input into batches of :data:`_LIVE_EVENT_BACKFILL_CHUNK`
     to stay under SQLite's variable-count ceiling on older builds
     (``SQLITE_MAX_VARIABLE_NUMBER`` is 999 on pre-3.32 SQLite).
-    Single short-lived connection across all chunks.
+    Single short-lived connection across all chunks. The two input
+    lists are chunked independently; the result sets are unioned
+    across chunks.
     """
-    if not legacy_ids:
-        return set()
+    if not legacy_ids and not source_paths:
+        return set(), set()
 
     pipeline_conn = sqlite3.connect(pipeline_db, timeout=10.0)
     try:
-        existing: set = set()
-        for start in range(0, len(legacy_ids), _LIVE_EVENT_BACKFILL_CHUNK):
-            chunk = legacy_ids[start:start + _LIVE_EVENT_BACKFILL_CHUNK]
-            placeholders = ','.join('?' * len(chunk))
-            existing.update(
-                row[0] for row in pipeline_conn.execute(
-                    f"SELECT legacy_id FROM pipeline_queue "
+        existing_ids: set = set()
+        existing_paths: set = set()
+
+        if legacy_ids:
+            for start in range(0, len(legacy_ids), _LIVE_EVENT_BACKFILL_CHUNK):
+                chunk = legacy_ids[start:start + _LIVE_EVENT_BACKFILL_CHUNK]
+                placeholders = ','.join('?' * len(chunk))
+                for row in pipeline_conn.execute(
+                    f"SELECT legacy_id, source_path FROM pipeline_queue "
                     f"WHERE legacy_table='live_event_queue' "
                     f"AND legacy_id IN ({placeholders})",
                     chunk,
-                ).fetchall()
-            )
-        return existing
+                ).fetchall():
+                    if row[0] is not None:
+                        existing_ids.add(row[0])
+                    if row[1]:
+                        existing_paths.add(row[1])
+
+        if source_paths:
+            for start in range(0, len(source_paths), _LIVE_EVENT_BACKFILL_CHUNK):
+                chunk = source_paths[start:start + _LIVE_EVENT_BACKFILL_CHUNK]
+                placeholders = ','.join('?' * len(chunk))
+                for row in pipeline_conn.execute(
+                    f"SELECT legacy_id, source_path FROM pipeline_queue "
+                    f"WHERE legacy_table='live_event_queue' "
+                    f"AND source_path IN ({placeholders})",
+                    chunk,
+                ).fetchall():
+                    if row[0] is not None:
+                        existing_ids.add(row[0])
+                    if row[1]:
+                        existing_paths.add(row[1])
+
+        return existing_ids, existing_paths
     finally:
         try:
             pipeline_conn.close()
@@ -853,40 +918,58 @@ def _query_existing_mirrors(
 
 def _refresh_stale_mirrors_to_done(
     pipeline_db: str,
-    stale_updates: List[Tuple[int, sqlite3.Row]],
-) -> None:
+    stale_updates: List[int],
+) -> int:
     """UPDATE existing pipeline_queue mirrors whose legacy status has
     advanced to ``'uploaded'`` but whose mirror is still in
     ``cloud_pending``. Without this, the cloud worker re-uploads
     completed live-event clips after the v4 migration runs.
 
     Single short-lived connection, single transaction. WHERE clause
-    matches on ``(legacy_table, legacy_id)`` to be specific.
+    matches on ``(legacy_table, legacy_id)`` and is gated on
+    ``stage <> 'cloud_done'`` so a re-running migration is a no-op for
+    rows that are already done.
+
+    Also clears ``claimed_by`` and ``claimed_at`` (re-review N4): if a
+    previous cloud-worker run had claimed the row (``status='in_progress'``)
+    and crashed before completing, the mirror would have stale claim
+    metadata that survives the migration. Clearing it matches the
+    pattern used by ``complete_pipeline_row``.
+
+    Returns the number of rows actually updated (re-review N2 — the
+    log line uses this rather than the input length so a partial
+    no-op retry doesn't inflate the count).
     """
     if not stale_updates:
-        return
+        return 0
 
     pipeline_conn = sqlite3.connect(pipeline_db, timeout=10.0)
     try:
-        for legacy_id, _row in stale_updates:
-            pipeline_conn.execute(
+        total_changed = 0
+        for legacy_id in stale_updates:
+            cur = pipeline_conn.execute(
                 """
                 UPDATE pipeline_queue
                 SET stage='cloud_done',
                     status='done',
-                    completed_at=?
+                    completed_at=?,
+                    claimed_by=NULL,
+                    claimed_at=NULL
                 WHERE legacy_table='live_event_queue'
                   AND legacy_id=?
                   AND stage <> 'cloud_done'
                 """,
                 (time.time(), legacy_id),
             )
+            total_changed += cur.rowcount
         pipeline_conn.commit()
         logger.info(
             "Cloud archive v4 migration: refreshed %d stale "
-            "live-event mirror(s) to cloud_done.",
-            len(stale_updates),
+            "live-event mirror(s) to cloud_done (%d candidate(s) "
+            "considered).",
+            total_changed, len(stale_updates),
         )
+        return total_changed
     finally:
         try:
             pipeline_conn.close()

--- a/scripts/web/services/cloud_archive_service.py
+++ b/scripts/web/services/cloud_archive_service.py
@@ -554,15 +554,24 @@ def _migrate_drop_live_event_queue_v4(
 
     Order:
       1. Existence check (no-op if table already absent).
-      2. Defensive zero-row check + cross-DB mirror reconciliation.
+      2. Defensive zero-row check + cross-DB mirror reconciliation
+         (backfill missing mirrors AND re-verify after the loop —
+         see :func:`_backfill_missing_live_event_mirrors` for the
+         post-loop verification that closes the silent-data-loss
+         path through ``dual_write_enqueue``'s ``sqlite3.Error →
+         return False`` branch).
       3. Drop secondary indexes (``idx_les_status``,
          ``idx_les_next_retry``).
       4. Drop the table itself (autoindex from UNIQUE drops with it).
 
-    All work runs in a single transaction (the caller owns the
-    connection and gates the version bump on this function returning
-    cleanly). On any exception the caller calls ``conn.rollback()``
-    and leaves the schema at v3 for retry on next start.
+    The caller (``_init_cloud_tables``) wraps this in a
+    ``try / except → conn.rollback() → migration_ok=False``
+    envelope. On any exception here the version bump is skipped and
+    the migration retries on next service start. Crucially, the call
+    site is gated on ``migration_ok`` being True from prior versions
+    so a v2 failure does not allow v4 work to land in a fresh
+    implicit transaction that downstream commits would persist
+    (review-pr finding #3).
     """
     if not _table_exists_local(conn, 'live_event_queue'):
         return
@@ -577,7 +586,7 @@ def _migrate_drop_live_event_queue_v4(
             "%d row(s); reconciling against pipeline_queue before DROP.",
             row_count,
         )
-        _reconcile_live_event_queue_into_pipeline(conn, db_path)
+        _backfill_missing_live_event_mirrors(conn, db_path)
 
     # Drop secondary indexes first. The autoindex from the UNIQUE
     # constraint drops automatically with the table itself.
@@ -594,19 +603,30 @@ def _migrate_drop_live_event_queue_v4(
 def _table_exists_local(conn: sqlite3.Connection, table: str) -> bool:
     """Return True if ``table`` exists in the connected DB.
 
-    Local copy (cloud_archive_service is not allowed to import from
-    pipeline_queue_service at module load — pipeline_queue_service
-    is a leaf module that lives in the same package). Tiny helper,
-    no need to share.
+    Thin wrapper around :func:`pipeline_queue_service._table_exists`
+    via lazy import — the lazy-import pattern is already used inside
+    :func:`_backfill_missing_live_event_mirrors`, so the no-cycle
+    constraint is satisfied. Falls back to an inline ``sqlite_master``
+    lookup if the import fails (corrupt install / deferred package
+    init during early gadget_web boot — same scenarios as the lazy
+    import below).
     """
-    row = conn.execute(
-        "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
-        (table,),
-    ).fetchone()
-    return row is not None
+    try:
+        from services import pipeline_queue_service as pqs
+        return pqs._table_exists(conn, table)  # noqa: SLF001
+    except Exception:  # noqa: BLE001
+        try:
+            row = conn.execute(
+                "SELECT name FROM sqlite_master "
+                "WHERE type='table' AND name=?",
+                (table,),
+            ).fetchone()
+            return row is not None
+        except sqlite3.Error:
+            return False
 
 
-def _reconcile_live_event_queue_into_pipeline(
+def _backfill_missing_live_event_mirrors(
     conn: sqlite3.Connection, db_path: str,
 ) -> None:
     """Cross-DB reconciliation: ensure every ``live_event_queue`` row
@@ -614,14 +634,35 @@ def _reconcile_live_event_queue_into_pipeline(
 
     Reads the LES rows from the connected cloud_sync.db, opens a
     short-lived geodata.db connection via
-    :func:`pipeline_queue_service.dual_write_enqueue`, and writes any
-    missing mirrors at ``priority=PRIORITY_LIVE_EVENT, stage='cloud_pending'``
-    so the unified cloud worker picks them up on its next claim.
+    :func:`pipeline_queue_service.dual_write_enqueue`, INSERTs any
+    missing mirrors at ``priority=PRIORITY_LIVE_EVENT,
+    stage='cloud_pending'`` (or ``stage='cloud_done', status='done'``
+    when the legacy row was already ``'uploaded'``) so the unified
+    cloud worker picks them up on its next claim. **Does not UPDATE
+    existing mirrors** — see the stale-mirror handling below.
+
+    Stale-mirror handling (review-pr finding #5): if a non-canonical
+    install mirrored a row at LES ``status='pending'`` time and LES
+    later finished the upload, the legacy row will say
+    ``status='uploaded'`` while the mirror still says ``cloud_pending``.
+    For each such row we UPDATE the mirror's stage to ``cloud_done``
+    and status to ``done`` so the worker doesn't re-upload completed
+    work.
 
     Status mapping mirrors the deleted ``_backfill_live_event_queue``:
     legacy ``uploaded`` → unified ``done`` at ``stage='cloud_done'``;
     legacy ``uploading`` → unified ``in_progress``; legacy ``failed``
-    → unified ``failed``; everything else → ``pending``.
+    → unified ``failed``; everything else → ``failed`` (review-pr
+    finding #4 — conservative default; an unknown legacy status
+    must NOT accidentally cause re-upload).
+
+    Post-loop verification (review-pr finding #1): after backfill,
+    re-query ``pipeline_queue`` for the unmirrored set. If any
+    legacy_id is still missing, raise ``RuntimeError`` so the caller
+    rolls back and the DROP doesn't run. This converts
+    ``dual_write_enqueue``'s ``sqlite3.Error → return False`` branch
+    (which only logs a WARNING in pqs) into the documented
+    abort-and-retry path.
 
     A failure here re-raises so the caller can rollback and leave
     the schema at v3 for retry.
@@ -639,7 +680,7 @@ def _reconcile_live_event_queue_into_pipeline(
     # initialisation during early gadget_web boot).
     from services import pipeline_queue_service as pqs
 
-    pipeline_db = pqs._resolve_pipeline_db()  # noqa: SLF001
+    pipeline_db = pqs.resolve_pipeline_db()
     if not pipeline_db or not os.path.exists(pipeline_db):
         logger.warning(
             "Cloud archive v4 migration: pipeline_queue DB not "
@@ -652,32 +693,28 @@ def _reconcile_live_event_queue_into_pipeline(
             "live_event_queue rows before DROP"
         )
 
-    # Open a single short-lived geodata.db connection to look up
-    # existing mirrors in one query, instead of one per legacy row.
-    pipeline_conn = sqlite3.connect(pipeline_db, timeout=10.0)
-    try:
-        legacy_ids = tuple(r[0] for r in rows)  # row[0] = id
-        placeholders = ','.join('?' * len(legacy_ids))
-        existing = {
-            r[0] for r in pipeline_conn.execute(
-                f"SELECT legacy_id FROM pipeline_queue "
-                f"WHERE legacy_table='live_event_queue' "
-                f"AND legacy_id IN ({placeholders})",
-                legacy_ids,
-            ).fetchall()
-        }
-    finally:
-        try:
-            pipeline_conn.close()
-        except sqlite3.Error:
-            pass
+    legacy_ids = [r[0] for r in rows]
+    existing_mirrors = _query_existing_mirrors(pipeline_db, legacy_ids)
 
-    unmirrored = [r for r in rows if r[0] not in existing]
+    # ------------------------------------------------------------------
+    # Stale-mirror UPDATE (finding #5): for rows that ARE mirrored but
+    # whose legacy status has advanced past the mirror's stage/status,
+    # update the mirror so the worker doesn't re-upload completed work.
+    # ------------------------------------------------------------------
+    stale_updates = [
+        (r[0], r) for r in rows
+        if r[0] in existing_mirrors and r[6] == 'uploaded'
+    ]
+    if stale_updates:
+        _refresh_stale_mirrors_to_done(pipeline_db, stale_updates)
+
+    unmirrored = [r for r in rows if r[0] not in existing_mirrors]
     if not unmirrored:
         logger.info(
             "Cloud archive v4 migration: all %d live_event_queue "
-            "row(s) already mirrored into pipeline_queue; safe to DROP.",
-            len(rows),
+            "row(s) already mirrored into pipeline_queue (%d stale "
+            "mirror(s) refreshed); safe to DROP.",
+            len(rows), len(stale_updates),
         )
         return
 
@@ -688,6 +725,9 @@ def _reconcile_live_event_queue_into_pipeline(
         len(unmirrored), [r[0] for r in unmirrored],
     )
 
+    # Default 'failed' is conservative (review-pr finding #4): an
+    # unrecognized legacy status must NOT accidentally cause the
+    # cloud worker to re-upload a row whose true state we don't know.
     status_map = {
         'pending': 'pending',
         'uploading': 'in_progress',
@@ -697,7 +737,7 @@ def _reconcile_live_event_queue_into_pipeline(
     for r in unmirrored:
         legacy_id, event_dir, event_json_path, event_timestamp, \
             event_reason, upload_scope, legacy_status = r
-        unified_status = status_map.get(legacy_status, 'pending')
+        unified_status = status_map.get(legacy_status, 'failed')
         # Mirror as a cloud_pending/cloud_done row at PRIORITY_LIVE_EVENT
         # so the unified cloud worker picks it up on its next claim.
         # The ``stage='cloud_done'`` mapping for already-uploaded rows
@@ -722,16 +762,147 @@ def _reconcile_live_event_queue_into_pipeline(
             db_path=pipeline_db,
         )
         if not ok:
-            # Idempotency note: a False return from dual_write_enqueue
-            # typically means the (source_path, stage, legacy_table)
-            # composite already exists — i.e. there IS a mirror, just
-            # under a different legacy_id. Don't treat as fatal.
+            # ok=False can mean either:
+            #   (a) UNIQUE-conflict idempotency — another writer (or
+            #       a prior partial migration) already inserted a row
+            #       with the same composite. Detected by the post-loop
+            #       verification below — that row IS mirrored.
+            #   (b) sqlite3.Error inside dual_write_enqueue (logged
+            #       there at WARNING). Detected by the post-loop
+            #       verification — that row is STILL not mirrored,
+            #       and we must abort to preserve it.
             logger.info(
-                "Cloud archive v4 migration: mirror skipped for "
-                "live_event_queue.id=%d (%r) — likely a pre-existing "
-                "pipeline_queue row with the same source_path.",
+                "Cloud archive v4 migration: dual_write_enqueue "
+                "returned False for live_event_queue.id=%d (%r); "
+                "post-loop verification will distinguish UNIQUE-"
+                "conflict idempotency from a DB error.",
                 legacy_id, event_json_path,
             )
+
+    # --------------------------------------------------------------
+    # Post-loop verification (review-pr finding #1): re-query the
+    # pipeline_queue for every unmirrored legacy_id. Anything still
+    # missing means dual_write_enqueue silently returned False on a
+    # sqlite3.Error and the row would be lost on DROP. Raise so the
+    # caller rolls back and the DROP is skipped — the LES table and
+    # its rows remain intact for the next migration attempt.
+    # --------------------------------------------------------------
+    after_backfill_mirrors = _query_existing_mirrors(
+        pipeline_db, [r[0] for r in unmirrored]
+    )
+    still_missing = [
+        r[0] for r in unmirrored if r[0] not in after_backfill_mirrors
+    ]
+    if still_missing:
+        logger.error(
+            "Cloud archive v4 migration: backfill failed for %d "
+            "live_event_queue row(s) (ids=%s); aborting DROP to "
+            "preserve the rows. The migration will retry on the "
+            "next service start.",
+            len(still_missing), still_missing,
+        )
+        raise RuntimeError(
+            f"backfill incomplete: {len(still_missing)} "
+            f"live_event_queue row(s) still unmirrored "
+            f"(ids={still_missing}); aborting DROP"
+        )
+
+
+# Chunk size for ``WHERE legacy_id IN (?,?,...)`` queries.
+# SQLite's SQLITE_MAX_VARIABLE_NUMBER is 32766 (3.32+) or 999 (older
+# builds). 500 stays well under both ceilings (review-pr finding #2)
+# while keeping per-query overhead negligible.
+_LIVE_EVENT_BACKFILL_CHUNK = 500
+
+
+def _query_existing_mirrors(
+    pipeline_db: str, legacy_ids: List[int],
+) -> set:
+    """Return the set of ``legacy_id`` values that already have a
+    ``pipeline_queue`` row with ``legacy_table='live_event_queue'``.
+
+    Chunks the input into batches of :data:`_LIVE_EVENT_BACKFILL_CHUNK`
+    to stay under SQLite's variable-count ceiling on older builds
+    (``SQLITE_MAX_VARIABLE_NUMBER`` is 999 on pre-3.32 SQLite).
+    Single short-lived connection across all chunks.
+    """
+    if not legacy_ids:
+        return set()
+
+    pipeline_conn = sqlite3.connect(pipeline_db, timeout=10.0)
+    try:
+        existing: set = set()
+        for start in range(0, len(legacy_ids), _LIVE_EVENT_BACKFILL_CHUNK):
+            chunk = legacy_ids[start:start + _LIVE_EVENT_BACKFILL_CHUNK]
+            placeholders = ','.join('?' * len(chunk))
+            existing.update(
+                row[0] for row in pipeline_conn.execute(
+                    f"SELECT legacy_id FROM pipeline_queue "
+                    f"WHERE legacy_table='live_event_queue' "
+                    f"AND legacy_id IN ({placeholders})",
+                    chunk,
+                ).fetchall()
+            )
+        return existing
+    finally:
+        try:
+            pipeline_conn.close()
+        except sqlite3.Error:
+            pass
+
+
+def _refresh_stale_mirrors_to_done(
+    pipeline_db: str,
+    stale_updates: List[Tuple[int, sqlite3.Row]],
+) -> None:
+    """UPDATE existing pipeline_queue mirrors whose legacy status has
+    advanced to ``'uploaded'`` but whose mirror is still in
+    ``cloud_pending``. Without this, the cloud worker re-uploads
+    completed live-event clips after the v4 migration runs.
+
+    Single short-lived connection, single transaction. WHERE clause
+    matches on ``(legacy_table, legacy_id)`` to be specific.
+    """
+    if not stale_updates:
+        return
+
+    pipeline_conn = sqlite3.connect(pipeline_db, timeout=10.0)
+    try:
+        for legacy_id, _row in stale_updates:
+            pipeline_conn.execute(
+                """
+                UPDATE pipeline_queue
+                SET stage='cloud_done',
+                    status='done',
+                    completed_at=?
+                WHERE legacy_table='live_event_queue'
+                  AND legacy_id=?
+                  AND stage <> 'cloud_done'
+                """,
+                (time.time(), legacy_id),
+            )
+        pipeline_conn.commit()
+        logger.info(
+            "Cloud archive v4 migration: refreshed %d stale "
+            "live-event mirror(s) to cloud_done.",
+            len(stale_updates),
+        )
+    finally:
+        try:
+            pipeline_conn.close()
+        except sqlite3.Error:
+            pass
+
+
+# Backward-compat alias. The function was renamed from
+# ``_reconcile_live_event_queue_into_pipeline`` to
+# ``_backfill_missing_live_event_mirrors`` per review-pr finding #5
+# (the original name implied a full reconcile but the function only
+# inserts missing mirrors; UPDATE-of-stale was added as part of the
+# rename). External callers (tests) reference the old name.
+_reconcile_live_event_queue_into_pipeline = (
+    _backfill_missing_live_event_mirrors
+)
 
 
 def _dual_write_pipeline_cloud_synced(file_path: str,
@@ -1860,11 +2031,13 @@ def _init_cloud_tables(db_path: str) -> sqlite3.Connection:
 
         # v4 (#202): drop the orphaned ``live_event_queue`` table left
         # behind when the standalone Live Event Sync subsystem was
-        # deleted in Wave 4 PR-F4 (issue #184). The DROP is gated on
-        # the same ``migration_ok`` flag as v2; if the cross-DB
-        # mirroring sanity check raises, we leave the table in place
-        # and retry on the next service start.
-        if current < 4:
+        # deleted in Wave 4 PR-F4 (issue #184). Gated on
+        # ``migration_ok`` (review-pr finding #3): if v2 failed and
+        # rolled back, we must NOT do v4 work in a fresh implicit
+        # transaction that downstream commits would persist while the
+        # version bump is correctly skipped. The inner try/except
+        # below is the per-version retry envelope.
+        if current < 4 and migration_ok:
             try:
                 _migrate_drop_live_event_queue_v4(conn, db_path)
             except Exception as e:  # noqa: BLE001

--- a/scripts/web/services/mapping_migrations.py
+++ b/scripts/web/services/mapping_migrations.py
@@ -273,10 +273,13 @@ CREATE TABLE IF NOT EXISTS kv_meta (
 );
 
 -- v16 (issue #184 Wave 4 — Phase I.1): unified ``pipeline_queue``.
--- Replaces (over the course of Wave 4) the four legacy queue tables
--- ``archive_queue``, ``indexing_queue``, ``live_event_queue``,
--- ``cloud_synced_files`` — each of which today has its own worker
--- thread, retry policy, and status enum. Wave 4 ships in sub-PRs:
+-- Replaces (over the course of Wave 4) the legacy queue tables
+-- ``archive_queue``, ``indexing_queue``, and ``cloud_synced_files``
+-- — each of which today has its own worker thread, retry policy,
+-- and status enum. (The fourth legacy table ``live_event_queue``
+-- was deleted in cloud_sync.db v4 / issue #202 after PR-F4 folded
+-- LES into the unified cloud worker as priority-0 rows.) Wave 4
+-- ships in sub-PRs:
 --
 --   I.1 — add this table; legacy producers dual-write to BOTH old +
 --         pipeline_queue. Reads still come from old tables (no

--- a/scripts/web/services/pipeline_queue_service.py
+++ b/scripts/web/services/pipeline_queue_service.py
@@ -1681,7 +1681,16 @@ def _backfill_cloud_synced_files(cloud_db: str, pipeline_db: Optional[str]) -> i
     return inserted
 
 
-def _table_exists(conn: sqlite3.Connection, table: str) -> bool:
+def table_exists(conn: sqlite3.Connection, table: str) -> bool:
+    """Public helper: True iff ``table`` exists in the connected DB.
+
+    Promoted from the private ``_table_exists`` to a public helper so
+    sibling service modules (e.g. cloud_archive_service v4 migration)
+    can call it without ``# noqa: SLF001`` (issue #202 review-pr
+    finding N1, mirroring how ``resolve_pipeline_db`` was promoted
+    for finding #7). The legacy private alias is preserved below for
+    backward compatibility.
+    """
     try:
         row = conn.execute(
             "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
@@ -1690,3 +1699,9 @@ def _table_exists(conn: sqlite3.Connection, table: str) -> bool:
         return row is not None
     except sqlite3.Error:
         return False
+
+
+# Backward-compat private alias. Existing in-tree callers and tests
+# referenced ``_table_exists`` before it was promoted; keep the name
+# working so we don't have to touch every call site at once.
+_table_exists = table_exists

--- a/scripts/web/services/pipeline_queue_service.py
+++ b/scripts/web/services/pipeline_queue_service.py
@@ -152,8 +152,8 @@ _recover_stale_claims_call_count = 0  # incl. zero-result calls
 # Internal helpers
 # ---------------------------------------------------------------------------
 
-def _resolve_pipeline_db() -> Optional[str]:
-    """Return the geodata.db path, or None if config can't be loaded.
+def resolve_pipeline_db() -> Optional[str]:
+    """Public helper: return the geodata.db path, or None if config can't be loaded.
 
     Lazy import of ``config`` so unit tests that don't bootstrap the
     Flask app can still import this module without side effects.
@@ -169,6 +169,12 @@ def _resolve_pipeline_db() -> Optional[str]:
     except Exception as e:  # noqa: BLE001
         logger.debug("pipeline_queue config not loaded: %s", e)
         return None
+
+
+# Backward-compat private alias. Existing in-tree callers and tests
+# referenced ``_resolve_pipeline_db`` before it was promoted; keep the
+# name working so we don't have to touch every call site at once.
+_resolve_pipeline_db = resolve_pipeline_db
 
 
 def _open_pipeline_conn(db_path: str) -> sqlite3.Connection:

--- a/scripts/web/services/pipeline_queue_service.py
+++ b/scripts/web/services/pipeline_queue_service.py
@@ -7,10 +7,10 @@ producer / consumer / backfill API.
 
 **Phase I.1 only adds the dual-write side.** Legacy producers
 (``archive_queue.enqueue_for_archive``, ``indexing_queue_service.
-enqueue_for_indexing``, ``live_event_sync_service.enqueue_event_json``,
-and the cloud-synced-files insertion path) call into this module's
-:func:`dual_write_enqueue` after they write to their own legacy table.
-Reads remain on the legacy tables — no behaviour change yet.
+enqueue_for_indexing``, and the cloud-synced-files insertion path)
+call into this module's :func:`dual_write_enqueue` after they write
+to their own legacy table. Reads remain on the legacy tables — no
+behaviour change yet.
 
 Design rules:
 
@@ -23,13 +23,14 @@ Design rules:
   makes repeated dual-writes harmless. Producers that re-enqueue
   (e.g. inotify firing on the same path twice) write at most one
   pipeline_queue row.
-* **Cross-DB writes are short-lived connections.** The LES dual-write
-  is the only cross-DB case (LES is in ``cloud_sync.db``;
-  ``pipeline_queue`` is in ``geodata.db``). Each dual-write opens a
-  fresh ``geodata.db`` connection, writes one row, and closes. No
-  long-lived second connection is held alongside the legacy DB
-  connection — that would double the connection count and complicate
-  task_coordinator semantics.
+* **Cross-DB writes are short-lived connections.** The
+  ``cloud_synced_files`` dual-write is the only cross-DB case (cloud
+  state is in ``cloud_sync.db``; ``pipeline_queue`` is in
+  ``geodata.db``). Each dual-write opens a fresh ``geodata.db``
+  connection, writes one row, and closes. No long-lived second
+  connection is held alongside the legacy DB connection — that
+  would double the connection count and complicate task_coordinator
+  semantics.
 
 Public API:
 
@@ -88,24 +89,31 @@ logger = logging.getLogger(__name__)
 # Stage values. The unified worker (Phase I.2) selects on
 # ``WHERE stage = ? AND status = 'pending'``; producer hooks set the
 # initial stage when enqueuing.
+#
+# Note: there is no ``STAGE_LIVE_EVENT_*`` family. Issue #184 PR-F4
+# folded LES into the unified cloud worker; live-event uploads are
+# now ``stage='cloud_pending'`` rows distinguished only by
+# ``priority=PRIORITY_LIVE_EVENT`` (0) vs. bulk catch-up at
+# ``priority=PRIORITY_CLOUD_BULK`` (4).
 STAGE_ARCHIVE_PENDING = 'archive_pending'
 STAGE_ARCHIVE_DONE = 'archive_done'
 STAGE_INDEX_PENDING = 'index_pending'
 STAGE_INDEX_DONE = 'index_done'
 STAGE_CLOUD_PENDING = 'cloud_pending'
 STAGE_CLOUD_DONE = 'cloud_done'
-STAGE_LIVE_EVENT_PENDING = 'live_event_pending'
-STAGE_LIVE_EVENT_DONE = 'live_event_done'
 
 # Legacy table names — used by the dual-write hooks to tag which
 # legacy producer created each pipeline_queue row.
+#
+# Note: there is no ``LEGACY_TABLE_LIVE_EVENT``. The
+# ``live_event_queue`` table was dropped in cloud_sync.db v4
+# (issue #202) after Wave 4 PR-F4 deleted the LES subsystem.
 LEGACY_TABLE_ARCHIVE = 'archive_queue'
 LEGACY_TABLE_INDEXING = 'indexing_queue'
-LEGACY_TABLE_LIVE_EVENT = 'live_event_queue'
 LEGACY_TABLE_CLOUD_SYNCED = 'cloud_synced_files'
 
 # Priority mapping — lower is more urgent.
-PRIORITY_LIVE_EVENT = 0          # LES real-time event upload
+PRIORITY_LIVE_EVENT = 0          # live-event upload (Sentry/Saved event.json)
 PRIORITY_ARCHIVE_EVENT = 1       # Sentry / Saved clips
 PRIORITY_ARCHIVE_RECENT = 2      # RecentClips (age-bound)
 PRIORITY_ARCHIVE_OTHER = 3       # ArchivedClips back-fill / other
@@ -1400,7 +1408,7 @@ def backfill_legacy_queues(*,
 
     Two source DBs:
       * ``pipeline_db_path`` (geodata.db): archive_queue + indexing_queue
-      * ``cloud_db_path`` (cloud_sync.db): live_event_queue + cloud_synced_files
+      * ``cloud_db_path`` (cloud_sync.db): cloud_synced_files
 
     Both default to the configured paths via lazy ``config`` import.
     """
@@ -1416,7 +1424,6 @@ def backfill_legacy_queues(*,
     counts = {
         LEGACY_TABLE_ARCHIVE: 0,
         LEGACY_TABLE_INDEXING: 0,
-        LEGACY_TABLE_LIVE_EVENT: 0,
         LEGACY_TABLE_CLOUD_SYNCED: 0,
     }
 
@@ -1435,9 +1442,6 @@ def backfill_legacy_queues(*,
         counts[LEGACY_TABLE_ARCHIVE] = _backfill_archive_queue(pipeline_db_path)
         counts[LEGACY_TABLE_INDEXING] = _backfill_indexing_queue(pipeline_db_path)
     if cloud_db_path and os.path.isfile(cloud_db_path):
-        counts[LEGACY_TABLE_LIVE_EVENT] = _backfill_live_event_queue(
-            cloud_db_path, pipeline_db_path,
-        )
         counts[LEGACY_TABLE_CLOUD_SYNCED] = _backfill_cloud_synced_files(
             cloud_db_path, pipeline_db_path,
         )
@@ -1602,77 +1606,6 @@ def _backfill_indexing_queue(pipeline_db: str) -> int:
                 conn.close()
             except sqlite3.Error:
                 pass
-
-
-def _backfill_live_event_queue(cloud_db: str, pipeline_db: Optional[str]) -> int:
-    """Backfill from ``live_event_queue`` (cloud_sync.db) into
-    ``pipeline_queue`` (geodata.db). CROSS-DB — read from cloud_db,
-    write to pipeline_db one row at a time.
-    """
-    if not pipeline_db or not os.path.isfile(pipeline_db):
-        return 0
-    src_conn = None
-    try:
-        src_conn = sqlite3.connect(cloud_db, timeout=10.0)
-        src_conn.row_factory = sqlite3.Row
-        # Existence check — LES may not have ever been enabled on
-        # this device, in which case the table is absent.
-        if not _table_exists(src_conn, 'live_event_queue'):
-            return 0
-        rows = src_conn.execute(
-            "SELECT id, event_dir, event_json_path, event_timestamp, "
-            "event_reason, upload_scope, status, attempts, last_error, "
-            "next_retry_at, enqueued_at FROM live_event_queue"
-        ).fetchall()
-    except sqlite3.Error as e:
-        logger.warning("backfill live_event_queue read failed: %s", e)
-        return 0
-    finally:
-        if src_conn is not None:
-            try:
-                src_conn.close()
-            except sqlite3.Error:
-                pass
-
-    if not rows:
-        return 0
-
-    inserted = 0
-    for r in rows:
-        stage = (
-            STAGE_LIVE_EVENT_DONE if r['status'] == 'uploaded'
-            else STAGE_LIVE_EVENT_PENDING
-        )
-        # Translate the legacy status to the unified within-stage
-        # status. Without this mapping an already-uploaded LES row
-        # would land as ``stage='live_event_done', status='pending'``,
-        # causing the Phase I.2 worker to either skip it or
-        # re-process completed work.
-        status = {
-            'pending': 'pending',
-            'uploading': 'in_progress',
-            'uploaded': 'done',
-            'failed': 'failed',
-        }.get(r['status'], 'failed')
-        if dual_write_enqueue(
-            source_path=r['event_json_path'],
-            stage=stage,
-            legacy_table=LEGACY_TABLE_LIVE_EVENT,
-            legacy_id=r['id'],
-            priority=PRIORITY_LIVE_EVENT,
-            payload={
-                'event_dir': r['event_dir'],
-                'event_timestamp': r['event_timestamp'],
-                'event_reason': r['event_reason'],
-                'upload_scope': r['upload_scope'],
-            },
-            status=status,
-            db_path=pipeline_db,
-        ):
-            inserted += 1
-        # Even on dup-skip we DON'T mark this as a failure — it just
-        # means the row was already backfilled.
-    return inserted
 
 
 def _backfill_cloud_synced_files(cloud_db: str, pipeline_db: Optional[str]) -> int:

--- a/tests/test_cloud_archive_canonicalization.py
+++ b/tests/test_cloud_archive_canonicalization.py
@@ -740,15 +740,21 @@ class TestRemoveFromQueueCanonical:
 
 
 class TestSchemaVersionBump:
-    def test_schema_version_is_3(self):
-        assert svc._CLOUD_SCHEMA_VERSION == 3
+    def test_schema_version_is_at_least_3(self):
+        # v3 added previous_last_error; v4 (issue #202) drops the
+        # orphaned live_event_queue table. Test verifies the floor —
+        # later versions must still satisfy the canonicalization +
+        # previous_last_error contracts these tests cover.
+        assert svc._CLOUD_SCHEMA_VERSION >= 3
 
     def test_init_cloud_tables_runs_migration_on_v1_db(self, tmp_path):
         # Build a DB at v1 with mixed-form rows, then call
         # _init_cloud_tables and verify the rows are canonical and the
         # version is bumped to the current schema (v3 includes both the
         # v2 path canonicalization and the v3 previous_last_error
-        # column).
+        # column; v4 additionally drops the orphaned live_event_queue
+        # table — but this test's pre-state has no LES table so v4 is
+        # a no-op).
         db = tmp_path / "cloud.db"
         conn = _seed_cloud_db(db, [
             ("/home/pi/ArchivedClips/clip.mp4", "pending", 0),
@@ -772,7 +778,7 @@ class TestSchemaVersionBump:
             ver = new_conn.execute(
                 "SELECT version FROM module_versions WHERE module = 'cloud_archive'"
             ).fetchone()[0]
-            assert ver == 3
+            assert ver == svc._CLOUD_SCHEMA_VERSION
             paths = sorted(
                 r[0] for r in new_conn.execute(
                     "SELECT file_path FROM cloud_synced_files"
@@ -867,7 +873,7 @@ class TestMigrationAtomicity:
             ver = retry_conn.execute(
                 "SELECT version FROM module_versions WHERE module = 'cloud_archive'"
             ).fetchone()[0]
-            assert ver == 3
+            assert ver == svc._CLOUD_SCHEMA_VERSION
             paths = sorted(
                 r[0] for r in retry_conn.execute(
                     "SELECT file_path FROM cloud_synced_files"

--- a/tests/test_cloud_archive_v4_migration.py
+++ b/tests/test_cloud_archive_v4_migration.py
@@ -1,0 +1,461 @@
+"""Tests for issue #202 — cloud_sync.db v3 → v4 migration.
+
+The v4 migration drops the orphaned ``live_event_queue`` table left
+behind when Wave 4 PR-F4 deleted the standalone Live Event Sync
+subsystem (issue #184 / PR #201). The defensive cross-DB sanity
+check + remediation path mirrors any unmirrored LES rows into
+``pipeline_queue`` BEFORE the DROP so no live-event upload work is
+lost.
+
+Test coverage:
+
+  1. Fresh DB without ``live_event_queue`` → no-op, version bumps to 4.
+  2. DB with empty ``live_event_queue`` → DROP succeeds, version bumps
+     to 4, table absent.
+  3. DB with mirrored rows in pipeline_queue → DROP succeeds, no
+     spurious warnings.
+  4. DB with **unmirrored** rows → backfill warning logged with row
+     IDs, then DROP, version bumps to 4.
+  5. Idempotency — re-running on a v4 DB is a no-op.
+  6. Failure during DROP → ``migration_ok = False``, version stays at
+     3, retries on next call.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sqlite3
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+# Allow importing the web modules without spinning up Flask.
+SCRIPTS_WEB = Path(__file__).resolve().parent.parent / 'scripts' / 'web'
+if str(SCRIPTS_WEB) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_WEB))
+
+from services import cloud_archive_service as cas  # noqa: E402
+from services import pipeline_queue_service as pqs  # noqa: E402
+from services.mapping_migrations import _init_db  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+LES_TABLE_DDL = """
+CREATE TABLE live_event_queue (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    event_dir TEXT NOT NULL,
+    event_json_path TEXT NOT NULL,
+    event_timestamp TEXT,
+    event_reason TEXT,
+    upload_scope TEXT DEFAULT 'event_minute',
+    status TEXT DEFAULT 'pending',
+    enqueued_at TEXT NOT NULL,
+    uploaded_at TEXT,
+    next_retry_at REAL,
+    attempts INTEGER DEFAULT 0,
+    last_error TEXT,
+    previous_last_error TEXT,
+    bytes_uploaded INTEGER DEFAULT 0,
+    UNIQUE(event_dir)
+);
+CREATE INDEX idx_les_status ON live_event_queue(status);
+CREATE INDEX idx_les_next_retry ON live_event_queue(next_retry_at);
+"""
+
+
+def _make_v3_cloud_db(db_path: str, *, with_les: bool = True) -> None:
+    """Build a cloud_sync.db at schema v3 — i.e. the state immediately
+    after PR-F4 / PR #201 deployed but before the v4 migration runs.
+    """
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.executescript(
+            """
+            CREATE TABLE module_versions (
+                module TEXT PRIMARY KEY,
+                version INTEGER NOT NULL,
+                updated_at TEXT
+            );
+            CREATE TABLE cloud_synced_files (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                file_path TEXT NOT NULL UNIQUE,
+                file_size INTEGER,
+                file_mtime REAL,
+                remote_path TEXT,
+                status TEXT DEFAULT 'pending',
+                synced_at TEXT,
+                retry_count INTEGER DEFAULT 0,
+                last_error TEXT,
+                previous_last_error TEXT
+            );
+            CREATE TABLE cloud_sync_sessions (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                started_at TEXT NOT NULL,
+                ended_at TEXT,
+                files_synced INTEGER DEFAULT 0,
+                bytes_transferred INTEGER DEFAULT 0,
+                status TEXT DEFAULT 'running',
+                trigger TEXT,
+                window_mode TEXT,
+                error_msg TEXT
+            );
+            INSERT INTO module_versions (module, version, updated_at)
+                VALUES ('cloud_archive', 3, '2026-05-13T09:54:21+00:00');
+            """
+        )
+        if with_les:
+            conn.executescript(LES_TABLE_DDL)
+        conn.commit()
+    finally:
+        conn.close()
+
+
+@pytest.fixture
+def cloud_db_v3_with_les(tmp_path):
+    db = str(tmp_path / 'cloud_sync.db')
+    _make_v3_cloud_db(db, with_les=True)
+    return db
+
+
+@pytest.fixture
+def cloud_db_v3_without_les(tmp_path):
+    db = str(tmp_path / 'cloud_sync.db')
+    _make_v3_cloud_db(db, with_les=False)
+    return db
+
+
+@pytest.fixture
+def geodata_db(tmp_path):
+    """A fresh ``geodata.db`` at the current schema (v17)."""
+    db_path = str(tmp_path / 'geodata.db')
+    conn = _init_db(db_path)
+    conn.close()
+    return db_path
+
+
+@pytest.fixture(autouse=True)
+def isolate_pipeline_db(monkeypatch, geodata_db):
+    """Force ``pipeline_queue_service._resolve_pipeline_db`` to return
+    the test geodata.db so the cross-DB reconciliation path uses the
+    isolated test DB, not whatever the host has configured.
+    """
+    monkeypatch.setattr(pqs, '_resolve_pipeline_db', lambda: geodata_db)
+    return geodata_db
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _table_exists(db_path: str, table: str) -> bool:
+    conn = sqlite3.connect(db_path)
+    try:
+        row = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+            (table,),
+        ).fetchone()
+        return row is not None
+    finally:
+        conn.close()
+
+
+def _index_exists(db_path: str, index: str) -> bool:
+    conn = sqlite3.connect(db_path)
+    try:
+        row = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='index' AND name=?",
+            (index,),
+        ).fetchone()
+        return row is not None
+    finally:
+        conn.close()
+
+
+def _module_version(db_path: str, module: str) -> int:
+    conn = sqlite3.connect(db_path)
+    try:
+        row = conn.execute(
+            "SELECT version FROM module_versions WHERE module=?",
+            (module,),
+        ).fetchone()
+        return row[0] if row else 0
+    finally:
+        conn.close()
+
+
+def _seed_les_rows(db_path: str, rows):
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.executemany(
+            "INSERT INTO live_event_queue "
+            "(event_dir, event_json_path, event_timestamp, "
+            " event_reason, upload_scope, status, enqueued_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            rows,
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _seed_pipeline_mirror(db_path: str, legacy_id: int,
+                          source_path: str,
+                          stage: str = 'cloud_pending') -> None:
+    """Insert a pipeline_queue row that mirrors a live_event_queue row."""
+    pqs.dual_write_enqueue(
+        source_path=source_path,
+        stage=stage,
+        legacy_table='live_event_queue',
+        legacy_id=legacy_id,
+        priority=pqs.PRIORITY_LIVE_EVENT,
+        payload={'mirror': True},
+        status='pending',
+        db_path=db_path,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Direct migration helper tests
+# ---------------------------------------------------------------------------
+
+class TestDropMigrationDirect:
+    """Drive ``_migrate_drop_live_event_queue_v4`` directly so each
+    branch is asserted in isolation."""
+
+    def test_no_op_when_table_absent(self, cloud_db_v3_without_les):
+        conn = sqlite3.connect(cloud_db_v3_without_les)
+        try:
+            cas._migrate_drop_live_event_queue_v4(
+                conn, cloud_db_v3_without_les,
+            )
+            conn.commit()
+        finally:
+            conn.close()
+        # Table never existed; nothing to assert except that the call
+        # didn't raise. cloud_synced_files must still be intact.
+        assert _table_exists(cloud_db_v3_without_les, 'cloud_synced_files')
+        assert not _table_exists(cloud_db_v3_without_les, 'live_event_queue')
+
+    def test_drops_empty_table(self, cloud_db_v3_with_les):
+        assert _table_exists(cloud_db_v3_with_les, 'live_event_queue')
+        assert _index_exists(cloud_db_v3_with_les, 'idx_les_status')
+        assert _index_exists(cloud_db_v3_with_les, 'idx_les_next_retry')
+
+        conn = sqlite3.connect(cloud_db_v3_with_les)
+        try:
+            cas._migrate_drop_live_event_queue_v4(
+                conn, cloud_db_v3_with_les,
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        assert not _table_exists(cloud_db_v3_with_les, 'live_event_queue')
+        assert not _index_exists(cloud_db_v3_with_les, 'idx_les_status')
+        assert not _index_exists(cloud_db_v3_with_les, 'idx_les_next_retry')
+        # cloud_synced_files must still be intact.
+        assert _table_exists(cloud_db_v3_with_les, 'cloud_synced_files')
+
+    def test_drop_succeeds_when_all_rows_already_mirrored(
+        self, cloud_db_v3_with_les, geodata_db, caplog,
+    ):
+        _seed_les_rows(cloud_db_v3_with_les, [
+            ('/Sentry/2026-05-14_10-00-00',
+             '/Sentry/2026-05-14_10-00-00/event.json',
+             '2026-05-14T10:00:00', 'sentry_aware_object_detection',
+             'event_minute', 'pending',
+             '2026-05-14T10:00:00'),
+            ('/Sentry/2026-05-14_11-00-00',
+             '/Sentry/2026-05-14_11-00-00/event.json',
+             '2026-05-14T11:00:00', 'user_interaction_horn',
+             'event_minute', 'uploaded',
+             '2026-05-14T11:00:00'),
+        ])
+        # Seed mirrors for both rows.
+        _seed_pipeline_mirror(geodata_db, 1,
+                              '/Sentry/2026-05-14_10-00-00/event.json')
+        _seed_pipeline_mirror(geodata_db, 2,
+                              '/Sentry/2026-05-14_11-00-00/event.json')
+
+        with caplog.at_level(logging.INFO):
+            conn = sqlite3.connect(cloud_db_v3_with_les)
+            try:
+                cas._migrate_drop_live_event_queue_v4(
+                    conn, cloud_db_v3_with_les,
+                )
+                conn.commit()
+            finally:
+                conn.close()
+
+        assert not _table_exists(cloud_db_v3_with_les, 'live_event_queue')
+        # The "all mirrored" path logs INFO, not WARNING.
+        assert any('already mirrored' in m for m in caplog.messages)
+
+    def test_backfills_unmirrored_rows_then_drops(
+        self, cloud_db_v3_with_les, geodata_db, caplog,
+    ):
+        _seed_les_rows(cloud_db_v3_with_les, [
+            ('/Sentry/2026-05-14_10-00-00',
+             '/Sentry/2026-05-14_10-00-00/event.json',
+             '2026-05-14T10:00:00', 'sentry_aware_object_detection',
+             'event_minute', 'pending',
+             '2026-05-14T10:00:00'),
+            ('/Sentry/2026-05-14_11-00-00',
+             '/Sentry/2026-05-14_11-00-00/event.json',
+             '2026-05-14T11:00:00', 'user_interaction_horn',
+             'event_minute', 'uploaded',
+             '2026-05-14T11:00:00'),
+        ])
+        # Only mirror row 1; row 2 is unmirrored.
+        _seed_pipeline_mirror(geodata_db, 1,
+                              '/Sentry/2026-05-14_10-00-00/event.json')
+
+        with caplog.at_level(logging.WARNING):
+            conn = sqlite3.connect(cloud_db_v3_with_les)
+            try:
+                cas._migrate_drop_live_event_queue_v4(
+                    conn, cloud_db_v3_with_les,
+                )
+                conn.commit()
+            finally:
+                conn.close()
+
+        # Table is gone.
+        assert not _table_exists(cloud_db_v3_with_les, 'live_event_queue')
+        # WARNING was logged listing the unmirrored ID.
+        warn_msgs = [
+            r.getMessage() for r in caplog.records
+            if r.levelno >= logging.WARNING
+        ]
+        assert any('unmirrored' in m for m in warn_msgs), warn_msgs
+        assert any('[2]' in m for m in warn_msgs), warn_msgs
+
+        # Row 2 was backfilled into pipeline_queue at PRIORITY_LIVE_EVENT
+        # with stage='cloud_done' (legacy status='uploaded').
+        gconn = sqlite3.connect(geodata_db)
+        try:
+            gconn.row_factory = sqlite3.Row
+            rows = gconn.execute(
+                "SELECT stage, status, priority, legacy_id "
+                "FROM pipeline_queue "
+                "WHERE legacy_table='live_event_queue' "
+                "ORDER BY legacy_id"
+            ).fetchall()
+        finally:
+            gconn.close()
+        assert len(rows) == 2
+        # Row 2 (uploaded → cloud_done/done at PRIORITY_LIVE_EVENT).
+        assert rows[1]['legacy_id'] == 2
+        assert rows[1]['stage'] == pqs.STAGE_CLOUD_DONE
+        assert rows[1]['status'] == 'done'
+        assert rows[1]['priority'] == pqs.PRIORITY_LIVE_EVENT
+
+    def test_unavailable_pipeline_db_aborts_drop(
+        self, cloud_db_v3_with_les, monkeypatch,
+    ):
+        """If the pipeline DB cannot be located, the DROP must abort
+        so we don't silently lose unmirrored rows."""
+        _seed_les_rows(cloud_db_v3_with_les, [
+            ('/Sentry/2026-05-14_10-00-00',
+             '/Sentry/2026-05-14_10-00-00/event.json',
+             '2026-05-14T10:00:00', 'sentry_aware_object_detection',
+             'event_minute', 'pending',
+             '2026-05-14T10:00:00'),
+        ])
+        # Force pipeline DB to a non-existent path.
+        monkeypatch.setattr(pqs, '_resolve_pipeline_db',
+                            lambda: '/nonexistent/path/geodata.db')
+
+        conn = sqlite3.connect(cloud_db_v3_with_les)
+        try:
+            with pytest.raises(RuntimeError, match='pipeline_queue DB'):
+                cas._migrate_drop_live_event_queue_v4(
+                    conn, cloud_db_v3_with_les,
+                )
+            conn.rollback()
+        finally:
+            conn.close()
+
+        # Table must still exist — DROP did not run.
+        assert _table_exists(cloud_db_v3_with_les, 'live_event_queue')
+
+
+# ---------------------------------------------------------------------------
+# End-to-end migration via _init_cloud_tables
+# ---------------------------------------------------------------------------
+
+class TestInitCloudDbV4:
+    """Drive the full ``_init_cloud_tables`` migration pipeline so the
+    version-bump gating, ``migration_ok`` flag, and idempotency are
+    all asserted together."""
+
+    def test_v3_to_v4_bumps_version_and_drops_table(
+        self, cloud_db_v3_with_les,
+    ):
+        conn = cas._init_cloud_tables(cloud_db_v3_with_les)
+        conn.close()
+
+        assert _module_version(cloud_db_v3_with_les, 'cloud_archive') == 4
+        assert not _table_exists(cloud_db_v3_with_les, 'live_event_queue')
+
+    def test_idempotent_on_v4(self, cloud_db_v3_with_les):
+        # First call lifts to v4.
+        conn = cas._init_cloud_tables(cloud_db_v3_with_les)
+        conn.close()
+        assert _module_version(cloud_db_v3_with_les, 'cloud_archive') == 4
+
+        # Second call must be a no-op (the ``if current < ...`` guard
+        # short-circuits the migration block entirely).
+        conn = cas._init_cloud_tables(cloud_db_v3_with_les)
+        conn.close()
+        assert _module_version(cloud_db_v3_with_les, 'cloud_archive') == 4
+        assert not _table_exists(cloud_db_v3_with_les, 'live_event_queue')
+
+    def test_failure_holds_version_at_3_for_retry(
+        self, cloud_db_v3_with_les, monkeypatch,
+    ):
+        """If the v4 migration helper raises, the version bump must NOT
+        run so the migration retries on the next service start."""
+        def boom(conn, db_path):
+            raise RuntimeError('simulated migration failure')
+        monkeypatch.setattr(
+            cas, '_migrate_drop_live_event_queue_v4', boom,
+        )
+
+        conn = cas._init_cloud_tables(cloud_db_v3_with_les)
+        conn.close()
+
+        # Version must remain at 3; table must still exist (rollback
+        # restored the pre-DROP state).
+        assert _module_version(cloud_db_v3_with_les, 'cloud_archive') == 3
+        assert _table_exists(cloud_db_v3_with_les, 'live_event_queue')
+
+
+# ---------------------------------------------------------------------------
+# Schema constant
+# ---------------------------------------------------------------------------
+
+class TestSchemaVersionConstant:
+    def test_cloud_schema_version_is_v4_or_later(self):
+        assert cas._CLOUD_SCHEMA_VERSION >= 4
+
+    def test_priority_live_event_is_kept(self):
+        # The issue body explicitly requires PRIORITY_LIVE_EVENT to
+        # remain a public constant — the cloud worker still uses it.
+        assert pqs.PRIORITY_LIVE_EVENT == 0
+
+    def test_legacy_table_live_event_is_removed(self):
+        assert not hasattr(pqs, 'LEGACY_TABLE_LIVE_EVENT')
+
+    def test_stage_live_event_constants_are_removed(self):
+        assert not hasattr(pqs, 'STAGE_LIVE_EVENT_PENDING')
+        assert not hasattr(pqs, 'STAGE_LIVE_EVENT_DONE')
+
+    def test_backfill_live_event_helper_is_removed(self):
+        assert not hasattr(pqs, '_backfill_live_event_queue')

--- a/tests/test_cloud_archive_v4_migration.py
+++ b/tests/test_cloud_archive_v4_migration.py
@@ -625,6 +625,175 @@ class TestDropMigrationDirect:
             is cas._backfill_missing_live_event_mirrors
         )
 
+    def test_stale_mirror_refresh_clears_claim_metadata(
+        self, cloud_db_v3_with_les, geodata_db,
+    ):
+        """Re-review N4: when a stale mirror is refreshed to
+        ``cloud_done``, any leftover ``claimed_by`` / ``claimed_at``
+        from a previous in-progress worker claim must be cleared.
+        Stale claim metadata on a ``cloud_done`` row is harmless but
+        confuses ``recover_stale_claims_pipeline`` and operator
+        diagnostics."""
+        _seed_les_rows(cloud_db_v3_with_les, [
+            ('/Sentry/clm', '/Sentry/clm/event.json',
+             '2026-05-14T10:00:00', 'r', 'event_minute',
+             'uploaded', '2026-05-14T10:00:00'),
+        ])
+        _seed_pipeline_mirror(geodata_db, 1,
+                              '/Sentry/clm/event.json',
+                              stage='cloud_pending')
+        # Inject leftover claim metadata to simulate a worker that
+        # claimed the row, started uploading, then crashed.
+        gconn = sqlite3.connect(geodata_db)
+        try:
+            gconn.execute(
+                "UPDATE pipeline_queue "
+                "SET claimed_by='ghost-worker-pid-9999', "
+                "    claimed_at=1234567890.0 "
+                "WHERE legacy_table='live_event_queue' "
+                "AND legacy_id=1"
+            )
+            gconn.commit()
+        finally:
+            gconn.close()
+
+        conn = sqlite3.connect(cloud_db_v3_with_les)
+        try:
+            cas._migrate_drop_live_event_queue_v4(
+                conn, cloud_db_v3_with_les,
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        gconn = sqlite3.connect(geodata_db)
+        try:
+            gconn.row_factory = sqlite3.Row
+            row = gconn.execute(
+                "SELECT stage, status, claimed_by, claimed_at "
+                "FROM pipeline_queue "
+                "WHERE legacy_table='live_event_queue' "
+                "AND legacy_id=1"
+            ).fetchone()
+        finally:
+            gconn.close()
+        assert row is not None
+        assert row['stage'] == pqs.STAGE_CLOUD_DONE
+        assert row['status'] == 'done'
+        assert row['claimed_by'] is None
+        assert row['claimed_at'] is None
+
+    def test_refresh_returns_actual_rowcount(self, geodata_db):
+        """Re-review N2: ``_refresh_stale_mirrors_to_done`` must return
+        the actual ``cur.rowcount`` summed across iterations, not the
+        input length. A row that's already ``cloud_done`` short-
+        circuits via the ``stage <> 'cloud_done'`` WHERE clause and
+        must NOT be counted."""
+        # Two mirrors: one at pending (will be updated), one already
+        # at done (no-op under the WHERE clause).
+        _seed_pipeline_mirror(geodata_db, 1, '/Sentry/a/event.json',
+                              stage='cloud_pending')
+        _seed_pipeline_mirror(geodata_db, 2, '/Sentry/b/event.json',
+                              stage='cloud_done')
+        # Pretend both legacy rows are stale candidates; the helper's
+        # SQL will short-circuit row 2.
+        n = cas._refresh_stale_mirrors_to_done(geodata_db, [1, 2])
+        assert n == 1  # only row 1 was actually updated
+
+    def test_orphan_mirror_with_null_legacy_id_recognised(
+        self, cloud_db_v3_with_les, geodata_db,
+    ):
+        """Re-review N5 (was: issue #207, fixed inline): a residual
+        mirror row from an early dev branch with the right
+        ``source_path`` but ``legacy_id = NULL`` would otherwise be
+        invisible to the legacy-id ``IN (...)`` lookup, hit the
+        UNIQUE constraint on backfill INSERT, fail post-loop
+        verification, and abort-loop on every service start. The
+        fix: ``_query_existing_mirrors`` also looks up by
+        ``source_path`` and a row counts as mirrored if EITHER key
+        matches. Migration completes; DROP runs; orphan row stays
+        intact (caller decides whether to reconcile its NULL id)."""
+        _seed_les_rows(cloud_db_v3_with_les, [
+            ('/Sentry/orphan', '/Sentry/orphan/event.json',
+             '2026-05-14T10:00:00', 'r', 'event_minute',
+             'pending', '2026-05-14T10:00:00'),
+        ])
+        # Insert an orphan mirror directly so we can set legacy_id=NULL.
+        gconn = sqlite3.connect(geodata_db)
+        try:
+            gconn.execute(
+                "INSERT INTO pipeline_queue "
+                "(source_path, stage, status, priority, "
+                " legacy_table, legacy_id, payload_json, "
+                " enqueued_at, attempts) "
+                "VALUES (?, ?, 'pending', ?, "
+                " 'live_event_queue', NULL, '{}', ?, 0)",
+                ('/Sentry/orphan/event.json', pqs.STAGE_CLOUD_PENDING,
+                 pqs.PRIORITY_LIVE_EVENT, 1234567890.0),
+            )
+            gconn.commit()
+        finally:
+            gconn.close()
+
+        conn = sqlite3.connect(cloud_db_v3_with_les)
+        try:
+            cas._migrate_drop_live_event_queue_v4(
+                conn, cloud_db_v3_with_les,
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        # Migration completed — table dropped.
+        assert not _table_exists(cloud_db_v3_with_les, 'live_event_queue')
+        # Orphan row preserved (no INSERT collision, no overwrite).
+        gconn = sqlite3.connect(geodata_db)
+        try:
+            cnt = gconn.execute(
+                "SELECT COUNT(*) FROM pipeline_queue "
+                "WHERE source_path='/Sentry/orphan/event.json' "
+                "AND legacy_table='live_event_queue'"
+            ).fetchone()[0]
+        finally:
+            gconn.close()
+        assert cnt == 1  # exactly one row, no duplicate
+
+    def test_query_existing_mirrors_returns_both_sets(
+        self, geodata_db,
+    ):
+        """N5 lower-level: ``_query_existing_mirrors`` returns a
+        ``(legacy_ids, source_paths)`` tuple. Verify both sets are
+        populated independently when the mirrors have different keys
+        (one has legacy_id, one has NULL legacy_id)."""
+        _seed_pipeline_mirror(geodata_db, 42, '/Sentry/with_id.json')
+        gconn = sqlite3.connect(geodata_db)
+        try:
+            gconn.execute(
+                "INSERT INTO pipeline_queue "
+                "(source_path, stage, status, priority, "
+                " legacy_table, legacy_id, payload_json, "
+                " enqueued_at, attempts) "
+                "VALUES (?, 'cloud_pending', 'pending', ?, "
+                " 'live_event_queue', NULL, '{}', ?, 0)",
+                ('/Sentry/no_id.json', pqs.PRIORITY_LIVE_EVENT,
+                 1234567890.0),
+            )
+            gconn.commit()
+        finally:
+            gconn.close()
+
+        ids, paths = cas._query_existing_mirrors(
+            geodata_db,
+            [42, 99],  # 99 doesn't exist
+            ['/Sentry/with_id.json', '/Sentry/no_id.json',
+             '/Sentry/missing.json'],
+        )
+        assert 42 in ids
+        assert 99 not in ids
+        assert '/Sentry/with_id.json' in paths
+        assert '/Sentry/no_id.json' in paths
+        assert '/Sentry/missing.json' not in paths
+
 
 # ---------------------------------------------------------------------------
 # End-to-end migration via _init_cloud_tables

--- a/tests/test_cloud_archive_v4_migration.py
+++ b/tests/test_cloud_archive_v4_migration.py
@@ -141,10 +141,14 @@ def geodata_db(tmp_path):
 
 @pytest.fixture(autouse=True)
 def isolate_pipeline_db(monkeypatch, geodata_db):
-    """Force ``pipeline_queue_service._resolve_pipeline_db`` to return
+    """Force ``pipeline_queue_service.resolve_pipeline_db`` to return
     the test geodata.db so the cross-DB reconciliation path uses the
-    isolated test DB, not whatever the host has configured.
+    isolated test DB, not whatever the host has configured. Patches
+    both the public ``resolve_pipeline_db`` and the legacy private
+    ``_resolve_pipeline_db`` alias so any caller (current or legacy)
+    is rerouted.
     """
+    monkeypatch.setattr(pqs, 'resolve_pipeline_db', lambda: geodata_db)
     monkeypatch.setattr(pqs, '_resolve_pipeline_db', lambda: geodata_db)
     return geodata_db
 
@@ -368,7 +372,10 @@ class TestDropMigrationDirect:
              'event_minute', 'pending',
              '2026-05-14T10:00:00'),
         ])
-        # Force pipeline DB to a non-existent path.
+        # Force pipeline DB to a non-existent path. Patches both names
+        # to defeat the autouse fixture (which patches them too).
+        monkeypatch.setattr(pqs, 'resolve_pipeline_db',
+                            lambda: '/nonexistent/path/geodata.db')
         monkeypatch.setattr(pqs, '_resolve_pipeline_db',
                             lambda: '/nonexistent/path/geodata.db')
 
@@ -384,6 +391,239 @@ class TestDropMigrationDirect:
 
         # Table must still exist — DROP did not run.
         assert _table_exists(cloud_db_v3_with_les, 'live_event_queue')
+
+    def test_backfill_maps_all_four_legacy_statuses(
+        self, cloud_db_v3_with_les, geodata_db,
+    ):
+        """Review-pr finding #8: exercise every entry in ``status_map``
+        (`pending` → `pending`, `uploading` → `in_progress`,
+        `uploaded` → `done`, `failed` → `failed`). Without coverage,
+        a future refactor could silently change the mapping for the
+        non-canonical statuses (`uploading` and `failed` were missed
+        in the initial PR)."""
+        _seed_les_rows(cloud_db_v3_with_les, [
+            ('/Sentry/event_a', '/Sentry/event_a/event.json',
+             '2026-05-14T10:00:00', 'reason_a', 'event_minute',
+             'pending', '2026-05-14T10:00:00'),
+            ('/Sentry/event_b', '/Sentry/event_b/event.json',
+             '2026-05-14T11:00:00', 'reason_b', 'event_minute',
+             'uploading', '2026-05-14T11:00:00'),
+            ('/Sentry/event_c', '/Sentry/event_c/event.json',
+             '2026-05-14T12:00:00', 'reason_c', 'event_minute',
+             'uploaded', '2026-05-14T12:00:00'),
+            ('/Sentry/event_d', '/Sentry/event_d/event.json',
+             '2026-05-14T13:00:00', 'reason_d', 'event_minute',
+             'failed', '2026-05-14T13:00:00'),
+        ])
+
+        conn = sqlite3.connect(cloud_db_v3_with_les)
+        try:
+            cas._migrate_drop_live_event_queue_v4(
+                conn, cloud_db_v3_with_les,
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        gconn = sqlite3.connect(geodata_db)
+        try:
+            gconn.row_factory = sqlite3.Row
+            rows = {
+                r['legacy_id']: r for r in gconn.execute(
+                    "SELECT legacy_id, stage, status "
+                    "FROM pipeline_queue "
+                    "WHERE legacy_table='live_event_queue'"
+                ).fetchall()
+            }
+        finally:
+            gconn.close()
+
+        assert len(rows) == 4
+        assert rows[1]['stage'] == pqs.STAGE_CLOUD_PENDING
+        assert rows[1]['status'] == 'pending'
+        assert rows[2]['stage'] == pqs.STAGE_CLOUD_PENDING
+        assert rows[2]['status'] == 'in_progress'
+        assert rows[3]['stage'] == pqs.STAGE_CLOUD_DONE
+        assert rows[3]['status'] == 'done'
+        assert rows[4]['stage'] == pqs.STAGE_CLOUD_PENDING
+        assert rows[4]['status'] == 'failed'
+
+    def test_unknown_legacy_status_defaults_to_failed(
+        self, cloud_db_v3_with_les, geodata_db,
+    ):
+        """Review-pr finding #4: an unrecognized legacy status MUST
+        default to ``'failed'`` (conservative). The deleted
+        ``_backfill_live_event_queue`` had this same behavior — a
+        ``'pending'`` default could let the unified worker re-upload a
+        row whose true state we don't know."""
+        _seed_les_rows(cloud_db_v3_with_les, [
+            ('/Sentry/weird', '/Sentry/weird/event.json',
+             '2026-05-14T10:00:00', 'r', 'event_minute',
+             'unrecognized_status', '2026-05-14T10:00:00'),
+        ])
+
+        conn = sqlite3.connect(cloud_db_v3_with_les)
+        try:
+            cas._migrate_drop_live_event_queue_v4(
+                conn, cloud_db_v3_with_les,
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        gconn = sqlite3.connect(geodata_db)
+        try:
+            gconn.row_factory = sqlite3.Row
+            row = gconn.execute(
+                "SELECT status FROM pipeline_queue "
+                "WHERE legacy_table='live_event_queue'"
+            ).fetchone()
+        finally:
+            gconn.close()
+
+        assert row is not None
+        assert row['status'] == 'failed'
+
+    def test_dual_write_failure_aborts_drop(
+        self, cloud_db_v3_with_les, geodata_db, monkeypatch, caplog,
+    ):
+        """Review-pr finding #9: if ``dual_write_enqueue`` returns
+        ``False`` (which can mean either UNIQUE-conflict idempotency
+        OR a swallowed ``sqlite3.Error``), the post-loop verification
+        must distinguish them. A genuine DB-error case leaves the row
+        unmirrored, so the migration must abort and preserve the
+        live_event_queue rows for retry."""
+        _seed_les_rows(cloud_db_v3_with_les, [
+            ('/Sentry/never_mirrored', '/Sentry/never_mirrored/event.json',
+             '2026-05-14T10:00:00', 'r', 'event_minute',
+             'pending', '2026-05-14T10:00:00'),
+        ])
+
+        # Patch dual_write_enqueue to return False without writing —
+        # simulating the sqlite3.Error → return False branch in pqs.
+        monkeypatch.setattr(
+            pqs, 'dual_write_enqueue', lambda **kwargs: False,
+        )
+
+        conn = sqlite3.connect(cloud_db_v3_with_les)
+        try:
+            with caplog.at_level(logging.ERROR):
+                with pytest.raises(RuntimeError, match='backfill incomplete'):
+                    cas._migrate_drop_live_event_queue_v4(
+                        conn, cloud_db_v3_with_les,
+                    )
+            conn.rollback()
+        finally:
+            conn.close()
+
+        # DROP did NOT run — the row is preserved for the next attempt.
+        assert _table_exists(cloud_db_v3_with_les, 'live_event_queue')
+        # ERROR log was emitted listing the abandoned IDs.
+        err_msgs = [
+            r.getMessage() for r in caplog.records
+            if r.levelno >= logging.ERROR
+        ]
+        assert any('backfill failed' in m for m in err_msgs), err_msgs
+
+    def test_stale_mirror_at_pending_is_refreshed_to_done(
+        self, cloud_db_v3_with_les, geodata_db,
+    ):
+        """Review-pr finding #5: if a non-canonical install mirrored a
+        row at LES ``status='pending'`` time and LES later finished
+        the upload (legacy ``status='uploaded'``), the mirror is stale.
+        The migration must UPDATE the mirror to ``cloud_done`` so the
+        worker doesn't re-upload completed work."""
+        _seed_les_rows(cloud_db_v3_with_les, [
+            ('/Sentry/stale', '/Sentry/stale/event.json',
+             '2026-05-14T10:00:00', 'r', 'event_minute',
+             'uploaded',  # legacy says: done
+             '2026-05-14T10:00:00'),
+        ])
+        # Mirror exists but at the OLDER stage='cloud_pending' — i.e.
+        # the worker would re-upload this row on its next claim.
+        _seed_pipeline_mirror(geodata_db, 1,
+                              '/Sentry/stale/event.json',
+                              stage='cloud_pending')
+
+        conn = sqlite3.connect(cloud_db_v3_with_les)
+        try:
+            cas._migrate_drop_live_event_queue_v4(
+                conn, cloud_db_v3_with_les,
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        # Table dropped (no unmirrored rows).
+        assert not _table_exists(cloud_db_v3_with_les, 'live_event_queue')
+
+        # Mirror was UPDATED to cloud_done/done.
+        gconn = sqlite3.connect(geodata_db)
+        try:
+            gconn.row_factory = sqlite3.Row
+            row = gconn.execute(
+                "SELECT stage, status FROM pipeline_queue "
+                "WHERE legacy_table='live_event_queue' "
+                "AND legacy_id=1"
+            ).fetchone()
+        finally:
+            gconn.close()
+        assert row is not None
+        assert row['stage'] == pqs.STAGE_CLOUD_DONE
+        assert row['status'] == 'done'
+
+    def test_chunked_existence_query_handles_large_input(
+        self, cloud_db_v3_with_les, geodata_db,
+    ):
+        """Review-pr finding #2: ``WHERE legacy_id IN (?,?,...)`` is
+        chunked at ``_LIVE_EVENT_BACKFILL_CHUNK`` to stay under
+        SQLite's variable-count ceiling (999 on pre-3.32 builds).
+        Seed ~1.5x the chunk size to exercise multi-chunk traversal
+        in :func:`_query_existing_mirrors`."""
+        chunk_sz = cas._LIVE_EVENT_BACKFILL_CHUNK
+        n = chunk_sz + chunk_sz // 2  # 750 by default
+
+        rows = [
+            (f'/dir/{i}', f'/dir/{i}/event.json',
+             '2026-05-14T10:00:00', 'r', 'event_minute',
+             'pending', '2026-05-14T10:00:00')
+            for i in range(n)
+        ]
+        _seed_les_rows(cloud_db_v3_with_les, rows)
+
+        conn = sqlite3.connect(cloud_db_v3_with_les)
+        try:
+            cas._migrate_drop_live_event_queue_v4(
+                conn, cloud_db_v3_with_les,
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        # All rows backfilled.
+        gconn = sqlite3.connect(geodata_db)
+        try:
+            cnt = gconn.execute(
+                "SELECT COUNT(*) FROM pipeline_queue "
+                "WHERE legacy_table='live_event_queue'"
+            ).fetchone()[0]
+        finally:
+            gconn.close()
+        assert cnt == n
+        assert not _table_exists(cloud_db_v3_with_les, 'live_event_queue')
+
+    def test_legacy_function_alias_still_works(
+        self, cloud_db_v3_with_les, geodata_db,
+    ):
+        """Review-pr finding #5 (continued): the function was renamed
+        from ``_reconcile_live_event_queue_into_pipeline`` to
+        ``_backfill_missing_live_event_mirrors``. The old name is
+        kept as a backward-compat alias so any external test or
+        helper that imported the old symbol keeps working."""
+        assert (
+            cas._reconcile_live_event_queue_into_pipeline
+            is cas._backfill_missing_live_event_mirrors
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -444,11 +684,6 @@ class TestInitCloudDbV4:
 class TestSchemaVersionConstant:
     def test_cloud_schema_version_is_v4_or_later(self):
         assert cas._CLOUD_SCHEMA_VERSION >= 4
-
-    def test_priority_live_event_is_kept(self):
-        # The issue body explicitly requires PRIORITY_LIVE_EVENT to
-        # remain a public constant — the cloud worker still uses it.
-        assert pqs.PRIORITY_LIVE_EVENT == 0
 
     def test_legacy_table_live_event_is_removed(self):
         assert not hasattr(pqs, 'LEGACY_TABLE_LIVE_EVENT')

--- a/tests/test_pipeline_queue_dualwrite.py
+++ b/tests/test_pipeline_queue_dualwrite.py
@@ -154,6 +154,30 @@ class TestSchema:
         finally:
             conn.close()
 
+    def test_priority_live_event_constant_kept(self):
+        """Issue #202: ``PRIORITY_LIVE_EVENT`` MUST remain a public
+        constant. The standalone Live Event Sync subsystem was deleted
+        in Wave 4 PR-F4 (#184) but the cloud worker still uses
+        ``PRIORITY_LIVE_EVENT = 0`` as the priority of live-event
+        rows in the unified ``pipeline_queue``. Without this constant
+        live events would lose their fast-path over bulk catch-up
+        rows. Moved here from ``test_cloud_archive_v4_migration.py``
+        per review-pr finding #10 (the constant is owned by this
+        module, so its assertion belongs here)."""
+        assert pqs.PRIORITY_LIVE_EVENT == 0
+
+    def test_resolve_pipeline_db_is_public(self):
+        """Issue #202 / review-pr finding #7: ``resolve_pipeline_db``
+        was promoted from a private helper to a public function so
+        sibling service modules (cloud_archive_service v4 migration)
+        can call it without ``# noqa: SLF001``. The legacy private
+        alias ``_resolve_pipeline_db`` is preserved for backward
+        compatibility."""
+        assert hasattr(pqs, 'resolve_pipeline_db')
+        assert callable(pqs.resolve_pipeline_db)
+        # Backward-compat alias still works.
+        assert pqs._resolve_pipeline_db is pqs.resolve_pipeline_db
+
 
 # ---------------------------------------------------------------------------
 # Dual-write helpers (direct calls)

--- a/tests/test_pipeline_queue_dualwrite.py
+++ b/tests/test_pipeline_queue_dualwrite.py
@@ -178,6 +178,26 @@ class TestSchema:
         # Backward-compat alias still works.
         assert pqs._resolve_pipeline_db is pqs.resolve_pipeline_db
 
+    def test_table_exists_is_public(self, geodata_db):
+        """Issue #202 / re-review N1: ``table_exists`` was promoted
+        from a private helper (``_table_exists``) to a public
+        function so sibling service modules (cloud_archive_service
+        v4 migration) can call it without ``# noqa: SLF001``,
+        mirroring the ``resolve_pipeline_db`` promotion in
+        finding #7. The legacy private alias is preserved for
+        backward compatibility."""
+        assert hasattr(pqs, 'table_exists')
+        assert callable(pqs.table_exists)
+        # Backward-compat alias still works.
+        assert pqs._table_exists is pqs.table_exists
+        # Functional check.
+        conn = sqlite3.connect(geodata_db)
+        try:
+            assert pqs.table_exists(conn, 'pipeline_queue') is True
+            assert pqs.table_exists(conn, 'no_such_table') is False
+        finally:
+            conn.close()
+
 
 # ---------------------------------------------------------------------------
 # Dual-write helpers (direct calls)

--- a/tests/test_pipeline_queue_dualwrite.py
+++ b/tests/test_pipeline_queue_dualwrite.py
@@ -4,8 +4,8 @@ Phase I.1 is the additive half of the queue unification:
 
   * The new ``pipeline_queue`` table exists in ``geodata.db`` (schema v16).
   * Every legacy enqueue (archive_queue, indexing_queue,
-    live_event_queue, cloud_synced_files) ALSO writes a row to
-    ``pipeline_queue`` tagged with ``legacy_table`` + ``legacy_id``.
+    cloud_synced_files) ALSO writes a row to ``pipeline_queue``
+    tagged with ``legacy_table`` + ``legacy_id``.
   * Reads still come from the legacy tables — no behaviour change.
   * A one-time backfill helper picks up rows that existed BEFORE
     dual-write was wired in (the upgrade backlog).
@@ -61,28 +61,16 @@ def geodata_db(tmp_path):
 
 @pytest.fixture
 def cloud_sync_db(tmp_path):
-    """A fresh ``cloud_sync.db`` with the LES + cloud_synced_files schemas."""
+    """A fresh ``cloud_sync.db`` with the cloud_synced_files schema.
+
+    Note: the ``live_event_queue`` table was dropped in cloud_sync.db
+    v4 (issue #202) after Wave 4 PR-F4 deleted the LES subsystem, so
+    this fixture no longer creates it.
+    """
     db_path = str(tmp_path / 'cloud_sync.db')
     conn = sqlite3.connect(db_path)
     conn.executescript(
         """
-        CREATE TABLE live_event_queue (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            event_dir TEXT NOT NULL,
-            event_json_path TEXT NOT NULL,
-            event_timestamp TEXT,
-            event_reason TEXT,
-            upload_scope TEXT DEFAULT 'event_minute',
-            status TEXT DEFAULT 'pending',
-            enqueued_at TEXT NOT NULL,
-            uploaded_at TEXT,
-            next_retry_at REAL,
-            attempts INTEGER DEFAULT 0,
-            last_error TEXT,
-            previous_last_error TEXT,
-            bytes_uploaded INTEGER DEFAULT 0,
-            UNIQUE(event_dir)
-        );
         CREATE TABLE cloud_synced_files (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             file_path TEXT NOT NULL UNIQUE,
@@ -350,66 +338,6 @@ class TestBackfill:
         )
         assert counts[pqs.LEGACY_TABLE_INDEXING] == 2
 
-    def test_backfill_live_event_queue_cross_db(
-        self, geodata_db, cloud_sync_db,
-    ):
-        conn = sqlite3.connect(cloud_sync_db)
-        conn.executemany(
-            "INSERT INTO live_event_queue "
-            "(event_dir, event_json_path, event_timestamp, "
-            " event_reason, upload_scope, status, enqueued_at) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?)",
-            [
-                ('/Sentry/2026-05-14_10-00-00',
-                 '/Sentry/2026-05-14_10-00-00/event.json',
-                 '2026-05-14T10:00:00', 'sentry_aware_object_detection',
-                 'event_minute', 'pending',
-                 '2026-05-14T10:00:00'),
-                ('/Sentry/2026-05-14_11-00-00',
-                 '/Sentry/2026-05-14_11-00-00/event.json',
-                 '2026-05-14T11:00:00', 'user_interaction_horn',
-                 'event_minute', 'uploaded',
-                 '2026-05-14T11:00:00'),
-            ],
-        )
-        conn.commit()
-        conn.close()
-
-        counts = pqs.backfill_legacy_queues(
-            pipeline_db_path=geodata_db,
-            cloud_db_path=cloud_sync_db,
-        )
-        assert counts[pqs.LEGACY_TABLE_LIVE_EVENT] == 2
-
-        conn = sqlite3.connect(geodata_db)
-        conn.row_factory = sqlite3.Row
-        try:
-            rows = conn.execute(
-                "SELECT * FROM pipeline_queue "
-                "WHERE legacy_table = ? ORDER BY source_path",
-                (pqs.LEGACY_TABLE_LIVE_EVENT,),
-            ).fetchall()
-            assert len(rows) == 2
-            stages = {r['stage'] for r in rows}
-            assert stages == {pqs.STAGE_LIVE_EVENT_PENDING,
-                              pqs.STAGE_LIVE_EVENT_DONE}
-            # Pair assertion would have caught W1 in PR #190 review:
-            # cross-DB backfill computed the translated status but
-            # discarded it, so 'uploaded' rows landed as
-            # ``stage='live_event_done'`` with ``status='pending'``.
-            stage_status_pairs = {(r['stage'], r['status']) for r in rows}
-            assert stage_status_pairs == {
-                (pqs.STAGE_LIVE_EVENT_PENDING, 'pending'),
-                (pqs.STAGE_LIVE_EVENT_DONE, 'done'),
-            }
-            for r in rows:
-                payload = json.loads(r['payload_json'])
-                assert 'event_dir' in payload
-                assert 'event_reason' in payload
-                assert payload['upload_scope'] == 'event_minute'
-        finally:
-            conn.close()
-
     def test_backfill_cloud_synced_files_cross_db(
         self, geodata_db, cloud_sync_db,
     ):
@@ -546,7 +474,6 @@ class TestBackfill:
         assert counts == {
             pqs.LEGACY_TABLE_ARCHIVE: 0,
             pqs.LEGACY_TABLE_INDEXING: 0,
-            pqs.LEGACY_TABLE_LIVE_EVENT: 0,
             pqs.LEGACY_TABLE_CLOUD_SYNCED: 0,
         }
 


### PR DESCRIPTION
Closes #202.

## What

Drop the orphaned `live_event_queue` table from `cloud_sync.db` via a new schema bump v3 → v4. The standalone Live Event Sync subsystem was deleted in Wave 4 PR-F4 (#201), but the table itself was deliberately left behind to preserve any in-flight rows across rollback. After the post-PR-F4 stable release, the table is now safe to drop.

## Why

Issue #202 — the table is dead weight: zero readers, zero writers, zero rows on the canonical install. Leaving it in place is misleading (suggests LES is still around) and clutters the failed-jobs UI with a queue that can never have new rows.

## Approach

- **Bumped `cloud_archive_service._CLOUD_SCHEMA_VERSION` 3 → 4** (each DB owns its own migration ladder; geodata.db stays at v17).
- **New `_migrate_drop_live_event_queue_v4`** runs in this order:
  1. Existence check (no-op if already dropped).
  2. Defensive cross-DB reconciliation: for any rows still in `live_event_queue`, verify each is mirrored into `pipeline_queue.legacy_table='live_event_queue'`. Backfill any unmirrored rows at `priority=PRIORITY_LIVE_EVENT, stage='cloud_pending'` so the unified cloud worker picks them up on the next claim.
  3. Drop secondary indexes (`idx_les_status`, `idx_les_next_retry`).
  4. Drop the table itself (autoindex from UNIQUE drops with it).
- **All work runs in a single transaction.** If anything raises, caller rolls back, holds at v3, retries on next service start. **Rows are never lost.**
- **If pipeline DB is unavailable AND the table has rows**, the migration aborts with a clear log line — preserves the rows for retry.

## Production state probe (cybertruckusb.local, pre-merge)

- `live_event_queue` table exists, **0 rows**.
- Indexes: `idx_les_status`, `idx_les_next_retry` (NOT `idx_live_event_queue_*` as the issue body speculated).
- `module_versions.cloud_archive = 3`.
- `pipeline_queue.legacy_table='live_event_queue'`: **0 mirrored rows**.

So the migration on this install will: existence-check passes → row-count is 0 → skips reconciliation → drops 2 indexes → drops table → bumps to v4. Zero warnings, zero orphans.

## Cleanup

- Removed `STAGE_LIVE_EVENT_PENDING/_DONE` and `LEGACY_TABLE_LIVE_EVENT` from `pipeline_queue_service`.
- Deleted `_backfill_live_event_queue` function + call site + counts initializer key.
- **Kept** `PRIORITY_LIVE_EVENT = 0` per the issue's explicit scope — that constant is the post-PR-F4 mechanism for live events in the unified queue.
- Updated `mapping_migrations.py` v16 DDL comment.
- Updated `DATABASES.md`, `GLOSSARY.md`, `ARCHITECTURE.md` to drop LES references and point at the unified pipeline_queue model.
- `.github/copilot-instructions.md` line 198 verified — already says LES "was **deleted**" with no "(table still exists)" qualifier. No edit needed.

## Tests

- **NEW** `tests/test_cloud_archive_v4_migration.py` (13 tests in 3 classes):
  - `TestDropMigrationDirect` — no-op when table absent, drop empty, drop with all-mirrored, drop with unmirrored backfill, abort on missing pipeline DB.
  - `TestInitCloudDbV4` — end-to-end version bump, idempotency, failure-holds-at-3 for retry.
  - `TestSchemaVersionConstant` — floor + presence/absence of constants.
- Updated `test_pipeline_queue_dualwrite.py` — removed LES from fixture, deleted `test_backfill_live_event_queue_cross_db`, dropped `LEGACY_TABLE_LIVE_EVENT` key from `test_backfill_with_no_dbs`.
- Fixed pre-existing `test_cloud_archive_canonicalization.py` — relaxed 3 hardcoded `== 3` schema-version assertions to symbolic `== svc._CLOUD_SCHEMA_VERSION` and `>= 3` so future bumps don't break them.
- **Full suite: 1,900 passed / 5 skipped** (was 1,888 baseline).

## Deploy plan

After merge, on the Pi:

1. `git pull && sudo systemctl restart gadget_web.service`
2. Verify in journal: a single `INFO Cloud archive v4 migration: dropped live_event_queue table and indexes` line, no warnings, no errors.
3. Verify in DB: `SELECT version FROM module_versions WHERE module='cloud_archive'` → 4; `SELECT name FROM sqlite_master WHERE name='live_event_queue'` → empty.

## Notes

- This PR finishes the Wave 4 PR-F4 cleanup. There is nothing about Wave 4 left to ship.
- The `docs/VIDEO_LIFECYCLE.md` modification and `docs/ARCHITECTURE_CRITIQUE.md` untracked file are intentional carry-overs from a prior session and are NOT part of this PR.
