### PR TITLE
chore: strip stale Phase 5 (preview) labels from Storage & Retention

### DIFF
--- a/scripts/web/templates/index.html
+++ b/scripts/web/templates/index.html
@@ -470,15 +470,16 @@
                     <div class="form-group">
                         <label style="font-size:0.85rem"><strong>Free-space target (% of SD card)</strong>
                             <span style="font-weight:normal; color:var(--text-secondary)">
-                                — Phase 5 (preview)
+                                — not yet enforced
                             </span>
                         </label>
                         <input type="number" name="free_space_target_pct" id="sr-free-space-target"
                                min="5" max="50" value="10"
                                class="settings-form-input">
                         <p style="font-size:0.8rem; color:var(--text-secondary); margin:4px 0 0">
-                            Saved now; not yet enforced by the prune. Phase 5 will use this to keep at
-                            least the requested free percentage.
+                            Saved to <code>config.yaml</code> for a future free-space-aware prune.
+                            The current pass deletes only by age (<strong>Default retention</strong> above and
+                            per-folder overrides below) — this value has no effect today.
                         </p>
                     </div>
                 </div>
@@ -487,15 +488,16 @@
                     <div class="form-group">
                         <label style="font-size:0.85rem"><strong>Maximum archive size (GB)</strong>
                             <span style="font-weight:normal; color:var(--text-secondary)">
-                                — Phase 5 (preview)
+                                — not yet enforced
                             </span>
                         </label>
                         <input type="number" name="max_archive_size_gb" id="sr-max-archive"
                                min="0" max="10000" value="0"
                                class="settings-form-input">
                         <p style="font-size:0.8rem; color:var(--text-secondary); margin:4px 0 0">
-                            Saved now; not yet enforced by the prune. Phase 5 will treat this as a hard
-                            cap. Leave at <strong>0</strong> to use only time-based retention.
+                            Saved to <code>config.yaml</code> for a future hard-cap prune.
+                            The current pass deletes only by age — this value has no effect today.
+                            Leave at <strong>0</strong> to use only time-based retention.
                         </p>
                     </div>
                     <div class="form-group">


### PR DESCRIPTION
## Summary

Strip the stale `Phase 5 (preview)` attribution from the two unenforced inputs on the **Settings → Storage & Retention** card and rewrite the help text to be honest about current behavior.

## Why now

The labels were added in PR #124 (Phase 3a.2) with a placeholder promise that **Phase 5** would wire up the enforcement. Phase 5 (issue #102) is now CLOSED and turned out to be performance-polish (caching, batched rclone, single-DB queries) — free-space-aware and hard-cap pruning was never picked up by it, and there's no current tracking issue. The labels imply imminent work that doesn't exist.

## Verified

- `free_space_target_pct` and `max_archive_size_gb` ARE saved to `config.yaml` via `cleanup_service` defaults + the `storage_retention` blueprint roundtrip
- Neither value is referenced anywhere in `archive_watchdog.py` (the only retention engine after Phase 3a unification) — confirmed by `grep`
- Today's prune is purely time-based: `default_retention_days` + per-folder `policies.<folder>`

## Changes

- `scripts/web/templates/index.html` (lines ~470–500):
  - Both labels: `— Phase 5 (preview)` → `— not yet enforced`
  - Help text rewritten to say the value is saved to `config.yaml` for a future free-space-aware / hard-cap prune but the current pass deletes only by age — no Phase 5 reference

## Verification

UI-only template edit. No tests assert on the old strings (verified via `grep` over `tests/`). No behavior change.

## Out of scope

- Implementing the enforcement itself (a real follow-up; would need `os.statvfs()` + directory walk + oldest-first prune with the "trips are sacred" invariant preserved). Per the user's standing constraint of "wrap things up, no new issues" — not opening a new issue, not starting that work in this PR.