### PR TITLE
fix(system-health): SD card severity respects configured retention thresholds

### DIFF
--- a/scripts/web/blueprints/system_health.py
+++ b/scripts/web/blueprints/system_health.py
@@ -474,8 +474,46 @@ def _cloud_block() -> Dict[str, Any]:
     }
 
 
+def _resolve_disk_thresholds_mb() -> Tuple[int, int]:
+    """Return ``(warning_mb, critical_mb)`` from config or sensible defaults.
+
+    Mirrors :func:`services.archive_watchdog._resolve_disk_thresholds` so
+    the System Health card uses the SAME thresholds the archive worker
+    and watchdog use to decide "is this actually a problem". Resolved on
+    every call so a Settings → config edit takes effect on the next poll
+    without restart.
+    """
+    try:
+        from config import (
+            CLOUD_ARCHIVE_DISK_SPACE_CRITICAL_MB,
+            CLOUD_ARCHIVE_DISK_SPACE_WARNING_MB,
+        )
+        return (
+            int(CLOUD_ARCHIVE_DISK_SPACE_WARNING_MB),
+            int(CLOUD_ARCHIVE_DISK_SPACE_CRITICAL_MB),
+        )
+    except Exception:  # noqa: BLE001
+        return (500, 100)
+
+
 def _disk_block() -> Dict[str, Any]:
-    """SD card free space (the home-directory filesystem)."""
+    """SD card free space (the home-directory filesystem).
+
+    Severity is keyed off **absolute free MB** vs. the same configured
+    ``cloud_archive.disk_space_warning_mb`` / ``disk_space_critical_mb``
+    thresholds the archive watchdog and worker use:
+
+    * **error** — free < ``disk_space_critical_mb`` (default 100 MB).
+      The worker is actively refusing new copies; this is real.
+    * **warn**  — free < ``disk_space_warning_mb`` (default 500 MB).
+      We're within margin of error of the critical threshold; retention
+      should already be aggressively pruning.
+    * **ok**    — otherwise. **High used-% is expected**: with a
+      ``cleanup.free_space_target_pct: 10`` configuration, the system
+      actively prunes to maintain ~90% used. Showing yellow at 85% used
+      contradicts the configured retention policy and was misleading
+      operators (issue: see `index.html` System Health card).
+    """
     target = GADGET_DIR or '/home/pi'
     try:
         usage = shutil.disk_usage(target)
@@ -488,14 +526,17 @@ def _disk_block() -> Dict[str, Any]:
 
     total_gb = usage.total / (1024 ** 3)
     free_gb = usage.free / (1024 ** 3)
+    free_mb = usage.free // (1024 * 1024)
     used_pct = (usage.used / usage.total) * 100 if usage.total else 0.0
 
-    if used_pct >= 95:
+    warning_mb, critical_mb = _resolve_disk_thresholds_mb()
+
+    if free_mb < critical_mb:
         sev = SEV_ERROR
-        msg = f'Critical: {used_pct:.1f}% full'
-    elif used_pct >= 85:
+        msg = f'Critical: only {free_mb} MB free'
+    elif free_mb < warning_mb:
         sev = SEV_WARN
-        msg = f'{used_pct:.1f}% full'
+        msg = f'Low: only {free_mb} MB free'
     else:
         sev = SEV_OK
         msg = f'{free_gb:.1f} GB free'
@@ -506,6 +547,9 @@ def _disk_block() -> Dict[str, Any]:
         'used_pct': round(used_pct, 1),
         'free_gb': round(free_gb, 2),
         'total_gb': round(total_gb, 2),
+        'free_mb': int(free_mb),
+        'warning_mb': warning_mb,
+        'critical_mb': critical_mb,
     }
 
 

--- a/tests/test_system_health_blueprint.py
+++ b/tests/test_system_health_blueprint.py
@@ -175,37 +175,51 @@ def test_probe_cache_caches_failure(monkeypatch):
 # ---------------------------------------------------------------------------
 
 def test_disk_block_critical(monkeypatch):
+    """free_mb < critical_mb (default 100 MB) → ERROR.
+
+    Worker is actively refusing copies, so this is real. The percent
+    used is irrelevant — what matters is absolute free MB vs. the
+    same threshold the watchdog uses.
+    """
     import blueprints.system_health as sh
     from collections import namedtuple
     Usage = namedtuple('Usage', ['total', 'used', 'free'])
     monkeypatch.setattr(
         sh.shutil, 'disk_usage',
-        lambda path: Usage(total=100 * 1024**3,
-                           used=96 * 1024**3,
-                           free=4 * 1024**3),
+        lambda path: Usage(total=470 * 1024**3,
+                           used=470 * 1024**3 - 50 * 1024**2,
+                           free=50 * 1024**2),  # 50 MB free
     )
     block = sh._disk_block()
     assert block['severity'] == 'error'
-    assert 'Critical' in block['message']
-    assert block['used_pct'] == 96.0
+    assert 'critical' in block['message'].lower()
+    assert block['free_mb'] == 50
+    assert block['critical_mb'] == 100
 
 
 def test_disk_block_warn(monkeypatch):
+    """free_mb < warning_mb (default 500 MB) → WARN.
+
+    Within margin of the critical threshold; retention should already
+    be aggressively pruning.
+    """
     import blueprints.system_health as sh
     from collections import namedtuple
     Usage = namedtuple('Usage', ['total', 'used', 'free'])
     monkeypatch.setattr(
         sh.shutil, 'disk_usage',
-        lambda path: Usage(total=100 * 1024**3,
-                           used=88 * 1024**3,
-                           free=12 * 1024**3),
+        lambda path: Usage(total=470 * 1024**3,
+                           used=470 * 1024**3 - 250 * 1024**2,
+                           free=250 * 1024**2),  # 250 MB free
     )
     block = sh._disk_block()
     assert block['severity'] == 'warn'
-    assert block['used_pct'] == 88.0
+    assert 'low' in block['message'].lower()
+    assert block['free_mb'] == 250
 
 
 def test_disk_block_ok(monkeypatch):
+    """Plenty of free space → OK with GB-free message."""
     import blueprints.system_health as sh
     from collections import namedtuple
     Usage = namedtuple('Usage', ['total', 'used', 'free'])
@@ -219,6 +233,71 @@ def test_disk_block_ok(monkeypatch):
     assert block['severity'] == 'ok'
     assert block['free_gb'] == 120.0
     assert 'free' in block['message']
+
+
+def test_disk_block_high_pct_used_but_ok_per_retention_policy(monkeypatch):
+    """Regression: high used-% with plenty of absolute MB free → OK.
+
+    The user configures ``cleanup.free_space_target_pct: 10`` (default),
+    so the system actively prunes to maintain ~90% used. A 470 GB SD
+    card sitting at 90% used / 49 GB free is operating EXACTLY per the
+    configured retention policy — flagging it yellow contradicts the
+    user's settings and was the original complaint.
+    """
+    import blueprints.system_health as sh
+    from collections import namedtuple
+    Usage = namedtuple('Usage', ['total', 'used', 'free'])
+    monkeypatch.setattr(
+        sh.shutil, 'disk_usage',
+        lambda path: Usage(total=470 * 1024**3,
+                           used=int(470 * 0.90) * 1024**3,
+                           free=int(470 * 0.10) * 1024**3),
+    )
+    block = sh._disk_block()
+    assert block['severity'] == 'ok', (
+        f"90% used / ~10% free should be OK per the configured retention "
+        f"policy, got {block['severity']!r} ({block['message']!r})"
+    )
+    # Sanity: free is in the GB range, well above warning/critical thresholds.
+    assert block['free_gb'] > 40
+    assert block['free_mb'] > block['warning_mb']
+
+
+def test_disk_block_threshold_overrides(monkeypatch):
+    """Operator-tunable thresholds (config-aware) drive severity.
+
+    Verifies that overriding ``CLOUD_ARCHIVE_DISK_SPACE_WARNING_MB`` /
+    ``CLOUD_ARCHIVE_DISK_SPACE_CRITICAL_MB`` at the config layer is
+    honoured on the next call (no restart needed).
+    """
+    import blueprints.system_health as sh
+    from collections import namedtuple
+    Usage = namedtuple('Usage', ['total', 'used', 'free'])
+    monkeypatch.setattr(
+        sh.shutil, 'disk_usage',
+        lambda path: Usage(total=100 * 1024**3,
+                           used=99 * 1024**3,
+                           free=1024 * 1024**2),  # 1024 MB free
+    )
+    # Default thresholds (500/100 MB) → 1 GB free is OK.
+    block = sh._disk_block()
+    assert block['severity'] == 'ok'
+
+    # Operator raises the warning threshold to 2 GB → now 1 GB free is WARN.
+    monkeypatch.setattr(
+        sh, '_resolve_disk_thresholds_mb',
+        lambda: (2048, 100),
+    )
+    block = sh._disk_block()
+    assert block['severity'] == 'warn'
+
+    # Operator raises critical to 1.5 GB → now 1 GB free is ERROR.
+    monkeypatch.setattr(
+        sh, '_resolve_disk_thresholds_mb',
+        lambda: (2048, 1536),
+    )
+    block = sh._disk_block()
+    assert block['severity'] == 'error'
 
 
 def test_disk_block_oserror(monkeypatch):


### PR DESCRIPTION
## Problem

The System Health card on Settings showed the **SD Card** row in **yellow (warn)** at ≥85% used and **red (error)** at ≥95% used — using fixed percent thresholds that ignored the configured retention policy.

With the default `cleanup.free_space_target_pct: 10`, the retention prune actively maintains ~90% used as the *expected normal operating state*. The result: a healthy, correctly-configured Pi would **always** show the dashboard in warning state, contradicting the user's settings and eroding trust in the dashboard ("warnings should mean something is actually wrong").

User-reported state on production Pi at the time of the bug report:
- 470 GB SD card, **90% used / 49 GB free** → row showed yellow.
- This was *exactly* at the configured `free_space_target_pct: 10` — the system was doing exactly what was configured.

## Fix

`_disk_block()` now drives severity off the **same thresholds the archive watchdog and worker already use** to decide whether the disk is actually a problem (`cloud_archive.disk_space_warning_mb` / `disk_space_critical_mb`):

| Severity | Condition | Default trigger | What it actually means |
|---|---|---|---|
| **error** | `free_mb < critical_mb` | `< 100 MB` free | Worker is refusing new copies |
| **warn** | `free_mb < warning_mb` | `< 500 MB` free | Within margin of critical; retention should have pruned by now |
| **ok** | otherwise | | High used-pct is expected per the configured retention policy |

The thresholds are resolved on every poll (no restart needed when operators tune them in `config.yaml`), and the JSON payload now includes `free_mb`, `warning_mb`, `critical_mb` for transparency / future UI surfaces.

## Behaviour comparison

| State | Old severity | New severity |
|---|---|---|
| 470 GB / 90% used / 49 GB free *(user's actual state)* | 🟡 warn | 🟢 ok |
| 470 GB / 99.95% used / 250 MB free | 🔴 error | 🟡 warn |
| 470 GB / 99.99% used / 50 MB free | 🔴 error | 🔴 error |
| 200 GB / 40% used / 120 GB free | 🟢 ok | 🟢 ok |

## Tests

`tests/test_system_health_blueprint.py`:
- `test_disk_block_critical` — rewritten to exercise absolute-MB threshold (50 MB free → error)
- `test_disk_block_warn` — rewritten (250 MB free → warn)
- `test_disk_block_ok` — unchanged (still passes)
- `test_disk_block_high_pct_used_but_ok_per_retention_policy` — **new regression case** locking in the user's exact complaint (90% used / 49 GB free → ok)
- `test_disk_block_threshold_overrides` — **new** verifies operator-tunable thresholds are honoured on next call (no restart needed)
- `test_disk_block_oserror` — unchanged

Full suite: **1978 pass / 5 skip** (was 1976 baseline).

## Out of scope

- The "Live Metrics" memory/swap tiles on the Settings page have their own client-side `severityFromPct(value, 80, 95)` thresholds. Those are RAM, not SD card, and a different conversation.
- Other percent-based dashboard severities (e.g. CPU%) are unrelated to retention configuration and remain unchanged.
