### PR TITLE
fix(settings): collapse all sections by default except System Health and Live Metrics

### DIFF
--- a/scripts/web/templates/index.html
+++ b/scripts/web/templates/index.html
@@ -296,7 +296,7 @@
     </style>
 
     <!-- WiFi Networks -->
-    <details class="settings-section" open>
+    <details class="settings-section">
         <summary>WiFi Networks</summary>
         <div class="section-content">
             {% if wifi_change_status %}
@@ -365,7 +365,7 @@
     </details>
 
     <!-- Access Point -->
-    <details class="settings-section" open>
+    <details class="settings-section">
         <summary>Access Point</summary>
         <div class="section-content">
             {% if ap_status.error %}
@@ -434,7 +434,7 @@
     </details>
 
     <!-- Storage & Retention (Phase 3a.2 — closes part of #98) -->
-    <details class="settings-section" id="storage-retention-section" open>
+    <details class="settings-section" id="storage-retention-section">
         <summary>Storage &amp; Retention</summary>
         <div class="section-content">
             <p style="font-size:0.85rem; color:var(--text-secondary); margin:0 0 12px">


### PR DESCRIPTION
## Problem

The Settings page (`templates/index.html`) opened with **five** `<details class="settings-section">` blocks expanded by default: System Health, Live Metrics, WiFi Networks, Access Point, and Storage & Retention. The result on a phone was a multi-screen scroll just to reach the at-a-glance overview, and the less-frequently-toggled content (WiFi networks, AP config, retention sliders) sat above sections users actually want to see at a glance.

Per the project's progressive-disclosure design rule (simple by default; power-user content behind a deliberate action), only the at-a-glance overview cards should be open by default.

## Fix

Removed the `open` attribute from three `<details>` elements:

| Section | Before | After |
|---|---|---|
| System Health | `open` | `open` (unchanged — keep) |
| Live Metrics | `open` | `open` (unchanged — keep) |
| WiFi Networks | `open` | collapsed |
| Access Point | `open` | collapsed |
| Storage & Retention | `open` | collapsed |

3 lines changed. No JavaScript, no CSS, no localStorage state to migrate (verified there's no client-side persistence of section state).

## Tests

`pytest tests/ -k "index or settings or template"` → **173 pass / 2 skip**. No regressions.
