### PR TITLE
feat(retention): enforce free-space target + max archive size cap

### DIFF
--- a/scripts/web/blueprints/storage_retention.py
+++ b/scripts/web/blueprints/storage_retention.py
@@ -76,7 +76,7 @@ ALLOWED_FOLDER_NAMES = (
 # accepts anything but the UI clamps to keep the system sane.
 RETENTION_DAYS_MIN = 1
 RETENTION_DAYS_MAX = 3650            # 10 years — a soft sanity cap
-FREE_SPACE_PCT_MIN = 5
+FREE_SPACE_PCT_MIN = 0               # 0 = disabled (no free-space-target enforcement)
 FREE_SPACE_PCT_MAX = 50
 MAX_ARCHIVE_GB_MIN = 0               # 0 = no cap
 MAX_ARCHIVE_GB_MAX = 10000           # 10 TB — absurdly high but bounded

--- a/scripts/web/services/archive_watchdog.py
+++ b/scripts/web/services/archive_watchdog.py
@@ -404,6 +404,54 @@ def _resolve_delete_unsynced() -> bool:
     return bool(CLOUD_ARCHIVE_DELETE_UNSYNCED)
 
 
+def _resolve_free_space_target_pct() -> int:
+    """Return ``cleanup.free_space_target_pct`` from config (0-50, int).
+
+    The capacity-aware prune uses this as a soft floor: when the SD
+    partition holding ``archive_root`` has less than this fraction of
+    its total capacity free, the prune deletes oldest archived clips
+    (subject to the same cloud-pending and protected-file safeguards
+    as the time-based pass) until free space crosses back above the
+    target.
+
+    Returns ``0`` when unset / out of range so the capacity prune
+    skips the free-space sub-pass entirely. Resolved on every prune
+    so a Settings UI change takes effect on the next tick without
+    restart.
+    """
+    try:
+        from config import CLEANUP_FREE_SPACE_TARGET_PCT
+        v = int(CLEANUP_FREE_SPACE_TARGET_PCT)
+    except Exception:  # noqa: BLE001
+        return 0
+    if v < 0 or v > 50:
+        return 0
+    return v
+
+
+def _resolve_max_archive_size_gb() -> int:
+    """Return ``cleanup.max_archive_size_gb`` from config (0+ int).
+
+    The capacity-aware prune uses this as a hard cap on the total
+    bytes occupied by ``.mp4`` files under ``archive_root``: when
+    the cap is exceeded, the prune deletes oldest archived clips
+    (subject to the same cloud-pending and protected-file safeguards
+    as the time-based pass) until total size is at or below the cap.
+
+    Returns ``0`` (interpreted as "disabled — use only time-based
+    retention"). Resolved on every prune so a Settings UI change
+    takes effect on the next tick without restart.
+    """
+    try:
+        from config import CLEANUP_MAX_ARCHIVE_SIZE_GB
+        v = int(CLEANUP_MAX_ARCHIVE_SIZE_GB)
+    except Exception:  # noqa: BLE001
+        return 0
+    if v < 0:
+        return 0
+    return v
+
+
 def _is_cloud_configured() -> bool:
     """Return True iff a cloud provider is set AND its creds file exists.
 
@@ -970,6 +1018,218 @@ def _run_retention_prune(archive_root: str, db_path: str,
     return summary
 
 
+def _run_capacity_prune(archive_root: str, db_path: str) -> Dict[str, Any]:
+    """Free-space-target + max-archive-size enforcement pass.
+
+    Runs AFTER :func:`_run_retention_prune` so the time-based pass has
+    already deleted everything past the day-count cutoff. This pass
+    handles the two capacity-driven Settings → Storage knobs:
+
+    * ``cleanup.free_space_target_pct`` — soft floor on SD-card free
+      space. When ``free_pct < target_pct``, delete oldest .mp4 files
+      first until free space crosses back above the target.
+    * ``cleanup.max_archive_size_gb`` — hard cap on the total bytes of
+      .mp4 files under ``archive_root``. When ``total_bytes > cap``,
+      delete oldest first until total is at or below the cap.
+
+    Both sub-passes share the same safeguards as the time-based pass:
+
+    * Routes deletes through :func:`_delete_one_mp4`, which calls
+      :func:`services.file_safety.safe_delete_archive_video` (refuses
+      ``*.img`` files and any path outside ``archive_root``) and
+      :func:`mapping_service.purge_deleted_videos` (preserves the
+      "trips are sacred" invariant — only the ``indexed_files`` row
+      is dropped; ``waypoints.video_path`` and
+      ``detected_events.video_path`` are NULL'd, never deleted).
+    * Honors :func:`_resolve_delete_unsynced` — when False AND a
+      cloud provider is configured, files not yet uploaded
+      (``cloud_synced_files.status != 'synced'``) are skipped and
+      counted in ``kept_unsynced_count``. An extended WiFi outage
+      cannot cause silent loss here.
+    * Yields the ``task_coordinator`` 'retention' slot every
+      :data:`_RETENTION_YIELD_EVERY_N_FILES` deletes so the indexer
+      and archive worker get fair turns.
+
+    Both sub-passes are skipped when their config value is 0/unset,
+    so an operator can opt into either, both, or neither
+    independently of the day-count rule.
+
+    Acquires its own ``task_coordinator`` 'retention' slot — the
+    time-based pass has already released its slot by the time this
+    runs. Caller MUST still hold the ``_retention_running`` flag for
+    the lifetime of this call (the duplicate-trigger guard).
+    """
+    started = time.time()
+    summary: Dict[str, Any] = {
+        'free_space_target_pct': 0,
+        'free_space_pct_before': None,
+        'free_space_pct_after': None,
+        'max_archive_size_gb': 0,
+        'archive_size_bytes_before': None,
+        'archive_size_bytes_after': None,
+        'capacity_deleted_count': 0,
+        'capacity_freed_bytes': 0,
+        'capacity_kept_unsynced_count': 0,
+        'capacity_kept_protected_count': 0,
+        'capacity_scanned': 0,
+        'duration_seconds': 0.0,
+    }
+    if not archive_root or not os.path.isdir(archive_root):
+        summary['duration_seconds'] = round(time.time() - started, 3)
+        return summary
+
+    free_target = _resolve_free_space_target_pct()
+    max_size_gb = _resolve_max_archive_size_gb()
+    summary['free_space_target_pct'] = free_target
+    summary['max_archive_size_gb'] = max_size_gb
+
+    if free_target == 0 and max_size_gb == 0:
+        # Both knobs disabled — nothing to do. Skip the walk + lock
+        # acquire entirely so a watchdog tick on a disabled config is
+        # essentially free.
+        summary['duration_seconds'] = round(time.time() - started, 3)
+        return summary
+
+    delete_unsynced = _resolve_delete_unsynced()
+    cloud_configured = _is_cloud_configured()
+    cloud_db_path = _resolve_cloud_db_path() if cloud_configured else None
+    enforce_cloud_check = (not delete_unsynced) and cloud_configured
+
+    # Snapshot before. Walk the tree once so a 5000-clip archive doesn't
+    # statvfs+walk twice.
+    du_before = _safe_disk_usage(archive_root)
+    if du_before is not None and du_before.total > 0:
+        summary['free_space_pct_before'] = round(
+            (du_before.free / du_before.total) * 100.0, 2,
+        )
+    files: list = []
+    total_bytes = 0
+    for path, mtime, size in _iter_archive_mp4_files(archive_root):
+        files.append((path, mtime, size))
+        total_bytes += size
+        summary['capacity_scanned'] += 1
+    summary['archive_size_bytes_before'] = total_bytes
+
+    cap_bytes = max_size_gb * 1024 * 1024 * 1024 if max_size_gb > 0 else 0
+    over_cap = cap_bytes > 0 and total_bytes > cap_bytes
+    under_target = False
+    if free_target > 0 and du_before is not None and du_before.total > 0:
+        free_pct = (du_before.free / du_before.total) * 100.0
+        under_target = free_pct < float(free_target)
+
+    if not over_cap and not under_target:
+        # Both thresholds satisfied — leave free_space_pct_after /
+        # archive_size_bytes_after equal to the before values so the
+        # summary always reflects the current state.
+        summary['free_space_pct_after'] = summary['free_space_pct_before']
+        summary['archive_size_bytes_after'] = total_bytes
+        summary['duration_seconds'] = round(time.time() - started, 3)
+        return summary
+
+    # Sort oldest-first so we delete the least-valuable footage first.
+    files.sort(key=lambda t: t[1])
+
+    # Acquire our own coordinator slot. The time-based pass released
+    # its slot before returning; we have to take it back to delete.
+    acquired = task_coordinator.acquire_task(
+        _RETENTION_COORDINATOR_TASK,
+        wait_seconds=_RETENTION_COORDINATOR_WAIT_SECONDS,
+    )
+    if not acquired:
+        logger.info(
+            "archive_capacity: skipped — could not acquire 'retention' "
+            "task slot within %.1fs",
+            _RETENTION_COORDINATOR_WAIT_SECONDS,
+        )
+        summary['status'] = 'lock_unavailable'
+        summary['free_space_pct_after'] = summary['free_space_pct_before']
+        summary['archive_size_bytes_after'] = total_bytes
+        summary['duration_seconds'] = round(time.time() - started, 3)
+        return summary
+
+    current_total = total_bytes
+    current_free = du_before.free if du_before is not None else 0
+    disk_total = du_before.total if du_before is not None else 0
+    target_free_bytes = (
+        int((float(free_target) / 100.0) * disk_total)
+        if free_target > 0 and disk_total > 0
+        else 0
+    )
+
+    lock_held = True
+    files_since_yield = 0
+    try:
+        for path, _mtime, size in files:
+            cap_done = cap_bytes == 0 or current_total <= cap_bytes
+            free_done = (
+                target_free_bytes == 0 or current_free >= target_free_bytes
+            )
+            if cap_done and free_done:
+                break
+
+            if enforce_cloud_check:
+                if not _is_synced_to_cloud(
+                    path, archive_root, cloud_db_path,
+                ):
+                    summary['capacity_kept_unsynced_count'] += 1
+                    logger.warning(
+                        "archive_capacity: KEPT %s past capacity "
+                        "threshold — not yet synced to cloud",
+                        path,
+                    )
+                    continue
+
+            freed = _delete_one_mp4(path, db_path)
+            if freed > 0 or not os.path.exists(path):
+                summary['capacity_deleted_count'] += 1
+                summary['capacity_freed_bytes'] += freed
+                current_total -= size
+                current_free += freed
+                logger.info(
+                    "archive_capacity: removed %s (freed=%d bytes, "
+                    "size_after=%d, free_after=%d)",
+                    path, freed, current_total, current_free,
+                )
+            else:
+                # safe_delete_archive_video refused (e.g. .img guard,
+                # path-outside-root, or stat failure). Count it so an
+                # admin can see we tried but were correctly blocked.
+                summary['capacity_kept_protected_count'] += 1
+
+            files_since_yield += 1
+            if files_since_yield >= _RETENTION_YIELD_EVERY_N_FILES:
+                files_since_yield = 0
+                if not _yield_retention_lock():
+                    lock_held = False
+                    summary['status'] = 'yielded_lost_lock'
+                    logger.info(
+                        "archive_capacity: yielded 'retention' lock "
+                        "after %d deleted and could not reacquire "
+                        "within %.1fs — bailing with partial summary; "
+                        "next tick will resume",
+                        summary['capacity_deleted_count'],
+                        _RETENTION_COORDINATOR_WAIT_SECONDS,
+                    )
+                    break
+    finally:
+        if lock_held:
+            task_coordinator.release_task(_RETENTION_COORDINATOR_TASK)
+
+    if summary['capacity_deleted_count'] > 0:
+        du_after = _safe_disk_usage(archive_root)
+        if du_after is not None and du_after.total > 0:
+            summary['free_space_pct_after'] = round(
+                (du_after.free / du_after.total) * 100.0, 2,
+            )
+        summary['archive_size_bytes_after'] = current_total
+    else:
+        summary['free_space_pct_after'] = summary['free_space_pct_before']
+        summary['archive_size_bytes_after'] = total_bytes
+
+    summary['duration_seconds'] = round(time.time() - started, 3)
+    return summary
+
+
 def force_prune_now() -> Dict[str, Any]:
     """Run a retention prune synchronously. Returns the summary dict.
 
@@ -997,13 +1257,27 @@ def force_prune_now() -> Dict[str, Any]:
     # propagates the ``status`` field to the front end.
     if summary.get('status') == 'already_running':
         return summary
+    # Capacity-aware sub-pass (free-space target + max-archive size).
+    # Runs AFTER the time-based pass so the day-count rule cleans up
+    # everything past the cutoff first; this then enforces the
+    # capacity ceilings on top. Skipped internally when both knobs
+    # are 0/unset.
+    capacity_summary = _run_capacity_prune(archive_root, db_path)
+    summary['capacity'] = capacity_summary
     # Update bookkeeping so the Settings panel reflects the manual run.
     with _state_lock:
         _retention_state['last_prune_at'] = _iso_now()
-        _retention_state['last_prune_deleted'] = int(summary['deleted_count'])
-        _retention_state['last_prune_freed_bytes'] = int(summary['freed_bytes'])
+        _retention_state['last_prune_deleted'] = int(
+            summary['deleted_count']
+            + capacity_summary['capacity_deleted_count']
+        )
+        _retention_state['last_prune_freed_bytes'] = int(
+            summary['freed_bytes']
+            + capacity_summary['capacity_freed_bytes']
+        )
         _retention_state['last_prune_kept_unsynced'] = int(
             summary.get('kept_unsynced_count', 0)
+            + capacity_summary['capacity_kept_unsynced_count']
         )
         _retention_state['last_prune_error'] = None
         _retention_state['next_prune_due_at'] = (
@@ -1373,16 +1647,25 @@ def _maybe_run_retention(archive_root: str, db_path: str) -> None:
         # completion will reset ``next_prune_due_at`` to "now + 24h").
         if summary.get('status') == 'already_running':
             return
+        # Capacity-aware sub-pass — runs after the time-based pass so
+        # the day-count rule cleans up everything past the cutoff
+        # first; this enforces the capacity ceilings on top. Skipped
+        # internally when both knobs are 0/unset (so a default-config
+        # tick is essentially free).
+        capacity_summary = _run_capacity_prune(archive_root, db_path)
         with _state_lock:
             _retention_state['last_prune_at'] = _iso_now()
             _retention_state['last_prune_deleted'] = int(
                 summary['deleted_count']
+                + capacity_summary['capacity_deleted_count']
             )
             _retention_state['last_prune_freed_bytes'] = int(
                 summary['freed_bytes']
+                + capacity_summary['capacity_freed_bytes']
             )
             _retention_state['last_prune_kept_unsynced'] = int(
                 summary.get('kept_unsynced_count', 0)
+                + capacity_summary['capacity_kept_unsynced_count']
             )
             _retention_state['last_prune_error'] = None
             _retention_state['next_prune_due_at'] = (
@@ -1390,11 +1673,17 @@ def _maybe_run_retention(archive_root: str, db_path: str) -> None:
             )
         logger.info(
             "archive_retention: prune complete (deleted=%d, freed=%d "
-            "bytes, scanned=%d, kept_unsynced=%d, %.2fs)",
+            "bytes, scanned=%d, kept_unsynced=%d, %.2fs); "
+            "capacity: deleted=%d, freed=%d, kept_unsynced=%d, "
+            "%.2fs",
             summary['deleted_count'], summary['freed_bytes'],
             summary['scanned'],
             summary.get('kept_unsynced_count', 0),
             summary['duration_seconds'],
+            capacity_summary['capacity_deleted_count'],
+            capacity_summary['capacity_freed_bytes'],
+            capacity_summary['capacity_kept_unsynced_count'],
+            capacity_summary['duration_seconds'],
         )
     except Exception as e:  # noqa: BLE001
         logger.exception("archive_retention: prune failed")

--- a/scripts/web/services/archive_watchdog.py
+++ b/scripts/web/services/archive_watchdog.py
@@ -165,6 +165,15 @@ _retention_state: Dict[str, Any] = {
 # Always read/written under ``_state_lock``.
 _retention_running: bool = False
 
+# PR #213 review finding 3 — behavior-change visibility. Set True on
+# the first ``_run_capacity_prune`` call where at least one knob is
+# enabled, so we emit a single INFO landmark per process showing the
+# active thresholds. Existing installs whose ``config.yaml`` carries
+# ``free_space_target_pct: 10`` (the previous "saved-but-not-enforced"
+# default) will see this line in ``journalctl`` the first time the
+# capacity pass actually runs, rather than silently start auto-pruning.
+_capacity_thresholds_logged: bool = False
+
 
 # ---------------------------------------------------------------------------
 # Public lifecycle API
@@ -953,6 +962,14 @@ def _run_retention_prune(archive_root: str, db_path: str,
                 if mtime > cutoff:
                     continue
                 age_days = (time.time() - mtime) / 86400.0
+                # PR #213 review finding 2 — every iteration past the
+                # cutoff (whether deleted, kept, or skipped) must
+                # count toward the yield budget so an unsynced
+                # backlog (extended WiFi outage where every old file
+                # is kept-pending-cloud) can't hold the 'retention'
+                # lock for the entire scan. Bumped BEFORE the
+                # cloud-pending ``continue``.
+                files_since_yield += 1
                 if enforce_cloud_check:
                     if not _is_synced_to_cloud(path, archive_root, cloud_db_path):
                         summary['kept_unsynced_count'] += 1
@@ -961,6 +978,25 @@ def _run_retention_prune(archive_root: str, db_path: str,
                             "(age=%.1f days) — not yet synced to cloud",
                             path, age_days,
                         )
+                        if files_since_yield >= (
+                            _RETENTION_YIELD_EVERY_N_FILES
+                        ):
+                            files_since_yield = 0
+                            if not _yield_retention_lock():
+                                lock_held = False
+                                summary['status'] = 'yielded_lost_lock'
+                                logger.info(
+                                    "archive_retention: yielded "
+                                    "'retention' lock after %d "
+                                    "scanned/%d deleted and could not "
+                                    "reacquire within %.1fs — bailing "
+                                    "with partial summary; next tick "
+                                    "will resume",
+                                    summary['scanned'],
+                                    summary['deleted_count'],
+                                    _RETENTION_COORDINATOR_WAIT_SECONDS,
+                                )
+                                break
                         continue
                 freed = _delete_one_mp4(path, db_path)
                 if freed > 0 or not os.path.exists(path):
@@ -974,7 +1010,6 @@ def _run_retention_prune(archive_root: str, db_path: str,
                 # Issue #208: yield the lock every N files so a 5904-clip
                 # sweep doesn't block the indexer / archive worker for
                 # 5+ minutes (max_hold = 311 s observed pre-fix).
-                files_since_yield += 1
                 if files_since_yield >= _RETENTION_YIELD_EVERY_N_FILES:
                     files_since_yield = 0
                     if not _yield_retention_lock():
@@ -1056,9 +1091,20 @@ def _run_capacity_prune(archive_root: str, db_path: str) -> Dict[str, Any]:
 
     Acquires its own ``task_coordinator`` 'retention' slot — the
     time-based pass has already released its slot by the time this
-    runs. Caller MUST still hold the ``_retention_running`` flag for
-    the lifetime of this call (the duplicate-trigger guard).
+    runs.
+
+    Issue #91 / PR #213 review: each prune function (this one and
+    :func:`_run_retention_prune`) self-manages the
+    ``_retention_running`` duplicate-trigger guard. The flag is set
+    BEFORE ``acquire_task`` and cleared in the outer ``finally``.
+    Worst-case race: a second caller arriving during the microsecond
+    gap between the time-based pass releasing the flag and this
+    pass acquiring it would run a second time-based pass; this
+    capacity pass would then short-circuit with ``status=
+    'already_running'``. The next watchdog tick re-runs the capacity
+    pass — system state stays consistent, no enforcement is lost.
     """
+    global _retention_running
     started = time.time()
     summary: Dict[str, Any] = {
         'free_space_target_pct': 0,
@@ -1070,6 +1116,15 @@ def _run_capacity_prune(archive_root: str, db_path: str) -> Dict[str, Any]:
         'capacity_deleted_count': 0,
         'capacity_freed_bytes': 0,
         'capacity_kept_unsynced_count': 0,
+        # PR #213 review finding 5: this bucket counts BOTH
+        # ``DeleteOutcome.PROTECTED`` (e.g. ``*.img`` guard hit) AND
+        # ``DeleteOutcome.ERROR`` (transient OSError on stat/remove).
+        # The shared bucket comes from routing through
+        # ``_delete_one_mp4``, which collapses both outcomes to
+        # ``freed=0``. ``_delete_one_mp4`` already logs each at
+        # WARNING with the outcome enum, so an admin can distinguish
+        # the two in the journal even though the summary collapses
+        # them.
         'capacity_kept_protected_count': 0,
         'capacity_scanned': 0,
         'duration_seconds': 0.0,
@@ -1086,148 +1141,258 @@ def _run_capacity_prune(archive_root: str, db_path: str) -> Dict[str, Any]:
     if free_target == 0 and max_size_gb == 0:
         # Both knobs disabled — nothing to do. Skip the walk + lock
         # acquire entirely so a watchdog tick on a disabled config is
-        # essentially free.
+        # essentially free. Skip the duplicate-trigger guard too —
+        # there's no work to short-circuit.
         summary['duration_seconds'] = round(time.time() - started, 3)
         return summary
 
-    delete_unsynced = _resolve_delete_unsynced()
-    cloud_configured = _is_cloud_configured()
-    cloud_db_path = _resolve_cloud_db_path() if cloud_configured else None
-    enforce_cloud_check = (not delete_unsynced) and cloud_configured
-
-    # Snapshot before. Walk the tree once so a 5000-clip archive doesn't
-    # statvfs+walk twice.
-    du_before = _safe_disk_usage(archive_root)
-    if du_before is not None and du_before.total > 0:
-        summary['free_space_pct_before'] = round(
-            (du_before.free / du_before.total) * 100.0, 2,
+    # PR #213 review finding 3 — emit a one-time landmark showing the
+    # resolved thresholds so an operator who upgraded from the
+    # saved-but-not-enforced era sees in ``journalctl`` exactly when
+    # auto-prune started and at what levels. Only logged when at
+    # least one knob is enabled; cheap path above never reaches this.
+    global _capacity_thresholds_logged
+    with _state_lock:
+        first_run = not _capacity_thresholds_logged
+        if first_run:
+            _capacity_thresholds_logged = True
+    if first_run:
+        free_desc = (
+            f"{free_target}%" if free_target > 0 else "disabled"
         )
-    files: list = []
-    total_bytes = 0
-    for path, mtime, size in _iter_archive_mp4_files(archive_root):
-        files.append((path, mtime, size))
-        total_bytes += size
-        summary['capacity_scanned'] += 1
-    summary['archive_size_bytes_before'] = total_bytes
-
-    cap_bytes = max_size_gb * 1024 * 1024 * 1024 if max_size_gb > 0 else 0
-    over_cap = cap_bytes > 0 and total_bytes > cap_bytes
-    under_target = False
-    if free_target > 0 and du_before is not None and du_before.total > 0:
-        free_pct = (du_before.free / du_before.total) * 100.0
-        under_target = free_pct < float(free_target)
-
-    if not over_cap and not under_target:
-        # Both thresholds satisfied — leave free_space_pct_after /
-        # archive_size_bytes_after equal to the before values so the
-        # summary always reflects the current state.
-        summary['free_space_pct_after'] = summary['free_space_pct_before']
-        summary['archive_size_bytes_after'] = total_bytes
-        summary['duration_seconds'] = round(time.time() - started, 3)
-        return summary
-
-    # Sort oldest-first so we delete the least-valuable footage first.
-    files.sort(key=lambda t: t[1])
-
-    # Acquire our own coordinator slot. The time-based pass released
-    # its slot before returning; we have to take it back to delete.
-    acquired = task_coordinator.acquire_task(
-        _RETENTION_COORDINATOR_TASK,
-        wait_seconds=_RETENTION_COORDINATOR_WAIT_SECONDS,
-    )
-    if not acquired:
+        cap_desc = (
+            f"{max_size_gb} GiB" if max_size_gb > 0 else "disabled"
+        )
         logger.info(
-            "archive_capacity: skipped — could not acquire 'retention' "
-            "task slot within %.1fs",
-            _RETENTION_COORDINATOR_WAIT_SECONDS,
+            "archive_capacity: enforcement active — "
+            "free_space_target=%s, max_archive_size=%s "
+            "(first capacity-pass run since process start; "
+            "cloud-pending clips are preserved; *.img files are "
+            "protected; trips/waypoints/events ROWS survive any "
+            "deletion via purge_deleted_videos)",
+            free_desc, cap_desc,
         )
-        summary['status'] = 'lock_unavailable'
-        summary['free_space_pct_after'] = summary['free_space_pct_before']
-        summary['archive_size_bytes_after'] = total_bytes
+
+    # PR #213 review finding 1 — duplicate-trigger guard. Mirror the
+    # pattern in :func:`_run_retention_prune` so a Settings UI
+    # double-click that arrives in the microsecond gap between the
+    # two passes can't spawn a second concurrent capacity walk.
+    # Set BEFORE ``acquire_task`` so the second caller short-circuits
+    # without waiting on the lock.
+    with _state_lock:
+        if _retention_running:
+            summary['status'] = 'already_running'
+            summary['duration_seconds'] = round(time.time() - started, 3)
+            logger.info(
+                "archive_capacity: skipped — another prune is already "
+                "in flight (returning status='already_running')"
+            )
+            return summary
+        _retention_running = True
+
+    try:
+        delete_unsynced = _resolve_delete_unsynced()
+        cloud_configured = _is_cloud_configured()
+        cloud_db_path = (
+            _resolve_cloud_db_path() if cloud_configured else None
+        )
+        enforce_cloud_check = (not delete_unsynced) and cloud_configured
+
+        # Snapshot before. Walk the tree once so a 5000-clip archive
+        # doesn't statvfs+walk twice.
+        du_before = _safe_disk_usage(archive_root)
+        if du_before is not None and du_before.total > 0:
+            summary['free_space_pct_before'] = round(
+                (du_before.free / du_before.total) * 100.0, 2,
+            )
+        elif free_target > 0:
+            # PR #213 review finding 4 — surface the silent
+            # degradation. Without statvfs we can't compute
+            # target_free_bytes, so the free-space sub-pass is
+            # effectively disabled this tick. Operator deserves a
+            # journal landmark.
+            logger.warning(
+                "archive_capacity: free-space target %d%% configured "
+                "but statvfs(%s) returned None — free-space sub-pass "
+                "is being skipped this tick",
+                free_target, archive_root,
+            )
+
+        files: list = []
+        total_bytes = 0
+        for path, mtime, size in _iter_archive_mp4_files(archive_root):
+            files.append((path, mtime, size))
+            total_bytes += size
+            summary['capacity_scanned'] += 1
+        summary['archive_size_bytes_before'] = total_bytes
+
+        cap_bytes = (
+            max_size_gb * 1024 * 1024 * 1024 if max_size_gb > 0 else 0
+        )
+        over_cap = cap_bytes > 0 and total_bytes > cap_bytes
+        under_target = False
+        if free_target > 0 and du_before is not None and du_before.total > 0:
+            free_pct = (du_before.free / du_before.total) * 100.0
+            under_target = free_pct < float(free_target)
+
+        if not over_cap and not under_target:
+            # Both thresholds satisfied — leave free_space_pct_after /
+            # archive_size_bytes_after equal to the before values so
+            # the summary always reflects the current state.
+            summary['free_space_pct_after'] = (
+                summary['free_space_pct_before']
+            )
+            summary['archive_size_bytes_after'] = total_bytes
+            summary['duration_seconds'] = round(time.time() - started, 3)
+            return summary
+
+        # Sort oldest-first so we delete the least-valuable footage
+        # first.
+        files.sort(key=lambda t: t[1])
+
+        # Acquire our own coordinator slot. The time-based pass
+        # released its slot before returning; we have to take it back
+        # to delete.
+        acquired = task_coordinator.acquire_task(
+            _RETENTION_COORDINATOR_TASK,
+            wait_seconds=_RETENTION_COORDINATOR_WAIT_SECONDS,
+        )
+        if not acquired:
+            logger.info(
+                "archive_capacity: skipped — could not acquire "
+                "'retention' task slot within %.1fs",
+                _RETENTION_COORDINATOR_WAIT_SECONDS,
+            )
+            summary['status'] = 'lock_unavailable'
+            summary['free_space_pct_after'] = (
+                summary['free_space_pct_before']
+            )
+            summary['archive_size_bytes_after'] = total_bytes
+            summary['duration_seconds'] = round(time.time() - started, 3)
+            return summary
+
+        current_total = total_bytes
+        current_free = du_before.free if du_before is not None else 0
+        disk_total = du_before.total if du_before is not None else 0
+        target_free_bytes = (
+            int((float(free_target) / 100.0) * disk_total)
+            if free_target > 0 and disk_total > 0
+            else 0
+        )
+
+        lock_held = True
+        files_since_yield = 0
+        try:
+            for path, _mtime, size in files:
+                cap_done = cap_bytes == 0 or current_total <= cap_bytes
+                free_done = (
+                    target_free_bytes == 0
+                    or current_free >= target_free_bytes
+                )
+                if cap_done and free_done:
+                    break
+
+                # PR #213 review finding 2 — every iteration must
+                # count toward the yield budget, regardless of which
+                # branch handles the file. Bumping the counter BEFORE
+                # the cloud-pending ``continue`` ensures an unsynced
+                # backlog (extended WiFi outage) can't hold the
+                # 'retention' lock for thousands of skipped files.
+                files_since_yield += 1
+
+                if enforce_cloud_check:
+                    if not _is_synced_to_cloud(
+                        path, archive_root, cloud_db_path,
+                    ):
+                        summary['capacity_kept_unsynced_count'] += 1
+                        logger.warning(
+                            "archive_capacity: KEPT %s past capacity "
+                            "threshold — not yet synced to cloud",
+                            path,
+                        )
+                        if files_since_yield >= (
+                            _RETENTION_YIELD_EVERY_N_FILES
+                        ):
+                            files_since_yield = 0
+                            if not _yield_retention_lock():
+                                lock_held = False
+                                summary['status'] = 'yielded_lost_lock'
+                                logger.info(
+                                    "archive_capacity: yielded "
+                                    "'retention' lock after %d "
+                                    "deleted and could not reacquire "
+                                    "within %.1fs — bailing with "
+                                    "partial summary; next tick will "
+                                    "resume",
+                                    summary['capacity_deleted_count'],
+                                    _RETENTION_COORDINATOR_WAIT_SECONDS,
+                                )
+                                break
+                        continue
+
+                freed = _delete_one_mp4(path, db_path)
+                if freed > 0 or not os.path.exists(path):
+                    summary['capacity_deleted_count'] += 1
+                    summary['capacity_freed_bytes'] += freed
+                    current_total -= size
+                    current_free += freed
+                    logger.info(
+                        "archive_capacity: removed %s (freed=%d "
+                        "bytes, size_after=%d, free_after=%d)",
+                        path, freed, current_total, current_free,
+                    )
+                else:
+                    # safe_delete_archive_video refused (PROTECTED:
+                    # ``*.img`` guard / path-outside-root) OR raised
+                    # an OSError (ERROR). Both collapse to ``freed=0
+                    # AND file still exists`` here. ``_delete_one_mp4``
+                    # already logged each at WARNING with the outcome
+                    # enum — see comment on
+                    # ``capacity_kept_protected_count`` initialiser
+                    # above.
+                    summary['capacity_kept_protected_count'] += 1
+
+                if files_since_yield >= _RETENTION_YIELD_EVERY_N_FILES:
+                    files_since_yield = 0
+                    if not _yield_retention_lock():
+                        lock_held = False
+                        summary['status'] = 'yielded_lost_lock'
+                        logger.info(
+                            "archive_capacity: yielded 'retention' "
+                            "lock after %d deleted and could not "
+                            "reacquire within %.1fs — bailing with "
+                            "partial summary; next tick will resume",
+                            summary['capacity_deleted_count'],
+                            _RETENTION_COORDINATOR_WAIT_SECONDS,
+                        )
+                        break
+        finally:
+            if lock_held:
+                task_coordinator.release_task(
+                    _RETENTION_COORDINATOR_TASK,
+                )
+
+        if summary['capacity_deleted_count'] > 0:
+            du_after = _safe_disk_usage(archive_root)
+            if du_after is not None and du_after.total > 0:
+                summary['free_space_pct_after'] = round(
+                    (du_after.free / du_after.total) * 100.0, 2,
+                )
+            summary['archive_size_bytes_after'] = current_total
+        else:
+            summary['free_space_pct_after'] = (
+                summary['free_space_pct_before']
+            )
+            summary['archive_size_bytes_after'] = total_bytes
+
         summary['duration_seconds'] = round(time.time() - started, 3)
         return summary
-
-    current_total = total_bytes
-    current_free = du_before.free if du_before is not None else 0
-    disk_total = du_before.total if du_before is not None else 0
-    target_free_bytes = (
-        int((float(free_target) / 100.0) * disk_total)
-        if free_target > 0 and disk_total > 0
-        else 0
-    )
-
-    lock_held = True
-    files_since_yield = 0
-    try:
-        for path, _mtime, size in files:
-            cap_done = cap_bytes == 0 or current_total <= cap_bytes
-            free_done = (
-                target_free_bytes == 0 or current_free >= target_free_bytes
-            )
-            if cap_done and free_done:
-                break
-
-            if enforce_cloud_check:
-                if not _is_synced_to_cloud(
-                    path, archive_root, cloud_db_path,
-                ):
-                    summary['capacity_kept_unsynced_count'] += 1
-                    logger.warning(
-                        "archive_capacity: KEPT %s past capacity "
-                        "threshold — not yet synced to cloud",
-                        path,
-                    )
-                    continue
-
-            freed = _delete_one_mp4(path, db_path)
-            if freed > 0 or not os.path.exists(path):
-                summary['capacity_deleted_count'] += 1
-                summary['capacity_freed_bytes'] += freed
-                current_total -= size
-                current_free += freed
-                logger.info(
-                    "archive_capacity: removed %s (freed=%d bytes, "
-                    "size_after=%d, free_after=%d)",
-                    path, freed, current_total, current_free,
-                )
-            else:
-                # safe_delete_archive_video refused (e.g. .img guard,
-                # path-outside-root, or stat failure). Count it so an
-                # admin can see we tried but were correctly blocked.
-                summary['capacity_kept_protected_count'] += 1
-
-            files_since_yield += 1
-            if files_since_yield >= _RETENTION_YIELD_EVERY_N_FILES:
-                files_since_yield = 0
-                if not _yield_retention_lock():
-                    lock_held = False
-                    summary['status'] = 'yielded_lost_lock'
-                    logger.info(
-                        "archive_capacity: yielded 'retention' lock "
-                        "after %d deleted and could not reacquire "
-                        "within %.1fs — bailing with partial summary; "
-                        "next tick will resume",
-                        summary['capacity_deleted_count'],
-                        _RETENTION_COORDINATOR_WAIT_SECONDS,
-                    )
-                    break
     finally:
-        if lock_held:
-            task_coordinator.release_task(_RETENTION_COORDINATOR_TASK)
-
-    if summary['capacity_deleted_count'] > 0:
-        du_after = _safe_disk_usage(archive_root)
-        if du_after is not None and du_after.total > 0:
-            summary['free_space_pct_after'] = round(
-                (du_after.free / du_after.total) * 100.0, 2,
-            )
-        summary['archive_size_bytes_after'] = current_total
-    else:
-        summary['free_space_pct_after'] = summary['free_space_pct_before']
-        summary['archive_size_bytes_after'] = total_bytes
-
-    summary['duration_seconds'] = round(time.time() - started, 3)
-    return summary
+        # Always clear the duplicate-trigger guard, even on exception
+        # or short-circuited acquire_task. Otherwise a single failed
+        # capacity prune would lock out every subsequent attempt.
+        with _state_lock:
+            _retention_running = False
 
 
 def force_prune_now() -> Dict[str, Any]:

--- a/scripts/web/templates/index.html
+++ b/scripts/web/templates/index.html
@@ -468,34 +468,31 @@
                         </p>
                     </div>
                     <div class="form-group">
-                        <label style="font-size:0.85rem"><strong>Free-space target (% of SD card)</strong>
-                            <span style="font-weight:normal; color:var(--text-secondary)">
-                                — Phase 5 (preview)
-                            </span>
-                        </label>
+                        <label style="font-size:0.85rem"><strong>Free-space target (% of SD card)</strong></label>
                         <input type="number" name="free_space_target_pct" id="sr-free-space-target"
-                               min="5" max="50" value="10"
+                               min="0" max="50" value="10"
                                class="settings-form-input">
                         <p style="font-size:0.8rem; color:var(--text-secondary); margin:4px 0 0">
-                            Saved now; not yet enforced by the prune. Phase 5 will use this to keep at
-                            least the requested free percentage.
+                            After the time-based pass, if SD-card free space drops below this
+                            percentage, the oldest archived clips are deleted (oldest first) until
+                            free space crosses back above the target. Cloud-pending clips are kept;
+                            disk image files are protected. Set to <strong>0</strong> to disable.
                         </p>
                     </div>
                 </div>
 
                 <div class="settings-form-grid">
                     <div class="form-group">
-                        <label style="font-size:0.85rem"><strong>Maximum archive size (GB)</strong>
-                            <span style="font-weight:normal; color:var(--text-secondary)">
-                                — Phase 5 (preview)
-                            </span>
-                        </label>
+                        <label style="font-size:0.85rem"><strong>Maximum archive size (GB)</strong></label>
                         <input type="number" name="max_archive_size_gb" id="sr-max-archive"
                                min="0" max="10000" value="0"
                                class="settings-form-input">
                         <p style="font-size:0.8rem; color:var(--text-secondary); margin:4px 0 0">
-                            Saved now; not yet enforced by the prune. Phase 5 will treat this as a hard
-                            cap. Leave at <strong>0</strong> to use only time-based retention.
+                            Hard cap on total archive size. After the time-based pass, if total
+                            <code>.mp4</code> bytes under the archive root exceed this cap, oldest
+                            clips are deleted until total is at or below the cap. Cloud-pending
+                            clips are kept; disk image files are protected. Leave at
+                            <strong>0</strong> to use only time-based retention.
                         </p>
                     </div>
                     <div class="form-group">

--- a/tests/test_archive_watchdog.py
+++ b/tests/test_archive_watchdog.py
@@ -87,6 +87,10 @@ def _reset_module_state():
     # exercises the short-circuit path doesn't leak the True flag
     # into the next test.
     archive_watchdog._retention_running = False
+    # PR #213 review finding 3 — reset the per-process "first capacity
+    # pass logged" flag so each test sees the one-time INFO landmark
+    # if it triggers an enforcement run.
+    archive_watchdog._capacity_thresholds_logged = False
     yield
     archive_watchdog.stop_watchdog(timeout=5.0)
     archive_worker.stop_worker(timeout=5.0)
@@ -96,6 +100,7 @@ def _reset_module_state():
         task_coordinator._task_started = 0.0
         task_coordinator._waiter_count = 0
     archive_watchdog._retention_running = False
+    archive_watchdog._capacity_thresholds_logged = False
 
 
 # ---------------------------------------------------------------------------
@@ -2247,3 +2252,264 @@ class TestCapacityPrune:
             cfg_mod, 'CLEANUP_MAX_ARCHIVE_SIZE_GB', 100, raising=False,
         )
         assert archive_watchdog._resolve_max_archive_size_gb() == 100
+
+    # --- PR #213 review fix coverage --------------------------------
+
+    def test_short_circuits_when_retention_running_flag_set(
+        self, db, archive_root, monkeypatch,
+    ):
+        # PR #213 review finding 1 — duplicate-trigger guard. When
+        # ``_retention_running`` is already True (e.g. the time-based
+        # pass is mid-flight, or another caller's capacity pass is
+        # running), this call must return ``status='already_running'``
+        # WITHOUT walking the tree or acquiring the coordinator slot.
+        _patch_capacity_config(monkeypatch, free_pct=10, max_gb=1)
+        archive_watchdog._retention_running = True
+        try:
+            walk_called = []
+            monkeypatch.setattr(
+                archive_watchdog, '_iter_archive_mp4_files',
+                lambda _root: walk_called.append(True) or iter([]),
+            )
+            summary = archive_watchdog._run_capacity_prune(
+                archive_root, db,
+            )
+            assert summary['status'] == 'already_running'
+            assert summary['capacity_deleted_count'] == 0
+            assert summary['capacity_scanned'] == 0
+            assert not walk_called, (
+                "Walk MUST NOT happen when the duplicate-trigger flag "
+                "is set — the whole point of the guard is to skip "
+                "the work, not just defer the deletes."
+            )
+        finally:
+            archive_watchdog._retention_running = False
+
+    def test_clears_retention_running_flag_on_normal_completion(
+        self, db, archive_root, monkeypatch,
+    ):
+        # PR #213 review finding 1 — flag must be cleared in the
+        # outer ``finally`` so a second caller (e.g. the next
+        # watchdog tick) can proceed.
+        _patch_capacity_config(monkeypatch, free_pct=0, max_gb=0)
+        assert archive_watchdog._retention_running is False
+        archive_watchdog._run_capacity_prune(archive_root, db)
+        # Cheap path doesn't acquire the flag at all.
+        assert archive_watchdog._retention_running is False
+        # Now an enforcement run.
+        _patch_capacity_config(monkeypatch, free_pct=10, max_gb=1)
+        gb = 1024 * 1024 * 1024
+        path = _make_archive_mp4(
+            archive_root, "RecentClips/old.mp4",
+            mtime=time.time() - 86400, size=10,
+        )
+        monkeypatch.setattr(
+            archive_watchdog, '_iter_archive_mp4_files',
+            lambda _root: iter([(path, time.time() - 86400, 2 * gb)]),
+        )
+        monkeypatch.setattr(
+            archive_watchdog, '_safe_disk_usage', lambda _p: None,
+        )
+        archive_watchdog._run_capacity_prune(archive_root, db)
+        assert archive_watchdog._retention_running is False, (
+            "Flag MUST be cleared after a normal run so the next "
+            "watchdog tick / UI click can proceed."
+        )
+
+    def test_clears_retention_running_flag_on_exception(
+        self, db, archive_root, monkeypatch,
+    ):
+        # PR #213 review finding 1 — flag must be cleared even if
+        # the walk or delete loop raises.
+        _patch_capacity_config(monkeypatch, free_pct=10, max_gb=1)
+
+        def boom(*a, **kw):
+            raise RuntimeError("synthetic walk failure")
+
+        monkeypatch.setattr(
+            archive_watchdog, '_iter_archive_mp4_files', boom,
+        )
+        with pytest.raises(RuntimeError, match="synthetic"):
+            archive_watchdog._run_capacity_prune(archive_root, db)
+        assert archive_watchdog._retention_running is False, (
+            "Flag MUST be released even when the walk raises — "
+            "otherwise a single failed capacity prune would lock "
+            "out every subsequent attempt forever."
+        )
+
+    def test_logs_warning_when_statvfs_fails_and_free_target_set(
+        self, db, archive_root, monkeypatch, caplog,
+    ):
+        # PR #213 review finding 4 — surface the silent degradation.
+        # When ``_safe_disk_usage`` returns None and the operator
+        # has a free-space target configured, we MUST log a warning
+        # so the failure is visible in journalctl.
+        import logging as _logging
+        _patch_capacity_config(monkeypatch, free_pct=15, max_gb=0)
+        monkeypatch.setattr(
+            archive_watchdog, '_safe_disk_usage', lambda _p: None,
+        )
+        # Empty iteration — we're testing the statvfs path, not deletes.
+        monkeypatch.setattr(
+            archive_watchdog, '_iter_archive_mp4_files',
+            lambda _root: iter([]),
+        )
+        with caplog.at_level(_logging.WARNING, logger=archive_watchdog.logger.name):
+            archive_watchdog._run_capacity_prune(archive_root, db)
+        warned = [
+            r for r in caplog.records
+            if r.levelname == 'WARNING'
+            and 'statvfs' in r.getMessage()
+            and 'free-space' in r.getMessage()
+        ]
+        assert warned, (
+            "Operator MUST see a WARNING when statvfs returns None "
+            "and free_space_target_pct > 0 — silent degradation "
+            "(target ignored without explanation) is the bug."
+        )
+
+    def test_no_warning_when_statvfs_fails_and_free_target_disabled(
+        self, db, archive_root, monkeypatch, caplog,
+    ):
+        # Counterpart to the above: when free_target is disabled the
+        # statvfs result is unused, so we should NOT spam a warning.
+        import logging as _logging
+        _patch_capacity_config(monkeypatch, free_pct=0, max_gb=1)
+        monkeypatch.setattr(
+            archive_watchdog, '_safe_disk_usage', lambda _p: None,
+        )
+        monkeypatch.setattr(
+            archive_watchdog, '_iter_archive_mp4_files',
+            lambda _root: iter([]),
+        )
+        with caplog.at_level(_logging.WARNING, logger=archive_watchdog.logger.name):
+            archive_watchdog._run_capacity_prune(archive_root, db)
+        unexpected = [
+            r for r in caplog.records
+            if r.levelname == 'WARNING' and 'statvfs' in r.getMessage()
+        ]
+        assert not unexpected, (
+            "Free-space target is disabled — statvfs failure is "
+            "irrelevant and MUST NOT spam the journal."
+        )
+
+    def test_emits_one_time_landmark_on_first_enforcement_run(
+        self, db, archive_root, monkeypatch, caplog,
+    ):
+        # PR #213 review finding 3 — emit a single INFO landmark
+        # showing the resolved thresholds the first time enforcement
+        # actually runs, so an operator who upgraded from the
+        # saved-but-not-enforced era sees in journalctl exactly when
+        # auto-prune started and at what levels.
+        import logging as _logging
+        _patch_capacity_config(monkeypatch, free_pct=12, max_gb=42)
+        monkeypatch.setattr(
+            archive_watchdog, '_iter_archive_mp4_files',
+            lambda _root: iter([]),
+        )
+        monkeypatch.setattr(
+            archive_watchdog, '_safe_disk_usage', lambda _p: None,
+        )
+        # Reset the flag (autouse fixture already did, but be explicit).
+        archive_watchdog._capacity_thresholds_logged = False
+        with caplog.at_level(_logging.INFO, logger=archive_watchdog.logger.name):
+            archive_watchdog._run_capacity_prune(archive_root, db)
+            archive_watchdog._run_capacity_prune(archive_root, db)
+            archive_watchdog._run_capacity_prune(archive_root, db)
+        landmarks = [
+            r for r in caplog.records
+            if r.levelname == 'INFO'
+            and 'enforcement active' in r.getMessage()
+            and '12%' in r.getMessage()
+            and '42 GiB' in r.getMessage()
+        ]
+        assert len(landmarks) == 1, (
+            "The threshold landmark MUST log exactly once per process, "
+            "not on every tick (would spam journalctl)."
+        )
+
+    def test_no_landmark_when_both_knobs_disabled(
+        self, db, archive_root, monkeypatch, caplog,
+    ):
+        # When the cheap path triggers (both knobs 0), no landmark
+        # should fire — there's no enforcement to announce.
+        import logging as _logging
+        _patch_capacity_config(monkeypatch, free_pct=0, max_gb=0)
+        archive_watchdog._capacity_thresholds_logged = False
+        with caplog.at_level(_logging.INFO, logger=archive_watchdog.logger.name):
+            archive_watchdog._run_capacity_prune(archive_root, db)
+        landmarks = [
+            r for r in caplog.records
+            if 'enforcement active' in r.getMessage()
+        ]
+        assert not landmarks
+        # And the flag stays False so a later config change that
+        # enables a knob still produces a landmark on its first run.
+        assert archive_watchdog._capacity_thresholds_logged is False
+
+    def test_yield_counter_bumps_on_cloud_pending_skip(
+        self, db, archive_root, monkeypatch,
+    ):
+        # PR #213 review finding 2 — every iteration must count
+        # toward the yield budget. With a backlog of unsynced files
+        # (extended WiFi outage), the loop should still hit
+        # ``_yield_retention_lock`` rather than hold the lock for
+        # the entire scan.
+        _patch_capacity_config(monkeypatch, free_pct=0, max_gb=1)
+        monkeypatch.setattr(
+            archive_watchdog, '_resolve_delete_unsynced', lambda: False,
+        )
+        monkeypatch.setattr(
+            archive_watchdog, '_is_cloud_configured', lambda: True,
+        )
+        monkeypatch.setattr(
+            archive_watchdog, '_resolve_cloud_db_path',
+            lambda: '/tmp/fake_cloud.db',
+        )
+        monkeypatch.setattr(
+            archive_watchdog, '_is_synced_to_cloud',
+            lambda *a, **kw: False,  # everything is unsynced
+        )
+        monkeypatch.setattr(
+            archive_watchdog, '_safe_disk_usage', lambda _p: None,
+        )
+        # Build a synthetic backlog larger than the yield interval so
+        # we know the counter has to fire at least once.
+        n = archive_watchdog._RETENTION_YIELD_EVERY_N_FILES * 2 + 5
+        gb = 1024 * 1024 * 1024
+        files = []
+        base_mtime = time.time() - (10 * 86400)
+        for i in range(n):
+            p = _make_archive_mp4(
+                archive_root, f"RecentClips/clip_{i:05d}.mp4",
+                mtime=base_mtime + i, size=1,
+            )
+            files.append((p, base_mtime + i, 2 * gb))
+        monkeypatch.setattr(
+            archive_watchdog, '_iter_archive_mp4_files',
+            lambda _root: iter(files),
+        )
+        yield_calls = []
+        monkeypatch.setattr(
+            archive_watchdog, '_yield_retention_lock',
+            lambda: yield_calls.append(True) or True,
+        )
+        summary = archive_watchdog._run_capacity_prune(
+            archive_root, db,
+        )
+        # Every file kept-unsynced → no deletes.
+        assert summary['capacity_deleted_count'] == 0
+        assert summary['capacity_kept_unsynced_count'] >= n - 1, (
+            "All synthetic files were unsynced; nearly all should "
+            "have been counted as kept_unsynced before the loop "
+            "exited (the cap-done check breaks once total is below "
+            "cap, but with 0 deletes total stays above)."
+        )
+        # The yield must have fired at least once for an N*2+5
+        # backlog — that's the bug fix.
+        assert len(yield_calls) >= 2, (
+            "Yield MUST fire on cloud-pending skips so an unsynced "
+            "backlog (extended WiFi outage) cannot hold the "
+            "'retention' lock for the entire scan."
+        )
+

--- a/tests/test_archive_watchdog.py
+++ b/tests/test_archive_watchdog.py
@@ -1843,3 +1843,407 @@ class TestRetentionRunningGuard:
         assert results['first']['deleted_count'] == 5
         # Flag must be cleared after the first finishes.
         assert archive_watchdog._retention_running is False
+
+
+# ---------------------------------------------------------------------------
+# TestCapacityPrune — free_space_target_pct + max_archive_size_gb enforcement
+# ---------------------------------------------------------------------------
+
+
+def _patch_capacity_config(monkeypatch, *, free_pct: int, max_gb: int):
+    """Helper: monkeypatch the two config resolvers used by capacity prune.
+
+    Patching ``_resolve_*`` (not the underlying ``config`` constants) so
+    each test gets exact, deterministic values regardless of the live
+    ``config.yaml`` on disk.
+    """
+    monkeypatch.setattr(
+        archive_watchdog, '_resolve_free_space_target_pct',
+        lambda: int(free_pct),
+    )
+    monkeypatch.setattr(
+        archive_watchdog, '_resolve_max_archive_size_gb',
+        lambda: int(max_gb),
+    )
+
+
+class TestCapacityPrune:
+    """``_run_capacity_prune`` enforces the two Settings → Storage knobs.
+
+    * ``free_space_target_pct`` (soft floor — delete oldest when free %
+      drops below the target)
+    * ``max_archive_size_gb`` (hard cap — delete oldest when total .mp4
+      bytes exceed the cap)
+
+    Both must honor:
+      - "trips are sacred" via ``purge_deleted_videos`` (only the
+        ``indexed_files`` row is dropped; trips/waypoints/events stay)
+      - cloud-pending preservation (skip files not yet synced when a
+        cloud provider is configured AND ``delete_unsynced=False``)
+      - the protected-file guard via ``safe_delete_archive_video``
+        (refuses ``*.img`` and any path outside ``archive_root``)
+    """
+
+    def test_no_op_when_both_knobs_disabled(
+        self, db, archive_root, monkeypatch,
+    ):
+        # Both 0 → walk is skipped entirely; not even the pre-walk
+        # statvfs runs. Verifies the cheap-path on a default config.
+        _patch_capacity_config(monkeypatch, free_pct=0, max_gb=0)
+        old = time.time() - (10 * 86400)
+        for i in range(3):
+            _make_archive_mp4(
+                archive_root, f"RecentClips/keep_{i}.mp4",
+                mtime=old + i, size=1024,
+            )
+        summary = archive_watchdog._run_capacity_prune(
+            archive_root, db,
+        )
+        assert summary['capacity_deleted_count'] == 0
+        assert summary['capacity_scanned'] == 0, (
+            "When both knobs are 0 the function MUST short-circuit "
+            "BEFORE the walk so a default-config tick is essentially "
+            "free."
+        )
+        assert summary['free_space_target_pct'] == 0
+        assert summary['max_archive_size_gb'] == 0
+
+    def test_no_op_when_under_cap_and_above_free_target(
+        self, db, archive_root, monkeypatch,
+    ):
+        # Cap = 1 GB, archive holds ~3 KB. Free space comfortably
+        # above the target. Nothing should be deleted.
+        _patch_capacity_config(monkeypatch, free_pct=5, max_gb=1)
+        # Synthesize a mostly-empty disk (50% free).
+        monkeypatch.setattr(
+            archive_watchdog, '_safe_disk_usage',
+            lambda _p: _fake_usage(free_mb=16_000, total_mb=32_000),
+        )
+        old = time.time() - (10 * 86400)
+        for i in range(3):
+            _make_archive_mp4(
+                archive_root, f"RecentClips/keep_{i}.mp4",
+                mtime=old + i, size=1024,
+            )
+        summary = archive_watchdog._run_capacity_prune(
+            archive_root, db,
+        )
+        assert summary['capacity_deleted_count'] == 0
+        assert summary['capacity_scanned'] == 3, (
+            "Walk must run when at least one knob is enabled so the "
+            "summary can report current totals."
+        )
+
+    def test_max_size_cap_deletes_oldest_first(
+        self, db, archive_root, monkeypatch,
+    ):
+        # Cap = 1 byte (so 4 × 1 KB clips → 4096 bytes is way over).
+        # Set the cap by patching the resolver directly to a fractional
+        # GB equivalent — but the resolver returns an int, so use a
+        # tiny cap_bytes by overriding the resolver to return 1 and
+        # intercepting the GB→bytes math via monkeypatch on the file
+        # itself. Simplest: write 4 clips totaling 4 GB worth of size
+        # via a fake size and use cap=2 GB.
+        # Actual approach: override _iter_archive_mp4_files so the size
+        # column is the synthetic "GB" we want, and set cap=2 GB.
+        _patch_capacity_config(monkeypatch, free_pct=0, max_gb=2)
+        # 4 clips at 1 GB each → 4 GB total, cap 2 GB → must delete 2
+        # oldest.
+        gb = 1024 * 1024 * 1024
+        files = []
+        base_mtime = time.time() - (10 * 86400)
+        for i in range(4):
+            p = _make_archive_mp4(
+                archive_root, f"RecentClips/clip_{i}.mp4",
+                mtime=base_mtime + i, size=10,  # tiny on disk
+            )
+            # Synthesize size at the iterator layer instead.
+            files.append((p, base_mtime + i, gb))
+        monkeypatch.setattr(
+            archive_watchdog, '_iter_archive_mp4_files',
+            lambda _root: iter(files),
+        )
+        # No disk_usage interference (None → free-space sub-pass off).
+        monkeypatch.setattr(
+            archive_watchdog, '_safe_disk_usage', lambda _p: None,
+        )
+        summary = archive_watchdog._run_capacity_prune(
+            archive_root, db,
+        )
+        # Cap is 2 GB; we have 4 GB; must delete 2 oldest to land
+        # at 2 GB (cap_bytes <= total).
+        assert summary['capacity_deleted_count'] == 2
+        # Oldest two (clip_0, clip_1) gone; newer two (clip_2, clip_3)
+        # kept.
+        assert not os.path.exists(files[0][0])
+        assert not os.path.exists(files[1][0])
+        assert os.path.exists(files[2][0])
+        assert os.path.exists(files[3][0])
+
+    def test_free_space_target_deletes_oldest_first(
+        self, db, archive_root, monkeypatch,
+    ):
+        # Disk: 32 GB total, only 1 GB free → 3.1% < target 20%.
+        # 4 clips at 0.5 GB each. Each delete frees 0.5 GB.
+        # Need to bring free from 1 GB → 6.4 GB (20% of 32 GB) =
+        # +5.4 GB → 11 deletes ... but we only have 4 clips. The
+        # loop should stop after deleting all available files.
+        # Verify oldest-first ordering on what IS deleted.
+        _patch_capacity_config(monkeypatch, free_pct=20, max_gb=0)
+        monkeypatch.setattr(
+            archive_watchdog, '_safe_disk_usage',
+            lambda _p: _fake_usage(free_mb=1_000, total_mb=32_000),
+        )
+        half_gb = 512 * 1024 * 1024
+        files = []
+        base_mtime = time.time() - (10 * 86400)
+        for i in range(4):
+            p = _make_archive_mp4(
+                archive_root, f"RecentClips/clip_{i}.mp4",
+                mtime=base_mtime + i, size=10,
+            )
+            files.append((p, base_mtime + i, half_gb))
+        monkeypatch.setattr(
+            archive_watchdog, '_iter_archive_mp4_files',
+            lambda _root: iter(files),
+        )
+        summary = archive_watchdog._run_capacity_prune(
+            archive_root, db,
+        )
+        # All 4 deleted, oldest-first.
+        assert summary['capacity_deleted_count'] == 4
+        for p, _m, _s in files:
+            assert not os.path.exists(p)
+
+    def test_protected_img_files_are_never_deleted(
+        self, db, archive_root, monkeypatch, tmp_path,
+    ):
+        # safe_delete_archive_video (file_safety) refuses .img by
+        # extension AND parent dir == GADGET_DIR. Verify the capacity
+        # prune routes through it: feed a .img through the iterator
+        # alongside an mp4, point GADGET_DIR at archive_root so the
+        # protection guard fires, and confirm the .img survives.
+        from services import file_safety
+        monkeypatch.setattr(
+            file_safety, '_get_gadget_dir', lambda: archive_root,
+        )
+        _patch_capacity_config(monkeypatch, free_pct=0, max_gb=1)
+        gb = 1024 * 1024 * 1024
+        img_path = os.path.join(archive_root, "usb_cam.img")
+        with open(img_path, 'wb') as f:
+            f.write(b"X" * 100)
+        mp4_path = _make_archive_mp4(
+            archive_root, "RecentClips/old.mp4",
+            mtime=time.time() - 86400, size=100,
+        )
+        # Iterator yields .img first (oldest), then mp4.
+        files = [
+            (img_path, time.time() - (3 * 86400), 2 * gb),
+            (mp4_path, time.time() - 86400, 2 * gb),
+        ]
+        monkeypatch.setattr(
+            archive_watchdog, '_iter_archive_mp4_files',
+            lambda _root: iter(files),
+        )
+        monkeypatch.setattr(
+            archive_watchdog, '_safe_disk_usage', lambda _p: None,
+        )
+        summary = archive_watchdog._run_capacity_prune(
+            archive_root, db,
+        )
+        # .img refused → counted as kept_protected; .mp4 deleted to
+        # bring total under cap.
+        assert os.path.exists(img_path), (
+            ".img files MUST never be deleted by the capacity prune "
+            "(safe_delete_archive_video.is_protected_file guard)"
+        )
+        assert summary['capacity_kept_protected_count'] >= 1
+
+    def test_trips_are_sacred_under_capacity_prune(
+        self, db, archive_root, monkeypatch,
+    ):
+        # Insert a trip + waypoint + detected_event tied to the file
+        # we're about to capacity-prune. After the prune: the file
+        # is gone, but the trip / waypoint / event rows must still
+        # be present (only video_path NULL'd on the linked rows).
+        old_mtime = time.time() - (60 * 86400)
+        path = _make_archive_mp4(
+            archive_root, "RecentClips/sacred.mp4",
+            mtime=old_mtime, size=10,
+        )
+        # mapping_service.purge_deleted_videos matches via
+        # canonical_key, which compares basenames + parent dir name.
+        # Insert the indexed_files row with the same path so the
+        # purge finds it and reconciles waypoints/events.
+        conn = sqlite3.connect(db)
+        try:
+            conn.execute(
+                "INSERT INTO trips "
+                "(start_time, end_time, distance_km, duration_seconds) "
+                "VALUES (?, ?, ?, ?)",
+                ("2026-05-01T00:00:00", "2026-05-01T00:30:00",
+                 5.0, 1800),
+            )
+            trip_id = conn.execute(
+                "SELECT last_insert_rowid()"
+            ).fetchone()[0]
+            conn.execute(
+                "INSERT INTO waypoints "
+                "(trip_id, timestamp, lat, lon, video_path) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (trip_id, "2026-05-01T00:15:00", 40.0, -111.0, path),
+            )
+            conn.execute(
+                "INSERT INTO detected_events "
+                "(trip_id, timestamp, lat, lon, event_type, "
+                "video_path) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                (trip_id, "2026-05-01T00:15:30", 40.0, -111.0,
+                 'hard_brake', path),
+            )
+            conn.execute(
+                "INSERT INTO indexed_files "
+                "(file_path, file_size, indexed_at) "
+                "VALUES (?, ?, ?)",
+                (path, 10, "2026-05-01T00:30:00"),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+        _patch_capacity_config(monkeypatch, free_pct=0, max_gb=1)
+        gb = 1024 * 1024 * 1024
+        files = [(path, old_mtime, 2 * gb)]
+        monkeypatch.setattr(
+            archive_watchdog, '_iter_archive_mp4_files',
+            lambda _root: iter(files),
+        )
+        monkeypatch.setattr(
+            archive_watchdog, '_safe_disk_usage', lambda _p: None,
+        )
+        summary = archive_watchdog._run_capacity_prune(
+            archive_root, db,
+        )
+        assert summary['capacity_deleted_count'] == 1
+        assert not os.path.exists(path)
+        # Trips + waypoints + events still present.
+        conn = sqlite3.connect(db)
+        try:
+            assert conn.execute(
+                "SELECT COUNT(*) FROM trips"
+            ).fetchone()[0] == 1, "trips ROW must survive capacity prune"
+            assert conn.execute(
+                "SELECT COUNT(*) FROM waypoints"
+            ).fetchone()[0] == 1, "waypoints ROW must survive capacity prune"
+            assert conn.execute(
+                "SELECT COUNT(*) FROM detected_events"
+            ).fetchone()[0] == 1, "events ROW must survive capacity prune"
+            # indexed_files row dropped (its purpose was tracking the
+            # file that no longer exists).
+            assert conn.execute(
+                "SELECT COUNT(*) FROM indexed_files WHERE file_path=?",
+                (path,),
+            ).fetchone()[0] == 0
+        finally:
+            conn.close()
+
+    def test_cloud_pending_files_are_kept(
+        self, db, archive_root, monkeypatch,
+    ):
+        # When a cloud provider is configured AND delete_unsynced=False,
+        # an unsynced file MUST be skipped past the capacity threshold
+        # and counted in capacity_kept_unsynced_count, not deleted.
+        _patch_capacity_config(monkeypatch, free_pct=0, max_gb=1)
+        monkeypatch.setattr(
+            archive_watchdog, '_resolve_delete_unsynced', lambda: False,
+        )
+        monkeypatch.setattr(
+            archive_watchdog, '_is_cloud_configured', lambda: True,
+        )
+        monkeypatch.setattr(
+            archive_watchdog, '_resolve_cloud_db_path',
+            lambda: '/tmp/fake_cloud.db',
+        )
+        monkeypatch.setattr(
+            archive_watchdog, '_is_synced_to_cloud',
+            lambda *a, **kw: False,  # nothing is synced
+        )
+        gb = 1024 * 1024 * 1024
+        path = _make_archive_mp4(
+            archive_root, "RecentClips/unsynced.mp4",
+            mtime=time.time() - 86400, size=10,
+        )
+        files = [(path, time.time() - 86400, 2 * gb)]
+        monkeypatch.setattr(
+            archive_watchdog, '_iter_archive_mp4_files',
+            lambda _root: iter(files),
+        )
+        monkeypatch.setattr(
+            archive_watchdog, '_safe_disk_usage', lambda _p: None,
+        )
+        summary = archive_watchdog._run_capacity_prune(
+            archive_root, db,
+        )
+        assert summary['capacity_deleted_count'] == 0
+        assert summary['capacity_kept_unsynced_count'] == 1
+        assert os.path.exists(path), (
+            "Unsynced file MUST be kept past capacity threshold "
+            "when cloud is configured + delete_unsynced=False — "
+            "extended WiFi outage cannot cause silent footage loss"
+        )
+
+    def test_force_prune_now_runs_capacity_pass_after_time_pass(
+        self, db, archive_root, monkeypatch,
+    ):
+        # Wire up the watchdog so force_prune_now has paths set, then
+        # verify the returned summary has a 'capacity' key — proving
+        # _run_capacity_prune is invoked from force_prune_now.
+        archive_watchdog._archive_root = archive_root
+        archive_watchdog._db_path = db
+        try:
+            _patch_capacity_config(monkeypatch, free_pct=0, max_gb=0)
+            old = time.time() - (60 * 86400)
+            _make_archive_mp4(
+                archive_root, "RecentClips/old.mp4",
+                mtime=old, size=10,
+            )
+            summary = archive_watchdog.force_prune_now()
+            assert 'capacity' in summary, (
+                "force_prune_now must call _run_capacity_prune so the "
+                "Settings → Storage page knobs are actually enforced"
+            )
+            assert summary['capacity']['free_space_target_pct'] == 0
+            assert summary['capacity']['max_archive_size_gb'] == 0
+        finally:
+            archive_watchdog._archive_root = None
+            archive_watchdog._db_path = None
+
+    def test_resolve_free_space_target_pct_clamps_invalid(
+        self, monkeypatch,
+    ):
+        # Negative or > 50 → 0 (disabled). Defends against misconfig.
+        import config as cfg_mod
+        monkeypatch.setattr(
+            cfg_mod, 'CLEANUP_FREE_SPACE_TARGET_PCT', -5, raising=False,
+        )
+        assert archive_watchdog._resolve_free_space_target_pct() == 0
+        monkeypatch.setattr(
+            cfg_mod, 'CLEANUP_FREE_SPACE_TARGET_PCT', 999, raising=False,
+        )
+        assert archive_watchdog._resolve_free_space_target_pct() == 0
+        monkeypatch.setattr(
+            cfg_mod, 'CLEANUP_FREE_SPACE_TARGET_PCT', 25, raising=False,
+        )
+        assert archive_watchdog._resolve_free_space_target_pct() == 25
+
+    def test_resolve_max_archive_size_gb_clamps_negative(
+        self, monkeypatch,
+    ):
+        import config as cfg_mod
+        monkeypatch.setattr(
+            cfg_mod, 'CLEANUP_MAX_ARCHIVE_SIZE_GB', -1, raising=False,
+        )
+        assert archive_watchdog._resolve_max_archive_size_gb() == 0
+        monkeypatch.setattr(
+            cfg_mod, 'CLEANUP_MAX_ARCHIVE_SIZE_GB', 100, raising=False,
+        )
+        assert archive_watchdog._resolve_max_archive_size_gb() == 100


### PR DESCRIPTION
## Summary

The Settings -> Storage & Retention card has had two inputs since PR #124 (May 2026) that were saved to `config.yaml` but never enforced anywhere in the codebase: `cleanup.free_space_target_pct` and `cleanup.max_archive_size_gb`. The UI hint said *""Phase 5 (preview)"" / ""Saved now; not yet enforced""* — in practice users could set them to anything and the device would silently ignore the value.

Per the project rule **""we can't have parameters or settings that a user can set but the device does not respect""**, this PR implements the enforcement in `archive_watchdog`, removes the apologetic UI hints, and replaces them with a description of the actual behavior.

Supersedes #212 (which only relabeled the inputs to ""not yet enforced"" — that softens the symptom but doesn't fix the rule violation).

## Implementation

A new capacity-aware sub-pass runs *after* the existing time-based `_run_retention_prune` on every periodic tick AND on every manual ""Run cleanup now"" click:

- `_resolve_free_space_target_pct()` — clamped `[0, 50]`; `0` disables.
- `_resolve_max_archive_size_gb()` — clamped `>= 0`; `0` disables.
- `_run_capacity_prune(archive_root, db_path)` — when at least one knob is enabled, walks the tree once, sorts oldest-first when *any* threshold is breached, and deletes until both thresholds are satisfied.

All deletes route through the existing `_delete_one_mp4`, which inherits every pre-existing safeguard:

- **`safe_delete_archive_video`** — protected-file guard refuses `*.img` files in `GADGET_DIR` and any path outside `archive_root`.
- **`mapping_service.purge_deleted_videos`** — preserves the **""trips are sacred""** invariant: only the `indexed_files` row is dropped; `waypoints.video_path` and `detected_events.video_path` are NULL'd, never deleted.

## Cloud-pending preservation

Honors `_resolve_delete_unsynced`: when **False** AND a cloud provider is configured, files not yet uploaded (`cloud_synced_files.status != 'synced'`) are skipped past the capacity threshold and counted in `capacity_kept_unsynced_count`. **Extended WiFi outage cannot silently lose footage to the capacity prune.**

## Lock & yielding

The capacity pass acquires its own `task_coordinator` `'retention'` slot (the time-based pass releases its slot before returning) and yields the slot every `_RETENTION_YIELD_EVERY_N_FILES` deletes via the same `_yield_retention_lock` helper. The outer `_retention_running` single-flight flag is held by the caller for the lifetime of both passes.

## Cheap path

When both knobs are `0` (the default), `_run_capacity_prune` short-circuits BEFORE walking the tree, statvfs, or acquiring the coordinator slot. **A default-config watchdog tick is essentially free.**

## UI cleanup

- Drops the ""Phase 5 (preview)"" / ""Saved now; not yet enforced"" qualifiers.
- Rewrites help text to describe actual behavior (oldest-first, cloud-pending preserved, .img protected, ""0 disables"" semantics).
- Lowers `free_space_target_pct` form min from 5 to 0 so an operator can explicitly disable the soft floor.
- Updates `FREE_SPACE_PCT_MIN = 0` in `storage_retention.py` to match.

## Tests

10 new tests in `TestCapacityPrune`:

- `test_no_op_when_both_knobs_disabled`
- `test_no_op_when_under_cap_and_above_free_target`
- `test_max_size_cap_deletes_oldest_first`
- `test_free_space_target_deletes_oldest_first`
- `test_protected_img_files_are_never_deleted`
- `test_trips_are_sacred_under_capacity_prune`
- `test_cloud_pending_files_are_kept`
- `test_force_prune_now_runs_capacity_pass_after_time_pass`
- `test_resolve_free_space_target_pct_clamps_invalid`
- `test_resolve_max_archive_size_gb_clamps_negative`

Full suite: **1957 pass / 5 skip** (was 1947 / 5).
