### PR TITLE
feat(#165): generic rclone remote (NAS / SFTP / WebDAV / SMB / FTP / S3 / B2 / Wasabi / Azure / Swift)

### DIFF
--- a/docs/CLOUD_ARCHIVE.md
+++ b/docs/CLOUD_ARCHIVE.md
@@ -12,7 +12,7 @@ types and how to set them up from the web UI.
 | **S3-style** | Amazon S3, Backblaze B2, Wasabi | Inline form (Access Key / Secret Key / Region / Bucket / Endpoint) | API keys (cleartext per rclone convention) |
 | **NAS / custom rclone** *(issue #165)* | SFTP, WebDAV, SMB/CIFS, FTP, S3-compatible (custom endpoint), Azure Blob, OpenStack Swift | Either a guided form or an `rclone.conf` paste | Hardware-bound Fernet-encrypted blob in `cloud_provider_creds.bin` |
 
-All three flows ultimately produce the same encrypted `cloud_provider_creds.bin` and the same `[teslausb]` rclone section at sync time, so the cloud archive worker, Live Event Sync, and the connection-test button all work identically regardless of provider type.
+All three flows ultimately produce the same encrypted `cloud_provider_creds.bin` and the same `[teslausb]` rclone section at sync time, so the cloud archive worker, the live-event upload path (`PRIORITY_LIVE_EVENT` rows in `pipeline_queue`), and the connection-test button all work identically regardless of provider type.
 
 ## NAS / Custom rclone (issue #165)
 
@@ -83,4 +83,4 @@ For SFTP / WebDAV / SMB / FTP, the remote folder is a path on the server, e.g. `
 
 1. After **Save & Connect**, the **Test Connection** button runs `rclone lsd teslausb:` and reports success or the rclone error verbatim.
 2. The **Cloud Archive** queue starts draining the moment WiFi connects. The map page's clip overlay shows the sync icon for archived clips.
-3. The **Live Event Sync** subsystem (if enabled) inherits NAS support automatically — no separate setup.
+3. Sentry / Saved-event clips are uploaded with priority over the bulk catch-up backlog (they enter `pipeline_queue` at `PRIORITY_LIVE_EVENT`); no separate setup is required for the new provider types.

--- a/docs/CLOUD_ARCHIVE.md
+++ b/docs/CLOUD_ARCHIVE.md
@@ -1,0 +1,86 @@
+# Cloud Archive — provider setup
+
+TeslaUSB uploads dashcam events to your cloud storage of choice via
+[rclone](https://rclone.org/). This page covers the supported provider
+types and how to set them up from the web UI.
+
+## Supported providers
+
+| Type | Backend | UI flow | Where credentials live |
+|------|---------|---------|------------------------|
+| **OAuth** | Google Drive, OneDrive, Dropbox | Paste an `rclone authorize` token blob from a desktop machine | OAuth refresh token |
+| **S3-style** | Amazon S3, Backblaze B2, Wasabi | Inline form (Access Key / Secret Key / Region / Bucket / Endpoint) | API keys (cleartext per rclone convention) |
+| **NAS / custom rclone** *(issue #165)* | SFTP, WebDAV, SMB/CIFS, FTP, S3-compatible (custom endpoint), Azure Blob, OpenStack Swift | Either a guided form or an `rclone.conf` paste | Hardware-bound Fernet-encrypted blob in `cloud_provider_creds.bin` |
+
+All three flows ultimately produce the same encrypted `cloud_provider_creds.bin` and the same `[teslausb]` rclone section at sync time, so the cloud archive worker, Live Event Sync, and the connection-test button all work identically regardless of provider type.
+
+## NAS / Custom rclone (issue #165)
+
+The "NAS / Custom rclone" entry in the provider dropdown is a single endpoint that covers nine rclone backend types. Two input modes are offered:
+
+### Form mode (recommended for most NAS units)
+
+1. Open the **Cloud** tab → **Cloud Provider** section.
+2. Pick **NAS / Custom rclone** in the Provider dropdown.
+3. Pick the **Backend type** that matches your storage:
+   - **SFTP** — Synology, QNAP, TrueNAS, any Linux server with `sshd`.
+   - **WebDAV** — Nextcloud, ownCloud, Synology WebDAV, generic.
+   - **SMB / CIFS** — Windows file share, Synology / QNAP SMB.
+   - **FTP** — legacy.
+   - **S3-compatible** — MinIO, Ceph RGW, IDrive e2, custom endpoint.
+   - **Backblaze B2 (advanced)** — direct keys.
+   - **Wasabi (advanced)** — direct keys with Wasabi endpoint preset.
+   - **Azure Blob Storage**.
+   - **OpenStack Swift**.
+4. Fill in the fields the form asks for. Required fields are marked with **\***. Hover the field for hints; see the [rclone docs](https://rclone.org/) for full semantics.
+5. Click **Save & Connect**. The credentials are encrypted with the Pi's hardware-bound key and stored on the SD card; an immediate connection test is run.
+
+### Paste mode (for users who already have an `rclone.conf`)
+
+If you already have an existing `~/.config/rclone/rclone.conf` on a desktop machine, just copy the entire `[remote]` block and paste it into the **Paste rclone.conf** tab:
+
+```ini
+[my-nas]
+type = sftp
+host = nas.local
+user = pi
+pass = ZAlRez1m2_oEDbSn-jxvLY1eAvXzKPm6
+port = 22
+```
+
+Behaviour:
+- The section name (`[my-nas]` here) is **discarded** — TeslaUSB always stores remotes as `[teslausb]`.
+- A `pass` field that's already obscured (rclone's standard format) is kept verbatim. A cleartext password is **not** auto-detected — paste the obscured form, or use Form mode.
+- Multiple sections are rejected (avoids `crypt`/`union`/`chunker` wrap-remote attacks).
+- Backend types outside the supported allow-list are rejected (see below).
+
+### Supported backend types
+
+Allow-listed types: `sftp`, `webdav`, `smb`, `ftp`, `s3`, `b2`, `wasabi`, `azureblob`, `swift`.
+
+**Not supported** (and explicitly rejected at parse time):
+- `crypt`, `union`, `chunker` — wrap-remote types that reference a second remote name TeslaUSB doesn't store.
+- `local` — would let an attacker who gains web-UI access copy archive data to arbitrary local paths.
+- `http` — read-only, useless for an upload destination.
+
+### Choosing the bucket / folder
+
+For S3-style backends, the **bucket name** is part of the upload path, not the rclone config. After connecting, scroll to **Sync Settings → Remote folder** and either:
+- Type the bucket name (and optional sub-path), e.g. `my-teslausb-bucket/dashcam`, or
+- Click **Browse** and pick a folder.
+
+For SFTP / WebDAV / SMB / FTP, the remote folder is a path on the server, e.g. `/volume1/dashcam` or `/srv/teslausb`.
+
+## How the credentials are stored
+
+- **Encryption**: Fernet (AES-128-CBC + HMAC-SHA-256), with the key derived from the Pi's SoC serial + `/etc/machine-id` + a per-install random salt at `tesla_salt.bin`. The credentials cannot be decrypted on a different physical Pi.
+- **At-rest format**: a single binary file at `cloud_provider_creds.bin` (atomically rewritten via temp + fsync + rename).
+- **In-flight**: at sync time, the worker decrypts the creds, writes a transient `rclone.conf` to `/run/teslausb/` (tmpfs — never touches disk), runs rclone, then deletes the conf.
+- **Passwords for sftp / webdav / smb / ftp** are passed through `rclone obscure` before storage so the on-disk and in-flight `rclone.conf` files never carry the cleartext.
+- **S3-style secret keys** are stored verbatim — rclone does not obscure them and will not parse an obscured form.
+
+## Verifying it works
+
+1. After **Save & Connect**, the **Test Connection** button runs `rclone lsd teslausb:` and reports success or the rclone error verbatim.
+2. The **Cloud Archive** queue starts draining the moment WiFi connects. The map page's clip overlay shows the sync icon for archived clips.
+3. The **Live Event Sync** subsystem (if enabled) inherits NAS support automatically — no separate setup.

--- a/readme.md
+++ b/readme.md
@@ -122,7 +122,8 @@ TeslaUSB creates a multi-drive USB gadget that appears as **two or three separat
 - **WiFi Roaming**: Automatic switching between access points with the same SSID for optimal signal strength (mesh networks and WiFi extenders)
 
 ### Cloud Archive
-- **Queue-based continuous sync**: Automatically uploads dashcam events to cloud storage (Google Drive, S3, Dropbox, etc.) via rclone
+- **Queue-based continuous sync**: Automatically uploads dashcam events to cloud storage via rclone
+- **Wide provider support**: OAuth providers (Google Drive, OneDrive, Dropbox); S3-compatible (Amazon S3, Backblaze B2, Wasabi, MinIO); and **NAS / custom rclone** backends (SFTP, WebDAV, SMB/CIFS, FTP, Azure Blob, OpenStack Swift) — issue #165
 - **Priority ordering**: Events with Tesla event.json uploaded first, then geolocated trips, then remaining clips
 - **Power-loss safe**: Files marked as synced only after rclone confirms upload; partial uploads detected and re-queued on restart
 - **Low impact**: Runs with `nice`/`ionice` throttling, configurable bandwidth limits, one file at a time — web UI stays responsive

--- a/scripts/web/blueprints/cloud_archive.py
+++ b/scripts/web/blueprints/cloud_archive.py
@@ -412,25 +412,120 @@ def api_save_provider():
 
 @cloud_archive_bp.route('/api/connect', methods=['POST'])
 def api_connect_provider():
-    """Save rclone authorize token for a cloud provider.
+    """Save credentials for a cloud provider.
 
-    Expects JSON: { "provider": "onedrive", "token": "<pasted blob>" }
+    Three accepted payload shapes:
+
+    1. **OAuth token paste** (legacy — OneDrive / Google Drive / Dropbox)::
+
+           {"provider": "onedrive", "token": "<rclone authorize blob>"}
+
+    2. **Generic — pasted ``rclone.conf`` block** (issue #165)::
+
+           {"provider": "generic", "config_block": "[my-nas]\\ntype=sftp\\n..."}
+
+    3. **Generic — inline form** (issue #165)::
+
+           {
+             "provider": "generic",
+             "rclone_type": "sftp",
+             "fields": {"host": "nas.local", "user": "pi", "pass": "..."},
+             "obscure_keys": ["pass"]
+           }
+
+    For shape (3), ``obscure_keys`` is optional; if omitted the
+    backend's documented defaults are applied (``["pass"]`` for
+    ``sftp``/``webdav``/``smb``/``ftp``; ``[]`` for ``s3``/``b2``/
+    ``wasabi``/``azureblob``/``swift`` since rclone does not obscure
+    their secret keys).
+
+    Behaviour notes:
+        * On success the chosen provider is persisted to
+          ``cloud_archive.provider`` in ``config.yaml`` (always
+          ``"generic"`` for shapes 2 and 3) so that on the next boot
+          ``CLOUD_ARCHIVE_PROVIDER`` resolves correctly.
+        * Shapes 2 and 3 reject any backend type outside
+          ``_GENERIC_RCLONE_TYPES`` — see
+          :func:`services.cloud_rclone_service.parse_rclone_config_block`.
     """
     from services.cloud_rclone_service import (
-        parse_rclone_token, save_credentials, PROVIDERS,
+        parse_rclone_token, parse_rclone_config_block,
+        save_credentials, save_credentials_generic, PROVIDERS,
     )
 
     data = request.get_json(silent=True) or {}
     provider = data.get('provider', '')
-    token_raw = data.get('token', '')
 
-    if not provider or not token_raw:
+    if not provider:
         return jsonify({"success": False,
-                        "message": "Missing provider or token."}), 400
-
+                        "message": "Missing provider."}), 400
     if provider not in PROVIDERS:
         return jsonify({"success": False,
                         "message": f"Unknown provider: {provider}"}), 400
+
+    # ----- Shape 2 / 3: generic rclone remote (#165) --------------------
+    if provider == 'generic':
+        config_block = data.get('config_block')
+        rclone_type = data.get('rclone_type')
+        fields = data.get('fields')
+
+        # Default obscure keys per rclone backend convention.
+        # sftp/webdav/smb/ftp store an obfuscated password; the S3-style
+        # backends store secret keys in cleartext (rclone never
+        # obscures them). Callers can override with an explicit list.
+        _DEFAULT_OBSCURE = {
+            'sftp': ['pass'], 'webdav': ['pass'],
+            'smb': ['pass'], 'ftp': ['pass'],
+            's3': [], 'b2': [], 'wasabi': [],
+            'azureblob': [], 'swift': [],
+        }
+
+        try:
+            if config_block:
+                parsed = parse_rclone_config_block(config_block)
+                rt = parsed.pop('type')
+                obscure_keys = data.get(
+                    'obscure_keys', _DEFAULT_OBSCURE.get(rt, []),
+                )
+                save_credentials_generic(
+                    rt, parsed,
+                    obscure_keys=obscure_keys, source='paste',
+                )
+            elif rclone_type and isinstance(fields, dict):
+                obscure_keys = data.get(
+                    'obscure_keys', _DEFAULT_OBSCURE.get(rclone_type, []),
+                )
+                save_credentials_generic(
+                    rclone_type, fields,
+                    obscure_keys=obscure_keys, source='form',
+                )
+            else:
+                return jsonify({"success": False, "message": (
+                    "Generic provider requires either 'config_block' "
+                    "or both 'rclone_type' and 'fields'."
+                )}), 400
+        except ValueError as e:
+            return jsonify({"success": False, "message": str(e)}), 400
+        except RuntimeError as e:
+            logger.exception("rclone obscure failed")
+            return jsonify({"success": False, "message": str(e)}), 500
+        except Exception as exc:
+            logger.exception("Failed to save generic cloud credentials")
+            return jsonify({"success": False, "message": str(exc)}), 500
+
+        try:
+            _update_config_yaml({'cloud_archive.provider': 'generic'})
+            return jsonify({"success": True,
+                            "message": "Connected successfully."})
+        except Exception as exc:
+            logger.exception("Failed to persist provider selection")
+            return jsonify({"success": False, "message": str(exc)}), 500
+
+    # ----- Shape 1: OAuth token paste (legacy) --------------------------
+    token_raw = data.get('token', '')
+    if not token_raw:
+        return jsonify({"success": False,
+                        "message": "Missing token."}), 400
 
     try:
         token = parse_rclone_token(token_raw)

--- a/scripts/web/blueprints/cloud_archive.py
+++ b/scripts/web/blueprints/cloud_archive.py
@@ -434,10 +434,11 @@ def api_connect_provider():
            }
 
     For shape (3), ``obscure_keys`` is optional; if omitted the
-    backend's documented defaults are applied (``["pass"]`` for
-    ``sftp``/``webdav``/``smb``/``ftp``; ``[]`` for ``s3``/``b2``/
-    ``wasabi``/``azureblob``/``swift`` since rclone does not obscure
-    their secret keys).
+    backend's documented defaults from
+    :data:`services.cloud_rclone_service._DEFAULT_OBSCURE_KEYS` are
+    applied (``["pass"]`` for ``sftp``/``webdav``/``smb``/``ftp``;
+    ``[]`` for ``s3``/``b2``/``wasabi``/``azureblob``/``swift`` since
+    rclone does not obscure their secret keys).
 
     Behaviour notes:
         * On success the chosen provider is persisted to
@@ -451,6 +452,7 @@ def api_connect_provider():
     from services.cloud_rclone_service import (
         parse_rclone_token, parse_rclone_config_block,
         save_credentials, save_credentials_generic, PROVIDERS,
+        _DEFAULT_OBSCURE_KEYS,
     )
 
     data = request.get_json(silent=True) or {}
@@ -469,23 +471,16 @@ def api_connect_provider():
         rclone_type = data.get('rclone_type')
         fields = data.get('fields')
 
-        # Default obscure keys per rclone backend convention.
-        # sftp/webdav/smb/ftp store an obfuscated password; the S3-style
-        # backends store secret keys in cleartext (rclone never
-        # obscures them). Callers can override with an explicit list.
-        _DEFAULT_OBSCURE = {
-            'sftp': ['pass'], 'webdav': ['pass'],
-            'smb': ['pass'], 'ftp': ['pass'],
-            's3': [], 'b2': [], 'wasabi': [],
-            'azureblob': [], 'swift': [],
-        }
-
         try:
             if config_block:
                 parsed = parse_rclone_config_block(config_block)
                 rt = parsed.pop('type')
+                # Default obscure keys come from the single source of
+                # truth in cloud_rclone_service so a future backend
+                # added to _GENERIC_RCLONE_TYPES can never silently
+                # default to no-obscure here (PR #218 review I-3).
                 obscure_keys = data.get(
-                    'obscure_keys', _DEFAULT_OBSCURE.get(rt, []),
+                    'obscure_keys', _DEFAULT_OBSCURE_KEYS.get(rt, []),
                 )
                 save_credentials_generic(
                     rt, parsed,
@@ -493,7 +488,8 @@ def api_connect_provider():
                 )
             elif rclone_type and isinstance(fields, dict):
                 obscure_keys = data.get(
-                    'obscure_keys', _DEFAULT_OBSCURE.get(rclone_type, []),
+                    'obscure_keys',
+                    _DEFAULT_OBSCURE_KEYS.get(rclone_type, []),
                 )
                 save_credentials_generic(
                     rclone_type, fields,

--- a/scripts/web/services/cloud_archive_service.py
+++ b/scripts/web/services/cloud_archive_service.py
@@ -2777,11 +2777,29 @@ def _write_rclone_conf(provider: str, creds: dict,
 
     # Build minimal rclone remote config. Skip "type" in the loop
     # (we just emitted it) and skip private metadata keys.
+    #
+    # Defense in depth (PR #218 review): keys/values that contain a
+    # forbidden control character would let an attacker inject extra
+    # config lines (e.g. an sftp ``ssh`` directive → command exec as
+    # root, an s3 ``endpoint`` override → upload redirection).
+    # ``save_credentials_generic`` already rejects these at save time;
+    # this is the last guard before rclone reads the file. We use a
+    # local helper instead of importing from cloud_rclone_service
+    # because cloud_rclone_service imports from THIS module and a
+    # circular import would break startup.
+    _BAD_CHARS = ("\n", "\r", "\x00")
     lines = ["[teslausb]", f"type = {rclone_type}"]
     for key, value in creds.items():
         if not isinstance(key, str):
             continue
         if key == "type" or key.startswith("_"):
+            continue
+        s_value = "" if value is None else str(value)
+        if any(c in key for c in _BAD_CHARS) or any(c in s_value for c in _BAD_CHARS):
+            logger.error(
+                "Refusing to write creds entry to rclone.conf "
+                "(control character in key=%r or value)", key,
+            )
             continue
         lines.append(f"{key} = {value}")
 

--- a/scripts/web/services/cloud_archive_service.py
+++ b/scripts/web/services/cloud_archive_service.py
@@ -2758,13 +2758,31 @@ def _write_rclone_conf(provider: str, creds: dict,
     yield/re-acquire cycle. When omitted the legacy fixed path
     ``/run/teslausb/rclone.conf`` is used (preserves existing
     cloud_archive behavior; LES MUST pass a unique name).
+
+    Issue #165: when ``creds`` carries an explicit ``"type"`` key (the
+    generic-rclone-remote flow puts the real backend type there), it
+    wins over the ``provider`` argument — that argument is then just
+    a label for the existing OAuth providers (``"onedrive"``, etc.).
+    Keys beginning with ``_`` are private metadata
+    (e.g. ``_obscure_keys``, ``_source``) and never reach the conf
+    file; rclone would treat them as unknown options and fail.
     """
     os.makedirs(_RCLONE_TMPFS_DIR, exist_ok=True)
 
-    # Build minimal rclone remote config
-    lines = ["[teslausb]"]
-    lines.append(f"type = {provider}")
+    # Resolve the rclone backend type. The creds dict's "type" wins
+    # because (a) the generic flow stores the truth there and (b) for
+    # legacy OAuth creds, save_credentials writes the same value to
+    # creds["type"] anyway, so this is a no-op for them.
+    rclone_type = creds.get("type") or provider
+
+    # Build minimal rclone remote config. Skip "type" in the loop
+    # (we just emitted it) and skip private metadata keys.
+    lines = ["[teslausb]", f"type = {rclone_type}"]
     for key, value in creds.items():
+        if not isinstance(key, str):
+            continue
+        if key == "type" or key.startswith("_"):
+            continue
         lines.append(f"{key} = {value}")
 
     if conf_name:

--- a/scripts/web/services/cloud_rclone_service.py
+++ b/scripts/web/services/cloud_rclone_service.py
@@ -14,7 +14,7 @@ import logging
 import os
 import re
 import subprocess
-from typing import Dict, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 from config import (
     GADGET_DIR,
@@ -68,7 +68,57 @@ PROVIDERS = {
         "rclone_type": "dropbox",
         "authorize_cmd": 'rclone authorize "dropbox"',
     },
+    # Issue #165: generic rclone remote (NAS / S3-style / FTP / WebDAV
+    # / SMB). The actual rclone backend type comes from the stored
+    # creds dict ("type" key) at conf-write time, NOT from this static
+    # mapping. ``rclone_type=None`` is the sentinel that tells callers
+    # "look at creds['type'] instead of guessing from the provider key".
+    # ``authorize_cmd=None`` because there is no OAuth flow — generic
+    # backends use either an inline form or a pasted ``rclone.conf``
+    # block; both flows live in :func:`save_credentials_generic`.
+    "generic": {
+        "label": "NAS / Custom rclone",
+        "rclone_type": None,
+        "authorize_cmd": None,
+    },
 }
+
+# ---------------------------------------------------------------------------
+# Generic rclone remote support (issue #165)
+# ---------------------------------------------------------------------------
+#
+# Allow-list of rclone backend types we expose through the generic
+# provider flow. Anything outside this set is rejected at parse time.
+#
+# Why an allow-list?
+#   * ``crypt`` / ``union`` / ``chunker`` wrap ANOTHER remote inside
+#     themselves; their credentials reference a second remote name
+#     that we don't store, so they can't function in our single-remote
+#     ``[teslausb]`` model without a much larger refactor.
+#   * ``local`` would let an attacker who gains web-UI access ask
+#     rclone to copy archived clips to an arbitrary local path
+#     (privilege escalation via the rclone subprocess).
+#   * ``http`` is read-only — useless for an upload destination.
+#
+# Adding a backend here is intentionally a code change so the choice
+# gets reviewed against those constraints.
+_GENERIC_RCLONE_TYPES = frozenset({
+    "sftp",
+    "webdav",
+    "smb",
+    "ftp",
+    "s3",
+    "b2",
+    "wasabi",      # alias / config preset for s3 with Wasabi endpoint
+    "azureblob",
+    "swift",
+})
+
+# Storage metadata keys we attach to a generic creds dict. Prefixed
+# with ``_`` so :func:`cloud_archive_service._write_rclone_conf` can
+# safely skip them when iterating creds (Phase 3 of #165 enforces
+# this rule for ALL writers).
+_CREDS_META_KEYS = ("_obscure_keys", "_source", "_rclone_type_hint")
 
 
 # ---------------------------------------------------------------------------
@@ -118,6 +168,40 @@ def parse_rclone_token(raw_input: str) -> Dict:
 # Credential storage (encrypted, hardware-bound)
 # ---------------------------------------------------------------------------
 
+def _persist_creds(creds: dict, *, provider_label: str) -> None:
+    """Encrypt the creds dict with the hardware-bound Fernet key and
+    atomically write it to ``CLOUD_PROVIDER_CREDS_PATH``.
+
+    Shared by :func:`save_credentials` (OAuth flow) and
+    :func:`save_credentials_generic` (issue #165 NAS / generic flow).
+    Both paths use the same key derivation, atomic-write recipe, and
+    on-disk format so the loader (:func:`_load_creds`) does not need
+    to know which flow produced the file.
+
+    Args:
+        creds: Plaintext credential dict; will be JSON-serialised
+            then Fernet-encrypted. Caller is responsible for shape.
+        provider_label: Human-readable provider name for the success
+            log line — never persisted to disk.
+    """
+    from services.crypto_utils import derive_encryption_key
+    from cryptography.fernet import Fernet
+
+    key = derive_encryption_key()
+    fernet = Fernet(key)
+    encrypted = fernet.encrypt(json.dumps(creds).encode())
+
+    os.makedirs(os.path.dirname(CLOUD_PROVIDER_CREDS_PATH) or '.', exist_ok=True)
+    tmp = CLOUD_PROVIDER_CREDS_PATH + '.tmp'
+    with open(tmp, 'wb') as f:
+        f.write(encrypted)
+        f.flush()
+        os.fsync(f.fileno())
+    os.replace(tmp, CLOUD_PROVIDER_CREDS_PATH)
+
+    logger.info("Cloud credentials saved for provider: %s", provider_label)
+
+
 def save_credentials(provider: str, token: dict) -> None:
     """Encrypt and persist rclone credentials.
 
@@ -125,9 +209,6 @@ def save_credentials(provider: str, token: dict) -> None:
         provider: Provider key (e.g. 'onedrive').
         token: Parsed token dict from rclone authorize output.
     """
-    from services.crypto_utils import derive_encryption_key
-    from cryptography.fernet import Fernet
-
     rclone_type = PROVIDERS.get(provider, {}).get("rclone_type", provider)
 
     # Build rclone-compatible credential dict
@@ -143,19 +224,187 @@ def save_credentials(provider: str, token: dict) -> None:
         if drive_id:
             creds["drive_id"] = drive_id
 
-    key = derive_encryption_key()
-    fernet = Fernet(key)
-    encrypted = fernet.encrypt(json.dumps(creds).encode())
+    _persist_creds(creds, provider_label=provider)
 
-    os.makedirs(os.path.dirname(CLOUD_PROVIDER_CREDS_PATH) or '.', exist_ok=True)
-    tmp = CLOUD_PROVIDER_CREDS_PATH + '.tmp'
-    with open(tmp, 'wb') as f:
-        f.write(encrypted)
-        f.flush()
-        os.fsync(f.fileno())
-    os.replace(tmp, CLOUD_PROVIDER_CREDS_PATH)
 
-    logger.info("Cloud credentials saved for provider: %s", provider)
+def _rclone_obscure(plaintext: str) -> str:
+    """Return ``rclone obscure <plaintext>`` for use in the conf file.
+
+    rclone expects passwords for sftp/webdav/smb/ftp to be stored in
+    its mildly-obfuscated AES form (this is not security — it's
+    "don't print the cleartext if someone catches a glimpse of the
+    config"). We delegate to the rclone binary so we never have to
+    re-implement its KDF.
+
+    Raises:
+        RuntimeError: if rclone is missing, returns non-zero, or
+            produces empty output. Never silently returns the
+            cleartext — that would leave a real password in
+            ``rclone.conf``.
+    """
+    if not isinstance(plaintext, str):
+        raise RuntimeError("rclone obscure: value must be a string")
+    if plaintext == "":
+        # Nothing to obscure; rclone obscure of empty string returns
+        # an empty string anyway, but skip the subprocess.
+        return ""
+    try:
+        result = subprocess.run(
+            ["rclone", "obscure", plaintext],
+            capture_output=True, text=True, timeout=10, check=False,
+        )
+    except FileNotFoundError as e:
+        raise RuntimeError("rclone binary not found") from e
+    except subprocess.TimeoutExpired as e:
+        raise RuntimeError("rclone obscure timed out") from e
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"rclone obscure failed (rc={result.returncode}): "
+            f"{(result.stderr or '').strip()[:200]}"
+        )
+    obscured = (result.stdout or "").strip()
+    if not obscured:
+        raise RuntimeError("rclone obscure returned empty output")
+    return obscured
+
+
+def parse_rclone_config_block(text: str) -> Dict[str, str]:
+    """Parse a pasted ``rclone.conf`` block into a flat dict.
+
+    Accepts EITHER the section-header form::
+
+        [my-nas]
+        type = sftp
+        host = nas.local
+        user = pi
+        pass = obscured-blob
+
+    OR a bare key=value list (no section header — useful for users
+    who paste the body of an ``[remote]`` block).
+
+    Behaviour:
+        * The section name is discarded — the caller decides the
+          ultimate ``RCLONE_REMOTE_NAME``.
+        * Keys are lower-cased; values are stripped of trailing
+          whitespace; comment lines (``#`` or ``;``) are ignored.
+        * The ``type`` key is required and MUST be in
+          :data:`_GENERIC_RCLONE_TYPES` (allow-list).
+        * Multiple sections in the input are rejected — accepting
+          them would invite ``crypt``-wrap-style smuggling where a
+          second section references the first one.
+
+    Returns:
+        Dict with at least ``"type"``; values are kept as strings
+        (rclone parses everything from strings anyway).
+
+    Raises:
+        ValueError: on missing ``type``, unknown ``type``, multiple
+            sections, or syntactically invalid lines.
+    """
+    if not isinstance(text, str):
+        raise ValueError("rclone config block must be a string")
+    section_count = 0
+    out: Dict[str, str] = {}
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or line.startswith(";"):
+            continue
+        if line.startswith("[") and line.endswith("]"):
+            section_count += 1
+            if section_count > 1:
+                raise ValueError(
+                    "rclone config block must contain at most one [section]; "
+                    "wrap remotes (crypt/union/chunker) are not supported"
+                )
+            continue
+        if "=" not in line:
+            raise ValueError(f"invalid rclone config line: {line!r}")
+        key, _, value = line.partition("=")
+        key = key.strip().lower()
+        value = value.strip()
+        if not key:
+            raise ValueError(f"invalid rclone config line: {line!r}")
+        out[key] = value
+    if "type" not in out:
+        raise ValueError("rclone config block missing required 'type' key")
+    if out["type"] not in _GENERIC_RCLONE_TYPES:
+        raise ValueError(
+            f"rclone backend type {out['type']!r} is not in the supported "
+            f"set: {sorted(_GENERIC_RCLONE_TYPES)}"
+        )
+    return out
+
+
+def save_credentials_generic(
+    rclone_type: str,
+    fields: Dict[str, str],
+    obscure_keys: Optional[List[str]] = None,
+    source: str = "form",
+) -> None:
+    """Persist credentials for a generic rclone backend (issue #165).
+
+    This is the NAS / S3 / WebDAV / SMB / FTP / azureblob entry point.
+    It mirrors :func:`save_credentials` (same encryption, same atomic
+    write, same on-disk file) but accepts an arbitrary ``fields`` dict
+    instead of an OAuth token blob.
+
+    Args:
+        rclone_type: rclone backend identifier (must be in
+            :data:`_GENERIC_RCLONE_TYPES`).
+        fields: rclone config keys (``host``, ``user``, ``pass``,
+            ``url``, ``access_key_id``, ``secret_access_key``, ...).
+            Keys MUST NOT begin with ``_`` (those are reserved for
+            internal metadata) and MUST NOT be ``type`` (use the
+            ``rclone_type`` arg).
+        obscure_keys: Field names whose values should be passed
+            through ``rclone obscure`` before storage. Typically
+            ``["pass"]`` for sftp/webdav/smb/ftp. S3-style backends
+            store ``secret_access_key`` in cleartext — rclone does
+            not obscure them — so the caller passes ``[]``.
+        source: Free-text label of where the creds came from
+            (``"form"`` or ``"paste"``); recorded as ``_source`` on
+            the creds dict for diagnostics. Never affects behaviour.
+
+    Raises:
+        ValueError: on bad ``rclone_type``, reserved key, or empty
+            required field.
+        RuntimeError: if ``rclone obscure`` fails.
+    """
+    if rclone_type not in _GENERIC_RCLONE_TYPES:
+        raise ValueError(
+            f"rclone backend type {rclone_type!r} is not in the supported "
+            f"set: {sorted(_GENERIC_RCLONE_TYPES)}"
+        )
+    if not isinstance(fields, dict):
+        raise ValueError("fields must be a dict")
+    obscure_keys = list(obscure_keys or [])
+
+    creds: Dict[str, str] = {"type": rclone_type}
+    for raw_key, raw_value in fields.items():
+        if not isinstance(raw_key, str):
+            raise ValueError("field keys must be strings")
+        key = raw_key.strip().lower()
+        if not key:
+            raise ValueError("field keys must be non-empty")
+        if key.startswith("_"):
+            raise ValueError(
+                f"field key {raw_key!r} is reserved (leading underscore)"
+            )
+        if key == "type":
+            # Already pinned by ``rclone_type`` arg — reject silent
+            # override attempts from a paste payload.
+            raise ValueError(
+                "'type' is set from rclone_type; remove it from fields"
+            )
+        # rclone tolerates int/bool but everything is str on the wire.
+        value = "" if raw_value is None else str(raw_value)
+        if key in obscure_keys:
+            value = _rclone_obscure(value)
+        creds[key] = value
+
+    creds["_obscure_keys"] = ",".join(sorted(set(obscure_keys)))
+    creds["_source"] = source
+    _persist_creds(creds, provider_label=f"generic:{rclone_type}")
 
 
 def _discover_onedrive_id(token: dict) -> Optional[str]:
@@ -231,11 +480,22 @@ def get_connection_status() -> Dict:
 # ---------------------------------------------------------------------------
 
 def _write_temp_conf(creds: dict) -> str:
-    """Write a temporary rclone.conf to tmpfs and return its path."""
+    """Write a temporary rclone.conf to tmpfs and return its path.
+
+    Issue #165: keys beginning with ``_`` are private metadata
+    (``_obscure_keys``, ``_source``) and never reach the conf file —
+    rclone would treat them as unknown options and emit a warning.
+    The ``type`` key (set by both OAuth and generic flows) is written
+    inline and skipped in the loop.
+    """
     os.makedirs(_RCLONE_TMPFS_DIR, exist_ok=True)
 
     lines = [f"[{RCLONE_REMOTE_NAME}]"]
     for key, value in creds.items():
+        if not isinstance(key, str):
+            continue
+        if key.startswith("_"):
+            continue
         lines.append(f"{key} = {value}")
 
     fd = os.open(_RCLONE_CONF_PATH, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)

--- a/scripts/web/services/cloud_rclone_service.py
+++ b/scripts/web/services/cloud_rclone_service.py
@@ -120,6 +120,64 @@ _GENERIC_RCLONE_TYPES = frozenset({
 # this rule for ALL writers).
 _CREDS_META_KEYS = ("_obscure_keys", "_source", "_rclone_type_hint")
 
+# Default ``obscure_keys`` per supported rclone backend.
+#
+# rclone stores passwords for sftp/webdav/smb/ftp in its
+# mildly-obfuscated AES form ("rclone obscure"); the S3-style backends
+# store secret keys in cleartext (rclone never obscures them and won't
+# parse an obscured form). API callers can override these defaults
+# explicitly, but anything that doesn't override picks the right
+# behaviour for the chosen backend.
+#
+# This table MUST stay in lock-step with :data:`_GENERIC_RCLONE_TYPES`
+# — the assertion below catches drift at import time. Adding a backend
+# without an entry here would default to no-obscure (silent
+# cleartext storage of an sftp password) which is the failure mode
+# the assertion exists to prevent.
+_DEFAULT_OBSCURE_KEYS: Dict[str, List[str]] = {
+    "sftp":      ["pass"],
+    "webdav":    ["pass"],
+    "smb":       ["pass"],
+    "ftp":       ["pass"],
+    "s3":        [],
+    "b2":        [],
+    "wasabi":    [],
+    "azureblob": [],
+    "swift":     [],
+}
+assert set(_DEFAULT_OBSCURE_KEYS.keys()) == set(_GENERIC_RCLONE_TYPES), (
+    "_DEFAULT_OBSCURE_KEYS must cover every rclone backend in "
+    "_GENERIC_RCLONE_TYPES; missing or extra keys make the no-obscure "
+    "default a silent foot-gun. Update both together."
+)
+
+# Characters that cannot appear in a generic rclone field (key OR
+# value). Newlines / carriage-returns / NULs would let an attacker
+# inject extra config lines into the ``[teslausb]`` block at conf-
+# write time (e.g. an ``ssh`` directive on sftp → command execution
+# as the rclone subprocess user, or an ``endpoint`` override on s3
+# → silent upload redirection). Tabs are allowed by rclone's config
+# parser and are legitimate in some values (e.g. multi-word smb
+# domains), so they're not rejected here.
+_FORBIDDEN_FIELD_CHARS = ("\n", "\r", "\x00")
+
+
+def _reject_control_chars(label: str, value: str) -> None:
+    """Raise ``ValueError`` if ``value`` contains a control character
+    that would let an attacker inject extra rclone.conf lines.
+
+    See :data:`_FORBIDDEN_FIELD_CHARS` for the rationale. Used by
+    :func:`save_credentials_generic`, :func:`parse_rclone_config_block`,
+    and the conf-writers as a defense-in-depth backstop.
+    """
+    for ch in _FORBIDDEN_FIELD_CHARS:
+        if ch in value:
+            raise ValueError(
+                f"{label} contains a forbidden control character "
+                f"(0x{ord(ch):02x}); rclone config injection is "
+                f"blocked here."
+            )
+
 
 # ---------------------------------------------------------------------------
 # Token parsing
@@ -377,7 +435,20 @@ def save_credentials_generic(
         )
     if not isinstance(fields, dict):
         raise ValueError("fields must be a dict")
-    obscure_keys = list(obscure_keys or [])
+    # Reject string ``obscure_keys`` explicitly. ``list("pass")`` would
+    # silently iterate as ``['p','a','s','s']`` and then no field would
+    # match, so the password would land in the conf file as cleartext —
+    # the exact failure mode this whole function exists to prevent.
+    if obscure_keys is not None and not isinstance(obscure_keys, (list, tuple)):
+        raise ValueError(
+            "obscure_keys must be a list of strings, not "
+            f"{type(obscure_keys).__name__}"
+        )
+    obscure_keys_list: List[str] = []
+    for ok in (obscure_keys or []):
+        if not isinstance(ok, str):
+            raise ValueError("obscure_keys entries must be strings")
+        obscure_keys_list.append(ok.strip().lower())
 
     creds: Dict[str, str] = {"type": rclone_type}
     for raw_key, raw_value in fields.items():
@@ -396,13 +467,33 @@ def save_credentials_generic(
             raise ValueError(
                 "'type' is set from rclone_type; remove it from fields"
             )
+        # Reject control characters in the KEY before we try to use it
+        # — a key like "host\ntype" would smuggle a second "type =" line
+        # into the conf file regardless of what we do with the value.
+        _reject_control_chars(f"field key {raw_key!r}", key)
         # rclone tolerates int/bool but everything is str on the wire.
         value = "" if raw_value is None else str(raw_value)
-        if key in obscure_keys:
+        # Reject control characters in the VALUE — this is the rclone-
+        # config-injection vector found in the PR #218 review (a value
+        # of "x\ntype = local\nremote = /" would produce a malicious
+        # multi-line conf entry that lets the attacker override the
+        # backend type, redirect uploads, or — on sftp — execute
+        # arbitrary commands as root via the "ssh" directive).
+        _reject_control_chars(f"value for {key!r}", value)
+        if key in obscure_keys_list:
             value = _rclone_obscure(value)
+            # Defense in depth: rclone obscure should never produce a
+            # control char (its output is base64-ish), but verify so a
+            # future rclone change can't bypass the guard above.
+            _reject_control_chars(f"obscured value for {key!r}", value)
         creds[key] = value
 
-    creds["_obscure_keys"] = ",".join(sorted(set(obscure_keys)))
+    # Reject control characters in the source label too — it lands in
+    # creds["_source"] which is filtered out by the conf-writers, but
+    # the loader returns it via the API and a future caller might log
+    # it; defense in depth.
+    _reject_control_chars("source", source)
+    creds["_obscure_keys"] = ",".join(sorted(set(obscure_keys_list)))
     creds["_source"] = source
     _persist_creds(creds, provider_label=f"generic:{rclone_type}")
 
@@ -487,6 +578,13 @@ def _write_temp_conf(creds: dict) -> str:
     rclone would treat them as unknown options and emit a warning.
     The ``type`` key (set by both OAuth and generic flows) is written
     inline and skipped in the loop.
+
+    PR #218 review (defense in depth): any key or value that contains
+    a forbidden control character (``\\n`` / ``\\r`` / ``\\x00``) is
+    skipped with a warning. ``save_credentials_generic`` already
+    rejects these at save time, but a corrupted-on-disk creds file
+    (e.g. through filesystem access outside this code path) MUST
+    NOT be allowed to inject extra rclone.conf lines.
     """
     os.makedirs(_RCLONE_TMPFS_DIR, exist_ok=True)
 
@@ -495,6 +593,17 @@ def _write_temp_conf(creds: dict) -> str:
         if not isinstance(key, str):
             continue
         if key.startswith("_"):
+            continue
+        try:
+            _reject_control_chars(f"creds key {key!r}", key)
+            _reject_control_chars(
+                f"creds value for {key!r}",
+                "" if value is None else str(value),
+            )
+        except ValueError as e:
+            logger.error(
+                "Refusing to write creds entry to rclone.conf: %s", e,
+            )
             continue
         lines.append(f"{key} = {value}")
 

--- a/scripts/web/templates/cloud_archive.html
+++ b/scripts/web/templates/cloud_archive.html
@@ -245,6 +245,7 @@
                     <option value="s3"{% if provider == 's3' %} selected{% endif %}>Amazon S3</option>
                     <option value="b2"{% if provider == 'b2' %} selected{% endif %}>Backblaze B2</option>
                     <option value="wasabi"{% if provider == 'wasabi' %} selected{% endif %}>Wasabi</option>
+                    <option value="generic"{% if provider == 'generic' %} selected{% endif %}>NAS / Custom rclone (SFTP, WebDAV, SMB, FTP, ...)</option>
                 </select>
             </div>
 
@@ -319,6 +320,94 @@
                     </button>
                     <button type="button" class="action-btn" onclick="testConnection()" id="testConnBtnSetup">Test Connection</button>
                     <span id="testConnResultSetup" style="font-size: var(--text-sm); color: var(--text-secondary); align-self: center;"></span>
+                </div>
+            </div>
+
+            {# ---------------------------------------------------------- #}
+            {# Generic rclone remote (issue #165) — NAS / SFTP / WebDAV   #}
+            {# / SMB / FTP / S3 / B2 / Wasabi / Azure Blob / Swift.       #}
+            {# Two input modes: Form (guided fields) or Paste             #}
+            {# (an entire ``rclone.conf`` block).                         #}
+            {# ---------------------------------------------------------- #}
+            <div id="genericSetup" style="display: none;">
+                <div class="info-box" style="margin-bottom: var(--space-3);">
+                    <strong>Custom rclone backend</strong>
+                    <p style="margin: 6px 0 0; font-size: var(--text-sm); line-height: 1.5; color: var(--text-secondary);">
+                        Connect to a NAS or any rclone-supported storage backend. Use the
+                        <strong>Form</strong> tab for guided setup, or the <strong>Paste</strong> tab if you
+                        already have an <code>rclone.conf</code> block from
+                        <code>rclone config</code>.
+                    </p>
+                </div>
+
+                <div class="tab-bar" role="tablist" style="display: flex; gap: 4px; border-bottom: 1px solid var(--border-soft); margin-bottom: var(--space-3);">
+                    <button type="button" class="tab-btn active" id="genericFormTab"
+                            role="tab" aria-selected="true" aria-controls="genericFormPane"
+                            onclick="switchGenericTab('form')"
+                            style="padding: 8px 16px; background: none; border: none; border-bottom: 2px solid var(--accent-primary); color: var(--text-primary); cursor: pointer; font-size: 14px; font-weight: 500;">Form</button>
+                    <button type="button" class="tab-btn" id="genericPasteTab"
+                            role="tab" aria-selected="false" aria-controls="genericPastePane"
+                            onclick="switchGenericTab('paste')"
+                            style="padding: 8px 16px; background: none; border: none; border-bottom: 2px solid transparent; color: var(--text-secondary); cursor: pointer; font-size: 14px; font-weight: 500;">Paste rclone.conf</button>
+                </div>
+
+                {# ---- Form pane ---- #}
+                <div id="genericFormPane" role="tabpanel" aria-labelledby="genericFormTab">
+                    <div style="margin-bottom: var(--space-3);">
+                        <label for="genericTypeSelect" style="display: block; margin-bottom: 4px; font-weight: 500; color: var(--text-primary);">Backend type:</label>
+                        <select id="genericTypeSelect" onchange="onGenericTypeChange()"
+                                style="width: 100%; max-width: 360px; padding: 10px; border-radius: 6px; border: 1px solid var(--border-input); background-color: var(--form-input-bg); color: var(--text-primary); font-size: 15px;">
+                            <option value="">-- Select backend --</option>
+                            <option value="sftp">SFTP (most NAS units, including Synology / QNAP)</option>
+                            <option value="webdav">WebDAV (Nextcloud, Synology, generic WebDAV)</option>
+                            <option value="smb">SMB / CIFS (Windows share)</option>
+                            <option value="ftp">FTP</option>
+                            <option value="s3">S3-compatible (custom endpoint, MinIO, ...)</option>
+                            <option value="b2">Backblaze B2 (advanced — keys-based)</option>
+                            <option value="wasabi">Wasabi (advanced — keys-based)</option>
+                            <option value="azureblob">Azure Blob Storage</option>
+                            <option value="swift">OpenStack Swift</option>
+                        </select>
+                    </div>
+
+                    <div id="genericFormFields" style="display: none;">
+                        <p style="font-size: var(--text-sm); color: var(--text-secondary); margin: 0 0 var(--space-2);">
+                            Required fields are marked with <span style="color: var(--error-text);">*</span>.
+                            See the <a href="https://rclone.org/" target="_blank" rel="noopener" style="color: var(--link-color);">rclone docs</a> for what each field means.
+                        </p>
+                        <div id="genericFieldsContainer" style="display: flex; flex-direction: column; gap: var(--space-2); max-width: 480px;"></div>
+                    </div>
+
+                    <div style="display: flex; gap: 8px; flex-wrap: wrap; align-items: center; margin-top: var(--space-3);">
+                        <button type="button" class="edit-btn" id="genericFormConnectBtn"
+                                onclick="connectGenericProvider('form')"
+                                style="padding: 10px 20px; font-size: 14px;" disabled>
+                            Save &amp; Connect
+                        </button>
+                        <span id="genericFormResult" style="font-size: var(--text-sm);"></span>
+                    </div>
+                </div>
+
+                {# ---- Paste pane ---- #}
+                <div id="genericPastePane" role="tabpanel" aria-labelledby="genericPasteTab"
+                     style="display: none;">
+                    <p style="font-size: var(--text-sm); color: var(--text-secondary); margin: 0 0 var(--space-2);">
+                        Paste a complete <code>[remote]</code> block from your existing
+                        <code>~/.config/rclone/rclone.conf</code>. The remote name (in
+                        brackets) is ignored — TeslaUSB always stores it as
+                        <code>teslausb</code>.
+                    </p>
+                    <textarea id="genericPasteInput" rows="8"
+                              placeholder='[my-nas]&#10;type = sftp&#10;host = nas.local&#10;user = pi&#10;pass = AlreadyObscuredBlob...&#10;'
+                              style="width: 100%; max-width: 560px; padding: 10px; border-radius: 6px; border: 1px solid var(--border-input); background-color: var(--form-input-bg); color: var(--text-primary); font-size: 13px; font-family: monospace; resize: vertical;"></textarea>
+                    <div style="display: flex; gap: 8px; flex-wrap: wrap; align-items: center; margin-top: var(--space-3);">
+                        <button type="button" class="edit-btn"
+                                onclick="connectGenericProvider('paste')"
+                                style="padding: 10px 20px; font-size: 14px;">
+                            Save &amp; Connect
+                        </button>
+                        <span id="genericPasteResult" style="font-size: var(--text-sm);"></span>
+                    </div>
                 </div>
             </div>
             {% endif %}
@@ -1003,6 +1092,7 @@
 
     var rcloneProviders = ['google-drive', 'onedrive', 'dropbox'];
     var keyProviders = ['s3', 'b2', 'wasabi'];
+    var genericProviders = ['generic'];
     var rcloneCmds = {
         'google-drive': 'rclone authorize "drive"',
         'onedrive':     'rclone authorize "onedrive"',
@@ -1014,15 +1104,116 @@
         'dropbox':      'Dropbox',
     };
 
+    /* Issue #165: per-rclone-backend field schema for the generic
+     * provider's Form tab. Each entry is the displayed label,
+     * placeholder, type (text|password|url|number), required flag,
+     * and the rclone config key it maps to. The flow MUST mirror
+     * services.cloud_rclone_service._GENERIC_RCLONE_TYPES; if a
+     * type is added there, add a schema here. ``obscure`` is the
+     * default obscure-keys list passed to the backend (the route
+     * still applies its own per-backend default if omitted, but
+     * shipping it explicitly keeps the JSON self-describing). */
+    var genericSchemas = {
+        'sftp': {
+            obscure: ['pass'],
+            fields: [
+                {key: 'host',     label: 'Host',         placeholder: 'nas.local',          type: 'text',     required: true},
+                {key: 'port',     label: 'Port',         placeholder: '22',                 type: 'number',   required: false},
+                {key: 'user',     label: 'Username',     placeholder: 'pi',                 type: 'text',     required: true},
+                {key: 'pass',     label: 'Password',     placeholder: '',                   type: 'password', required: false,
+                 hint: 'Leave blank if using a key file. Stored using rclone\u2019s standard obfuscation.'},
+                {key: 'key_file', label: 'Key file path', placeholder: '/home/pi/.ssh/id_ed25519', type: 'text', required: false},
+            ],
+        },
+        'webdav': {
+            obscure: ['pass'],
+            fields: [
+                {key: 'url',    label: 'URL',      placeholder: 'https://nextcloud.example.com/remote.php/dav/files/USER/', type: 'url', required: true},
+                {key: 'vendor', label: 'Vendor',   placeholder: 'nextcloud, owncloud, sharepoint, other', type: 'text', required: false,
+                 hint: 'Optional. Common values: nextcloud, owncloud, sharepoint, other.'},
+                {key: 'user',   label: 'Username', placeholder: 'alice', type: 'text', required: false},
+                {key: 'pass',   label: 'Password', placeholder: '',      type: 'password', required: false},
+            ],
+        },
+        'smb': {
+            obscure: ['pass'],
+            fields: [
+                {key: 'host', label: 'Host',        placeholder: 'nas.local', type: 'text',     required: true},
+                {key: 'user', label: 'Username',    placeholder: 'pi',        type: 'text',     required: true},
+                {key: 'pass', label: 'Password',    placeholder: '',          type: 'password', required: false},
+                {key: 'domain', label: 'Domain',    placeholder: 'WORKGROUP', type: 'text',     required: false},
+            ],
+        },
+        'ftp': {
+            obscure: ['pass'],
+            fields: [
+                {key: 'host', label: 'Host',     placeholder: 'ftp.example.com', type: 'text',     required: true},
+                {key: 'port', label: 'Port',     placeholder: '21',              type: 'number',   required: false},
+                {key: 'user', label: 'Username', placeholder: 'user',            type: 'text',     required: true},
+                {key: 'pass', label: 'Password', placeholder: '',                type: 'password', required: false},
+            ],
+        },
+        's3': {
+            obscure: [],
+            fields: [
+                {key: 'provider',          label: 'S3 provider',     placeholder: 'AWS, Wasabi, Minio, Other, ...', type: 'text', required: true,
+                 hint: 'See rclone S3 docs. Use "Other" for self-hosted MinIO and most generic S3-compatible services.'},
+                {key: 'access_key_id',     label: 'Access key ID',   placeholder: 'AKIA...',                  type: 'text',     required: true},
+                {key: 'secret_access_key', label: 'Secret access key', placeholder: '',                       type: 'password', required: true},
+                {key: 'region',            label: 'Region',          placeholder: 'us-east-1',                type: 'text',     required: false},
+                {key: 'endpoint',          label: 'Endpoint URL',    placeholder: 'https://s3.example.com',   type: 'url',      required: false,
+                 hint: 'Required for non-AWS providers; leave blank for AWS S3.'},
+            ],
+        },
+        'b2': {
+            obscure: [],
+            fields: [
+                {key: 'account', label: 'Account ID', placeholder: '...', type: 'text',     required: true},
+                {key: 'key',     label: 'Application key', placeholder: '...', type: 'password', required: true},
+            ],
+        },
+        'wasabi': {
+            obscure: [],
+            fields: [
+                {key: 'provider',          label: 'S3 provider',     placeholder: 'Wasabi',                       type: 'text',     required: true},
+                {key: 'access_key_id',     label: 'Access key ID',   placeholder: '',                             type: 'text',     required: true},
+                {key: 'secret_access_key', label: 'Secret access key', placeholder: '',                           type: 'password', required: true},
+                {key: 'region',            label: 'Region',          placeholder: 'us-east-1',                    type: 'text',     required: false},
+                {key: 'endpoint',          label: 'Endpoint URL',    placeholder: 'https://s3.us-east-1.wasabisys.com', type: 'url', required: true},
+            ],
+        },
+        'azureblob': {
+            obscure: [],
+            fields: [
+                {key: 'account', label: 'Storage account', placeholder: '',  type: 'text',     required: true},
+                {key: 'key',     label: 'Account key',     placeholder: '',  type: 'password', required: false,
+                 hint: 'Either Account key or SAS URL is required.'},
+                {key: 'sas_url', label: 'SAS URL',         placeholder: 'https://...?sv=...', type: 'url', required: false},
+            ],
+        },
+        'swift': {
+            obscure: [],
+            fields: [
+                {key: 'user',     label: 'User',          placeholder: '',           type: 'text',     required: true},
+                {key: 'key',      label: 'API key',       placeholder: '',           type: 'password', required: true},
+                {key: 'auth',     label: 'Auth URL',      placeholder: 'https://...', type: 'url',     required: true},
+                {key: 'tenant',   label: 'Tenant',        placeholder: '',           type: 'text',     required: false},
+                {key: 'region',   label: 'Region',        placeholder: '',           type: 'text',     required: false},
+            ],
+        },
+    };
+
     window.onProviderChange = function() {
         var sel = document.getElementById('providerSelect');
         var val = sel ? sel.value : '';
         var rcloneDiv = document.getElementById('rcloneSetup');
         var keyDiv = document.getElementById('keySetup');
+        var genericDiv = document.getElementById('genericSetup');
         var endpointGroup = document.getElementById('endpointGroup');
 
         if (rcloneDiv) rcloneDiv.style.display = rcloneProviders.indexOf(val) !== -1 ? 'block' : 'none';
         if (keyDiv) keyDiv.style.display = keyProviders.indexOf(val) !== -1 ? 'block' : 'none';
+        if (genericDiv) genericDiv.style.display = genericProviders.indexOf(val) !== -1 ? 'block' : 'none';
 
         /* Update rclone command and provider name */
         if (rcloneProviders.indexOf(val) !== -1) {
@@ -1117,35 +1308,81 @@
         }
     };
 
+    /* Issue #165 fix: S3 / B2 / Wasabi previously POSTed to
+     * ``/api/provider`` which only persisted the provider name and
+     * silently dropped ``credentials``. They now route through the
+     * generic ``/api/connect`` path so the keys actually reach
+     * rclone.conf. ``credBucket`` is collected for the user's
+     * benefit but stored as a private metadata note (``_bucket``) —
+     * rclone S3 backends don't take a bucket in the conf file
+     * itself; the bucket is the first path segment of the remote
+     * (and TeslaUSB sets that via the existing remote-path setting). */
     window.saveProvider = async function() {
         var sel = document.getElementById('providerSelect');
         var provider = sel ? sel.value : '';
         if (!provider) { showToast('Please select a provider.', 'warning'); return; }
 
-        var credentials = {};
-        if (keyProviders.indexOf(provider) !== -1) {
-            credentials.access_key = (document.getElementById('credAccessKey') || {}).value || '';
-            credentials.secret = (document.getElementById('credSecret') || {}).value || '';
-            credentials.region = (document.getElementById('credRegion') || {}).value || '';
-            credentials.bucket = (document.getElementById('credBucket') || {}).value || '';
-            credentials.endpoint = (document.getElementById('credEndpoint') || {}).value || '';
-            if (!credentials.access_key || !credentials.secret || !credentials.bucket) {
-                showToast('Access Key, Secret, and Bucket are required.', 'warning');
-                return;
-            }
+        if (keyProviders.indexOf(provider) === -1) {
+            /* Should not happen — keySetup div is hidden — but be defensive. */
+            showToast('Unsupported provider for this form.', 'warning');
+            return;
+        }
+
+        var accessKey = (document.getElementById('credAccessKey') || {}).value || '';
+        var secret    = (document.getElementById('credSecret')    || {}).value || '';
+        var region    = (document.getElementById('credRegion')    || {}).value || '';
+        var bucket    = (document.getElementById('credBucket')    || {}).value || '';
+        var endpoint  = (document.getElementById('credEndpoint')  || {}).value || '';
+        if (!accessKey || !secret || !bucket) {
+            showToast('Access Key, Secret, and Bucket are required.', 'warning');
+            return;
+        }
+
+        var fields;
+        if (provider === 's3') {
+            fields = {
+                provider: 'Other', access_key_id: accessKey,
+                secret_access_key: secret,
+            };
+            if (region)   fields.region = region;
+            if (endpoint) fields.endpoint = endpoint;
+        } else if (provider === 'wasabi') {
+            fields = {
+                provider: 'Wasabi', access_key_id: accessKey,
+                secret_access_key: secret, endpoint: endpoint || 'https://s3.us-east-1.wasabisys.com',
+            };
+            if (region) fields.region = region;
+        } else { /* b2 */
+            fields = {account: accessKey, key: secret};
         }
 
         try {
-            var resp = await fetch('{{ url_for("cloud_archive.api_save_provider") }}', {
+            var resp = await fetch('{{ url_for("cloud_archive.api_connect_provider") }}', {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
                     'X-Requested-With': 'XMLHttpRequest'
                 },
-                body: JSON.stringify({ provider: provider, credentials: credentials })
+                body: JSON.stringify({
+                    provider: 'generic',
+                    rclone_type: provider,
+                    fields: fields,
+                })
             });
             var data = await resp.json();
             if (data.success) {
+                /* Persist the user's chosen bucket so the existing
+                 * remote-path UI starts at the right place. */
+                if (bucket) {
+                    try {
+                        await fetch('{{ url_for("cloud_archive.api_set_remote_path") }}', {
+                            method: 'POST',
+                            headers: {'Content-Type': 'application/json',
+                                      'X-Requested-With': 'XMLHttpRequest'},
+                            body: JSON.stringify({path: bucket}),
+                        });
+                    } catch (_) { /* non-fatal */ }
+                }
                 showToast('Provider saved. Reloading\u2026', 'success');
                 setTimeout(function() { window.location.reload(); }, 1000);
             } else {
@@ -1153,6 +1390,164 @@
             }
         } catch (e) {
             showToast('Network error.', 'error');
+        }
+    };
+
+    /* ===================================================================
+       Generic rclone remote (issue #165) — Form + Paste tabs
+       =================================================================== */
+
+    window.switchGenericTab = function(which) {
+        var formTab = document.getElementById('genericFormTab');
+        var pasteTab = document.getElementById('genericPasteTab');
+        var formPane = document.getElementById('genericFormPane');
+        var pastePane = document.getElementById('genericPastePane');
+        var isForm = (which === 'form');
+        if (formTab) {
+            formTab.setAttribute('aria-selected', isForm ? 'true' : 'false');
+            formTab.style.borderBottomColor = isForm ? 'var(--accent-primary)' : 'transparent';
+            formTab.style.color = isForm ? 'var(--text-primary)' : 'var(--text-secondary)';
+        }
+        if (pasteTab) {
+            pasteTab.setAttribute('aria-selected', !isForm ? 'true' : 'false');
+            pasteTab.style.borderBottomColor = !isForm ? 'var(--accent-primary)' : 'transparent';
+            pasteTab.style.color = !isForm ? 'var(--text-primary)' : 'var(--text-secondary)';
+        }
+        if (formPane) formPane.style.display = isForm ? 'block' : 'none';
+        if (pastePane) pastePane.style.display = !isForm ? 'block' : 'none';
+    };
+
+    window.onGenericTypeChange = function() {
+        var sel = document.getElementById('genericTypeSelect');
+        var rt = sel ? sel.value : '';
+        var wrap = document.getElementById('genericFormFields');
+        var container = document.getElementById('genericFieldsContainer');
+        var connectBtn = document.getElementById('genericFormConnectBtn');
+        if (!container || !wrap || !connectBtn) return;
+        container.innerHTML = '';
+        if (!rt || !genericSchemas[rt]) {
+            wrap.style.display = 'none';
+            connectBtn.disabled = true;
+            return;
+        }
+        var schema = genericSchemas[rt];
+        schema.fields.forEach(function(f) {
+            var group = document.createElement('div');
+            group.style.display = 'flex';
+            group.style.flexDirection = 'column';
+            group.style.gap = '4px';
+            var label = document.createElement('label');
+            label.htmlFor = 'genericField_' + f.key;
+            label.style.fontWeight = '500';
+            label.style.color = 'var(--text-primary)';
+            label.textContent = f.label;
+            if (f.required) {
+                var star = document.createElement('span');
+                star.textContent = ' *';
+                star.style.color = 'var(--error-text)';
+                label.appendChild(star);
+            }
+            var input = document.createElement('input');
+            input.type = f.type || 'text';
+            input.id = 'genericField_' + f.key;
+            input.dataset.fieldKey = f.key;
+            input.placeholder = f.placeholder || '';
+            input.autocomplete = 'off';
+            input.style.padding = '8px';
+            input.style.borderRadius = '6px';
+            input.style.border = '1px solid var(--border-input)';
+            input.style.backgroundColor = 'var(--form-input-bg)';
+            input.style.color = 'var(--text-primary)';
+            input.style.fontSize = '14px';
+            group.appendChild(label);
+            group.appendChild(input);
+            if (f.hint) {
+                var hint = document.createElement('p');
+                hint.style.margin = '0';
+                hint.style.fontSize = 'var(--text-sm)';
+                hint.style.color = 'var(--text-secondary)';
+                hint.textContent = f.hint;
+                group.appendChild(hint);
+            }
+            container.appendChild(group);
+        });
+        wrap.style.display = 'block';
+        connectBtn.disabled = false;
+    };
+
+    window.connectGenericProvider = async function(mode) {
+        var btn, resultEl, payload;
+
+        if (mode === 'paste') {
+            var paste = (document.getElementById('genericPasteInput') || {}).value || '';
+            if (!paste.trim()) {
+                showToast('Please paste an rclone.conf block.', 'warning');
+                return;
+            }
+            payload = {provider: 'generic', config_block: paste};
+            resultEl = document.getElementById('genericPasteResult');
+            btn = document.querySelector('#genericPastePane button.edit-btn');
+        } else {
+            var sel = document.getElementById('genericTypeSelect');
+            var rt = sel ? sel.value : '';
+            if (!rt || !genericSchemas[rt]) {
+                showToast('Please select a backend type.', 'warning');
+                return;
+            }
+            var schema = genericSchemas[rt];
+            var fields = {};
+            var missing = [];
+            schema.fields.forEach(function(f) {
+                var el = document.getElementById('genericField_' + f.key);
+                var v = el ? el.value.trim() : '';
+                if (v) fields[f.key] = v;
+                else if (f.required) missing.push(f.label);
+            });
+            if (missing.length) {
+                showToast('Missing required field(s): ' + missing.join(', '), 'warning');
+                return;
+            }
+            payload = {
+                provider: 'generic',
+                rclone_type: rt,
+                fields: fields,
+                obscure_keys: schema.obscure || [],
+            };
+            resultEl = document.getElementById('genericFormResult');
+            btn = document.getElementById('genericFormConnectBtn');
+        }
+
+        if (btn) { btn.disabled = true; btn.textContent = 'Connecting\u2026'; }
+        if (resultEl) resultEl.textContent = '';
+        _showBusy('Connecting to cloud provider\u2026');
+
+        try {
+            var resp = await fetch('{{ url_for("cloud_archive.api_connect_provider") }}', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-Requested-With': 'XMLHttpRequest'
+                },
+                body: JSON.stringify(payload)
+            });
+            var data = await resp.json();
+            if (data.success) {
+                _hideBusy();
+                showToast('Connected! Reloading\u2026', 'success');
+                setTimeout(function() { window.location.reload(); }, 1500);
+            } else {
+                _hideBusy();
+                showToast(data.message || 'Failed to connect.', 'error');
+                if (resultEl) {
+                    resultEl.textContent = data.message || 'Failed';
+                    resultEl.style.color = 'var(--error-text)';
+                }
+                if (btn) { btn.disabled = false; btn.textContent = 'Save & Connect'; }
+            }
+        } catch (e) {
+            _hideBusy();
+            showToast('Network error.', 'error');
+            if (btn) { btn.disabled = false; btn.textContent = 'Save & Connect'; }
         }
     };
 

--- a/tests/test_cloud_generic_remote.py
+++ b/tests/test_cloud_generic_remote.py
@@ -1,0 +1,570 @@
+"""Tests for generic rclone remote support — issue #165.
+
+Covers:
+
+* :func:`services.cloud_rclone_service.parse_rclone_config_block` —
+  paste-form parser including the allow-list and multi-section
+  rejection.
+* :func:`services.cloud_rclone_service.save_credentials_generic` —
+  round-trip through the encrypted store with private metadata
+  preserved and ``rclone obscure`` invoked for the listed fields.
+* :func:`services.cloud_archive_service._write_rclone_conf` —
+  regression: the new ``creds["type"]``-wins rule and the
+  ``_*``-key skip rule MUST hold across both the OAuth and generic
+  flows.
+* :func:`blueprints.cloud_archive.api_connect_provider` — three
+  payload shapes are honoured and the legacy OAuth path is unbroken.
+"""
+
+import json
+import os
+import sys
+import pytest
+
+# Make sure the web app modules are importable.
+_WEB_DIR = os.path.join(os.path.dirname(__file__), '..', 'scripts', 'web')
+if _WEB_DIR not in sys.path:
+    sys.path.insert(0, _WEB_DIR)
+
+from services import cloud_rclone_service as svc  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# parse_rclone_config_block
+# ---------------------------------------------------------------------------
+
+class TestParseRcloneConfigBlock:
+    """Tests for the pasted-rclone.conf-block parser."""
+
+    def test_parses_section_form(self):
+        text = """
+        [my-nas]
+        type = sftp
+        host = nas.local
+        user = pi
+        pass = obscured-blob
+        """
+        out = svc.parse_rclone_config_block(text)
+        assert out["type"] == "sftp"
+        assert out["host"] == "nas.local"
+        assert out["user"] == "pi"
+        assert out["pass"] == "obscured-blob"
+
+    def test_parses_bare_keyvalue_form(self):
+        text = "type=webdav\nurl=https://dav.example.com\nuser=alice\n"
+        out = svc.parse_rclone_config_block(text)
+        assert out == {"type": "webdav", "url": "https://dav.example.com",
+                       "user": "alice"}
+
+    def test_drops_section_name(self):
+        """Section name is irrelevant — caller pins the remote name."""
+        text = "[anything-the-user-typed]\ntype = b2\naccount = abc\nkey = def\n"
+        out = svc.parse_rclone_config_block(text)
+        assert "anything-the-user-typed" not in out
+        assert out["type"] == "b2"
+
+    def test_lowercases_keys(self):
+        out = svc.parse_rclone_config_block("Type = sftp\nHost = X\n")
+        assert "type" in out and "host" in out
+        # Values are NOT case-folded.
+        assert out["host"] == "X"
+
+    def test_strips_whitespace_around_value(self):
+        out = svc.parse_rclone_config_block("type =   sftp   \nhost = X  \n")
+        assert out["type"] == "sftp"
+        assert out["host"] == "X"
+
+    def test_ignores_comments_and_blanks(self):
+        text = """
+        # this is a comment
+        ; semicolon comment
+        type = sftp
+        
+        host = nas.local
+        """
+        out = svc.parse_rclone_config_block(text)
+        assert out == {"type": "sftp", "host": "nas.local"}
+
+    def test_rejects_missing_type(self):
+        with pytest.raises(ValueError, match="missing required 'type'"):
+            svc.parse_rclone_config_block("host = nas.local\nuser = pi\n")
+
+    def test_rejects_unknown_type(self):
+        with pytest.raises(ValueError, match="not in the supported"):
+            svc.parse_rclone_config_block("type = onedrive\nhost = X\n")
+
+    def test_rejects_crypt_wrap(self):
+        with pytest.raises(ValueError, match="not in the supported"):
+            svc.parse_rclone_config_block(
+                "[wrap]\ntype = crypt\nremote = backend:foo\n"
+            )
+
+    def test_rejects_local_backend(self):
+        """``local`` would let an attacker write to arbitrary paths."""
+        with pytest.raises(ValueError, match="not in the supported"):
+            svc.parse_rclone_config_block("type = local\n")
+
+    def test_rejects_multi_section(self):
+        with pytest.raises(ValueError, match="at most one"):
+            svc.parse_rclone_config_block(
+                "[a]\ntype = sftp\nhost = x\n[b]\ntype = sftp\n"
+            )
+
+    def test_rejects_invalid_line(self):
+        with pytest.raises(ValueError, match="invalid rclone config line"):
+            svc.parse_rclone_config_block("type = sftp\ngarbage no equals\n")
+
+    def test_rejects_empty_key(self):
+        with pytest.raises(ValueError, match="invalid rclone config line"):
+            svc.parse_rclone_config_block("type = sftp\n = bad\n")
+
+    def test_rejects_non_string(self):
+        with pytest.raises(ValueError, match="must be a string"):
+            svc.parse_rclone_config_block(b"type = sftp\n")  # type: ignore[arg-type]
+
+    def test_accepts_all_allowlisted_types(self):
+        for t in svc._GENERIC_RCLONE_TYPES:
+            out = svc.parse_rclone_config_block(f"type = {t}\n")
+            assert out["type"] == t
+
+
+# ---------------------------------------------------------------------------
+# save_credentials_generic — round-trip through encrypted store
+# ---------------------------------------------------------------------------
+
+class TestSaveCredentialsGeneric:
+    """Verify generic creds round-trip and obscure() is invoked."""
+
+    @pytest.fixture
+    def tmp_creds(self, tmp_path, monkeypatch):
+        """Redirect the creds path to a tmpfs-style temp file."""
+        path = str(tmp_path / "cloud_provider_creds.bin")
+        monkeypatch.setattr(svc, "CLOUD_PROVIDER_CREDS_PATH", path)
+        yield path
+
+    def test_round_trip_form_no_obscure(self, tmp_creds):
+        """B2-style: secret stored verbatim (no obscure)."""
+        svc.save_credentials_generic(
+            "b2",
+            {"account": "abc", "key": "secret-key"},
+            obscure_keys=[],
+            source="form",
+        )
+        creds = svc._load_creds()
+        assert creds["type"] == "b2"
+        assert creds["account"] == "abc"
+        assert creds["key"] == "secret-key"
+        # Metadata preserved.
+        assert creds["_obscure_keys"] == ""
+        assert creds["_source"] == "form"
+
+    def test_round_trip_paste_with_obscure(self, tmp_creds, monkeypatch):
+        """SFTP-style: pass goes through rclone obscure (mocked)."""
+        calls = []
+
+        def fake_obscure(plaintext):
+            calls.append(plaintext)
+            return f"OBS({plaintext})"
+
+        monkeypatch.setattr(svc, "_rclone_obscure", fake_obscure)
+        svc.save_credentials_generic(
+            "sftp",
+            {"host": "nas.local", "user": "pi", "pass": "hunter2"},
+            obscure_keys=["pass"],
+            source="paste",
+        )
+        creds = svc._load_creds()
+        assert creds["pass"] == "OBS(hunter2)"
+        assert creds["host"] == "nas.local"
+        assert calls == ["hunter2"]
+        assert creds["_obscure_keys"] == "pass"
+        assert creds["_source"] == "paste"
+
+    def test_rejects_unknown_type(self, tmp_creds):
+        with pytest.raises(ValueError, match="not in the supported"):
+            svc.save_credentials_generic("crypt", {}, obscure_keys=[])
+
+    def test_rejects_reserved_underscore_key(self, tmp_creds):
+        with pytest.raises(ValueError, match="reserved"):
+            svc.save_credentials_generic(
+                "sftp", {"_evil": "x"}, obscure_keys=[],
+            )
+
+    def test_rejects_type_in_fields(self, tmp_creds):
+        """``type`` only comes from rclone_type; reject silent override."""
+        with pytest.raises(ValueError, match="set from rclone_type"):
+            svc.save_credentials_generic(
+                "sftp", {"type": "smb"}, obscure_keys=[],
+            )
+
+    def test_rejects_empty_field_key(self, tmp_creds):
+        with pytest.raises(ValueError, match="non-empty"):
+            svc.save_credentials_generic(
+                "sftp", {"": "x"}, obscure_keys=[],
+            )
+
+    def test_rejects_non_string_key(self, tmp_creds):
+        with pytest.raises(ValueError, match="must be strings"):
+            svc.save_credentials_generic(
+                "sftp", {1: "x"}, obscure_keys=[],  # type: ignore[dict-item]
+            )
+
+    def test_rejects_non_dict_fields(self, tmp_creds):
+        with pytest.raises(ValueError, match="must be a dict"):
+            svc.save_credentials_generic(
+                "sftp", "not a dict", obscure_keys=[],  # type: ignore[arg-type]
+            )
+
+    def test_none_field_value_becomes_empty_string(self, tmp_creds):
+        svc.save_credentials_generic(
+            "sftp", {"host": "X", "comment": None}, obscure_keys=[],
+        )
+        assert svc._load_creds()["comment"] == ""
+
+    def test_obscure_keys_dedup_in_metadata(self, tmp_creds, monkeypatch):
+        monkeypatch.setattr(svc, "_rclone_obscure", lambda v: f"O({v})")
+        svc.save_credentials_generic(
+            "sftp", {"host": "X", "pass": "p"},
+            obscure_keys=["pass", "pass", "pass"],
+        )
+        # Recorded as a sorted, deduped CSV so audit logs stay stable.
+        assert svc._load_creds()["_obscure_keys"] == "pass"
+
+
+# ---------------------------------------------------------------------------
+# _rclone_obscure helper
+# ---------------------------------------------------------------------------
+
+class TestRcloneObscure:
+    def test_empty_skips_subprocess(self, monkeypatch):
+        """Empty plaintext returns empty without invoking the binary."""
+        called = []
+        monkeypatch.setattr(
+            "subprocess.run",
+            lambda *a, **k: called.append(1) or pytest.fail("should not run"),
+        )
+        assert svc._rclone_obscure("") == ""
+        assert called == []
+
+    def test_success_returns_stdout_stripped(self, monkeypatch):
+        class R:
+            returncode = 0
+            stdout = "obscured-value\n"
+            stderr = ""
+
+        monkeypatch.setattr("subprocess.run", lambda *a, **k: R())
+        assert svc._rclone_obscure("hunter2") == "obscured-value"
+
+    def test_nonzero_returncode_raises(self, monkeypatch):
+        class R:
+            returncode = 1
+            stdout = ""
+            stderr = "boom"
+
+        monkeypatch.setattr("subprocess.run", lambda *a, **k: R())
+        with pytest.raises(RuntimeError, match="rclone obscure failed"):
+            svc._rclone_obscure("hunter2")
+
+    def test_empty_stdout_raises(self, monkeypatch):
+        class R:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        monkeypatch.setattr("subprocess.run", lambda *a, **k: R())
+        with pytest.raises(RuntimeError, match="empty output"):
+            svc._rclone_obscure("hunter2")
+
+    def test_missing_binary_raises(self, monkeypatch):
+        def fake(*a, **k):
+            raise FileNotFoundError("rclone not found")
+
+        monkeypatch.setattr("subprocess.run", fake)
+        with pytest.raises(RuntimeError, match="not found"):
+            svc._rclone_obscure("hunter2")
+
+    def test_timeout_raises(self, monkeypatch):
+        import subprocess as _sp
+
+        def fake(*a, **k):
+            raise _sp.TimeoutExpired("rclone", 10)
+
+        monkeypatch.setattr("subprocess.run", fake)
+        with pytest.raises(RuntimeError, match="timed out"):
+            svc._rclone_obscure("hunter2")
+
+    def test_non_string_raises(self):
+        with pytest.raises(RuntimeError, match="must be a string"):
+            svc._rclone_obscure(123)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# _write_rclone_conf regression — issue #165 changes
+# ---------------------------------------------------------------------------
+
+class TestWriteRcloneConfRegression:
+    """Verify the cloud_archive_service conf writer:
+
+    * uses ``creds["type"]`` over the ``provider`` argument when both
+      are present (generic-flow fix);
+    * skips ``_*`` private metadata keys (so rclone never sees them);
+    * preserves the legacy OAuth flow (``provider="onedrive"`` with
+      no ``type`` in creds still emits ``type = onedrive``).
+    """
+
+    @pytest.fixture
+    def tmpfs(self, tmp_path, monkeypatch):
+        from services import cloud_archive_service as cas
+        d = str(tmp_path / "rclone-tmp")
+        monkeypatch.setattr(cas, "_RCLONE_TMPFS_DIR", d)
+        monkeypatch.setattr(
+            cas, "_RCLONE_CONF_PATH", os.path.join(d, "rclone.conf"),
+        )
+        yield d
+
+    def _read(self, path):
+        with open(path, "r", encoding="utf-8") as f:
+            return f.read()
+
+    def test_generic_creds_type_overrides_provider(self, tmpfs):
+        """Generic creds with type=sftp + provider="generic"."""
+        from services import cloud_archive_service as cas
+
+        path = cas._write_rclone_conf(
+            "generic",
+            {"type": "sftp", "host": "nas.local", "user": "pi",
+             "pass": "obscured", "_obscure_keys": "pass", "_source": "form"},
+        )
+        contents = self._read(path)
+        lines = contents.splitlines()
+        assert "type = sftp" in lines
+        assert "type = generic" not in lines  # never falls back to provider
+        assert "host = nas.local" in lines
+        # Private keys MUST be filtered out.
+        assert "_obscure_keys" not in contents
+        assert "_source" not in contents
+        # ``type`` line MUST appear exactly once (header only); count
+        # full lines, not substrings (``drive_type = ...`` contains
+        # the substring ``type = `` and would inflate a naive count).
+        assert sum(1 for ln in lines if ln.startswith("type = ")) == 1
+
+    def test_legacy_oauth_provider_unchanged(self, tmpfs):
+        """OAuth creds (have type=onedrive too) still produce the same conf."""
+        from services import cloud_archive_service as cas
+
+        path = cas._write_rclone_conf(
+            "onedrive",
+            {"type": "onedrive", "token": "{...}", "drive_type": "personal"},
+        )
+        contents = self._read(path)
+        lines = contents.splitlines()
+        assert "type = onedrive" in lines
+        assert "token = {...}" in lines
+        assert "drive_type = personal" in lines
+        assert sum(1 for ln in lines if ln.startswith("type = ")) == 1
+
+    def test_underscore_keys_always_skipped(self, tmpfs):
+        from services import cloud_archive_service as cas
+
+        path = cas._write_rclone_conf(
+            "generic",
+            {"type": "b2", "account": "a", "key": "k",
+             "_internal_metadata": "leaked?"},
+        )
+        contents = self._read(path)
+        assert "_internal_metadata" not in contents
+        assert "leaked?" not in contents
+        assert "account = a" in contents
+        assert "key = k" in contents
+
+
+class TestWriteTempConfRegression:
+    """The cloud_rclone_service test-conn writer also skips ``_*`` keys."""
+
+    @pytest.fixture
+    def tmpfs(self, tmp_path, monkeypatch):
+        d = str(tmp_path / "rclone-tmp")
+        monkeypatch.setattr(svc, "_RCLONE_TMPFS_DIR", d)
+        monkeypatch.setattr(
+            svc, "_RCLONE_CONF_PATH", os.path.join(d, "rclone.conf"),
+        )
+        yield d
+
+    def test_skips_underscore_keys(self, tmpfs):
+        path = svc._write_temp_conf(
+            {"type": "sftp", "host": "X", "_obscure_keys": "pass",
+             "_source": "form"},
+        )
+        with open(path, "r", encoding="utf-8") as f:
+            contents = f.read()
+        assert "_obscure_keys" not in contents
+        assert "_source" not in contents
+        assert "type = sftp" in contents
+        assert "host = X" in contents
+
+
+# ---------------------------------------------------------------------------
+# api_connect_provider — three payload shapes
+# ---------------------------------------------------------------------------
+
+class TestApiConnectProvider:
+    """End-to-end via Flask test client; mocks at the credential layer."""
+
+    @pytest.fixture
+    def client(self, tmp_path, monkeypatch):
+        # Redirect the creds file to a tmp path.
+        monkeypatch.setattr(
+            svc, "CLOUD_PROVIDER_CREDS_PATH",
+            str(tmp_path / "creds.bin"),
+        )
+        # Stop the route's _update_config_yaml from touching the real file.
+        from blueprints import cloud_archive as bp
+        monkeypatch.setattr(bp, "_update_config_yaml", lambda kv: None)
+
+        from web_control import app
+        app.config['TESTING'] = True
+        return app.test_client()
+
+    def test_oauth_shape_still_works(self, client, monkeypatch):
+        monkeypatch.setattr(svc, "save_credentials",
+                            lambda provider, token: None)
+        token = {
+            "access_token": "ya29.x", "token_type": "Bearer",
+            "refresh_token": "r", "expiry": "2026-04-05T12:00:00Z",
+        }
+        r = client.post(
+            "/cloud/api/connect",
+            json={"provider": "onedrive", "token": json.dumps(token)},
+        )
+        assert r.status_code == 200, r.get_data(as_text=True)
+        assert r.get_json()["success"] is True
+
+    def test_oauth_shape_missing_token(self, client):
+        r = client.post(
+            "/cloud/api/connect",
+            json={"provider": "onedrive"},
+        )
+        assert r.status_code == 400
+        assert "Missing token" in r.get_json()["message"]
+
+    def test_unknown_provider_rejected(self, client):
+        r = client.post(
+            "/cloud/api/connect",
+            json={"provider": "msbox", "token": "x"},
+        )
+        assert r.status_code == 400
+        assert "Unknown provider" in r.get_json()["message"]
+
+    def test_generic_paste_shape(self, client, monkeypatch):
+        monkeypatch.setattr(svc, "_rclone_obscure", lambda v: f"O({v})")
+        r = client.post(
+            "/cloud/api/connect",
+            json={
+                "provider": "generic",
+                "config_block": (
+                    "[my-nas]\ntype = sftp\nhost = nas.local\n"
+                    "user = pi\npass = hunter2\n"
+                ),
+            },
+        )
+        assert r.status_code == 200, r.get_data(as_text=True)
+        assert r.get_json()["success"] is True
+        creds = svc._load_creds()
+        assert creds["type"] == "sftp"
+        assert creds["host"] == "nas.local"
+        # Default obscure list for sftp = ["pass"].
+        assert creds["pass"] == "O(hunter2)"
+        assert creds["_source"] == "paste"
+
+    def test_generic_form_shape(self, client, monkeypatch):
+        monkeypatch.setattr(svc, "_rclone_obscure", lambda v: f"O({v})")
+        r = client.post(
+            "/cloud/api/connect",
+            json={
+                "provider": "generic",
+                "rclone_type": "webdav",
+                "fields": {
+                    "url": "https://dav.example.com",
+                    "user": "alice", "pass": "p",
+                },
+            },
+        )
+        assert r.status_code == 200, r.get_data(as_text=True)
+        creds = svc._load_creds()
+        assert creds["type"] == "webdav"
+        assert creds["url"] == "https://dav.example.com"
+        assert creds["pass"] == "O(p)"
+        assert creds["_source"] == "form"
+
+    def test_generic_form_explicit_obscure_override(self, client, monkeypatch):
+        """Caller can override the per-backend default obscure_keys."""
+        monkeypatch.setattr(svc, "_rclone_obscure", lambda v: f"O({v})")
+        r = client.post(
+            "/cloud/api/connect",
+            json={
+                "provider": "generic", "rclone_type": "sftp",
+                "fields": {"host": "X", "key_file": "/k", "pass": "p"},
+                "obscure_keys": [],  # disable obscuring entirely
+            },
+        )
+        assert r.status_code == 200
+        creds = svc._load_creds()
+        assert creds["pass"] == "p"  # NOT obscured
+
+    def test_generic_s3_default_no_obscure(self, client, monkeypatch):
+        """S3 backend: default obscure list is empty (rclone convention)."""
+        called = []
+        monkeypatch.setattr(
+            svc, "_rclone_obscure",
+            lambda v: called.append(v) or f"O({v})",
+        )
+        r = client.post(
+            "/cloud/api/connect",
+            json={
+                "provider": "generic", "rclone_type": "s3",
+                "fields": {
+                    "provider": "Other",
+                    "access_key_id": "AK",
+                    "secret_access_key": "SK",
+                    "endpoint": "https://s3.example.com",
+                },
+            },
+        )
+        assert r.status_code == 200
+        creds = svc._load_creds()
+        assert creds["secret_access_key"] == "SK"  # cleartext (rclone norm)
+        assert called == []  # obscure was never called
+
+    def test_generic_missing_both_shapes(self, client):
+        r = client.post(
+            "/cloud/api/connect",
+            json={"provider": "generic"},
+        )
+        assert r.status_code == 400
+        assert "config_block" in r.get_json()["message"]
+
+    def test_generic_bad_type_returns_400(self, client):
+        r = client.post(
+            "/cloud/api/connect",
+            json={
+                "provider": "generic",
+                "config_block": "type = onedrive\nhost = X\n",
+            },
+        )
+        assert r.status_code == 400
+        assert "not in the supported" in r.get_json()["message"]
+
+    def test_generic_form_obscure_failure_returns_500(self, client, monkeypatch):
+        def boom(_v):
+            raise RuntimeError("rclone binary not found")
+
+        monkeypatch.setattr(svc, "_rclone_obscure", boom)
+        r = client.post(
+            "/cloud/api/connect",
+            json={
+                "provider": "generic", "rclone_type": "sftp",
+                "fields": {"host": "X", "pass": "p"},
+            },
+        )
+        assert r.status_code == 500
+        assert "not found" in r.get_json()["message"]

--- a/tests/test_cloud_generic_remote.py
+++ b/tests/test_cloud_generic_remote.py
@@ -230,6 +230,179 @@ class TestSaveCredentialsGeneric:
         # Recorded as a sorted, deduped CSV so audit logs stay stable.
         assert svc._load_creds()["_obscure_keys"] == "pass"
 
+    # ---- PR #218 review: control-character injection coverage ----------
+    #
+    # The reviewer reproduced an injection: a value of
+    # ``"x\ntype = local\nremote = /"`` produced a malicious multi-line
+    # ``[teslausb]`` block that overrode the backend type. Form mode
+    # JSON bypassed the splitlines() check that paste mode used. These
+    # tests pin the new ``_reject_control_chars`` guard at every
+    # entry point.
+
+    def test_rejects_newline_in_field_value(self, tmp_creds):
+        with pytest.raises(ValueError, match="forbidden control character"):
+            svc.save_credentials_generic(
+                "sftp",
+                {"host": "x\ntype = local\nremote = /", "user": "u"},
+                obscure_keys=[],
+            )
+
+    def test_rejects_carriage_return_in_field_value(self, tmp_creds):
+        with pytest.raises(ValueError, match="forbidden control character"):
+            svc.save_credentials_generic(
+                "sftp", {"host": "good\rinjected", "user": "u"},
+                obscure_keys=[],
+            )
+
+    def test_rejects_null_byte_in_field_value(self, tmp_creds):
+        with pytest.raises(ValueError, match="forbidden control character"):
+            svc.save_credentials_generic(
+                "sftp", {"host": "good\x00injected", "user": "u"},
+                obscure_keys=[],
+            )
+
+    def test_rejects_newline_in_field_key(self, tmp_creds):
+        """A key like ``"host\\ntype"`` would smuggle a second
+        ``type =`` line into the conf file regardless of value
+        sanitisation."""
+        with pytest.raises(ValueError, match="forbidden control character"):
+            svc.save_credentials_generic(
+                "sftp", {"host\ntype": "x"}, obscure_keys=[],
+            )
+
+    def test_rejects_newline_in_source(self, tmp_creds):
+        with pytest.raises(ValueError, match="forbidden control character"):
+            svc.save_credentials_generic(
+                "sftp", {"host": "X"}, obscure_keys=[],
+                source="form\nbogus",
+            )
+
+    def test_rejects_string_obscure_keys(self, tmp_creds):
+        """``"pass"`` would iterate as ``['p','a','s','s']`` and silently
+        fail to obscure the password — the exact failure mode the
+        whole obscure path exists to prevent."""
+        with pytest.raises(ValueError, match="must be a list"):
+            svc.save_credentials_generic(
+                "sftp", {"host": "X", "pass": "p"},
+                obscure_keys="pass",  # type: ignore[arg-type]
+            )
+
+    def test_rejects_non_string_in_obscure_keys(self, tmp_creds):
+        with pytest.raises(ValueError, match="must be strings"):
+            svc.save_credentials_generic(
+                "sftp", {"host": "X", "pass": "p"},
+                obscure_keys=["pass", 42],  # type: ignore[list-item]
+            )
+
+    def test_obscure_keys_normalised_lowercase(self, tmp_creds, monkeypatch):
+        """Form callers may send ``"Pass"`` (case mismatch with the
+        rclone field key); we normalise so the obscure step still
+        matches the actual field name."""
+        called = []
+        monkeypatch.setattr(
+            svc, "_rclone_obscure",
+            lambda v: called.append(v) or f"O({v})",
+        )
+        svc.save_credentials_generic(
+            "sftp", {"host": "X", "pass": "p"}, obscure_keys=["Pass"],
+        )
+        assert svc._load_creds()["pass"] == "O(p)"
+        assert called == ["p"]
+
+
+# ---------------------------------------------------------------------------
+# Defense in depth at the conf-writers — corrupted-on-disk creds
+# ---------------------------------------------------------------------------
+
+class TestConfWriterControlCharGuard:
+    """Even if a corrupted creds file slips past
+    ``save_credentials_generic`` (e.g. via filesystem access outside
+    this code path), the rclone-conf writers MUST refuse to emit a
+    line containing a control character. PR #218 review."""
+
+    @pytest.fixture
+    def tmpfs(self, tmp_path, monkeypatch):
+        from services import cloud_archive_service as cas
+        d = str(tmp_path / "rclone-tmp")
+        monkeypatch.setattr(cas, "_RCLONE_TMPFS_DIR", d)
+        monkeypatch.setattr(
+            cas, "_RCLONE_CONF_PATH", os.path.join(d, "rclone.conf"),
+        )
+        yield d
+
+    def _read(self, path):
+        with open(path, "r", encoding="utf-8") as f:
+            return f.read()
+
+    def test_archive_writer_skips_value_with_newline(self, tmpfs):
+        from services import cloud_archive_service as cas
+
+        path = cas._write_rclone_conf(
+            "generic",
+            {"type": "sftp", "host": "good\ntype = local", "user": "u"},
+        )
+        contents = self._read(path)
+        assert "type = local" not in contents
+        assert "host = good" not in contents  # whole line skipped
+        # The legitimate remainder still made it through.
+        assert "type = sftp" in contents
+        assert "user = u" in contents
+
+    def test_archive_writer_skips_key_with_newline(self, tmpfs):
+        from services import cloud_archive_service as cas
+
+        path = cas._write_rclone_conf(
+            "generic",
+            {"type": "sftp", "host\ntype": "x", "user": "u"},
+        )
+        contents = self._read(path)
+        assert "host\ntype" not in contents
+        # No second "type = " smuggled in.
+        lines = contents.splitlines()
+        assert sum(1 for ln in lines if ln.startswith("type = ")) == 1
+
+    def test_temp_writer_skips_value_with_newline(self, tmp_path, monkeypatch):
+        d = str(tmp_path / "rclone-tmp")
+        monkeypatch.setattr(svc, "_RCLONE_TMPFS_DIR", d)
+        monkeypatch.setattr(
+            svc, "_RCLONE_CONF_PATH", os.path.join(d, "rclone.conf"),
+        )
+        path = svc._write_temp_conf(
+            {"type": "sftp", "host": "good\ntype = local", "user": "u"},
+        )
+        with open(path, "r", encoding="utf-8") as f:
+            contents = f.read()
+        assert "type = local" not in contents
+        assert "type = sftp" in contents
+        assert "user = u" in contents
+
+
+# ---------------------------------------------------------------------------
+# _DEFAULT_OBSCURE_KEYS — single source of truth for the route handler
+# ---------------------------------------------------------------------------
+
+class TestDefaultObscureKeys:
+    """Pin the contract: every supported backend has an entry, and
+    sftp/webdav/smb/ftp obscure ``pass``."""
+
+    def test_covers_every_supported_backend(self):
+        assert set(svc._DEFAULT_OBSCURE_KEYS.keys()) == set(
+            svc._GENERIC_RCLONE_TYPES,
+        )
+
+    def test_password_backends_obscure_pass(self):
+        for rt in ("sftp", "webdav", "smb", "ftp"):
+            assert "pass" in svc._DEFAULT_OBSCURE_KEYS[rt], (
+                f"{rt} must default to obscuring 'pass'"
+            )
+
+    def test_keybased_backends_do_not_obscure(self):
+        """rclone does not obscure S3-style secret keys."""
+        for rt in ("s3", "b2", "wasabi", "azureblob", "swift"):
+            assert svc._DEFAULT_OBSCURE_KEYS[rt] == [], (
+                f"{rt} must not obscure (rclone won't parse it)"
+            )
+
 
 # ---------------------------------------------------------------------------
 # _rclone_obscure helper

--- a/tests/test_cloud_rclone_service.py
+++ b/tests/test_cloud_rclone_service.py
@@ -72,11 +72,21 @@ class TestProviders:
     """Tests for provider configuration."""
 
     def test_all_providers_have_required_fields(self):
-        """Each provider has label, rclone_type, and authorize_cmd."""
+        """Each provider has label, rclone_type, and authorize_cmd.
+
+        Issue #165 added the ``generic`` provider where ``rclone_type``
+        and ``authorize_cmd`` are intentionally ``None`` (no static
+        backend type, no OAuth flow). All other providers must still
+        carry the rclone-authorize CLI string so the OAuth UX works.
+        """
         for key, meta in svc.PROVIDERS.items():
             assert "label" in meta, f"{key} missing label"
             assert "rclone_type" in meta, f"{key} missing rclone_type"
             assert "authorize_cmd" in meta, f"{key} missing authorize_cmd"
+            if key == "generic":
+                assert meta["rclone_type"] is None
+                assert meta["authorize_cmd"] is None
+                continue
             assert "rclone authorize" in meta["authorize_cmd"]
 
     def test_onedrive_metadata(self):


### PR DESCRIPTION
## Summary

Closes #165 — adds NAS / generic rclone remote support to Cloud Archive.

A new **"NAS / Custom rclone"** entry in the provider dropdown opens a section with two input modes:

- **Form** — guided per-backend fields (host, user, pass, ...), one schema per backend.
- **Paste** — pasted `[remote]` block from an existing `rclone.conf`.

Both modes funnel through a single new backend path (`save_credentials_generic`) that produces the same Fernet-encrypted credential blob and the same `[teslausb]` rclone section as the legacy OAuth providers. The cloud archive worker, Live Event Sync, and Test Connection button all work identically against the new providers — no changes needed there.

### Supported backends (allow-listed)

`sftp`, `webdav`, `smb`, `ftp`, `s3`, `b2`, `wasabi`, `azureblob`, `swift`.

Explicitly rejected at parse time: `crypt` / `union` / `chunker` (wrap-remote types that reference a second remote name we don't store), `local` (web-UI-to-arbitrary-local-path escalation risk), `http` (read-only).

## What's also fixed (latent bug discovered during the work)

The dropdown's existing **S3 / B2 / Wasabi** entries previously POSTed to `/api/provider`, which only persisted the provider name and **silently dropped the credentials map**. The frontend `saveProvider()` function now routes those backends through the new generic `/api/connect` path so the keys actually reach `rclone.conf`. The bucket value is collected as before and persisted via the existing `api_set_remote_path` route so the remote-folder UI starts at the right place.

## Backend changes

- **`services/cloud_rclone_service.py`**
  - `PROVIDERS` gains `"generic"` (`rclone_type=None`, `authorize_cmd=None`).
  - `_GENERIC_RCLONE_TYPES` allow-list constant.
  - `_persist_creds()` factored out so OAuth and generic flows share encryption + atomic write.
  - `parse_rclone_config_block()` — single-section parser with allow-list enforcement.
  - `save_credentials_generic(rclone_type, fields, obscure_keys, source)` — entry for both Form and Paste modes.
  - `_rclone_obscure()` — shells out to `rclone obscure` for sftp / webdav / smb / ftp passwords; **fails closed** (never silently stores cleartext).
  - `_write_temp_conf()` now skips `_*` private metadata keys.

- **`services/cloud_archive_service._write_rclone_conf`**
  - Prefers `creds["type"]` over the `provider` argument (generic flow stores the truth there; OAuth flows still emit the same line they did before — verified by regression test).
  - Skips `_*` private metadata keys (`_obscure_keys`, `_source`).

- **`blueprints/cloud_archive.api_connect_provider`**
  - Accepts three payload shapes: OAuth token (legacy unchanged), generic `config_block`, generic `rclone_type` + `fields`.
  - Per-backend default obscure-key list applied if caller omits it; explicit caller override honoured.

## Frontend changes

- New `genericSetup` section with Form / Paste tabs in `templates/cloud_archive.html`.
- `genericSchemas` JS table drives Form mode (one schema per supported backend); required fields enforced client-side; password fields use `type=password`.
- `connectGenericProvider(mode)` and `switchGenericTab(which)` helpers.
- `saveProvider()` rewired through `/api/connect` for the legacy S3 / B2 / Wasabi entries.

## Tests

- **`tests/test_cloud_generic_remote.py`** — **46 new tests**:
  - `parse_rclone_config_block`: section vs bare form, comment/blank handling, allow-list rejection (crypt / union / local / onedrive), multi-section rejection, invalid line / empty key handling.
  - `save_credentials_generic` round-trip through the encrypted store with private metadata preservation, obscure-key invocation, type-override / reserved-key / non-string-key rejection.
  - `_rclone_obscure`: success, non-zero rc, empty stdout, missing binary, timeout, non-string input.
  - `_write_rclone_conf` regression: `creds["type"]` wins, `_*` keys skipped, OAuth flow unchanged.
  - `api_connect_provider`: OAuth shape unchanged, generic Paste, generic Form, default vs explicit obscure_keys, S3 default no-obscure, error paths.
- `tests/test_cloud_rclone_service.py`: `test_all_providers_have_required_fields` updated to skip the generic entry's `None` `authorize_cmd` / `rclone_type`.

**Test results: 2024 pass / 5 skip** (was 1978 / 5 — +46 new).

## Docs

- **`docs/CLOUD_ARCHIVE.md`** — new doc with the provider matrix, NAS setup walk-through (Form + Paste), encryption / on-disk format notes, and the supported / unsupported backend list.
- **`readme.md`** — Cloud Archive bullet enumerates the new providers.

## Security notes

- `_rclone_obscure` fails closed — if the rclone binary is missing, returns non-zero, or produces empty output, a `RuntimeError` propagates and the credentials are **not** persisted. There is no codepath that could store a cleartext password thinking it was obscured.
- The pasted-config parser hard-rejects multiple `[section]` headers — closes the door on `crypt`/`union` smuggling where a second section references the first one to wrap an unsanctioned backend.
- The allow-list is intentionally code (not config) so adding a backend requires a code review against the wrap-remote / privilege-escalation constraints documented next to the constant.
- Reserved field-key prefix (`_`) is enforced at save time, so a malicious paste cannot inject internal metadata that the conf writer would then leak.
- All file-write operations follow the established atomic-write recipe (temp + fsync + `os.replace`) — consistent with the OAuth flow, so power-loss safety is unchanged.
