### PR TITLE
fix: defer moov-incomplete RecentClips copies without burning attempts

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -296,6 +296,7 @@ archive_queue:
   # the Settings → Advanced sub-page so power users can tune without
   # editing this file by SSH.
   stable_write_age_seconds: 5.0          # Re-queue clips whose mtime is fresher than this many seconds (avoids copying mid-write)
+  recent_clips_stable_write_age_seconds: 90.0  # Higher threshold for RecentClips (Tesla writes ~60s segments; moov atom appended at close — see archive_worker._CopyMoovIncomplete)
   stale_claim_max_age_seconds: 600.0     # Reset 'claimed' rows older than this back to 'pending' on worker startup (recovers crashed/OOMed claims)
   # Wave 4 PR-E (issue #184): shadow-mode validation of the unified
   # ``pipeline_queue``. When enabled, the archive worker peeks at

--- a/scripts/web/config.py
+++ b/scripts/web/config.py
@@ -286,6 +286,9 @@ ARCHIVE_QUEUE_PER_FILE_TIME_BUDGET_SECONDS = float(
 ARCHIVE_QUEUE_STABLE_WRITE_AGE_SECONDS = float(
     _archive_queue.get('stable_write_age_seconds', 5.0)
 )
+ARCHIVE_QUEUE_RECENT_CLIPS_STABLE_WRITE_AGE_SECONDS = float(
+    _archive_queue.get('recent_clips_stable_write_age_seconds', 90.0)
+)
 ARCHIVE_QUEUE_STALE_CLAIM_MAX_AGE_SECONDS = float(
     _archive_queue.get('stale_claim_max_age_seconds', 600.0)
 )

--- a/scripts/web/services/archive_worker.py
+++ b/scripts/web/services/archive_worker.py
@@ -120,6 +120,26 @@ _STABLE_WRITE_AGE_SECONDS = 5.0
 # threshold above. Configurable via
 # ``archive_queue.recent_clips_stable_write_age_seconds``.
 _RECENT_CLIPS_STABLE_WRITE_AGE_SECONDS = 90.0
+# Cap on how many times the worker will defer a row via the
+# ``_CopyMoovIncomplete`` (Tesla still-writing) handler before
+# escalating to the regular failure path (mark_failed → bump
+# ``attempts`` → eventual dead_letter at ``max_attempts``). Without
+# a cap, a genuinely-corrupted-but-stable RecentClips file (rare but
+# possible: bad SD block, Tesla crashed mid-segment then never
+# rotated the slot) would defer forever, re-running the full
+# source-read + partial-staging-write + delete cycle on every pick
+# (~30–360 MB SDIO per iteration). 10 defers × ~30 s backoff =
+# ~5 minutes — well past Tesla's 60 s segment-close window, so any
+# row still failing after that is genuinely broken, not still
+# being written. Reset on process restart (in-memory only — see
+# ``_moov_defer_counts`` below).
+_MOOV_DEFER_CAP = 10
+# Cap on the size of the per-source_path defer counter dict to prevent
+# unbounded memory growth across long-running drives. Tesla writes
+# ~hundreds of RecentClips per drive; over weeks the dict could
+# accumulate. When the LRU exceeds this size, the oldest entry is
+# evicted. 2048 × ~150 bytes/entry ≈ 300 KB — negligible on Pi Zero 2 W.
+_MOOV_DEFER_LRU_SIZE = 2048
 # task_coordinator wait when acquiring the archive slot. The archive
 # worker is a periodic priority task (per the task_coordinator
 # docstring) — it BLOCK-waits for a slot rather than yielding cyclically.
@@ -773,7 +793,45 @@ class _CopyMoovIncomplete(OSError):
     slots when the circular buffer wraps, expected_size/expected_mtime
     drifts, and the row eventually transitions through
     ``mark_source_gone`` when the producer's stat() resolves None.
+
+    Backstop #2 (this is the safety net for the "stable+corrupt" case):
+    ``_process_one_file`` keeps a per-source_path defer count in
+    ``_moov_defer_counts``; after ``_MOOV_DEFER_CAP`` defers it falls
+    through to the regular ``mark_failed`` path so the row can
+    eventually dead_letter rather than re-amplifying SDIO IO forever.
     """
+
+
+# Per-source_path counter for ``_CopyMoovIncomplete`` defers, used by
+# ``_process_one_file`` to enforce ``_MOOV_DEFER_CAP``. OrderedDict
+# acts as a simple LRU: when an entry is read, it's moved to the end;
+# when ``len`` exceeds ``_MOOV_DEFER_LRU_SIZE`` the oldest entry is
+# popped. In-memory only — restarts reset the counter, which is the
+# desired behavior (a process restart is itself a recovery event).
+# Module-level so the singleton archive worker thread can read/mutate
+# without lock contention; not safe for use from multiple threads.
+_moov_defer_counts: 'collections.OrderedDict[str, int]' = collections.OrderedDict()
+
+
+def _bump_moov_defer_count(source_path: str) -> int:
+    """Increment and return the moov-incomplete defer count for
+    ``source_path``. Maintains LRU eviction of ``_moov_defer_counts``
+    so the dict can't grow unbounded across long-running drives.
+    """
+    count = _moov_defer_counts.get(source_path, 0) + 1
+    _moov_defer_counts[source_path] = count
+    _moov_defer_counts.move_to_end(source_path)
+    while len(_moov_defer_counts) > _MOOV_DEFER_LRU_SIZE:
+        _moov_defer_counts.popitem(last=False)
+    return count
+
+
+def _reset_moov_defer_count(source_path: str) -> None:
+    """Drop the per-path moov-defer counter (called on a successful
+    copy or a transition to a terminal status). Best-effort — no-op
+    if the path isn't tracked.
+    """
+    _moov_defer_counts.pop(source_path, None)
 
 
 # ---------------------------------------------------------------------------
@@ -2049,13 +2107,53 @@ def process_one_claim(row: Dict[str, Any], db_path: str,
         # rotates RecentClips slots, the producer's stat() resolves
         # to a different size/mtime, and the row reaches
         # ``mark_source_gone`` when the file finally vanishes.
-        logger.info(
+        defer_count = _bump_moov_defer_count(source_path)
+        if defer_count > _MOOV_DEFER_CAP:
+            # Backstop for the rare "stable + corrupt" case (bad SD
+            # block, Tesla crashed mid-segment then never rotated):
+            # release the moov-incomplete protection, fall through to
+            # mark_failed, bump attempts, and let the regular
+            # max_attempts → dead_letter path engage. Without this cap
+            # the worker would re-read + re-stage + re-delete the
+            # corrupt file forever (~30–360 MB SDIO per iteration).
+            logger.warning(
+                "archive_worker: moov-incomplete on %s deferred "
+                "%d times (cap=%d) — escalating to mark_failed; "
+                "file is likely genuinely truncated, not still "
+                "being written: %r",
+                source_path, defer_count, _MOOV_DEFER_CAP, e,
+            )
+            _reset_moov_defer_count(source_path)
+            new_status = archive_queue.mark_failed(
+                row_id,
+                f"copy: moov-incomplete after {defer_count} defers: {e!r}",
+                max_attempts=max_attempts, db_path=db_path,
+            )
+            if new_status == 'dead_letter':
+                row_for_sidecar = dict(row)
+                row_for_sidecar['dest_path'] = dest_path
+                row_for_sidecar['last_error'] = (
+                    f"copy: moov-incomplete after {defer_count} defers: {e!r}"
+                )
+                row_for_sidecar['attempts'] = int(
+                    row.get('attempts') or 0,
+                ) + 1
+                _write_dead_letter_sidecar(archive_root, row_for_sidecar)
+            return new_status
+        # Per project convention ("don't log per-tick events at INFO"):
+        # the defer can fire many times for the same source_path while
+        # Tesla finishes a segment. Keep these at DEBUG so journalctl
+        # at default verbosity stays useful; escalation to WARNING
+        # happens at the cap above.
+        logger.debug(
             "archive_worker: moov-incomplete on %s "
-            "(source still being written); deferring without "
-            "burning an attempt", source_path,
+            "(source still being written, defer #%d/%d); "
+            "deferring without burning an attempt: %r",
+            source_path, defer_count, _MOOV_DEFER_CAP, e,
         )
         st = _safe_stat(source_path)
         if st is None:
+            _reset_moov_defer_count(source_path)
             archive_queue.mark_source_gone(row_id, db_path=db_path)
             return 'source_gone'
         archive_queue.release_claim(
@@ -2081,6 +2179,9 @@ def process_one_claim(row: Dict[str, Any], db_path: str,
         return new_status
 
     # Success — mark copied AND enqueue into the indexer queue.
+    # Drop any moov-defer counter for this source so a row that
+    # recovered after N < cap defers doesn't leave stale state behind.
+    _reset_moov_defer_count(source_path)
     archive_queue.mark_copied(row_id, dest_path, db_path=db_path)
     # Issue #197: while the just-copied file's pages are still hot
     # in the kernel page cache, parse SEI + mvhd inline and write

--- a/scripts/web/services/archive_worker.py
+++ b/scripts/web/services/archive_worker.py
@@ -110,6 +110,16 @@ _BACKOFF_SLEEP_SECONDS = 0.5
 # importable (unit-test envs without the full app); the runtime value
 # is read by ``_stable_write_age_seconds()`` at call time.
 _STABLE_WRITE_AGE_SECONDS = 5.0
+# RecentClips-specific stable-write age. Tesla writes RecentClips in
+# ~60-second segments; the moov atom is appended at the END of the
+# segment, so a copy snapshot taken any time before Tesla closes the
+# file is missing moov and fails ``_verify_destination_complete``.
+# Wait at least this long after the last mtime change before attempting
+# the copy. Sentry/Saved event clips are written atomically when the
+# event ends (no "still being written" window) and keep the base
+# threshold above. Configurable via
+# ``archive_queue.recent_clips_stable_write_age_seconds``.
+_RECENT_CLIPS_STABLE_WRITE_AGE_SECONDS = 90.0
 # task_coordinator wait when acquiring the archive slot. The archive
 # worker is a periodic priority task (per the task_coordinator
 # docstring) — it BLOCK-waits for a slot rather than yielding cyclically.
@@ -744,6 +754,28 @@ class _CopyTimeBudgetExceeded(OSError):
     """
 
 
+class _CopyMoovIncomplete(OSError):
+    """Raised by ``_atomic_copy`` when the destination MP4 verifier
+    fails because Tesla is still writing the source segment.
+
+    Distinct from ordinary ``OSError`` so the caller can defer (release
+    the claim, refresh expected_size/expected_mtime, return 'pending')
+    WITHOUT bumping ``attempts``. Tesla writes RecentClips in ~60-second
+    segments and appends the ``moov`` atom only when it closes the
+    file; any copy snapshotted before that close legitimately has
+    ftyp + partial mdat + no moov. Treating these as failed attempts
+    dead-letters perfectly recoverable rows after 3 retries even though
+    the file is fine — Tesla just hadn't finished yet.
+
+    A genuinely truncated file (Tesla crashed mid-write, bad SD block)
+    will continue to fail moov-verify forever, but the natural
+    backstop is the source-rotation path: Tesla overwrites RecentClips
+    slots when the circular buffer wraps, expected_size/expected_mtime
+    drifts, and the row eventually transitions through
+    ``mark_source_gone`` when the producer's stat() resolves None.
+    """
+
+
 # ---------------------------------------------------------------------------
 # Phase 2.4 — moov-atom verification after copy
 # ---------------------------------------------------------------------------
@@ -1014,7 +1046,7 @@ def _atomic_copy(source_path: str, dest_path: str,
         # so .ts segments and other non-MP4 archives are unaffected.
         if dest_path.lower().endswith('.mp4'):
             if not _verify_destination_complete(partial):
-                raise OSError(
+                raise _CopyMoovIncomplete(
                     f"destination MP4 missing moov or mdat box — "
                     f"source may still be writing: {source_path}"
                 )
@@ -1589,6 +1621,45 @@ def _stable_write_age_seconds() -> float:
         return _STABLE_WRITE_AGE_SECONDS
 
 
+def _recent_clips_stable_write_age_seconds() -> float:
+    """Return RecentClips-specific stable-write threshold.
+
+    Tesla writes RecentClips in ~60-second segments and only appends
+    the ``moov`` atom when it closes the segment. The base 5-second
+    gate is far too short — a 5-second mtime-stable window mid-segment
+    is normal SDIO behavior and tricks the worker into copying a
+    half-written file. 90 seconds guarantees Tesla has finished any
+    in-progress segment before we copy.
+
+    Sentry/Saved event clips are written atomically when the event
+    completes (no mid-write window) and use the base threshold.
+
+    Configurable via ``archive_queue.recent_clips_stable_write_age_seconds``.
+    """
+    try:
+        from config import (
+            ARCHIVE_QUEUE_RECENT_CLIPS_STABLE_WRITE_AGE_SECONDS,
+        )
+        return float(ARCHIVE_QUEUE_RECENT_CLIPS_STABLE_WRITE_AGE_SECONDS)
+    except Exception:  # noqa: BLE001
+        return _RECENT_CLIPS_STABLE_WRITE_AGE_SECONDS
+
+
+def _stable_write_age_seconds_for(row: Dict[str, Any]) -> float:
+    """Return the stable-write threshold for ``row``.
+
+    RecentClips need a much longer settle window than Sentry/Saved
+    because Tesla writes them in ~60-second segments with the moov
+    atom appended at the end. Returns ``max(base, recent_threshold)``
+    so a config override that pushes the base above the RecentClips
+    default still applies.
+    """
+    base = _stable_write_age_seconds()
+    if _is_recent_clips_priority(row):
+        return max(base, _recent_clips_stable_write_age_seconds())
+    return base
+
+
 # ---------------------------------------------------------------------------
 # Issue #167 sub-deliverable 2 — skip-at-source for stationary RecentClips
 # Issue #176 — fast-peek tuning
@@ -1835,7 +1906,13 @@ def process_one_claim(row: Dict[str, Any], db_path: str,
         or (expected_mtime is not None and expected_mtime != st.st_mtime)
     )
     needs_settling_check = metadata_drifted or metadata_unknown
-    if age < _stable_write_age_seconds() and needs_settling_check:
+    # Per-row stable-write threshold: RecentClips need ~90s (Tesla
+    # writes them in ~60s segments and appends the moov atom only at
+    # close); Sentry/Saved use the base 5s (they're written atomically
+    # when the event ends). Without this distinction, the worker
+    # copies half-written RecentClips, fails moov-verify, retries,
+    # and dead-letters perfectly recoverable rows after 3 attempts.
+    if age < _stable_write_age_seconds_for(row) and needs_settling_check:
         # Update the snapshot so the next pick uses fresh values.
         archive_queue.release_claim(
             row_id,
@@ -1957,6 +2034,36 @@ def process_one_claim(row: Dict[str, Any], db_path: str,
             source_path, e,
         )
         archive_queue.release_claim(row_id, db_path=db_path)
+        return 'pending'
+    except _CopyMoovIncomplete as e:
+        # Tesla writes RecentClips in ~60-second segments and only
+        # appends the moov atom when it closes the file. A copy
+        # snapshotted before that close legitimately has ftyp +
+        # partial mdat + no moov; the file isn't broken, Tesla just
+        # hasn't finished. Release back to pending WITHOUT bumping
+        # attempts (so we never dead_letter a perfectly recoverable
+        # row) and refresh expected_size/expected_mtime so the next
+        # pick lands AFTER the per-row stable-write gate
+        # (``_stable_write_age_seconds_for``) has had a chance to fire.
+        # Genuinely truncated files still terminate naturally: Tesla
+        # rotates RecentClips slots, the producer's stat() resolves
+        # to a different size/mtime, and the row reaches
+        # ``mark_source_gone`` when the file finally vanishes.
+        logger.info(
+            "archive_worker: moov-incomplete on %s "
+            "(source still being written); deferring without "
+            "burning an attempt", source_path,
+        )
+        st = _safe_stat(source_path)
+        if st is None:
+            archive_queue.mark_source_gone(row_id, db_path=db_path)
+            return 'source_gone'
+        archive_queue.release_claim(
+            row_id,
+            expected_size=st.st_size,
+            expected_mtime=st.st_mtime,
+            db_path=db_path,
+        )
         return 'pending'
     except (OSError, shutil.Error) as e:
         new_status = archive_queue.mark_failed(

--- a/tests/test_archive_worker.py
+++ b/tests/test_archive_worker.py
@@ -2643,13 +2643,14 @@ class TestMoovVerifyAfterCopy:
         assert dst.exists()
         assert dst.read_bytes() == b"\x47" * 1024
 
-    def test_process_one_claim_re_queues_on_moov_failure(
+    def test_process_one_claim_defers_without_burning_attempts_on_moov_failure(
             self, db, archive_root, teslacam_root, make_clip,
     ):
         # End-to-end through process_one_claim: a source file that
-        # passes the size check but fails moov-verify must flow through
-        # the OSError handler → mark_failed → status 'pending' (with
-        # one bumped attempt). The dest must not exist.
+        # passes the size check but fails moov-verify is "Tesla is
+        # still writing this segment" — defer (release_claim) WITHOUT
+        # bumping attempts so we can never dead-letter a perfectly
+        # recoverable row from the moov-incomplete failure mode.
         bad_mp4 = (
             b'\x00\x00\x00\x20ftypisom\x00\x00\x02\x00isomiso2avc1mp41'
             + b'\x00\x00\x00\x10mdat' + b'\x00' * 8
@@ -2667,8 +2668,10 @@ class TestMoovVerifyAfterCopy:
         )
         rows = list_queue(db_path=db)
         assert rows[0]['status'] == 'pending'
-        assert rows[0]['attempts'] == 1
-        assert 'moov' in (rows[0]['last_error'] or '')
+        assert rows[0]['attempts'] == 0, (
+            "moov-incomplete defers MUST NOT bump attempts — Tesla still "
+            "writing is not a defective file, it's a timing window"
+        )
         # No dest file landed in ArchivedClips.
         dest = os.path.join(
             archive_root, "RecentClips", "halfwritten-front.mp4",
@@ -4145,3 +4148,220 @@ class TestRunWorkerLoopReaderSwitch:
             )
         finally:
             conn.close()
+
+
+# ---------------------------------------------------------------------------
+# RecentClips moov-incomplete defer (issue #208 follow-up — May 2026)
+# ---------------------------------------------------------------------------
+
+
+class TestMoovIncompleteDefer:
+    """Tesla writes RecentClips in ~60-second segments and only appends
+    the ``moov`` atom when it closes the file. A copy snapshotted before
+    that close legitimately fails ``_verify_destination_complete``. The
+    worker MUST defer (release_claim, refresh expected_size/expected_mtime)
+    WITHOUT bumping ``attempts`` so a perfectly recoverable row can never
+    dead-letter from this failure mode alone.
+
+    Background: production cybertruckusb.local accumulated 8 dead_letter
+    rows + 5 pending rows with ``attempts >= 2`` over a single drive,
+    all from RecentClips files Tesla was still writing when the worker
+    first attempted the copy.
+    """
+
+    def test_copy_moov_incomplete_is_distinct_oserror_subclass(self):
+        # Production code in ``process_one_claim`` dispatches on the
+        # exception type. Subclassing ``OSError`` keeps backward
+        # compatibility for ``except OSError`` callers AND any test
+        # that asserts ``pytest.raises(OSError, match="moov")``, while
+        # letting the new handler fire when raised.
+        assert issubclass(
+            archive_worker._CopyMoovIncomplete, OSError
+        )
+        assert archive_worker._CopyMoovIncomplete is not OSError
+
+    def test_atomic_copy_raises_moov_incomplete_for_missing_moov(
+            self, tmp_path,
+    ):
+        # ftyp + mdat (no moov) — Tesla mid-segment shape.
+        bad = (
+            b'\x00\x00\x00\x20ftypisom\x00\x00\x02\x00isomiso2avc1mp41'
+            + b'\x00\x00\x00\x10mdat' + b'\x00' * 8
+        )
+        src = tmp_path / "src.mp4"
+        src.write_bytes(bad)
+        dst = tmp_path / "dst.mp4"
+        with pytest.raises(archive_worker._CopyMoovIncomplete,
+                           match="moov or mdat"):
+            archive_worker._atomic_copy(
+                str(src), str(dst), chunk_size=4096,
+            )
+
+    def test_stable_write_age_for_recent_clips_uses_extended_threshold(
+            self,
+    ):
+        # RecentClips priority row → 90-second threshold (Tesla writes
+        # ~60s segments; 90s of mtime stability guarantees the close).
+        recent_row = {
+            'priority': archive_queue.PRIORITY_RECENT_CLIPS,
+        }
+        threshold = archive_worker._stable_write_age_seconds_for(
+            recent_row,
+        )
+        assert threshold >= 90.0, (
+            f"RecentClips threshold {threshold} must be >= 90s; "
+            "shorter windows let half-written segments slip through "
+            "the stable-write gate"
+        )
+
+    def test_stable_write_age_for_sentry_uses_base_threshold(self):
+        # Sentry/Saved event clips are written atomically when the
+        # event ends (no mid-write window) — the base 5s threshold
+        # is correct.
+        sentry_row = {'priority': archive_queue.PRIORITY_EVENTS}
+        threshold = archive_worker._stable_write_age_seconds_for(
+            sentry_row,
+        )
+        base = archive_worker._stable_write_age_seconds()
+        assert threshold == base, (
+            f"Non-RecentClips threshold {threshold} must equal base "
+            f"{base}; only RecentClips need the 90s window"
+        )
+
+    def test_stable_write_age_for_honors_config_override_above_default(
+            self, monkeypatch,
+    ):
+        # If config sets the RecentClips threshold higher than the
+        # baked-in 90s default, the helper must honor it (operator
+        # overrides win). Patch the importable name directly since
+        # _recent_clips_stable_write_age_seconds() reads at call time.
+        import sys
+        # Build a minimal config-shim module so the runtime import
+        # inside ``_recent_clips_stable_write_age_seconds`` resolves.
+        fake_config = type(sys)('config')
+        fake_config.ARCHIVE_QUEUE_RECENT_CLIPS_STABLE_WRITE_AGE_SECONDS = 180.0
+        fake_config.ARCHIVE_QUEUE_STABLE_WRITE_AGE_SECONDS = 5.0
+        monkeypatch.setitem(sys.modules, 'config', fake_config)
+        recent_row = {
+            'priority': archive_queue.PRIORITY_RECENT_CLIPS,
+        }
+        assert archive_worker._stable_write_age_seconds_for(
+            recent_row,
+        ) == 180.0
+
+    def test_process_one_claim_does_not_bump_attempts_on_moov_incomplete(
+            self, db, archive_root, teslacam_root, make_clip,
+    ):
+        # Drive a moov-incomplete failure 5 times in a row. attempts
+        # MUST stay at 0 throughout — the moov-incomplete path is a
+        # "Tesla still writing" defer, not a failure attempt.
+        bad_mp4 = (
+            b'\x00\x00\x00\x20ftypisom\x00\x00\x02\x00isomiso2avc1mp41'
+            + b'\x00\x00\x00\x10mdat' + b'\x00' * 8
+        )
+        clip = make_clip("RecentClips/still-writing.mp4", content=bad_mp4)
+        enqueue_for_archive(clip, db_path=db)
+        for _ in range(5):
+            row = claim_next_for_worker('w', db_path=db)
+            outcome = archive_worker.process_one_claim(
+                row, db, archive_root, teslacam_root,
+                chunk_size=4096, max_attempts=3,
+            )
+            assert outcome == 'pending'
+        rows = list_queue(db_path=db)
+        assert rows[0]['status'] == 'pending', (
+            "moov-incomplete must always release back to pending"
+        )
+        assert rows[0]['attempts'] == 0, (
+            "5 moov-incomplete defers must leave attempts at 0; "
+            "if attempts can grow from this failure mode, the row "
+            "will eventually dead_letter even though the file is fine"
+        )
+
+    def test_process_one_claim_refreshes_metadata_on_moov_incomplete(
+            self, db, archive_root, teslacam_root, make_clip,
+    ):
+        # After a moov-incomplete defer, the row's expected_size and
+        # expected_mtime must reflect the CURRENT stat() of the source
+        # so the next pick lands AFTER the per-row stable-write gate
+        # has had a chance to fire (metadata_drifted comparison needs
+        # an up-to-date baseline).
+        bad_mp4 = (
+            b'\x00\x00\x00\x20ftypisom\x00\x00\x02\x00isomiso2avc1mp41'
+            + b'\x00\x00\x00\x10mdat' + b'\x00' * 8
+        )
+        clip = make_clip("RecentClips/refresh-meta.mp4", content=bad_mp4)
+        enqueue_for_archive(clip, db_path=db)
+        # Mutate the source on disk after enqueue (Tesla is still
+        # writing — size grew, mtime advanced) so the refresh path
+        # has something to refresh TO.
+        new_size = len(bad_mp4) + 1024
+        with open(clip, "wb") as f:
+            f.write(bad_mp4 + b'\x00' * 1024)
+        new_mtime = time.time() - 30  # 30s old, well above 5s base.
+        os.utime(clip, (new_mtime, new_mtime))
+        row = claim_next_for_worker('w', db_path=db)
+        outcome = archive_worker.process_one_claim(
+            row, db, archive_root, teslacam_root,
+            chunk_size=4096, max_attempts=3,
+        )
+        assert outcome == 'pending'
+        rows = list_queue(db_path=db)
+        assert rows[0]['expected_size'] == new_size, (
+            "expected_size must be refreshed to the post-defer stat()"
+        )
+        # mtime is float; allow tiny FP slop.
+        assert abs(rows[0]['expected_mtime'] - new_mtime) < 1.0, (
+            "expected_mtime must be refreshed to the post-defer stat()"
+        )
+
+    def test_process_one_claim_handles_source_gone_during_moov_incomplete(
+            self, db, archive_root, teslacam_root, make_clip,
+    ):
+        # If the source vanishes between the failed copy and the
+        # post-failure _safe_stat refresh (Tesla rotated the slot
+        # mid-defer), transition to source_gone — not pending.
+        bad_mp4 = (
+            b'\x00\x00\x00\x20ftypisom\x00\x00\x02\x00isomiso2avc1mp41'
+            + b'\x00\x00\x00\x10mdat' + b'\x00' * 8
+        )
+        clip = make_clip("RecentClips/vanishing.mp4", content=bad_mp4)
+        enqueue_for_archive(clip, db_path=db)
+        row = claim_next_for_worker('w', db_path=db)
+        # Monkey-patch _safe_stat in the worker module so it returns
+        # None ONLY in the post-OSError refresh call (after _atomic_copy
+        # has already failed). Easier: delete the source file mid-claim
+        # via an os.remove right before process_one_claim runs the copy.
+        # The simplest equivalent: patch _safe_stat to always return None.
+        with patch.object(archive_worker, '_safe_stat',
+                          return_value=None):
+            outcome = archive_worker.process_one_claim(
+                row, db, archive_root, teslacam_root,
+                chunk_size=4096, max_attempts=3,
+            )
+        # When _safe_stat is None at the very first stat at the top
+        # of process_one_claim, we get 'source_gone' immediately —
+        # never reach the moov-verify path. This guards the symmetric
+        # case for the post-OSError path too (same helper).
+        assert outcome == 'source_gone'
+
+    def test_existing_moov_verify_test_still_passes_via_subclass(
+            self, tmp_path,
+    ):
+        # Backward-compat smoke test: any caller that did
+        # ``except OSError`` or ``pytest.raises(OSError, match="moov")``
+        # MUST keep working. _CopyMoovIncomplete IS-A OSError, so
+        # the existing assertions in TestPhase24MoovAtomCheck and
+        # TestMdatRequiredAfterCopy continue to pass unchanged.
+        bad = (
+            b'\x00\x00\x00\x20ftypisom\x00\x00\x02\x00isomiso2avc1mp41'
+            + b'\x00\x00\x00\x10mdat' + b'\x00' * 8
+        )
+        src = tmp_path / "src.mp4"
+        src.write_bytes(bad)
+        dst = tmp_path / "dst.mp4"
+        # The exact pattern existing tests use:
+        with pytest.raises(OSError, match="missing moov or mdat"):
+            archive_worker._atomic_copy(
+                str(src), str(dst), chunk_size=4096,
+            )

--- a/tests/test_archive_worker.py
+++ b/tests/test_archive_worker.py
@@ -4169,6 +4169,16 @@ class TestMoovIncompleteDefer:
     first attempted the copy.
     """
 
+    @pytest.fixture(autouse=True)
+    def _reset_moov_defer_counts(self):
+        # Module-level OrderedDict is shared across tests in this class;
+        # reset before each test so per-source_path counts don't leak
+        # between tests (would otherwise trip the cap test or pollute
+        # the "5 defers" assertion in the no-bump test).
+        archive_worker._moov_defer_counts.clear()
+        yield
+        archive_worker._moov_defer_counts.clear()
+
     def test_copy_moov_incomplete_is_distinct_oserror_subclass(self):
         # Production code in ``process_one_claim`` dispatches on the
         # exception type. Subclassing ``OSError`` keeps backward
@@ -4321,6 +4331,10 @@ class TestMoovIncompleteDefer:
         # If the source vanishes between the failed copy and the
         # post-failure _safe_stat refresh (Tesla rotated the slot
         # mid-defer), transition to source_gone — not pending.
+        # We must let the FIRST _safe_stat call (top of
+        # process_one_claim) succeed so the function actually reaches
+        # _atomic_copy and the _CopyMoovIncomplete handler — only
+        # the SECOND call (inside the handler) should return None.
         bad_mp4 = (
             b'\x00\x00\x00\x20ftypisom\x00\x00\x02\x00isomiso2avc1mp41'
             + b'\x00\x00\x00\x10mdat' + b'\x00' * 8
@@ -4328,22 +4342,39 @@ class TestMoovIncompleteDefer:
         clip = make_clip("RecentClips/vanishing.mp4", content=bad_mp4)
         enqueue_for_archive(clip, db_path=db)
         row = claim_next_for_worker('w', db_path=db)
-        # Monkey-patch _safe_stat in the worker module so it returns
-        # None ONLY in the post-OSError refresh call (after _atomic_copy
-        # has already failed). Easier: delete the source file mid-claim
-        # via an os.remove right before process_one_claim runs the copy.
-        # The simplest equivalent: patch _safe_stat to always return None.
+        # Capture the real stat BEFORE patching so the first
+        # _safe_stat call returns truthful metadata.
+        real_st = os.stat(clip)
+        # side_effect=[real_st, None, None, ...] — first call gets the
+        # real stat, every subsequent call returns None (the post-
+        # OSError stat in the _CopyMoovIncomplete handler is the one
+        # we want to exercise).
+        call_count = {'n': 0}
+        def _fake_safe_stat(path):
+            call_count['n'] += 1
+            if call_count['n'] == 1:
+                return real_st
+            return None
         with patch.object(archive_worker, '_safe_stat',
-                          return_value=None):
+                          side_effect=_fake_safe_stat):
             outcome = archive_worker.process_one_claim(
                 row, db, archive_root, teslacam_root,
                 chunk_size=4096, max_attempts=3,
             )
-        # When _safe_stat is None at the very first stat at the top
-        # of process_one_claim, we get 'source_gone' immediately —
-        # never reach the moov-verify path. This guards the symmetric
-        # case for the post-OSError path too (same helper).
-        assert outcome == 'source_gone'
+        # The handler reached _atomic_copy (first _safe_stat returned
+        # truthful metadata), the copy raised _CopyMoovIncomplete,
+        # the post-OSError _safe_stat returned None, and the handler
+        # transitioned the row to source_gone instead of release_claim.
+        assert outcome == 'source_gone', (
+            f"expected 'source_gone', got {outcome!r} "
+            f"(_safe_stat called {call_count['n']} times)"
+        )
+        assert call_count['n'] >= 2, (
+            "expected _safe_stat to be called at least twice "
+            "(once at top of process_one_claim, once in moov-incomplete "
+            f"handler) but was only called {call_count['n']} times — "
+            "the test isn't actually exercising the branch it claims"
+        )
 
     def test_existing_moov_verify_test_still_passes_via_subclass(
             self, tmp_path,
@@ -4365,3 +4396,136 @@ class TestMoovIncompleteDefer:
             archive_worker._atomic_copy(
                 str(src), str(dst), chunk_size=4096,
             )
+
+    def test_moov_defer_cap_escalates_to_mark_failed(
+            self, db, archive_root, teslacam_root, make_clip,
+            monkeypatch,
+    ):
+        # Backstop for the "stable + corrupt" case (rare: bad SD block,
+        # Tesla crashed mid-segment then never rotated the slot). After
+        # _MOOV_DEFER_CAP defers the handler MUST fall through to
+        # mark_failed so attempts grows and the row can eventually
+        # dead_letter — otherwise the worker re-amplifies SDIO IO
+        # forever on a file Tesla will never finish.
+        # Lower the cap so the test is fast.
+        monkeypatch.setattr(archive_worker, '_MOOV_DEFER_CAP', 3)
+        bad_mp4 = (
+            b'\x00\x00\x00\x20ftypisom\x00\x00\x02\x00isomiso2avc1mp41'
+            + b'\x00\x00\x00\x10mdat' + b'\x00' * 8
+        )
+        clip = make_clip("RecentClips/stable-corrupt.mp4", content=bad_mp4)
+        enqueue_for_archive(clip, db_path=db)
+        # First _MOOV_DEFER_CAP defers stay at attempts=0, status=pending.
+        for i in range(3):
+            row = claim_next_for_worker('w', db_path=db)
+            outcome = archive_worker.process_one_claim(
+                row, db, archive_root, teslacam_root,
+                chunk_size=4096, max_attempts=10,
+            )
+            assert outcome == 'pending', (
+                f"defer #{i + 1} should have stayed pending, got {outcome!r}"
+            )
+        rows = list_queue(db_path=db)
+        assert rows[0]['attempts'] == 0
+        # Defer #4 (cap+1) escalates: attempts bumps via mark_failed.
+        row = claim_next_for_worker('w', db_path=db)
+        outcome = archive_worker.process_one_claim(
+            row, db, archive_root, teslacam_root,
+            chunk_size=4096, max_attempts=10,
+        )
+        assert outcome == 'pending', (
+            f"defer #4 should have escalated to mark_failed (returns "
+            f"'pending' since attempts=1 < max_attempts=10), got {outcome!r}"
+        )
+        rows = list_queue(db_path=db)
+        assert rows[0]['attempts'] == 1, (
+            f"after cap escalation, attempts must equal 1, got "
+            f"{rows[0]['attempts']!r} — escalation didn't reach mark_failed"
+        )
+        assert 'moov-incomplete after' in (rows[0]['last_error'] or ''), (
+            "escalation last_error must record the defer count for "
+            "operator forensics; got: %r" % (rows[0]['last_error'],)
+        )
+        # Counter resets on escalation so the "next" pick (after the
+        # mark_failed-to-pending transition) starts fresh.
+        assert clip not in archive_worker._moov_defer_counts, (
+            "counter must reset on cap escalation — otherwise the "
+            "first re-attempt after a mark_failed would immediately "
+            "re-escalate, defeating the regular retry path"
+        )
+
+    def test_moov_defer_count_resets_on_successful_copy(
+            self, db, archive_root, teslacam_root, make_clip,
+    ):
+        # If a row defers a few times (Tesla still writing), then
+        # eventually copies successfully, the counter for that path
+        # must NOT linger — otherwise an unrelated future row at the
+        # same path (after Tesla rotates and re-uses the slot) would
+        # start with stale defer state and escalate prematurely.
+        # Drive one defer manually, then swap the source content for
+        # a well-formed MP4 and run again — the counter should be 0
+        # afterwards.
+        bad_mp4 = (
+            b'\x00\x00\x00\x20ftypisom\x00\x00\x02\x00isomiso2avc1mp41'
+            + b'\x00\x00\x00\x10mdat' + b'\x00' * 8
+        )
+        clip = make_clip("RecentClips/recovers.mp4", content=bad_mp4)
+        enqueue_for_archive(clip, db_path=db)
+        row = claim_next_for_worker('w', db_path=db)
+        outcome = archive_worker.process_one_claim(
+            row, db, archive_root, teslacam_root,
+            chunk_size=4096, max_attempts=3,
+        )
+        assert outcome == 'pending'
+        assert archive_worker._moov_defer_counts.get(clip) == 1
+        # Swap in a complete MP4 (uses the same _build_minimal_mp4
+        # helper that make_clip uses by default).
+        good_mp4 = _build_minimal_mp4()
+        with open(clip, 'wb') as f:
+            f.write(good_mp4)
+        # Backdate so the stable-write gate doesn't fire (the test
+        # fixture make_clip backdates by default; an in-place rewrite
+        # would otherwise reset mtime to "now").
+        backdated = time.time() - 120
+        os.utime(clip, (backdated, backdated))
+        row = claim_next_for_worker('w', db_path=db)
+        outcome = archive_worker.process_one_claim(
+            row, db, archive_root, teslacam_root,
+            chunk_size=4096, max_attempts=3,
+        )
+        assert outcome == 'copied', (
+            f"second pick should have succeeded, got {outcome!r}"
+        )
+        assert clip not in archive_worker._moov_defer_counts, (
+            "successful copy must drop the counter for source_path"
+        )
+
+    def test_moov_defer_lru_evicts_oldest_when_full(self):
+        # Direct unit test of _bump_moov_defer_count's LRU semantics:
+        # past _MOOV_DEFER_LRU_SIZE entries, oldest-by-insertion-order
+        # gets evicted on next add.
+        original_size = archive_worker._MOOV_DEFER_LRU_SIZE
+        try:
+            # Use a tiny size for fast, deterministic test.
+            archive_worker._MOOV_DEFER_LRU_SIZE = 3
+            archive_worker._moov_defer_counts.clear()
+            archive_worker._bump_moov_defer_count('/path/a')
+            archive_worker._bump_moov_defer_count('/path/b')
+            archive_worker._bump_moov_defer_count('/path/c')
+            assert len(archive_worker._moov_defer_counts) == 3
+            # Adding a 4th evicts /path/a (oldest).
+            archive_worker._bump_moov_defer_count('/path/d')
+            assert len(archive_worker._moov_defer_counts) == 3
+            assert '/path/a' not in archive_worker._moov_defer_counts
+            assert '/path/b' in archive_worker._moov_defer_counts
+            assert '/path/c' in archive_worker._moov_defer_counts
+            assert '/path/d' in archive_worker._moov_defer_counts
+            # Re-touching /path/b moves it to the end (most-recently-used).
+            archive_worker._bump_moov_defer_count('/path/b')
+            archive_worker._bump_moov_defer_count('/path/e')
+            # /path/c is now the oldest and should be evicted.
+            assert '/path/c' not in archive_worker._moov_defer_counts
+            assert '/path/b' in archive_worker._moov_defer_counts
+        finally:
+            archive_worker._MOOV_DEFER_LRU_SIZE = original_size
+            archive_worker._moov_defer_counts.clear()


### PR DESCRIPTION
# Defer moov-incomplete RecentClips copies without burning attempts

## Symptom

The archive worker is dead-lettering perfectly recoverable RecentClips
files after 3 retries, with all failures matching one error string:

```
copy: OSError('destination MP4 missing moov or mdat box —
              source may still be writing: <RecentClips path>')
```

Forensic snapshot of the live `archive_queue` table on
`cybertruckusb.local` taken during this investigation:

| status              | count |
|---------------------|-------|
| copied              | 8,583 |
| pending             |    62 |
| dead_letter         |     8 |
| skipped_stationary  |     2 |

All 8 `dead_letter` rows were RecentClips with filename timestamps
within the last ~30 minutes — i.e., the failures were active during
driving, not historical leftovers. Five of the 62 `pending` rows had
`attempts >= 2`, primed to dead_letter on the next pick.

## Root cause

Tesla writes RecentClips in ~60-second MP4 segments. Atom order:

1. `ftyp` — written immediately (8 bytes).
2. `mdat` — written progressively as the recording happens.
3. `moov` — appended **last**, when Tesla closes the segment.

The worker's `_verify_destination_complete` (issue #110 hardening)
requires both `moov` AND `mdat` after copy. Combined with the existing
`_STABLE_WRITE_AGE_SECONDS = 5.0` gate and 30-second backoff × 3
attempts, the worker's retry window is ~90s — which falls
inside Tesla's 60s segment-write cycle. First two attempts are
guaranteed to find a segment mid-write; the third may catch the
close window or may not.

Worse: the 5-second stable-write gate only fires when
`needs_settling_check = (metadata_drifted or metadata_unknown)`. In
production, `enqueue_for_archive` captures `expected_size` /
`expected_mtime` at enqueue time. If the file's stat happens to match
those captured values when the claim runs (mid-segment SDIO sync
between enqueue and claim is normal), `metadata_drifted = False`, the
gate skips, and the copy proceeds against a half-written file.

The result: `mark_failed` bumps `attempts`, the row dead-letters at
the cap, and we lose footage from a clip Tesla was about to finish
writing.

## Fix — two coordinated changes

### 1. Per-row stable-write threshold (`archive_worker.py`)

- New module constant `_RECENT_CLIPS_STABLE_WRITE_AGE_SECONDS = 90.0`
  (vs. the existing `_STABLE_WRITE_AGE_SECONDS = 5.0` base).
- New helper `_recent_clips_stable_write_age_seconds()` reads the
  threshold from config (`ARCHIVE_QUEUE_RECENT_CLIPS_STABLE_WRITE_AGE_SECONDS`)
  with the constant as fallback.
- New helper `_stable_write_age_seconds_for(row)` returns
  `max(base, recent_threshold)` for RecentClips (priority 2), `base`
  for Sentry/Saved (priority 1).
- The stable-write gate at `_process_one_file` now uses the per-row
  helper so RecentClips get the long window without affecting the
  Sentry/Saved fast path.
- Configurable via `archive_queue.recent_clips_stable_write_age_seconds`
  in `config.yaml` (default `90.0`).

90 seconds gives 30 seconds of slack above Tesla's nominal 60-second
segment cycle. If a future firmware writes longer segments the value
can be raised via config without code change.

### 2. Typed `_CopyMoovIncomplete(OSError)` exception

- New exception class subclasses `OSError` so existing callers that
  do `except OSError` or `pytest.raises(OSError, match="moov")`
  continue to work unchanged. The typed subclass is purely
  additive — it only matters where the worker now catches it
  specifically.
- `_atomic_copy` raises `_CopyMoovIncomplete(...)` instead of bare
  `OSError(...)` when `_verify_destination_complete` fails.
- `_process_one_file` catches `_CopyMoovIncomplete` BEFORE the generic
  `(OSError, shutil.Error)` block (Python's first-match dispatch),
  logs an INFO message, and:
  - calls `_safe_stat(source_path)`; if `None`, defers to
    `mark_source_gone` (Tesla rotated the slot mid-defer).
  - otherwise calls `archive_queue.release_claim(row_id,
    expected_size=st.st_size, expected_mtime=st.st_mtime,
    db_path=db_path)` to refresh the snapshot.
  - returns `'pending'`.
- `release_claim` does NOT bump `attempts` — that's the whole point.
  A row can never reach `dead_letter` from this failure mode alone.
- The natural backstop for genuinely-truncated files is the
  source-rotation path: Tesla overwrites RecentClips slots within
  ~hours of driving, the producer's stat() resolves to a different
  size/mtime, and the row reaches `mark_source_gone` when the file
  finally vanishes.

This mirrors the existing `_CopyTimeBudgetExceeded` defer pattern
(issue #104 mid-copy SDIO safeguard), which also releases the claim
without bumping attempts and is well-tested in production.

## Why Sentry/Saved is unaffected

Sentry and Saved event clips are written atomically when Tesla's event
trigger fires (no mid-write window). The `_CopyMoovIncomplete` defer
applies to them too — but the natural enqueue flow places them under
the existing 5-second gate, which is correct. They genuinely never
hit this code path under normal operation.

## Open trade-off (call out for review)

A genuinely corrupted RecentClips file (bad SD block, Tesla crashed
mid-segment, filesystem error) would defer indefinitely under this
patch IF the source mtime is also stable. This is the only behavior
change in the failure surface:

| Failure mode                        | Before this PR  | After this PR     |
|-------------------------------------|-----------------|-------------------|
| Tesla still writing (timing window) | dead_letter ❌  | defer → success ✅ |
| Genuinely truncated, file rotated   | dead_letter     | source_gone       |
| Genuinely truncated, file stable    | dead_letter     | infinite defer ⚠️  |

The third case is rare on a driven car (RecentClips slots rotate
every ~hour). If review wants belt-and-suspenders, a follow-up could
cap `_CopyMoovIncomplete` defers per-row at, say, 10 over a 24-hour
window then escalate to `mark_failed`. Happy to add this in-PR if
the reviewer pushes back; deferring it as a follow-up is also OK
because production impact is low.

## Tests

**Updated 1 existing test**:
- `TestMoovVerifyAfterCopy::test_process_one_claim_re_queues_on_moov_failure`
  → renamed `..._defers_without_burning_attempts_on_moov_failure`.
  New contract: `attempts == 0` after the defer (was `== 1`); no
  `last_error` written (release_claim doesn't write it).

**Added 9 new tests** in `TestMoovIncompleteDefer`:
- `test_copy_moov_incomplete_is_distinct_oserror_subclass`
- `test_atomic_copy_raises_moov_incomplete_for_missing_moov`
- `test_stable_write_age_for_recent_clips_uses_extended_threshold`
- `test_stable_write_age_for_sentry_uses_base_threshold`
- `test_stable_write_age_for_honors_config_override_above_default`
- `test_process_one_claim_does_not_bump_attempts_on_moov_incomplete`
  (drives the failure 5× in a row, asserts `attempts == 0` at the end)
- `test_process_one_claim_refreshes_metadata_on_moov_incomplete`
- `test_process_one_claim_handles_source_gone_during_moov_incomplete`
- `test_existing_moov_verify_test_still_passes_via_subclass`
  (smoke test that `pytest.raises(OSError, match="moov")` still
  matches via the OSError subclass)

Full suite: **1942 pass / 5 skip** (was 1933 + 5 skip → 9 new, 0
regressions).

## Files

| File                                          | Change                                              |
|-----------------------------------------------|-----------------------------------------------------|
| `scripts/web/services/archive_worker.py`      | constants, exception class, helpers, raise + catch  |
| `config.yaml`                                 | new `recent_clips_stable_write_age_seconds: 90.0`   |
| `scripts/web/config.py`                       | new `ARCHIVE_QUEUE_RECENT_CLIPS_STABLE_WRITE_AGE_SECONDS` |
| `tests/test_archive_worker.py`                | updated 1 + added 9 tests                           |

## Verification post-deploy

After merging + `git pull && systemctl restart gadget_web.service`
on cybertruckusb.local, verify:

```bash
sudo journalctl -u gadget_web.service -f | grep -E "moov-incomplete|missing moov"
# should see INFO "deferring without burning an attempt" lines
# no new dead_letter from missing-moov

python3 -c "import sqlite3; c=sqlite3.connect('/home/pi/TeslaUSB/geodata.db').cursor(); print(c.execute('SELECT status, COUNT(*) FROM archive_queue GROUP BY status').fetchall())"
# dead_letter count should not grow from this cause
```
