### PR TITLE
fix: short-circuit peek-and-skip for stale unreadable RecentClips

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -297,6 +297,7 @@ archive_queue:
   # editing this file by SSH.
   stable_write_age_seconds: 5.0          # Re-queue clips whose mtime is fresher than this many seconds (avoids copying mid-write)
   recent_clips_stable_write_age_seconds: 90.0  # Higher threshold for RecentClips (Tesla writes ~60s segments; moov atom appended at close — see archive_worker._CopyMoovIncomplete)
+  peek_give_up_age_seconds: 300.0        # If SEI peek raises a parser error AND file mtime is older than this, treat as stationary (skip) instead of falling through to copy — prevents queue cascade when VFS page cache holds a stale view of files Tesla wrote via the gadget block layer
   stale_claim_max_age_seconds: 600.0     # Reset 'claimed' rows older than this back to 'pending' on worker startup (recovers crashed/OOMed claims)
   # Wave 4 PR-E (issue #184): shadow-mode validation of the unified
   # ``pipeline_queue``. When enabled, the archive worker peeks at

--- a/scripts/web/blueprints/settings_advanced.py
+++ b/scripts/web/blueprints/settings_advanced.py
@@ -166,6 +166,42 @@ def _build_tunables() -> List[Dict[str, Any]]:
             'cast': _bounded_float(0.0, 60.0),
         },
         {
+            'key': 'archive_queue.recent_clips_stable_write_age_seconds',
+            'form_name': 'archive_recent_clips_stable_write_age_seconds',
+            'label': 'Archive: RecentClips stable-write age',
+            'description': (
+                'Higher stable-write threshold for RecentClips. Tesla '
+                'writes the moov atom at the end of each ~60s segment, '
+                'so RecentClips need extra settling time before copy '
+                '(see archive_worker._CopyMoovIncomplete).'
+            ),
+            'current': float(
+                config.ARCHIVE_QUEUE_RECENT_CLIPS_STABLE_WRITE_AGE_SECONDS
+            ),
+            'default': 90.0,
+            'unit': 'seconds',
+            'min': 30.0, 'max': 300.0, 'step': 5.0,
+            'cast': _bounded_float(30.0, 300.0),
+        },
+        {
+            'key': 'archive_queue.peek_give_up_age_seconds',
+            'form_name': 'archive_peek_give_up_age_seconds',
+            'label': 'Archive: peek give-up age',
+            'description': (
+                'When the SEI peek raises a parser error AND the '
+                'file is older than this, treat it as stationary '
+                '(skip) instead of falling through to copy. Prevents '
+                'the worker from cycling on files Tesla wrote via the '
+                'gadget block layer where the Pi VFS page cache holds '
+                'a stale view.'
+            ),
+            'current': float(config.ARCHIVE_QUEUE_PEEK_GIVE_UP_AGE_SECONDS),
+            'default': 300.0,
+            'unit': 'seconds',
+            'min': 60.0, 'max': 3600.0, 'step': 30.0,
+            'cast': _bounded_float(60.0, 3600.0),
+        },
+        {
             'key': 'archive_queue.stale_claim_max_age_seconds',
             'form_name': 'archive_stale_claim_max_age_seconds',
             'label': 'Archive: stale-claim max age',

--- a/scripts/web/config.py
+++ b/scripts/web/config.py
@@ -289,6 +289,9 @@ ARCHIVE_QUEUE_STABLE_WRITE_AGE_SECONDS = float(
 ARCHIVE_QUEUE_RECENT_CLIPS_STABLE_WRITE_AGE_SECONDS = float(
     _archive_queue.get('recent_clips_stable_write_age_seconds', 90.0)
 )
+ARCHIVE_QUEUE_PEEK_GIVE_UP_AGE_SECONDS = float(
+    _archive_queue.get('peek_give_up_age_seconds', 300.0)
+)
 ARCHIVE_QUEUE_STALE_CLAIM_MAX_AGE_SECONDS = float(
     _archive_queue.get('stale_claim_max_age_seconds', 600.0)
 )

--- a/scripts/web/services/archive_worker.py
+++ b/scripts/web/services/archive_worker.py
@@ -1679,6 +1679,23 @@ def _stable_write_age_seconds() -> float:
         return _STABLE_WRITE_AGE_SECONDS
 
 
+def _peek_give_up_age_seconds() -> float:
+    """Return the SEI-peek give-up age threshold from config, falling
+    back to the module-level ``_PEEK_GIVE_UP_AGE_SECONDS``.
+
+    See ``_clip_has_gps_signal`` for the rationale: when the SEI peek
+    raises a parser error on a stale file (mtime older than this
+    threshold), the file is permanently unreadable from VFS and we
+    treat it as stationary so the worker can mark it
+    ``skipped_stationary`` and stop cycling on it.
+    """
+    try:
+        from config import ARCHIVE_QUEUE_PEEK_GIVE_UP_AGE_SECONDS
+        return float(ARCHIVE_QUEUE_PEEK_GIVE_UP_AGE_SECONDS)
+    except Exception:  # noqa: BLE001
+        return _PEEK_GIVE_UP_AGE_SECONDS
+
+
 def _recent_clips_stable_write_age_seconds() -> float:
     """Return RecentClips-specific stable-write threshold.
 
@@ -1751,6 +1768,21 @@ _SKIP_GPS_PEEK_SAMPLE_RATE = 30
 # misclassified as stationary, but the user already opted in to skipping
 # stationary clips and that edge case is far rarer than the stall it cures.
 _SKIP_GPS_PEEK_MAX_WALK_BYTES = 2 * 1024 * 1024
+# May 2026 — when ``_clip_has_gps_signal`` raises a parser exception
+# (commonly: the ``mdat`` or ``moov`` box is unreadable from VFS
+# because the Pi's page cache holds a stale view of a file Tesla
+# wrote via the gadget block layer), retrying is pointless once the
+# file's mtime is older than this threshold. Tesla writes RecentClips
+# in ~60-second segments; if the file hasn't changed in 5 minutes,
+# Tesla isn't writing to it anymore and our view is whatever it is.
+# Treating these as stationary (False, → ``mark_skipped_stationary``)
+# instead of ambiguous (None, → fall through to copy → repeated
+# ``_CopyMoovIncomplete`` defers blocking the queue) is the correct
+# trade: a clip we can't peek won't be useful to copy either, and the
+# ``skipped_stationary`` row acts as a permanent memo so the producer
+# never re-enqueues the same path. Configurable via
+# ``archive_queue.peek_give_up_age_seconds``.
+_PEEK_GIVE_UP_AGE_SECONDS = 300.0
 
 
 def _clip_has_gps_signal(source_path: str) -> Optional[bool]:
@@ -1825,8 +1857,47 @@ def _clip_has_gps_signal(source_path: str) -> Optional[bool]:
         return None
     except Exception as e:  # noqa: BLE001
         # Any parse error (corrupt MP4, mmap failure, protobuf decode
-        # blow-up) — fall through to the existing copy path so we
-        # never lose data on a parser bug.
+        # blow-up, "No mdat box found", "MP4 box 'moov' not found")
+        # — the original behavior was "fall through to the existing
+        # copy path so we never lose data on a parser bug" (None).
+        #
+        # May 2026 update: that fail-open behavior caused a queue
+        # cascade in production. Tesla writes RecentClips via the
+        # USB gadget block layer; the Pi's page cache holds a STALE
+        # view of those files (cached inode reports old i_size,
+        # reads stop short of Tesla's appended bytes). For those
+        # files the SEI peek raises "No mdat" / "no moov", we return
+        # None, the worker falls through to ``_atomic_copy``, which
+        # also can't see the appended boxes and raises
+        # ``_CopyMoovIncomplete``, the row defers, the cap escalates
+        # via ``mark_failed`` to status='pending', the worker re-
+        # claims the SAME row, and the queue blocks.
+        #
+        # Mitigation: if the file's mtime is stale (>= threshold),
+        # the file has been quiescent for far longer than Tesla's
+        # 60 s segment cycle. It's not going to suddenly become
+        # parseable. Treat it as stationary (False) — the worker
+        # marks it ``skipped_stationary`` and the producer's dedup
+        # gate prevents re-enqueue. We're trading a tiny risk
+        # (unreadable file *might* contain GPS) for queue health
+        # (worker can drain). The unreadable file would also have
+        # failed the copy path, so the data is lost either way —
+        # this just makes the loss happen fast and stop blocking
+        # other work.
+        try:
+            age = time.time() - os.stat(source_path).st_mtime
+        except OSError:
+            age = 0.0
+        give_up_age = _peek_give_up_age_seconds()
+        if age >= give_up_age:
+            logger.warning(
+                "_clip_has_gps_signal: peek failed for %s (%s); "
+                "file mtime is %.0fs old (>= %.0fs threshold); "
+                "treating as stationary so the worker can mark it "
+                "skipped_stationary instead of cycling on it",
+                source_path, e, age, give_up_age,
+            )
+            return False
         logger.warning(
             "_clip_has_gps_signal: peek failed for %s (%s); "
             "deferring to copy", source_path, e,

--- a/tests/test_archive_worker.py
+++ b/tests/test_archive_worker.py
@@ -1027,9 +1027,73 @@ class TestClipHasGpsSignal:
         monkeypatch.setattr(
             sei_parser, 'extract_sei_messages', fake_extract,
         )
-        # Parse error → ambiguous → caller must fall through to copy.
-        # NEVER return False on a parse error (that would silently
-        # drop a potentially-valid clip on a parser bug).
+        # Parse error on a FRESH file (mtime=now) → ambiguous → caller
+        # must fall through to copy. NEVER return False on a parse
+        # error for a recently-written file (Tesla may still be in
+        # the middle of a segment write — the next peek may succeed).
+        # See test_returns_false_on_parse_error_when_file_is_stale
+        # below for the May 2026 stale-file mitigation.
+        assert archive_worker._clip_has_gps_signal(str(clip)) is None
+
+    def test_returns_false_on_parse_error_when_file_is_stale(
+        self, monkeypatch, tmp_path,
+    ):
+        # May 2026 — when the SEI peek fails AND the file's mtime is
+        # older than _PEEK_GIVE_UP_AGE_SECONDS, treat as stationary
+        # (False) so the worker marks the row skipped_stationary
+        # instead of falling through to copy → moov-incomplete →
+        # repeated defers blocking the queue. Production cause: the
+        # Pi's VFS page cache holds a stale view of files Tesla wrote
+        # via the gadget block layer; reads return "no mdat" / "no
+        # moov" indefinitely. Treating these as stationary unblocks
+        # the queue. Trade-off: a corrupted-but-has-GPS file would
+        # be skipped, but it would also fail the copy path, so it's
+        # lost either way — this just makes the loss happen quickly.
+        clip = tmp_path / "stale.mp4"
+        clip.write_bytes(b"x" * 100)
+        # Backdate well past the give-up threshold (default 300s).
+        old_mtime = time.time() - (
+            archive_worker._peek_give_up_age_seconds() + 60
+        )
+        os.utime(str(clip), (old_mtime, old_mtime))
+
+        def fake_extract(path, sample_rate, max_walk_bytes=None):
+            raise ValueError("No mdat box found in " + path)
+            yield  # unreachable
+
+        from services import sei_parser
+        monkeypatch.setattr(
+            sei_parser, 'extract_sei_messages', fake_extract,
+        )
+        result = archive_worker._clip_has_gps_signal(str(clip))
+        assert result is False, (
+            f"stale unparseable file should return False (treat as "
+            f"stationary so the worker can mark it skipped_stationary "
+            f"and stop cycling on it), got {result!r}"
+        )
+
+    def test_returns_none_on_parse_error_when_file_is_fresh(
+        self, monkeypatch, tmp_path,
+    ):
+        # Symmetric guard: a parse error on a file whose mtime is
+        # WITHIN the give-up threshold MUST still return None (not
+        # False), because Tesla may still be writing — a future peek
+        # may succeed. Returning False here would silently drop
+        # legitimate moving-clip data.
+        clip = tmp_path / "fresh.mp4"
+        clip.write_bytes(b"x" * 100)
+        # Use a very recent mtime — well below the give-up threshold.
+        recent_mtime = time.time() - 10
+        os.utime(str(clip), (recent_mtime, recent_mtime))
+
+        def fake_extract(path, sample_rate, max_walk_bytes=None):
+            raise ValueError("No mdat box found")
+            yield
+
+        from services import sei_parser
+        monkeypatch.setattr(
+            sei_parser, 'extract_sei_messages', fake_extract,
+        )
         assert archive_worker._clip_has_gps_signal(str(clip)) is None
 
     def test_returns_none_on_file_not_found(


### PR DESCRIPTION
## Summary

Short-circuit `_clip_has_gps_signal`'s parser-error path: when the SEI peek raises an exception **and** the file's mtime is older than `_PEEK_GIVE_UP_AGE_SECONDS` (default 300 s), return `False` (treat as stationary) instead of `None` (fall through to copy). Stops the worker from cycling indefinitely on files that are permanently unreadable from VFS.

## Production trigger (cybertruckusb.local)

Vehicle parked for hours. After service restart at the deploy of PR #210:

- `archive_queue` `pending` jumped from 40 → 264 → 287+ in minutes
- `copied` did NOT advance (stuck at 8583 for 15+ minutes)
- producer correctly logged `enqueued=0, skipped_stationary=227 (saw 2275 total)` every scan — producer NOT re-enqueueing
- worker log every ~20 s on the SAME file `2026-05-15_12-30-08-front.mp4`:
  - `_clip_has_gps_signal: peek failed (No mdat box found); deferring to copy`
  - 11 cycles → `moov-incomplete deferred 11 times (cap=10) — escalating to mark_failed`
  - `mark_failed` bumps attempts → status='pending' → re-claimed → loop
  - ~3.5 min per file × 287 files × 3 cycles to dead_letter ≈ 48 hours to drain

## Root cause

The Pi's VFS page cache holds a **stale view** of files Tesla wrote via the USB gadget block layer. The cached inode reports an old `i_size`; reads stop short of Tesla's appended `mdat`/`moov` boxes. Per project rules:

- `drop_caches=2` (slabs only) does NOT clear the page cache
- `drop_caches=1` (page cache) is unsafe — risks data loss if Tesla is mid-write
- `umount + remount` is forbidden — would disrupt the gadget LUN and lose footage

So the file is permanently unreadable from VFS for the lifetime of the cached page. The previous `return None` policy was correct for transient errors (Tesla still mid-write), but wrong for this permanent-failure mode.

## Fix

When the peek exception fires and `mtime` is older than 5 minutes (well past Tesla's 60 s segment cycle), the file isn't going to suddenly become parseable. Treat it as stationary: the worker calls `mark_skipped_stationary`, the producer's dedup gate prevents re-enqueue, and the next claim moves on.

**Trade-off:** a clip that's genuinely moving but has a corrupted `moov` would be misclassified as stationary and skipped. But that file would also fail the `_atomic_copy` `moov`-verify path (PR #210), so it's lost either way — this just makes the loss happen quickly and stops it from blocking the queue.

## Changes

- **`scripts/web/services/archive_worker.py`**
  - New constant `_PEEK_GIVE_UP_AGE_SECONDS = 300.0` with rationale comment
  - New helper `_peek_give_up_age_seconds()` modeled on `_recent_clips_stable_write_age_seconds()`
  - `_clip_has_gps_signal` exception handler now stat()s the source, returns `False` when `age >= threshold`, `None` otherwise (backward compatible for fresh files)
- **`scripts/web/config.py`**: `ARCHIVE_QUEUE_PEEK_GIVE_UP_AGE_SECONDS` (default 300.0)
- **`config.yaml`**: `archive_queue.peek_give_up_age_seconds` with descriptive comment
- **`tests/test_archive_worker.py`**: 2 new tests
  - `test_returns_false_on_parse_error_when_file_is_stale` — stale + unreadable → `False`
  - `test_returns_none_on_parse_error_when_file_is_fresh` — fresh + unreadable → `None` (existing behavior)
  - Existing `test_returns_none_on_parse_error` annotated with reference to the May 2026 mitigation

## Verification

- Full test suite: **1947 pass / 5 skip** (was 1945, +2 new)
- Targeted `TestClipHasGpsSignal` and `TestMoovIncompleteDefer` all green
- Backward compatible: existing `test_returns_none_on_parse_error` (fresh file, mtime = `now`) still asserts `None`

## Operational follow-up (separate from this PR)

Existing 287 pending rows on the Pi need a one-shot SQL kick to `status='skipped_stationary'` so the queue drains immediately — the code fix only stops FUTURE cycling. Will run post-deploy.

## Out of scope

- `docs/VIDEO_LIFECYCLE.md` and `docs/ARCHITECTURE_CRITIQUE.md` are carry-overs from prior sessions, intentionally NOT included.

Ref #65