### PR TITLE
fix(#208): cache producer SEI peek + yield retention lock + live metrics panel

### DIFF
--- a/scripts/web/blueprints/system_health.py
+++ b/scripts/web/blueprints/system_health.py
@@ -694,3 +694,291 @@ def api_clear_lost_clips():
         'rows_deleted': n,
         'dismissed_at': dismissed_at,
     })
+
+
+# ---------------------------------------------------------------------------
+# Issue #208 — live system metrics for the Settings "Live Metrics" widget
+# ---------------------------------------------------------------------------
+#
+# Cheap, near-realtime snapshot of CPU / memory / disk I/O / lock holder /
+# queue depths, intended for a 5-second poll loop on the Settings page.
+# The Pi Zero 2 W only has 4 cores and 512 MB of RAM, so every byte and
+# every syscall on the hot path is accounted for:
+#
+# * /proc/loadavg, /proc/meminfo, /proc/uptime, /proc/stat, /proc/diskstats
+#   are all in-kernel virtual files — reading them is a few hundred bytes
+#   of memcpy and zero disk I/O.
+# * Queue depths use the existing ``COUNT(*)`` helpers which are backed by
+#   indexed columns (sub-millisecond on the production DB).
+# * The peek-cache stats and task_coordinator info are pure in-memory
+#   reads under their own short locks.
+#
+# CPU and disk I/O are inherently delta-based — we cache the previous
+# sample in module state and compute the rate as (current - previous) /
+# elapsed. Concurrency: a single ``_metrics_lock`` serialises updates so
+# two simultaneous polls can't corrupt the cached previous sample. The
+# critical section is short (a few microseconds) so contention is fine.
+#
+# All accessors are wrapped in try/except — a missing file (e.g. running
+# in a container without /proc/diskstats) returns null fields rather than
+# 500ing the whole endpoint.
+
+_METRICS_DISK_DEVICES = ('mmcblk0', 'loop0')
+_metrics_lock = threading.Lock()
+_metrics_prev: Dict[str, Any] = {
+    'cpu_total': None,    # tuple (total_jiffies, idle_jiffies, ts)
+    'diskstats': None,    # dict device -> (read_sectors, write_sectors, ts)
+}
+_SECTOR_BYTES = 512
+
+
+def _read_loadavg() -> Dict[str, Any]:
+    try:
+        with open('/proc/loadavg', 'r', encoding='ascii') as f:
+            parts = f.read().split()
+        return {
+            'one': float(parts[0]),
+            'five': float(parts[1]),
+            'fifteen': float(parts[2]),
+        }
+    except Exception:  # noqa: BLE001
+        return {'one': None, 'five': None, 'fifteen': None}
+
+
+def _read_meminfo() -> Dict[str, Any]:
+    """Return memory and swap totals/used in MiB plus percentage used."""
+    info: Dict[str, int] = {}
+    try:
+        with open('/proc/meminfo', 'r', encoding='ascii') as f:
+            for line in f:
+                key, _, rest = line.partition(':')
+                value_kb_str = rest.strip().split()[0] if rest else '0'
+                try:
+                    info[key.strip()] = int(value_kb_str)
+                except ValueError:
+                    continue
+    except Exception:  # noqa: BLE001
+        return {
+            'mem_total_mb': None, 'mem_available_mb': None,
+            'mem_used_pct': None,
+            'swap_total_mb': None, 'swap_used_mb': None,
+            'swap_used_pct': None,
+        }
+
+    total_kb = info.get('MemTotal', 0)
+    avail_kb = info.get('MemAvailable', 0)
+    swap_total_kb = info.get('SwapTotal', 0)
+    swap_free_kb = info.get('SwapFree', 0)
+    swap_used_kb = max(0, swap_total_kb - swap_free_kb)
+
+    used_pct = None
+    if total_kb > 0:
+        used_pct = round((1.0 - avail_kb / total_kb) * 100.0, 1)
+    swap_pct = None
+    if swap_total_kb > 0:
+        swap_pct = round(swap_used_kb / swap_total_kb * 100.0, 1)
+
+    return {
+        'mem_total_mb': total_kb // 1024,
+        'mem_available_mb': avail_kb // 1024,
+        'mem_used_pct': used_pct,
+        'swap_total_mb': swap_total_kb // 1024,
+        'swap_used_mb': swap_used_kb // 1024,
+        'swap_used_pct': swap_pct,
+    }
+
+
+def _read_uptime_seconds() -> Any:
+    try:
+        with open('/proc/uptime', 'r', encoding='ascii') as f:
+            return int(float(f.read().split()[0]))
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _read_cpu_total() -> Any:
+    """Return (total_jiffies, idle_jiffies) from /proc/stat first line."""
+    try:
+        with open('/proc/stat', 'r', encoding='ascii') as f:
+            line = f.readline()
+        # Format: "cpu  user nice system idle iowait irq softirq steal ..."
+        parts = line.split()
+        if not parts or parts[0] != 'cpu':
+            return None
+        nums = [int(x) for x in parts[1:]]
+        # idle = field index 3 (0-based after dropping label); also count
+        # iowait as idle (matches the convention `top` uses) so a worker
+        # blocked on disk doesn't get counted as CPU-busy.
+        idle = nums[3] + (nums[4] if len(nums) > 4 else 0)
+        total = sum(nums)
+        return (total, idle)
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _read_diskstats() -> Dict[str, tuple]:
+    """Return ``{device_name: (read_sectors, write_sectors)}``."""
+    out: Dict[str, tuple] = {}
+    try:
+        with open('/proc/diskstats', 'r', encoding='ascii') as f:
+            for line in f:
+                fields = line.split()
+                if len(fields) < 14:
+                    continue
+                # Field index 2 = device name; field 5 = sectors read;
+                # field 9 = sectors written. (Linux kernel diskstats spec.)
+                name = fields[2]
+                if name not in _METRICS_DISK_DEVICES:
+                    continue
+                try:
+                    read_sectors = int(fields[5])
+                    write_sectors = int(fields[9])
+                except (ValueError, IndexError):
+                    continue
+                out[name] = (read_sectors, write_sectors)
+    except Exception:  # noqa: BLE001
+        pass
+    return out
+
+
+def _compute_cpu_pct(now_ts: float) -> Any:
+    """Return CPU utilisation % (0-100) since the previous call.
+
+    Returns None on the very first poll (no previous sample) or when
+    /proc/stat couldn't be read.
+    """
+    cur = _read_cpu_total()
+    if cur is None:
+        return None
+    cur_total, cur_idle = cur
+    with _metrics_lock:
+        prev = _metrics_prev['cpu_total']
+        _metrics_prev['cpu_total'] = (cur_total, cur_idle, now_ts)
+    if prev is None:
+        return None
+    prev_total, prev_idle, _prev_ts = prev
+    dt_total = cur_total - prev_total
+    dt_idle = cur_idle - prev_idle
+    if dt_total <= 0:
+        return None
+    busy_pct = (dt_total - dt_idle) / dt_total * 100.0
+    return round(max(0.0, min(busy_pct, 100.0)), 1)
+
+
+def _compute_disk_io(now_ts: float) -> Dict[str, Dict[str, Any]]:
+    """Return per-device read/write rates in KB/s since the previous call."""
+    cur = _read_diskstats()
+    with _metrics_lock:
+        prev = _metrics_prev['diskstats']
+        _metrics_prev['diskstats'] = (cur, now_ts)
+    out: Dict[str, Dict[str, Any]] = {}
+    if prev is None:
+        # First sample — report 0 rates so the UI doesn't show "—" for
+        # the entire startup window. Counters are still cached for the
+        # next poll's delta.
+        for name in _METRICS_DISK_DEVICES:
+            out[name] = {'read_kbs': 0.0, 'write_kbs': 0.0}
+        return out
+    prev_stats, prev_ts = prev
+    elapsed = max(0.001, now_ts - prev_ts)
+    for name in _METRICS_DISK_DEVICES:
+        cur_v = cur.get(name)
+        prev_v = prev_stats.get(name)
+        if cur_v is None or prev_v is None:
+            out[name] = {'read_kbs': 0.0, 'write_kbs': 0.0}
+            continue
+        d_read = max(0, cur_v[0] - prev_v[0]) * _SECTOR_BYTES
+        d_write = max(0, cur_v[1] - prev_v[1]) * _SECTOR_BYTES
+        out[name] = {
+            'read_kbs': round(d_read / 1024.0 / elapsed, 1),
+            'write_kbs': round(d_write / 1024.0 / elapsed, 1),
+        }
+    return out
+
+
+def _coordinator_block() -> Dict[str, Any]:
+    try:
+        from services import task_coordinator
+        info = task_coordinator.current_task_info() or {}
+        return {
+            'busy': bool(info.get('busy')),
+            'task': info.get('task'),
+            'elapsed_seconds': info.get('elapsed', 0) or 0,
+            'waiters': int(info.get('waiters') or 0),
+        }
+    except Exception:  # noqa: BLE001
+        return {'busy': False, 'task': None,
+                'elapsed_seconds': 0, 'waiters': 0}
+
+
+def _queue_depth_block() -> Dict[str, Any]:
+    """Return cheap pending-row counts for each background subsystem.
+
+    Each helper failure is isolated so one bad DB doesn't blank the
+    whole row. Returns ints (or None on failure) — never raises.
+    """
+    out: Dict[str, Any] = {
+        'archive_pending': None,
+        'index_pending': None,
+        'cloud_pending': None,
+    }
+    try:
+        from services import archive_queue
+        counts = archive_queue.get_queue_status() or {}
+        out['archive_pending'] = int(counts.get('pending', 0))
+    except Exception:  # noqa: BLE001
+        pass
+    try:
+        from services import indexing_queue_service
+        from config import MAPPING_DB_PATH
+        counts = indexing_queue_service.get_queue_status(MAPPING_DB_PATH) or {}
+        out['index_pending'] = int(counts.get('queue_depth', 0))
+    except Exception:  # noqa: BLE001
+        pass
+    try:
+        from services import cloud_archive_service
+        # ``get_sync_queue`` returns ``{queue: [...], total: N}`` — N is
+        # the count of (queued | pending | uploading) rows, which is the
+        # operator-facing "how many are waiting" number.
+        cloud_q = cloud_archive_service.get_sync_queue() or {}
+        out['cloud_pending'] = int(cloud_q.get('total', 0))
+    except Exception:  # noqa: BLE001
+        pass
+    return out
+
+
+def _peek_cache_block() -> Dict[str, Any]:
+    """Issue #208: surface SEI-peek cache effectiveness in the UI."""
+    try:
+        from services.archive_producer import get_peek_cache_stats
+        return get_peek_cache_stats()
+    except Exception:  # noqa: BLE001
+        return {'size': 0, 'capacity': 0, 'hits': 0, 'misses': 0,
+                'invalidations': 0, 'evictions': 0}
+
+
+@system_health_bp.route('/api/system/metrics', methods=['GET'])
+def api_system_metrics():
+    """Return a near-realtime snapshot of CPU, memory, disk I/O, queues.
+
+    Designed for a 5-second poll from the Settings "Live Metrics"
+    panel (Issue #208). Every reader is a /proc file or an in-memory
+    counter — no subprocesses, no rclone, no SEI parses. Total cost
+    per call is well under 5 ms on a Pi Zero 2 W.
+    """
+    now_ts = time.time()
+    cpu_pct = _compute_cpu_pct(now_ts)
+    io = _compute_disk_io(now_ts)
+    payload = {
+        'loadavg': _read_loadavg(),
+        'cpu_count': os.cpu_count() or 1,
+        'cpu_pct': cpu_pct,
+        'memory': _read_meminfo(),
+        'io': io,
+        'task_coordinator': _coordinator_block(),
+        'queues': _queue_depth_block(),
+        'peek_cache': _peek_cache_block(),
+        'uptime_seconds': _read_uptime_seconds(),
+        'generated_at': int(now_ts),
+    }
+    return jsonify(payload)

--- a/scripts/web/services/archive_producer.py
+++ b/scripts/web/services/archive_producer.py
@@ -141,6 +141,43 @@ _skipped_tally: 'collections.deque[float]' = collections.deque(
 )
 
 
+# Issue #208: in-memory cache of "this RecentClips path is stationary"
+# decisions so the once-a-minute producer scan does NOT re-mmap every
+# parked clip on every iteration. Each cache entry maps
+# ``path -> (mtime, size, cached_at_monotonic)``. A cache hit means we
+# previously SEI-peeked this exact file (same mtime & size) and found
+# no GPS-bearing message; we can skip the peek and record the skip
+# without touching the file at all.
+#
+# Why ``mtime`` AND ``size``? Tesla rotates the RecentClips slot by
+# overwriting the file in place. The new clip will have a different
+# mtime AND a different size (camera bitrates vary clip-to-clip). Any
+# mismatch invalidates the cache entry and forces a re-peek.
+#
+# Why bounded? RecentClips holds ~360 .mp4s (6 cameras x 60 minutes).
+# We cap at 1000 entries so even a transient mount-point glitch that
+# enumerates other directories cannot grow this without limit. LRU
+# eviction is approximated by deleting the oldest 25% of entries when
+# we hit the cap — cheap (one sort) vs. maintaining a true LRU and
+# rare enough (only on overflow) that the approximation is fine.
+#
+# Why ``time.monotonic()`` for the timestamp? We use it for TTL
+# eviction (``_PEEK_CACHE_TTL_SECONDS``) which protects against an
+# entry living forever after the file is deleted but the cache key is
+# stale. Wall clock would be wrong if the system clock jumps.
+_PEEK_CACHE_MAX_ENTRIES = 1000
+_PEEK_CACHE_TTL_SECONDS = 24 * 3600  # one day; well past Tesla rotation
+_peek_cache_lock = threading.Lock()
+_peek_cache: Dict[str, tuple] = {}
+# Stats for the System Health metrics widget — reset on service start.
+_peek_cache_stats: Dict[str, int] = {
+    'hits': 0,         # cumulative cache hits (peek skipped)
+    'misses': 0,       # cumulative cache misses (peek ran, result added)
+    'invalidations': 0,  # entries rejected because mtime/size changed
+    'evictions': 0,    # entries dropped due to TTL or LRU pressure
+}
+
+
 def _is_running() -> bool:
     with _state_lock:
         t = _thread
@@ -179,6 +216,100 @@ def _record_skip() -> None:
     """Append a skip timestamp to the in-memory tally."""
     with _skipped_tally_lock:
         _skipped_tally.append(time.time())
+
+
+# ---------------------------------------------------------------------------
+# Issue #208: SEI-peek decision cache for stationary RecentClips.
+# ---------------------------------------------------------------------------
+
+
+def _peek_cache_lookup(path: str, mtime: float, size: int) -> bool:
+    """Return True if ``path`` is cached as stationary at this ``(mtime, size)``.
+
+    A False return means either no entry, or the entry is stale
+    (mtime/size differ — Tesla rotated the slot, file content changed).
+    Stale entries are evicted on lookup so a hot file gets re-peeked
+    immediately rather than next sweep.
+
+    Pure read path: caller still needs to ``_peek_clip_for_gps`` on a
+    miss.
+    """
+    now = time.monotonic()
+    with _peek_cache_lock:
+        entry = _peek_cache.get(path)
+        if entry is None:
+            _peek_cache_stats['misses'] += 1
+            return False
+        cached_mtime, cached_size, cached_at = entry
+        # TTL safety net — entries should be invalidated by mtime/size
+        # change long before this fires, but if a file lingered for a
+        # full day with the same metadata (RecentClips slot Tesla
+        # stopped writing to), refresh so we don't trust forever-old
+        # decisions.
+        if now - cached_at > _PEEK_CACHE_TTL_SECONDS:
+            del _peek_cache[path]
+            _peek_cache_stats['evictions'] += 1
+            _peek_cache_stats['misses'] += 1
+            return False
+        if cached_mtime == mtime and cached_size == size:
+            _peek_cache_stats['hits'] += 1
+            return True
+        # mtime / size mismatch — Tesla rotated this slot, or some
+        # other writer modified the file. Drop the stale entry and
+        # signal a miss so the caller re-peeks.
+        del _peek_cache[path]
+        _peek_cache_stats['invalidations'] += 1
+        _peek_cache_stats['misses'] += 1
+        return False
+
+
+def _peek_cache_store(path: str, mtime: float, size: int) -> None:
+    """Record that ``path`` was peeked and found to be stationary.
+
+    Only call after :func:`_peek_clip_for_gps` returned ``False``.
+    Caching ``True`` (has GPS) is pointless because the caller
+    enqueues those clips immediately and the queue's UNIQUE constraint
+    handles dedup; caching ``None`` (parse error) is harmful because
+    we WANT to retry next sweep in case the error was transient.
+
+    Bounded eviction: when the cache is at capacity, drop the oldest
+    25% of entries by ``cached_at``. This is cheap (one sort over
+    1000 entries) and rare (only happens when the cache is genuinely
+    full).
+    """
+    now = time.monotonic()
+    with _peek_cache_lock:
+        if (path not in _peek_cache
+                and len(_peek_cache) >= _PEEK_CACHE_MAX_ENTRIES):
+            # LRU-ish eviction: drop oldest 25% by cached_at.
+            victims = sorted(
+                _peek_cache.items(),
+                key=lambda kv: kv[1][2],
+            )[: max(1, _PEEK_CACHE_MAX_ENTRIES // 4)]
+            for victim_path, _ in victims:
+                del _peek_cache[victim_path]
+                _peek_cache_stats['evictions'] += 1
+        _peek_cache[path] = (mtime, size, now)
+
+
+def reset_peek_cache() -> None:
+    """Clear the SEI-peek decision cache. Test / admin helper."""
+    with _peek_cache_lock:
+        _peek_cache.clear()
+
+
+def get_peek_cache_stats() -> Dict[str, int]:
+    """Return cache size and cumulative hit/miss counters.
+
+    Surfaced through ``/api/system/metrics`` (Issue #208) so operators
+    can see the cache is actually doing its job. Returns a copy so
+    callers can mutate freely.
+    """
+    with _peek_cache_lock:
+        snapshot = dict(_peek_cache_stats)
+        snapshot['size'] = len(_peek_cache)
+        snapshot['capacity'] = _PEEK_CACHE_MAX_ENTRIES
+    return snapshot
 
 
 def _peek_clip_for_gps(source_path: str) -> Optional[bool]:
@@ -278,20 +409,35 @@ def enqueue_with_peek(paths: Iterable[str],
             continue
         # RecentClips — apply the freshness gate, then peek.
         try:
-            mtime = os.path.getmtime(raw)
+            st = os.stat(raw)
         except OSError:
             # Source vanished between watcher fire and our stat;
             # silently drop — next scan will not see it either.
             continue
+        mtime = st.st_mtime
+        size = st.st_size
         if (time.time() - mtime) < stable_age:
             # Too fresh — defer to the worker so we never misclassify
             # a half-written clip as stationary.
             pending_enqueue.append(raw)
             continue
+        # Issue #208: skip the SEI peek if we already decided this
+        # exact ``(path, mtime, size)`` was stationary on a prior
+        # iteration. Eliminates the ~700 MB/min of mmap reads the
+        # naive 60-s rescan was doing on parked-overnight RecentClips.
+        if _peek_cache_lookup(raw, mtime, size):
+            _record_skip()
+            skipped += 1
+            logger.debug(
+                "archive_producer: skipped stationary RecentClips "
+                "(cached): %s", raw,
+            )
+            continue
         verdict = _peek_clip_for_gps(raw)
         if verdict is False:
             _record_skip()
             skipped += 1
+            _peek_cache_store(raw, mtime, size)
             logger.debug(
                 "archive_producer: skipped stationary RecentClips at "
                 "source: %s", raw,

--- a/scripts/web/services/archive_watchdog.py
+++ b/scripts/web/services/archive_watchdog.py
@@ -90,6 +90,18 @@ _RETENTION_FIRST_RUN_JITTER_MAX_SECONDS = 15 * 60
 _RETENTION_COORDINATOR_WAIT_SECONDS = 60.0
 _RETENTION_COORDINATOR_TASK = 'retention'
 
+# Issue #208: yield the 'retention' task_coordinator lock every N files
+# so a multi-thousand-file sweep doesn't block the indexer / archive
+# worker for 5+ minutes (observed pre-fix max_hold = 311 s on 5904
+# clips, which is 3.5x the 90 s hardware watchdog timeout). At 100 files
+# per batch and ~30-50 ms per delete decision (stat + DB reconcile),
+# each held window is ≤ 5 s — well within safety.
+_RETENTION_YIELD_EVERY_N_FILES = 100
+# Brief sleep between batches so other workers can actually grab the
+# lock before we re-acquire. Long enough to let a waiter through, short
+# enough that a 5904-file sweep adds < 4 s of yield overhead total.
+_RETENTION_YIELD_SLEEP_SECONDS = 0.05
+
 # Diagnostic subdirectory inside ``archive_root`` that the prune must
 # never touch. Mirrors the worker's dead-letter sidecar location.
 _DEAD_LETTER_DIRNAME = '.dead_letter'
@@ -777,6 +789,30 @@ def _delete_one_mp4(path: str, db_path: str) -> int:
     return result.bytes_freed
 
 
+def _yield_retention_lock() -> bool:
+    """Issue #208: drop the 'retention' task slot, sleep briefly, re-acquire.
+
+    Lets a waiting indexer / archive_worker get a turn between
+    batches of N files. Returns True when the lock was reacquired
+    (caller should keep going), False when reacquire failed (caller
+    should bail with a partial summary — something else is genuinely
+    holding the lock and we shouldn't starve it forever).
+
+    Implementation note: we always sleep ``_RETENTION_YIELD_SLEEP_SECONDS``
+    even if no waiter exists. Asking ``task_coordinator.waiter_count()``
+    is cheap, but the sleep itself is the cooperation primitive — without
+    it a quick release/reacquire round-trip would not give a competing
+    thread enough time to actually wake from its ``threading.Event.wait``
+    and grab the lock.
+    """
+    task_coordinator.release_task(_RETENTION_COORDINATOR_TASK)
+    time.sleep(_RETENTION_YIELD_SLEEP_SECONDS)
+    return task_coordinator.acquire_task(
+        _RETENTION_COORDINATOR_TASK,
+        wait_seconds=_RETENTION_COORDINATOR_WAIT_SECONDS,
+    )
+
+
 def _run_retention_prune(archive_root: str, db_path: str,
                          retention_days: int) -> Dict[str, Any]:
     """Walk ``archive_root`` and delete .mp4 files older than retention.
@@ -857,7 +893,13 @@ def _run_retention_prune(archive_root: str, db_path: str,
             summary['duration_seconds'] = round(time.time() - started, 3)
             return summary
 
+        # ``lock_held`` tracks whether we still own the 'retention'
+        # task slot at any given point in the loop body. It is set
+        # to False by the yield-bailout branch so the ``finally`` below
+        # knows not to double-release a lock we already gave up.
+        lock_held = True
         try:
+            files_since_yield = 0
             for path, mtime, _size in _iter_archive_mp4_files(archive_root):
                 summary['scanned'] += 1
                 if mtime > cutoff:
@@ -881,9 +923,34 @@ def _run_retention_prune(archive_root: str, db_path: str,
                         "freed=%d bytes)",
                         path, age_days, freed,
                     )
+                # Issue #208: yield the lock every N files so a 5904-clip
+                # sweep doesn't block the indexer / archive worker for
+                # 5+ minutes (max_hold = 311 s observed pre-fix).
+                files_since_yield += 1
+                if files_since_yield >= _RETENTION_YIELD_EVERY_N_FILES:
+                    files_since_yield = 0
+                    if not _yield_retention_lock():
+                        # Couldn't reacquire — something else is
+                        # genuinely holding the lock. Bail with the
+                        # partial summary we've built so far; next
+                        # retention tick will pick up where we left off.
+                        lock_held = False
+                        summary['status'] = 'yielded_lost_lock'
+                        logger.info(
+                            "archive_retention: yielded 'retention' "
+                            "lock after %d scanned/%d deleted and could "
+                            "not reacquire within %.1fs — bailing with "
+                            "partial summary; next tick will resume",
+                            summary['scanned'], summary['deleted_count'],
+                            _RETENTION_COORDINATOR_WAIT_SECONDS,
+                        )
+                        break
         finally:
             # Release BEFORE any further sleep / outside callers.
-            task_coordinator.release_task(_RETENTION_COORDINATOR_TASK)
+            # When the loop bailed via yielded_lost_lock we already do
+            # NOT hold the lock; only release if we still do.
+            if lock_held:
+                task_coordinator.release_task(_RETENTION_COORDINATOR_TASK)
             summary['duration_seconds'] = round(time.time() - started, 3)
     finally:
         # Always clear the duplicate-trigger guard, even on exception
@@ -1098,6 +1165,8 @@ def reclaim_stationary_recent_clips(*,
             )
             event_basenames = _collect_event_basenames(archive_root)
 
+            lock_held = True
+            files_since_yield = 0
             for raw_path, mtime, _size in _iter_archive_mp4_files(
                 recent_root,
             ):
@@ -1138,8 +1207,27 @@ def reclaim_stationary_recent_clips(*,
                         "reclaim_stationary: removed %s (freed=%d bytes)",
                         path, freed,
                     )
+                # Issue #208: yield the lock every N files so a
+                # large RecentClips sweep doesn't block the indexer /
+                # archive worker for minutes at a time.
+                files_since_yield += 1
+                if files_since_yield >= _RETENTION_YIELD_EVERY_N_FILES:
+                    files_since_yield = 0
+                    if not _yield_retention_lock():
+                        lock_held = False
+                        summary['status'] = 'yielded_lost_lock'
+                        logger.info(
+                            "reclaim_stationary: yielded 'retention' "
+                            "lock after %d scanned/%d deleted and "
+                            "could not reacquire within %.1fs — bailing "
+                            "with partial summary; next tick will resume",
+                            summary['scanned'], summary['deleted_count'],
+                            _RETENTION_COORDINATOR_WAIT_SECONDS,
+                        )
+                        break
         finally:
-            task_coordinator.release_task(_RETENTION_COORDINATOR_TASK)
+            if lock_held:
+                task_coordinator.release_task(_RETENTION_COORDINATOR_TASK)
             summary['duration_seconds'] = round(time.time() - started, 3)
     finally:
         with _state_lock:

--- a/scripts/web/templates/index.html
+++ b/scripts/web/templates/index.html
@@ -170,6 +170,131 @@
         </div>
     </details>
 
+    <!-- Live Metrics (Issue #208) — near-realtime CPU / memory / I/O.
+         Auto-pauses when the tab is hidden so we never poll a backgrounded
+         page. /api/system/metrics is /proc-only (no subprocesses, no DB
+         writes), so a 5 s poll on the device itself is essentially free. -->
+    <details class="settings-section" id="live-metrics-section" open>
+        <summary>Live Metrics</summary>
+        <div class="section-content">
+            <div id="live-metrics-card"
+                 data-poll-url="{{ url_for('system_health.api_system_metrics') }}"
+                 style="display:flex; flex-direction:column; gap:8px;">
+                <div id="live-metrics-grid"
+                     style="display:grid;
+                            grid-template-columns:repeat(auto-fit,
+                                                  minmax(200px, 1fr));
+                            gap:10px;">
+                    <!-- Tiles rendered by JS from /api/system/metrics -->
+                    <div class="metric-tile" id="metric-load">
+                        <div class="metric-label">Load (1m / 5m / 15m)</div>
+                        <div class="metric-value" data-field="load">—</div>
+                        <div class="metric-detail" data-field="load-detail">
+                            &nbsp;
+                        </div>
+                    </div>
+                    <div class="metric-tile" id="metric-cpu">
+                        <div class="metric-label">CPU</div>
+                        <div class="metric-value" data-field="cpu">—</div>
+                        <div class="metric-detail" data-field="cpu-detail">
+                            &nbsp;
+                        </div>
+                    </div>
+                    <div class="metric-tile" id="metric-mem">
+                        <div class="metric-label">Memory</div>
+                        <div class="metric-value" data-field="mem">—</div>
+                        <div class="metric-detail" data-field="mem-detail">
+                            &nbsp;
+                        </div>
+                    </div>
+                    <div class="metric-tile" id="metric-swap">
+                        <div class="metric-label">Swap</div>
+                        <div class="metric-value" data-field="swap">—</div>
+                        <div class="metric-detail" data-field="swap-detail">
+                            &nbsp;
+                        </div>
+                    </div>
+                    <div class="metric-tile" id="metric-sd">
+                        <div class="metric-label">SD Card I/O</div>
+                        <div class="metric-value" data-field="sd">—</div>
+                        <div class="metric-detail" data-field="sd-detail">
+                            &nbsp;
+                        </div>
+                    </div>
+                    <div class="metric-tile" id="metric-loop">
+                        <div class="metric-label">USB Image I/O</div>
+                        <div class="metric-value" data-field="loop">—</div>
+                        <div class="metric-detail" data-field="loop-detail">
+                            &nbsp;
+                        </div>
+                    </div>
+                    <div class="metric-tile" id="metric-coord">
+                        <div class="metric-label">Active Worker</div>
+                        <div class="metric-value" data-field="coord">—</div>
+                        <div class="metric-detail" data-field="coord-detail">
+                            &nbsp;
+                        </div>
+                    </div>
+                    <div class="metric-tile" id="metric-queues">
+                        <div class="metric-label">Queue Depths</div>
+                        <div class="metric-value" data-field="queues">—</div>
+                        <div class="metric-detail" data-field="queues-detail">
+                            &nbsp;
+                        </div>
+                    </div>
+                    <div class="metric-tile" id="metric-cache">
+                        <div class="metric-label">Stationary Cache</div>
+                        <div class="metric-value" data-field="cache">—</div>
+                        <div class="metric-detail" data-field="cache-detail">
+                            &nbsp;
+                        </div>
+                    </div>
+                </div>
+                <p id="live-metrics-foot"
+                   style="margin:0; font-size:0.78rem;
+                          color:var(--text-secondary);">
+                    Updated <span id="live-metrics-updated">—</span>
+                    · <span id="live-metrics-uptime">—</span>
+                </p>
+            </div>
+        </div>
+    </details>
+    <style>
+        #live-metrics-card .metric-tile {
+            background: var(--bg-secondary);
+            border: 1px solid var(--border-color);
+            border-radius: 8px;
+            padding: 10px 12px;
+            display: flex;
+            flex-direction: column;
+            gap: 2px;
+            min-height: 72px;
+        }
+        #live-metrics-card .metric-label {
+            font-size: 0.78rem;
+            color: var(--text-secondary);
+            text-transform: uppercase;
+            letter-spacing: 0.04em;
+        }
+        #live-metrics-card .metric-value {
+            font-size: 1.15rem;
+            font-weight: 600;
+            color: var(--text-primary);
+            font-variant-numeric: tabular-nums;
+        }
+        #live-metrics-card .metric-detail {
+            font-size: 0.82rem;
+            color: var(--text-secondary);
+            font-variant-numeric: tabular-nums;
+        }
+        #live-metrics-card .metric-tile.warn {
+            border-color: var(--accent-warning, #ff9800);
+        }
+        #live-metrics-card .metric-tile.error {
+            border-color: var(--accent-error, #f44336);
+        }
+    </style>
+
     <!-- WiFi Networks -->
     <details class="settings-section" open>
         <summary>WiFi Networks</summary>
@@ -2210,6 +2335,214 @@ if (document.getElementById('fsck-status-container')) {
     }
 
     if (retryBtn) retryBtn.addEventListener('click', loadHealth);
+
+    document.addEventListener('visibilitychange', function() {
+        if (document.hidden) stopPoll();
+        else startPoll();
+    });
+
+    if (!document.hidden) startPoll();
+})();
+
+// ---------------------------------------------------------------------------
+// Live Metrics card (Issue #208)
+// Polls /api/system/metrics every 5 s while the tab is visible. The endpoint
+// reads /proc files + in-memory counters only — no subprocesses, no DB
+// writes, no SEI parses — so this is essentially free even on a Pi Zero 2 W.
+// Stops polling on visibilitychange to avoid wasted cycles when the user has
+// the tab in the background.
+// ---------------------------------------------------------------------------
+(function() {
+    var card = document.getElementById('live-metrics-card');
+    if (!card) return;
+    var pollUrl = card.getAttribute('data-poll-url');
+    var POLL_MS = 5000;
+    var pollHandle = null;
+    var grid = document.getElementById('live-metrics-grid');
+    var updatedEl = document.getElementById('live-metrics-updated');
+    var uptimeEl = document.getElementById('live-metrics-uptime');
+
+    function fmtNum(n, digits) {
+        if (n == null || isNaN(n)) return '—';
+        if (digits == null) digits = 1;
+        return Number(n).toFixed(digits);
+    }
+
+    function fmtBytes(kbs) {
+        if (kbs == null || isNaN(kbs)) return '—';
+        if (kbs >= 1024) return fmtNum(kbs / 1024, 1) + ' MB/s';
+        return fmtNum(kbs, 1) + ' KB/s';
+    }
+
+    function fmtUptime(secs) {
+        if (secs == null || isNaN(secs)) return 'uptime —';
+        var d = Math.floor(secs / 86400);
+        var h = Math.floor((secs % 86400) / 3600);
+        var m = Math.floor((secs % 3600) / 60);
+        if (d > 0) return 'uptime ' + d + 'd ' + h + 'h';
+        if (h > 0) return 'uptime ' + h + 'h ' + m + 'm';
+        return 'uptime ' + m + 'm';
+    }
+
+    function setTile(tileId, value, detail, severity) {
+        var tile = document.getElementById(tileId);
+        if (!tile) return;
+        var v = tile.querySelector('[data-field]:not([data-field$=detail])');
+        var d = tile.querySelector('[data-field$=detail]');
+        if (v) v.textContent = value;
+        if (d) d.textContent = detail || '\u00a0';
+        tile.classList.remove('warn', 'error');
+        if (severity === 'warn') tile.classList.add('warn');
+        else if (severity === 'error') tile.classList.add('error');
+    }
+
+    function severityFromLoad(loadOne, cpuCount) {
+        if (loadOne == null || cpuCount == null) return 'ok';
+        var ratio = loadOne / cpuCount;
+        if (ratio > 1.5) return 'error';
+        if (ratio > 1.0) return 'warn';
+        return 'ok';
+    }
+
+    function severityFromPct(pct, warn, err) {
+        if (pct == null) return 'ok';
+        if (pct >= err) return 'error';
+        if (pct >= warn) return 'warn';
+        return 'ok';
+    }
+
+    function renderMetrics(p) {
+        var load = p.loadavg || {};
+        var cpuCount = p.cpu_count || 1;
+        var loadStr = fmtNum(load.one, 2) + '  ' +
+                      fmtNum(load.five, 2) + '  ' +
+                      fmtNum(load.fifteen, 2);
+        var loadDetail = cpuCount > 0 && load.one != null
+            ? fmtNum(load.one / cpuCount * 100, 0) + '% of ' +
+              cpuCount + ' cores'
+            : cpuCount + ' cores';
+        setTile('metric-load', loadStr, loadDetail,
+                severityFromLoad(load.one, cpuCount));
+
+        var cpuPct = p.cpu_pct;
+        setTile('metric-cpu',
+                cpuPct != null ? fmtNum(cpuPct, 1) + '%' : '—',
+                'across ' + cpuCount + ' cores',
+                severityFromPct(cpuPct, 70, 90));
+
+        var mem = p.memory || {};
+        setTile('metric-mem',
+                mem.mem_used_pct != null
+                    ? fmtNum(mem.mem_used_pct, 0) + '%'
+                    : '—',
+                mem.mem_total_mb != null
+                    ? (mem.mem_total_mb - (mem.mem_available_mb || 0)) +
+                      ' / ' + mem.mem_total_mb + ' MB used'
+                    : '—',
+                severityFromPct(mem.mem_used_pct, 80, 95));
+
+        setTile('metric-swap',
+                mem.swap_used_pct != null
+                    ? fmtNum(mem.swap_used_pct, 0) + '%'
+                    : '—',
+                mem.swap_total_mb != null
+                    ? (mem.swap_used_mb || 0) + ' / ' +
+                      mem.swap_total_mb + ' MB used'
+                    : '—',
+                severityFromPct(mem.swap_used_pct, 30, 60));
+
+        var io = p.io || {};
+        var sd = io.mmcblk0 || {};
+        setTile('metric-sd',
+                fmtBytes((sd.read_kbs || 0) + (sd.write_kbs || 0)),
+                'r ' + fmtBytes(sd.read_kbs) + '  w ' + fmtBytes(sd.write_kbs),
+                'ok');
+
+        var loop = io.loop0 || {};
+        // Loop reads are the producer SEI peeks (Issue #208). Sustained
+        // reads above ~3 MB/s with no driving means the cache isn't
+        // catching — surface as warn so the operator notices.
+        var loopTotal = (loop.read_kbs || 0) + (loop.write_kbs || 0);
+        var loopSev = loopTotal > 6144
+            ? 'error'
+            : (loopTotal > 3072 ? 'warn' : 'ok');
+        setTile('metric-loop',
+                fmtBytes(loopTotal),
+                'r ' + fmtBytes(loop.read_kbs) +
+                '  w ' + fmtBytes(loop.write_kbs),
+                loopSev);
+
+        var coord = p.task_coordinator || {};
+        var coordVal, coordDetail, coordSev;
+        if (coord.busy && coord.task) {
+            coordVal = coord.task;
+            coordDetail = 'held ' + fmtNum(coord.elapsed_seconds, 1) +
+                          's, ' + (coord.waiters || 0) + ' waiting';
+            coordSev = coord.elapsed_seconds > 60
+                ? 'error'
+                : (coord.elapsed_seconds > 30 ? 'warn' : 'ok');
+        } else {
+            coordVal = 'idle';
+            coordDetail = (coord.waiters || 0) + ' waiting';
+            coordSev = 'ok';
+        }
+        setTile('metric-coord', coordVal, coordDetail, coordSev);
+
+        var q = p.queues || {};
+        function qStr(n) { return n == null ? '—' : String(n); }
+        setTile('metric-queues',
+                qStr(q.archive_pending) + ' / ' +
+                qStr(q.index_pending) + ' / ' +
+                qStr(q.cloud_pending),
+                'archive / index / cloud',
+                'ok');
+
+        var pc = p.peek_cache || {};
+        var hits = pc.hits || 0;
+        var misses = pc.misses || 0;
+        var total = hits + misses;
+        var hitRate = total > 0 ? (hits / total * 100) : null;
+        setTile('metric-cache',
+                hitRate != null
+                    ? fmtNum(hitRate, 0) + '% hit'
+                    : '—',
+                (pc.size || 0) + ' / ' + (pc.capacity || 0) +
+                ' entries, ' + hits + ' hits / ' + misses + ' misses',
+                'ok');
+
+        var ts = p.generated_at
+            ? new Date(p.generated_at * 1000)
+            : new Date();
+        if (updatedEl) {
+            updatedEl.textContent = ts.toLocaleTimeString();
+        }
+        if (uptimeEl) {
+            uptimeEl.textContent = fmtUptime(p.uptime_seconds);
+        }
+    }
+
+    function loadMetrics() {
+        fetch(pollUrl, { cache: 'no-store' })
+            .then(function(r) {
+                if (!r.ok) throw new Error('HTTP ' + r.status);
+                return r.json();
+            })
+            .then(renderMetrics)
+            .catch(function(e) {
+                console.warn('live_metrics load failed:', e);
+            });
+    }
+
+    function startPoll() {
+        if (pollHandle) return;
+        loadMetrics();
+        pollHandle = setInterval(loadMetrics, POLL_MS);
+    }
+
+    function stopPoll() {
+        if (pollHandle) clearInterval(pollHandle);
+        pollHandle = null;
+    }
 
     document.addEventListener('visibilitychange', function() {
         if (document.hidden) stopPoll();

--- a/tests/test_archive_producer.py
+++ b/tests/test_archive_producer.py
@@ -499,3 +499,167 @@ class TestEnqueueWithPeek:
         assert archive_producer.get_skipped_stationary_count(24) == 1
         archive_producer.reset_skipped_stationary_tally()
         assert archive_producer.get_skipped_stationary_count(24) == 0
+
+
+# ---------------------------------------------------------------------------
+# Issue #208: SEI-peek decision cache
+# ---------------------------------------------------------------------------
+
+class TestPeekCache:
+    """Cache should eliminate repeated SEI peeks on stationary RecentClips.
+
+    Pre-fix the producer mmap-read every parked clip on every 60s sweep
+    (~700 MB/min on a parked overnight Pi). The cache stores ``False``
+    verdicts keyed by ``(path, mtime, size)`` so a re-scan with no file
+    change skips the peek entirely.
+    """
+
+    def setup_method(self):
+        archive_producer.reset_peek_cache()
+        archive_producer.reset_skipped_stationary_tally()
+
+    def teardown_method(self):
+        # Reset both the cache AND the skipped-stationary tally so the
+        # in-memory deque doesn't leak across tests (the storage_retention
+        # blueprint's badge endpoint sums producer skips into its
+        # 24-hour count, and would otherwise see our test skips as
+        # real skips).
+        archive_producer.reset_peek_cache()
+        archive_producer.reset_skipped_stationary_tally()
+
+    def test_first_call_runs_peek_subsequent_call_uses_cache(
+            self, db, tmp_path, monkeypatch,
+    ):
+        recent = tmp_path / "TeslaCam" / "RecentClips"
+        recent.mkdir(parents=True)
+        path = str(recent / "2026-05-11_09-00-00-front.mp4")
+        with open(path, 'wb') as f:
+            f.write(b"x")
+        old = time.time() - 60
+        os.utime(path, (old, old))
+        called = {'count': 0}
+
+        def _fake_peek(_p):
+            called['count'] += 1
+            return False
+
+        monkeypatch.setattr(
+            archive_producer, '_peek_clip_for_gps', _fake_peek,
+        )
+        # First sweep: peek runs, verdict is cached.
+        r1 = archive_producer.enqueue_with_peek([path], db_path=db)
+        assert called['count'] == 1
+        assert r1['skipped_stationary'] == 1
+        # Second sweep with the file unchanged: peek MUST NOT run again.
+        r2 = archive_producer.enqueue_with_peek([path], db_path=db)
+        assert called['count'] == 1, (
+            "cache hit must skip the SEI peek on the second sweep"
+        )
+        assert r2['skipped_stationary'] == 1
+
+    def test_mtime_change_invalidates_cache_and_repeeks(
+            self, db, tmp_path, monkeypatch,
+    ):
+        recent = tmp_path / "TeslaCam" / "RecentClips"
+        recent.mkdir(parents=True)
+        path = str(recent / "2026-05-11_09-00-00-front.mp4")
+        with open(path, 'wb') as f:
+            f.write(b"x")
+        old = time.time() - 60
+        os.utime(path, (old, old))
+        called = {'count': 0}
+        monkeypatch.setattr(
+            archive_producer, '_peek_clip_for_gps',
+            lambda _p: (called.update(count=called['count'] + 1) or False),
+        )
+        archive_producer.enqueue_with_peek([path], db_path=db)
+        assert called['count'] == 1
+        # Tesla rotates the slot — mtime changes.
+        newer = time.time() - 30
+        os.utime(path, (newer, newer))
+        archive_producer.enqueue_with_peek([path], db_path=db)
+        assert called['count'] == 2, (
+            "mtime change must invalidate the cache entry"
+        )
+        stats = archive_producer.get_peek_cache_stats()
+        assert stats['invalidations'] >= 1
+
+    def test_size_change_invalidates_cache_and_repeeks(
+            self, db, tmp_path, monkeypatch,
+    ):
+        recent = tmp_path / "TeslaCam" / "RecentClips"
+        recent.mkdir(parents=True)
+        path = str(recent / "2026-05-11_09-00-00-front.mp4")
+        with open(path, 'wb') as f:
+            f.write(b"x")
+        old = time.time() - 60
+        os.utime(path, (old, old))
+        called = {'count': 0}
+        monkeypatch.setattr(
+            archive_producer, '_peek_clip_for_gps',
+            lambda _p: (called.update(count=called['count'] + 1) or False),
+        )
+        archive_producer.enqueue_with_peek([path], db_path=db)
+        assert called['count'] == 1
+        # Same mtime but a different size — Tesla reused the slot with
+        # a different-bitrate camera. Cache must invalidate.
+        with open(path, 'wb') as f:
+            f.write(b"x" * 4096)
+        os.utime(path, (old, old))
+        archive_producer.enqueue_with_peek([path], db_path=db)
+        assert called['count'] == 2
+
+    def test_true_verdict_is_not_cached(self, db, tmp_path, monkeypatch):
+        # Caching ``True`` would be pointless (the file gets enqueued
+        # and removed from RecentClips by the worker). Verify only False
+        # is cached.
+        recent = tmp_path / "TeslaCam" / "RecentClips"
+        recent.mkdir(parents=True)
+        path = str(recent / "2026-05-11_09-00-00-front.mp4")
+        with open(path, 'wb') as f:
+            f.write(b"x")
+        old = time.time() - 60
+        os.utime(path, (old, old))
+        monkeypatch.setattr(
+            archive_producer, '_peek_clip_for_gps', lambda _p: True,
+        )
+        archive_producer.enqueue_with_peek([path], db_path=db)
+        stats = archive_producer.get_peek_cache_stats()
+        assert stats['size'] == 0
+
+    def test_none_verdict_is_not_cached(self, db, tmp_path, monkeypatch):
+        # Caching ``None`` (parser failure) is harmful — the next sweep
+        # would never retry. Verify only False is cached.
+        recent = tmp_path / "TeslaCam" / "RecentClips"
+        recent.mkdir(parents=True)
+        path = str(recent / "2026-05-11_09-00-00-front.mp4")
+        with open(path, 'wb') as f:
+            f.write(b"x")
+        old = time.time() - 60
+        os.utime(path, (old, old))
+        monkeypatch.setattr(
+            archive_producer, '_peek_clip_for_gps', lambda _p: None,
+        )
+        archive_producer.enqueue_with_peek([path], db_path=db)
+        stats = archive_producer.get_peek_cache_stats()
+        assert stats['size'] == 0
+
+    def test_cache_bounded_by_max_entries(self, monkeypatch):
+        # Stuff more than _PEEK_CACHE_MAX_ENTRIES synthetic entries and
+        # verify the cache stays bounded with a non-zero eviction count.
+        archive_producer.reset_peek_cache()
+        cap = archive_producer._PEEK_CACHE_MAX_ENTRIES
+        for i in range(cap + 50):
+            archive_producer._peek_cache_store(
+                f'/fake/path/{i}.mp4', mtime=1000.0 + i, size=100 + i,
+            )
+        stats = archive_producer.get_peek_cache_stats()
+        assert stats['size'] <= cap
+        assert stats['evictions'] > 0
+
+    def test_get_peek_cache_stats_returns_copy(self):
+        archive_producer.reset_peek_cache()
+        s1 = archive_producer.get_peek_cache_stats()
+        s1['size'] = 99999
+        s2 = archive_producer.get_peek_cache_stats()
+        assert s2['size'] == 0, "stats dict mutation must not leak"

--- a/tests/test_archive_watchdog.py
+++ b/tests/test_archive_watchdog.py
@@ -941,6 +941,127 @@ class TestArchiveRetention:
 
 
 # ---------------------------------------------------------------------------
+# Issue #208 — retention prune yields the 'retention' lock between batches
+# ---------------------------------------------------------------------------
+
+
+class TestRetentionLockYield:
+    """Pre-fix the prune held the 'retention' task slot for 5+ minutes
+    on a 5904-file sweep, blocking the indexer / archive worker and
+    triggering hardware watchdog resets. The fix releases & re-acquires
+    every N files so other workers get a turn.
+    """
+
+    def test_yield_releases_then_reacquires_lock(self):
+        # Take the lock manually, then exercise the helper. After the
+        # call the helper must own the lock again.
+        ok = task_coordinator.acquire_task('retention', wait_seconds=1.0)
+        assert ok
+        try:
+            assert archive_watchdog._yield_retention_lock() is True
+            info = task_coordinator.current_task_info()
+            assert info['busy'] is True
+            assert info['task'] == 'retention'
+        finally:
+            task_coordinator.release_task('retention')
+
+    def test_prune_yields_every_n_files(
+            self, db, archive_root, monkeypatch,
+    ):
+        # Force a tiny yield batch so the test stays fast.
+        monkeypatch.setattr(
+            archive_watchdog, '_RETENTION_YIELD_EVERY_N_FILES', 3,
+        )
+        old = time.time() - (40 * 86400)
+        # 7 old files → expect 2 yields (after files 3 and 6).
+        for i in range(7):
+            _make_archive_mp4(
+                archive_root, f"RecentClips/old_{i}.mp4", mtime=old,
+            )
+        yields = {'count': 0}
+        real_yield = archive_watchdog._yield_retention_lock
+
+        def _spy():
+            yields['count'] += 1
+            return real_yield()
+
+        monkeypatch.setattr(
+            archive_watchdog, '_yield_retention_lock', _spy,
+        )
+        summary = archive_watchdog._run_retention_prune(
+            archive_root, db, retention_days=30,
+        )
+        assert summary['deleted_count'] == 7
+        # Floor(7/3) = 2 yields.
+        assert yields['count'] == 2
+
+    def test_prune_bails_with_partial_summary_when_reacquire_fails(
+            self, db, archive_root, monkeypatch,
+    ):
+        # Configure tiny batch so we yield after the first file.
+        monkeypatch.setattr(
+            archive_watchdog, '_RETENTION_YIELD_EVERY_N_FILES', 1,
+        )
+        # Stub the yield helper to simulate "we released the slot and
+        # another worker grabbed it and won't release it within the
+        # wait window" — including the actual release so the lock state
+        # the prune sees matches the real failure mode.
+        def _release_and_fail():
+            task_coordinator.release_task('retention')
+            return False
+        monkeypatch.setattr(
+            archive_watchdog, '_yield_retention_lock', _release_and_fail,
+        )
+        old = time.time() - (40 * 86400)
+        for i in range(5):
+            _make_archive_mp4(
+                archive_root, f"RecentClips/old_{i}.mp4", mtime=old,
+            )
+        summary = archive_watchdog._run_retention_prune(
+            archive_root, db, retention_days=30,
+        )
+        # First file deleted before the yield. Loop bails with a
+        # partial summary tagged ``yielded_lost_lock``; the unprocessed
+        # files remain on disk for the next prune tick.
+        assert summary['deleted_count'] >= 1
+        assert summary['deleted_count'] < 5
+        assert summary['status'] == 'yielded_lost_lock'
+        # The duplicate-trigger guard MUST still be cleared so the
+        # next caller is not locked out.
+        assert archive_watchdog._retention_running is False
+        # And the lock itself must be released so other tasks can run.
+        assert task_coordinator.current_task_info()['busy'] is False
+
+    def test_prune_releases_lock_normally_when_no_yield_needed(
+            self, db, archive_root, monkeypatch,
+    ):
+        # Yield batch larger than the file count → no yield should fire.
+        monkeypatch.setattr(
+            archive_watchdog, '_RETENTION_YIELD_EVERY_N_FILES', 1000,
+        )
+        called = {'count': 0}
+
+        def _should_not_run():
+            called['count'] += 1
+            return True
+        monkeypatch.setattr(
+            archive_watchdog, '_yield_retention_lock', _should_not_run,
+        )
+        old = time.time() - (40 * 86400)
+        for i in range(3):
+            _make_archive_mp4(
+                archive_root, f"RecentClips/old_{i}.mp4", mtime=old,
+            )
+        summary = archive_watchdog._run_retention_prune(
+            archive_root, db, retention_days=30,
+        )
+        assert summary['deleted_count'] == 3
+        assert called['count'] == 0
+        # And the lock must be free at the end.
+        assert task_coordinator.current_task_info()['busy'] is False
+
+
+# ---------------------------------------------------------------------------
 # Hard-contract grep (mirrors the archive_worker test pattern)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_system_health_blueprint.py
+++ b/tests/test_system_health_blueprint.py
@@ -1262,3 +1262,178 @@ def test_clear_lost_clips_older_than_hours_skips_tombstone_lookup(
     assert body['rows_deleted'] == 9
     assert body['dismissed_at'] is None
     assert lookup_called['flag'] is False
+
+
+# ---------------------------------------------------------------------------
+# Issue #208 — /api/system/metrics live snapshot
+# ---------------------------------------------------------------------------
+
+
+class TestSystemMetricsEndpoint:
+    """Cheap /proc-only snapshot consumed by the Settings Live Metrics
+    panel. Never raises; missing /proc files yield null fields rather
+    than 500s.
+    """
+
+    def test_payload_shape(self, health_app):
+        client = health_app.test_client()
+        rv = client.get('/api/system/metrics')
+        assert rv.status_code == 200
+        body = rv.get_json()
+        for key in (
+            'loadavg', 'cpu_count', 'cpu_pct', 'memory', 'io',
+            'task_coordinator', 'queues', 'peek_cache',
+            'uptime_seconds', 'generated_at',
+        ):
+            assert key in body, f"missing top-level key: {key}"
+        assert isinstance(body['cpu_count'], int)
+        assert isinstance(body['memory'], dict)
+        assert isinstance(body['queues'], dict)
+        for key in ('archive_pending', 'index_pending', 'cpu_pending'
+                    if False else 'cloud_pending'):
+            assert key in body['queues']
+        for dev in ('mmcblk0', 'loop0'):
+            assert dev in body['io']
+            assert 'read_kbs' in body['io'][dev]
+            assert 'write_kbs' in body['io'][dev]
+
+    def test_endpoint_is_idempotent_and_cheap(self, health_app):
+        # Two back-to-back calls must both return 200 (and the second
+        # should compute a CPU delta from the first call's cached
+        # /proc/stat snapshot).
+        client = health_app.test_client()
+        rv1 = client.get('/api/system/metrics')
+        rv2 = client.get('/api/system/metrics')
+        assert rv1.status_code == 200
+        assert rv2.status_code == 200
+
+    def test_loadavg_parsed(self, monkeypatch):
+        import blueprints.system_health as sh
+
+        def fake_open(path, *a, **kw):
+            assert path == '/proc/loadavg'
+            from io import StringIO
+            return StringIO('0.42 0.55 0.66 1/123 9876\n')
+        monkeypatch.setattr('builtins.open', fake_open)
+        out = sh._read_loadavg()
+        assert out['one'] == 0.42
+        assert out['five'] == 0.55
+        assert out['fifteen'] == 0.66
+
+    def test_loadavg_missing_file_returns_nulls(self, monkeypatch):
+        import blueprints.system_health as sh
+
+        def fake_open(*a, **kw):
+            raise FileNotFoundError
+        monkeypatch.setattr('builtins.open', fake_open)
+        out = sh._read_loadavg()
+        assert out == {'one': None, 'five': None, 'fifteen': None}
+
+    def test_meminfo_used_pct(self, monkeypatch):
+        import blueprints.system_health as sh
+        sample = (
+            'MemTotal:        524288 kB\n'
+            'MemFree:          50000 kB\n'
+            'MemAvailable:    104857 kB\n'
+            'SwapTotal:      1048576 kB\n'
+            'SwapFree:        524288 kB\n'
+        )
+
+        def fake_open(path, *a, **kw):
+            from io import StringIO
+            return StringIO(sample)
+        monkeypatch.setattr('builtins.open', fake_open)
+        out = sh._read_meminfo()
+        assert out['mem_total_mb'] == 512
+        assert out['mem_available_mb'] == 102
+        # used = 1 - 104857/524288 = ~80%
+        assert 79.5 <= out['mem_used_pct'] <= 80.5
+        assert out['swap_total_mb'] == 1024
+        assert out['swap_used_mb'] == 512
+        assert out['swap_used_pct'] == 50.0
+
+    def test_compute_cpu_pct_first_call_is_none(self, monkeypatch):
+        import blueprints.system_health as sh
+        # Reset the module's cached previous sample so the test is
+        # deterministic regardless of order.
+        with sh._metrics_lock:
+            sh._metrics_prev['cpu_total'] = None
+        # First call: no previous → returns None.
+        # We patch _read_cpu_total to a known value to make
+        # the test deterministic.
+        monkeypatch.setattr(sh, '_read_cpu_total',
+                            lambda: (1000, 800))
+        assert sh._compute_cpu_pct(now_ts=100.0) is None
+        # Second call: delta over (1100-1000)=100 total, idle delta
+        # (820-800)=20 → busy = (100-20)/100 = 80%.
+        monkeypatch.setattr(sh, '_read_cpu_total',
+                            lambda: (1100, 820))
+        pct = sh._compute_cpu_pct(now_ts=101.0)
+        assert pct == 80.0
+
+    def test_compute_disk_io_returns_zero_on_first_call(self, monkeypatch):
+        import blueprints.system_health as sh
+        with sh._metrics_lock:
+            sh._metrics_prev['diskstats'] = None
+        monkeypatch.setattr(
+            sh, '_read_diskstats',
+            lambda: {'mmcblk0': (1000, 2000), 'loop0': (5000, 0)},
+        )
+        out = sh._compute_disk_io(now_ts=100.0)
+        # First call returns 0 rates (and caches the sample).
+        assert out['mmcblk0']['read_kbs'] == 0.0
+        assert out['mmcblk0']['write_kbs'] == 0.0
+        assert out['loop0']['read_kbs'] == 0.0
+
+    def test_compute_disk_io_delta_kbs(self, monkeypatch):
+        import blueprints.system_health as sh
+        with sh._metrics_lock:
+            sh._metrics_prev['diskstats'] = None
+        # Prime the cache.
+        monkeypatch.setattr(
+            sh, '_read_diskstats',
+            lambda: {'mmcblk0': (0, 0), 'loop0': (0, 0)},
+        )
+        sh._compute_disk_io(now_ts=100.0)
+        # 2 sectors = 1024 bytes = 1 KB per second over 1s window.
+        # 2048 sectors over 1s = 1024 KB/s = 1 MB/s.
+        monkeypatch.setattr(
+            sh, '_read_diskstats',
+            lambda: {'mmcblk0': (2048, 4096), 'loop0': (0, 0)},
+        )
+        out = sh._compute_disk_io(now_ts=101.0)
+        # 2048 sectors * 512 B / 1024 / 1s = 1024 KB/s read.
+        assert out['mmcblk0']['read_kbs'] == 1024.0
+        assert out['mmcblk0']['write_kbs'] == 2048.0
+
+    def test_queue_depth_block_isolates_failures(self, monkeypatch):
+        import blueprints.system_health as sh
+        # Force one importable-but-failing helper, leave others untouched.
+        from services import archive_queue
+
+        def boom(*a, **kw):
+            raise RuntimeError('synthetic')
+        monkeypatch.setattr(archive_queue, 'get_queue_status', boom)
+        out = sh._queue_depth_block()
+        assert out['archive_pending'] is None
+        # Other keys still exist; types depend on env, but presence is required.
+        assert 'index_pending' in out
+        assert 'cloud_pending' in out
+
+    def test_peek_cache_block_returns_dict_when_helper_missing(
+            self, monkeypatch,
+    ):
+        import blueprints.system_health as sh
+        # Even if archive_producer raises on import, the block must
+        # return a stable empty dict shape.
+        import services.archive_producer as ap
+        monkeypatch.setattr(
+            ap, 'get_peek_cache_stats',
+            lambda: (_ for _ in ()).throw(RuntimeError('boom')),
+        )
+        out = sh._peek_cache_block()
+        for key in ('size', 'capacity', 'hits', 'misses',
+                    'invalidations', 'evictions'):
+            assert key in out
+
+

--- a/tests/test_system_health_blueprint.py
+++ b/tests/test_system_health_blueprint.py
@@ -1289,8 +1289,7 @@ class TestSystemMetricsEndpoint:
         assert isinstance(body['cpu_count'], int)
         assert isinstance(body['memory'], dict)
         assert isinstance(body['queues'], dict)
-        for key in ('archive_pending', 'index_pending', 'cpu_pending'
-                    if False else 'cloud_pending'):
+        for key in ('archive_pending', 'index_pending', 'cloud_pending'):
             assert key in body['queues']
         for dev in ('mmcblk0', 'loop0'):
             assert dev in body['io']


### PR DESCRIPTION
## Summary

Resolves the high-load + hardware-watchdog-reset incident on cybertruckusb.local. Three independent regressions were combining to drive the device into an unrecoverable state every ~1.5 hours.

**Root cause and full forensic analysis:** [#208](https://github.com/mphacker/TeslaUSB/issues/208).

## Changes

### 1. Cached SEI peek decisions (`archive_producer.py`)
- Pre-fix: every 60 s scan re-mmaps every parked clip via `_peek_clip_for_gps` (~700 MB/min wasted reads on a parked overnight Pi).
- Bounded (1000-entry, LRU-ish, 24 h TTL) cache keyed by `(path, mtime, size)`. Cache hit on a stationary verdict skips the SEI peek entirely.
- Only `False` is cached. `True` and `None` (parser error) fall through so a parser bug never silently drops a clip and a stationary→driving transition is re-checked next sweep.
- New helpers: `reset_peek_cache`, `get_peek_cache_stats`, `_peek_cache_lookup`, `_peek_cache_store`.

### 2. Yield `'retention'` lock between batches (`archive_watchdog.py`)
- Pre-fix: `_run_retention_prune` and `reclaim_stationary_recent_clips` held the `'retention'` `task_coordinator` slot for the entire walk (5904 .mp4s = 311 s observed — 3.5× the 90 s hardware watchdog).
- New `_yield_retention_lock()` helper releases the slot, sleeps 50 ms, reacquires (60 s wait). Both prune loops yield every N=100 files. If reacquire fails, bail with partial summary tagged `status='yielded_lost_lock'`; next tick resumes.
- Caps lock-held window at ~5 s. `_retention_running` short-circuit and `try/finally` cleanup paths preserved.

### 3. New `/api/system/metrics` + Live Metrics Settings panel
- /proc-only endpoint: loadavg, CPU% (delta from `/proc/stat`), memory + swap (`/proc/meminfo`), per-device read/write KB/s (`/proc/diskstats` — mmcblk0 + loop0), `task_coordinator` holder + waiters + elapsed, queue depths (archive / index / cloud), SEI-peek cache stats, uptime. Sub-100 ms per call.
- Settings page polls every 5 s while tab is visible (`visibilitychange` auto-pauses).
- Tile severity colors: load > 1× cores = warn, CPU > 70% = warn, memory > 80% = warn, swap > 30% = warn, loop0 sustained > 3 MB/s = warn (peek cache failing), coordinator hold > 30 s = warn.
- All CSS uses `var(--*)` tokens (dark/light mode safe). No emoji. Mobile-responsive grid.

## Verification

- `python3 -m py_compile` passes on all changed files.
- Flask app loads cleanly: `from web_control import app` → 180 routes.
- **Full test suite: 1933 pass / 5 skip** (was 1912+5; +21 net new tests across 3 files):
  - 7 new in `test_archive_producer.py::TestPeekCache` covering: cache hit skips peek, mtime change invalidates, size change invalidates, True is not cached, None is not cached, max-entries eviction, stats dict isolation.
  - 4 new in `test_archive_watchdog.py::TestRetentionLockYield` covering: yield helper releases+reacquires, prune yields every N files, prune bails with partial summary on reacquire failure, no-yield path when batch is large.
  - 10 new in `test_system_health_blueprint.py::TestSystemMetricsEndpoint` covering: payload shape, idempotent calls, loadavg parsing + missing-file fallback, meminfo parsing, CPU delta math, disk-IO first-call zero + delta KB/s, queue-depth failure isolation, peek-cache block failure isolation.

## Closes

Closes #208
