### PR TITLE
Cloud Sync: add Reset Stats button + rework folders (RecentClips -> ArchivedClips)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -120,11 +120,11 @@ cloud_archive:
   sync_folders:                          # Which TeslaCam subfolders to sync
     - SentryClips
     - SavedClips
-    - RecentClips
+    - ArchivedClips                      # SD-card-resident copy of clips (RecentClips rotates hourly, so we sync the archived snapshot instead)
   priority_order:                        # Sync priority (first = highest, user-configurable)
     - SentryClips
     - SavedClips
-    - RecentClips
+    - ArchivedClips
   max_upload_mbps: 5                     # Bandwidth limit (Pi has limited upload)
   cloud_reserve_gb: 1                    # Keep this much free on cloud (don't fill to 100%)
   keep_local_after_upload: true          # Keep local files after uploading to cloud

--- a/scripts/web/blueprints/cloud_archive.py
+++ b/scripts/web/blueprints/cloud_archive.py
@@ -124,18 +124,29 @@ def index():
         sync_history = []
 
     # Re-read dynamic settings from config.yaml (cached for 30s to reduce I/O)
+    # Normalise sync_folders / priority_order via the same allow-list +
+    # legacy-RecentClips rewrite that config.py uses at boot — that way
+    # the Settings UI never shows a stale ``RecentClips`` checkbox even
+    # if the user's config.yaml predates the rename. The normalised
+    # values flow through both the template render and the form-submit
+    # handler so the next "Save" call also writes back the canonical form.
+    from config import _normalize_cloud_folder_list, _CLOUD_DEFAULT_FOLDERS
     import yaml
     _provider = CLOUD_ARCHIVE_PROVIDER
-    _sync_folders = CLOUD_ARCHIVE_SYNC_FOLDERS
-    _priority_order = CLOUD_ARCHIVE_PRIORITY_ORDER
+    _sync_folders = list(CLOUD_ARCHIVE_SYNC_FOLDERS)
+    _priority_order = list(CLOUD_ARCHIVE_PRIORITY_ORDER)
     _max_upload_mbps = CLOUD_ARCHIVE_MAX_UPLOAD_MBPS
     _remote_path = CLOUD_ARCHIVE_REMOTE_PATH
     _sync_enabled = True
     try:
         _cloud = _get_cloud_config_cached()
         _provider = _cloud.get('provider', '') or _provider
-        _sync_folders = _cloud.get('sync_folders', _sync_folders)
-        _priority_order = _cloud.get('priority_order', _priority_order)
+        _sync_folders = _normalize_cloud_folder_list(
+            _cloud.get('sync_folders', _sync_folders), _sync_folders,
+        )
+        _priority_order = _normalize_cloud_folder_list(
+            _cloud.get('priority_order', _priority_order), _sync_folders,
+        )
         _max_upload_mbps = int(_cloud.get('max_upload_mbps', _max_upload_mbps))
         _remote_path = _cloud.get('remote_path', _remote_path)
         _sync_enabled = bool(_cloud.get('sync_enabled', True))
@@ -197,9 +208,19 @@ def index():
 def save_settings():
     """Save cloud sync settings from form submission."""
     try:
-        sync_folders = request.form.getlist('sync_folders')
+        from config import _normalize_cloud_folder_list, _CLOUD_DEFAULT_FOLDERS
+        # Form posts the raw checkbox values; run them through the same
+        # allow-list + RecentClips-rewrite as the boot-time loader so a
+        # stale browser cache (or a hand-crafted POST) can never persist
+        # an unsupported folder name to config.yaml.
+        sync_folders = _normalize_cloud_folder_list(
+            request.form.getlist('sync_folders'), _CLOUD_DEFAULT_FOLDERS,
+        )
         priority_raw = request.form.get('priority_order', '')
-        priority_order = [p.strip() for p in priority_raw.split(',') if p.strip()]
+        priority_order = _normalize_cloud_folder_list(
+            [p.strip() for p in priority_raw.split(',') if p.strip()],
+            sync_folders,
+        )
         max_upload_mbps = int(request.form.get('max_upload_mbps', 5))
         cloud_reserve_gb = max(0, float(request.form.get('cloud_reserve_gb', 1)))
         sync_non_event = 'sync_non_event_videos' in request.form
@@ -386,6 +407,42 @@ def api_history():
     except Exception as exc:
         logger.exception("Failed to fetch sync history")
         return jsonify({"error": str(exc)}), 500
+
+
+@cloud_archive_bp.route('/api/reset_stats', methods=['POST'])
+def api_reset_stats():
+    """Reset the dashboard counter baseline.
+
+    Non-destructive: the underlying ``cloud_synced_files`` rows are
+    preserved so already-uploaded clips stay deduped and are NEVER
+    re-uploaded on the next sync pass. Only the displayed cumulative
+    counters (``total_synced`` count and ``total_bytes`` sum) start
+    over from zero. ``total_pending`` and ``total_failed`` are
+    unaffected because they reflect current work / failures, not
+    cumulative history.
+
+    Invalidates the 10-second ``api_status`` cache so the UI sees the
+    reset reflected on the next poll instead of waiting up to 10 s.
+    """
+    from services.cloud_archive_service import reset_stats_baseline
+
+    try:
+        ok, payload = reset_stats_baseline(CLOUD_ARCHIVE_DB_PATH)
+        if not ok:
+            return jsonify({"success": False, "message": payload}), 500
+
+        # Drop the cached stats so the next poll reflects the reset
+        if hasattr(api_status, '_cache'):
+            try:
+                del api_status._cache
+            except AttributeError:
+                pass
+
+        logger.info("Cloud sync stats counters reset by user (baseline=%s)", payload)
+        return jsonify({"success": True, "stats_baseline_at": payload})
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("Failed to reset cloud sync stats counters")
+        return jsonify({"success": False, "message": str(exc)}), 500
 
 
 

--- a/scripts/web/config.py
+++ b/scripts/web/config.py
@@ -101,8 +101,46 @@ CLOUD_ARCHIVE_ENABLED = bool(_cloud.get('enabled', False))
 CLOUD_ARCHIVE_SYNC_ENABLED = bool(_cloud.get('sync_enabled', True))  # auto-sync on/off (separate from page access)
 CLOUD_ARCHIVE_PROVIDER = _cloud.get('provider', '')
 CLOUD_ARCHIVE_REMOTE_PATH = _cloud.get('remote_path', 'TeslaUSB')
-CLOUD_ARCHIVE_SYNC_FOLDERS = _cloud.get('sync_folders', ['SentryClips', 'SavedClips'])
-CLOUD_ARCHIVE_PRIORITY_ORDER = _cloud.get('priority_order', ['SentryClips', 'SavedClips'])
+
+
+def _normalize_cloud_folder_list(values, default):
+    """Filter a cloud_archive folder list to the supported set.
+
+    * Drops non-string entries.
+    * Rewrites legacy ``RecentClips`` → ``ArchivedClips`` so installs
+      that ever had RecentClips checked silently switch to the
+      SD-card-resident ArchivedClips (RecentClips rotates hourly and
+      was never a useful sync target; the previous default produced
+      misleading UI without doing real work).
+    * Keeps only ``SentryClips`` / ``SavedClips`` / ``ArchivedClips``.
+    * Deduplicates while preserving order.
+    * Falls back to *default* if the normalised result is empty (so a
+      typo in config.yaml cannot silently disable all sync).
+    """
+    valid = ("SentryClips", "SavedClips", "ArchivedClips")
+    if not isinstance(values, (list, tuple)):
+        return list(default)
+    seen = []
+    for v in values:
+        if not isinstance(v, str):
+            continue
+        folder = v.strip()
+        if folder == "RecentClips":
+            folder = "ArchivedClips"
+        if folder in valid and folder not in seen:
+            seen.append(folder)
+    return seen if seen else list(default)
+
+
+_CLOUD_DEFAULT_FOLDERS = ['SentryClips', 'SavedClips', 'ArchivedClips']
+CLOUD_ARCHIVE_SYNC_FOLDERS = _normalize_cloud_folder_list(
+    _cloud.get('sync_folders', _CLOUD_DEFAULT_FOLDERS),
+    _CLOUD_DEFAULT_FOLDERS,
+)
+CLOUD_ARCHIVE_PRIORITY_ORDER = _normalize_cloud_folder_list(
+    _cloud.get('priority_order', _CLOUD_DEFAULT_FOLDERS),
+    CLOUD_ARCHIVE_SYNC_FOLDERS,
+)
 CLOUD_ARCHIVE_MAX_UPLOAD_MBPS = int(_cloud.get('max_upload_mbps', 5))
 CLOUD_ARCHIVE_RESERVE_GB = float(_cloud.get('cloud_reserve_gb', 1))
 CLOUD_ARCHIVE_SYNC_NON_EVENT = bool(_cloud.get('sync_non_event_videos', False))

--- a/scripts/web/services/cloud_archive_service.py
+++ b/scripts/web/services/cloud_archive_service.py
@@ -61,6 +61,18 @@ _RETRY_MAX_ATTEMPTS_MAX = 20
 _KNOWN_CLOUD_ROOTS = ("ArchivedClips", "RecentClips", "SentryClips",
                       "SavedClips", "TeslaTrackMode")
 
+# Event-style folder names — every entry under one of these on the
+# remote is a per-event SUBDIRECTORY containing the 6 cam clips +
+# event.json. Used by ``_reconcile_with_remote_legacy`` to know which
+# folders are worth a ``--dirs-only`` listing. These names are dictated
+# by Tesla firmware and never change at user request; they are
+# independent of the user-configurable ``cloud_archive.sync_folders``
+# setting (which controls what to UPLOAD, not what to RECONCILE — we
+# always want to mark already-uploaded events ``synced`` so a folder
+# the user temporarily unchecks doesn't trigger a re-upload when they
+# re-check it).
+_EVENT_FOLDER_NAMES = ("SentryClips", "SavedClips")
+
 
 def canonical_cloud_path(file_path: str) -> str:
     """Normalize a cloud-sync ``file_path`` to canonical relative form.
@@ -158,7 +170,16 @@ def canonical_cloud_path(file_path: str) -> str:
 # ---------------------------------------------------------------------------
 
 _CLOUD_MODULE = "cloud_archive"
-_CLOUD_SCHEMA_VERSION = 4
+_CLOUD_SCHEMA_VERSION = 5
+
+# Key in ``cloud_archive_meta`` holding the ISO-8601 UTC timestamp at
+# which the user last reset the dashboard counters. ``get_sync_stats``
+# uses this to filter the cumulative ``total_synced`` / ``total_bytes``
+# values without touching the underlying ``cloud_synced_files`` rows
+# (preserving dedup so already-synced files are never re-uploaded).
+# Absent row / NULL value = no reset performed (counters show full
+# lifetime totals).
+_CLOUD_STATS_BASELINE_KEY = "stats_baseline_at"
 
 _CLOUD_TABLES_SQL = """\
 CREATE TABLE IF NOT EXISTS module_versions (
@@ -192,8 +213,19 @@ CREATE TABLE IF NOT EXISTS cloud_sync_sessions (
     error_msg TEXT
 );
 
+-- v5: simple key/value table for user-controlled UI state. Currently
+-- holds the dashboard counter reset timestamp (stats_baseline_at) so
+-- the "Reset Stats" button on the cloud sync page can hide historical
+-- synced counts WITHOUT deleting the dedup-critical cloud_synced_files
+-- rows (which would cause everything-on-cloud to be re-uploaded).
+CREATE TABLE IF NOT EXISTS cloud_archive_meta (
+    key TEXT PRIMARY KEY,
+    value TEXT
+);
+
 CREATE INDEX IF NOT EXISTS idx_cloud_synced_status ON cloud_synced_files(status);
 CREATE INDEX IF NOT EXISTS idx_cloud_synced_mtime ON cloud_synced_files(file_mtime);
+CREATE INDEX IF NOT EXISTS idx_cloud_synced_synced_at ON cloud_synced_files(synced_at);
 CREATE INDEX IF NOT EXISTS idx_cloud_sessions_started ON cloud_sync_sessions(started_at);
 """
 
@@ -2136,6 +2168,17 @@ def _init_cloud_tables(db_path: str) -> sqlite3.Connection:
                     e, current,
                 )
 
+        # v5 (#218 follow-up): adds the ``cloud_archive_meta`` key/value
+        # table and the ``idx_cloud_synced_synced_at`` index. Both are
+        # created idempotently by the ``executescript(_CLOUD_TABLES_SQL)``
+        # call at the top of this block, so no separate migration
+        # function is needed. The table backs the dashboard "Reset
+        # Stats" button (stats_baseline_at row) WITHOUT touching the
+        # dedup-critical cloud_synced_files rows that prevent
+        # already-synced clips from being re-uploaded. The new index
+        # makes the baseline-filtered SUM(file_size) / COUNT(*) queries
+        # in ``get_sync_stats`` cheap even after years of sync history.
+
         if migration_ok:
             conn.execute(
                 "INSERT OR REPLACE INTO module_versions (module, version, updated_at) "
@@ -2460,6 +2503,102 @@ def _read_sync_non_event_setting() -> bool:
         return CLOUD_ARCHIVE_SYNC_NON_EVENT
 
 
+# Valid sync-folder names. ``RecentClips`` was supported historically
+# but is excluded from the allow-list because Tesla rotates that folder
+# hourly — uploading the rolling buffer wastes bandwidth and the clips
+# disappear before the next sync run anyway. ``ArchivedClips`` (the
+# SD-card-resident copy preserved by the archive subsystem) is the
+# correct target for "all driving footage" uploads.
+_VALID_SYNC_FOLDERS = ("SentryClips", "SavedClips", "ArchivedClips")
+
+# Multiplier applied to the folder-priority index when composing the
+# per-event sort key in ``_discover_events``. Must be strictly larger
+# than the maximum content score returned by ``_score_event_priority``
+# (currently 200 + 99 age = 299) so the user-configured folder order
+# is guaranteed to dominate the sort regardless of clip age or trigger
+# type.
+_FOLDER_PRIORITY_MULTIPLIER = 1000
+
+
+def _normalize_folder_list(values: object) -> List[str]:
+    """Coerce a config value into a clean folder list.
+
+    * Filters out non-string entries (defensive against malformed YAML).
+    * Normalises legacy ``RecentClips`` entries to ``ArchivedClips`` —
+      RecentClips rotates hourly so it was never a useful sync target;
+      operators with old config.yaml installs (RecentClips checked)
+      should silently start syncing the SD-card archive instead.
+    * Drops anything not in ``_VALID_SYNC_FOLDERS`` after normalisation.
+    * Deduplicates while preserving order (so ``priority_order``
+      semantics survive the rewrite).
+    """
+    if not isinstance(values, (list, tuple)):
+        return []
+    seen = []
+    for v in values:
+        if not isinstance(v, str):
+            continue
+        folder = v.strip()
+        if folder == "RecentClips":
+            folder = "ArchivedClips"
+        if folder in _VALID_SYNC_FOLDERS and folder not in seen:
+            seen.append(folder)
+    return seen
+
+
+def _read_sync_folders_setting() -> List[str]:
+    """Re-read ``cloud_archive.sync_folders`` from config.yaml.
+
+    Same per-call YAML re-read pattern as
+    :func:`_read_sync_non_event_setting` so a Settings change takes
+    effect on the next sync iteration without restarting
+    ``gadget_web.service``. The returned list is filtered through
+    :func:`_normalize_folder_list` so legacy ``RecentClips`` values are
+    silently rewritten to ``ArchivedClips`` and unknown folder names
+    are dropped. Empty result falls back to the import-time default to
+    avoid a config typo silently disabling all sync.
+    """
+    try:
+        import yaml
+        from config import CONFIG_YAML
+        with open(CONFIG_YAML, 'r') as f:
+            cfg = yaml.safe_load(f) or {}
+        raw = cfg.get('cloud_archive', {}).get('sync_folders', None)
+        normalised = _normalize_folder_list(raw) if raw is not None else []
+        if normalised:
+            return normalised
+    except Exception:
+        pass
+    fallback = _normalize_folder_list(list(CLOUD_ARCHIVE_SYNC_FOLDERS))
+    return fallback or list(_VALID_SYNC_FOLDERS)
+
+
+def _read_priority_order_setting() -> List[str]:
+    """Re-read ``cloud_archive.priority_order`` from config.yaml.
+
+    Same per-call YAML re-read pattern as
+    :func:`_read_sync_non_event_setting`. The returned list is filtered
+    through :func:`_normalize_folder_list`. Empty result falls back to
+    the live ``sync_folders`` order (any folder being synced is at
+    least as important as not being in the priority list at all).
+    """
+    try:
+        import yaml
+        from config import CONFIG_YAML
+        with open(CONFIG_YAML, 'r') as f:
+            cfg = yaml.safe_load(f) or {}
+        raw = cfg.get('cloud_archive', {}).get('priority_order', None)
+        normalised = _normalize_folder_list(raw) if raw is not None else []
+        if normalised:
+            return normalised
+    except Exception:
+        pass
+    # Final fallback: import-time default, then if even that's empty
+    # use sync_folders so priority sort still does something useful.
+    fallback = _normalize_folder_list(list(CLOUD_ARCHIVE_PRIORITY_ORDER))
+    return fallback or _read_sync_folders_setting()
+
+
 def _read_retry_max_attempts_setting() -> int:
     """Re-read ``cloud_archive.retry_max_attempts`` from config.yaml.
 
@@ -2595,6 +2734,39 @@ def _is_path_skipped(
         return False
 
 
+def _folder_priority_index(folder: str, priority_order: List[str]) -> int:
+    """Return the position of *folder* in *priority_order*, or len() if absent.
+
+    Used by ``_discover_events`` to multiply against the per-event content
+    score so the user-configured folder order is the PRIMARY sort axis.
+    Folders not in the priority list are sorted to the end of the queue
+    (they'll still upload, but only after every configured folder is
+    drained).
+    """
+    try:
+        return priority_order.index(folder)
+    except ValueError:
+        return len(priority_order)
+
+
+def _folder_of_event_rel(rel_path: str) -> str:
+    """Extract the parent folder name from a canonical relative path.
+
+    ``"SentryClips/2026-05-12_10-00-00"`` → ``"SentryClips"``
+    ``"ArchivedClips/foo.mp4"``           → ``"ArchivedClips"``
+
+    Returns ``""`` if the path has no leading folder component (which
+    should not happen for paths produced by ``canonical_cloud_path``
+    but is handled defensively so a malformed entry sorts to the end).
+    """
+    if not rel_path:
+        return ""
+    first_slash = rel_path.find("/")
+    if first_slash < 0:
+        return ""
+    return rel_path[:first_slash]
+
+
 def _discover_events(
     teslacam_path: str,
     conn: Optional[sqlite3.Connection] = None,
@@ -2603,13 +2775,24 @@ def _discover_events(
 
     Syncs event subdirectories from SentryClips/SavedClips plus flat files
     from ArchivedClips on the SD card. Returns a list of
-    ``(event_dir_path, relative_path, total_size)`` sorted **oldest-first**
-    so the most at-risk clips get preserved first.
+    ``(event_dir_path, relative_path, total_size)`` sorted by the
+    user-configured ``cloud_archive.priority_order`` (folder-level
+    primary axis) and then by ``_score_event_priority`` within each
+    folder (event-trigger > geo-located > other, oldest-first within
+    each band).
 
     If *conn* is provided, events already marked ``synced`` or ``dead_letter``
     in the database are excluded via ``_is_path_skipped`` (Phase 5.3
     streaming dedup — one indexed point-lookup per candidate, no in-memory
     snapshot of the table).
+
+    ``ArchivedClips`` is gated on membership in
+    ``CLOUD_ARCHIVE_SYNC_FOLDERS``. Removing it from the Settings page
+    therefore stops including SD-card archived clips in the upload
+    queue (mirroring the behaviour of unchecking ``SentryClips`` or
+    ``SavedClips``). The legacy "always-on" behaviour was a foot-gun
+    because the UI exposed a checkbox that had no effect on
+    ArchivedClips.
     """
     # Phase 5.3 — streaming dedup. Each candidate event is checked with a
     # single indexed ``_is_path_skipped`` lookup; we no longer load the
@@ -2619,7 +2802,19 @@ def _discover_events(
 
     events: List[Tuple[str, str, int]] = []
 
-    for folder in CLOUD_ARCHIVE_SYNC_FOLDERS:
+    # Re-read sync_folders from the live config so a Settings save
+    # takes effect on the next discovery without restarting the
+    # service. CLOUD_ARCHIVE_SYNC_FOLDERS is snapshotted at config.py
+    # import time, so we re-read here for the freshest view.
+    sync_folders = _read_sync_folders_setting()
+
+    for folder in sync_folders:
+        # ArchivedClips lives on the SD card (ARCHIVE_DIR), not under
+        # ``teslacam_path``. Handle it in the dedicated block below so
+        # we walk the right directory tree.
+        if folder == "ArchivedClips":
+            continue
+
         folder_path = os.path.join(teslacam_path, folder)
         if not os.path.isdir(folder_path):
             continue
@@ -2659,25 +2854,31 @@ def _discover_events(
 
             events.append((event_dir, rel_path, total_size))
 
-    # Also include ArchivedClips from SD card (individual files)
-    try:
-        from config import ARCHIVE_DIR, ARCHIVE_ENABLED
-        if ARCHIVE_ENABLED and os.path.isdir(ARCHIVE_DIR):
-            try:
-                for f in sorted(os.listdir(ARCHIVE_DIR)):
-                    fpath = os.path.join(ARCHIVE_DIR, f)
-                    if os.path.isfile(fpath) and f.lower().endswith(('.mp4', '.ts')):
-                        rel_path = canonical_cloud_path(f"ArchivedClips/{f}")
-                        if _is_path_skipped(conn, rel_path):
-                            continue
-                        fsize = os.path.getsize(fpath)
-                        # Use the individual file path (not ARCHIVE_DIR)
-                        # so rclone copyto can handle file-to-file copy
-                        events.append((fpath, rel_path, fsize))
-            except OSError:
-                pass
-    except ImportError:
-        pass
+    # ArchivedClips on the SD card — flat files. Only include when the
+    # user has checked ArchivedClips in the Settings ``sync_folders``
+    # list. The legacy code unconditionally appended these clips even
+    # when the user had unchecked every folder; that silently uploaded
+    # archived footage the operator had explicitly opted out of and is
+    # exactly the foot-gun this gate fixes.
+    if "ArchivedClips" in sync_folders:
+        try:
+            from config import ARCHIVE_DIR, ARCHIVE_ENABLED
+            if ARCHIVE_ENABLED and os.path.isdir(ARCHIVE_DIR):
+                try:
+                    for f in sorted(os.listdir(ARCHIVE_DIR)):
+                        fpath = os.path.join(ARCHIVE_DIR, f)
+                        if os.path.isfile(fpath) and f.lower().endswith(('.mp4', '.ts')):
+                            rel_path = canonical_cloud_path(f"ArchivedClips/{f}")
+                            if _is_path_skipped(conn, rel_path):
+                                continue
+                            fsize = os.path.getsize(fpath)
+                            # Use the individual file path (not ARCHIVE_DIR)
+                            # so rclone copyto can handle file-to-file copy
+                            events.append((fpath, rel_path, fsize))
+                except OSError:
+                    pass
+        except ImportError:
+            pass
 
     # Phase 5.2 — pre-fetch the geo-hit set ONCE so the scorer doesn't
     # open a fresh SQLite connection per event. For a queue of N candidate
@@ -2719,7 +2920,31 @@ def _discover_events(
                 "(sync_non_event_videos=false)", dropped,
             )
 
-    scored.sort(key=lambda x: x[1])
+    # Apply the user-configured folder priority as the PRIMARY sort axis.
+    # ``priority_order`` is a list like ``['SentryClips', 'SavedClips',
+    # 'ArchivedClips']`` — items in earlier positions get a smaller
+    # composite score and are uploaded first. Within each folder the
+    # existing per-event content score (event-trigger > geo-located >
+    # other, oldest-first within each band) preserves the
+    # "preserve-the-most-at-risk-first" intent.
+    #
+    # Composite score = folder_index * _FOLDER_PRIORITY_MULTIPLIER + content_score.
+    # _FOLDER_PRIORITY_MULTIPLIER (1000) is strictly larger than the
+    # maximum content score (200 + age cap of 99 = 299), so the folder
+    # axis is guaranteed to dominate even for ancient clips in a
+    # lower-priority folder.
+    priority_order = _read_priority_order_setting()
+    composite = [
+        (
+            t,
+            _folder_priority_index(
+                _folder_of_event_rel(t[1]), priority_order,
+            ) * _FOLDER_PRIORITY_MULTIPLIER + s,
+        )
+        for (t, s) in scored
+    ]
+    composite.sort(key=lambda x: x[1])
+    scored = composite
     result = [t for (t, _s) in scored]
 
     # Wave 4 PR-F2 (issue #184): PRODUCER hook for unified pipeline_queue.
@@ -2899,7 +3124,16 @@ def _list_remote_tree(
     to the legacy per-folder path so reconciliation still happens (just
     slower). Returns an empty dict if the remote is reachable but empty.
     """
-    interest = list(CLOUD_ARCHIVE_SYNC_FOLDERS) + ["ArchivedClips"]
+    # Reconciliation must scan EVERY folder that could possibly contain
+    # previously-uploaded rows, not just the folders the operator is
+    # currently configured to sync. If the user unchecks ``SentryClips``
+    # today we still need to discover existing SentryClips rows on the
+    # remote so they get marked ``synced`` rather than re-uploaded the
+    # next time the box is checked. Use the canonical ``_KNOWN_CLOUD_ROOTS``
+    # list — it includes legacy ``RecentClips`` for installs that ever
+    # uploaded the rolling buffer before the folder choice was
+    # narrowed.
+    interest = list(_KNOWN_CLOUD_ROOTS)
     try:
         result = subprocess.run(
             ["rclone", "lsf", "--config", conf_path,
@@ -2983,8 +3217,11 @@ def _reconcile_with_remote(
         )
 
     # List event directories on remote (SentryClips/*, SavedClips/*) — now
-    # served from the single batched listing.
-    for folder in CLOUD_ARCHIVE_SYNC_FOLDERS:
+    # served from the single batched listing. Folder set is fixed by Tesla
+    # firmware (``_EVENT_FOLDER_NAMES``); reconciliation must scan these
+    # regardless of which folders the user currently has checked in
+    # Settings — see ``_EVENT_FOLDER_NAMES`` docstring for why.
+    for folder in _EVENT_FOLDER_NAMES:
         try:
             entries = tree.get(folder, set())
             # event-dir entries have a trailing slash from rclone lsf;
@@ -3098,8 +3335,11 @@ def _reconcile_with_remote_legacy(
     reconciled = 0
     pending_pipeline: List[Tuple[str, Optional[str], str]] = []
 
-    # List event directories on remote (SentryClips/*, SavedClips/*)
-    for folder in CLOUD_ARCHIVE_SYNC_FOLDERS:
+    # List event directories on remote (SentryClips/*, SavedClips/*).
+    # Folder set is fixed by Tesla firmware (``_EVENT_FOLDER_NAMES``); see
+    # the constant docstring for why this is NOT
+    # ``CLOUD_ARCHIVE_SYNC_FOLDERS``.
+    for folder in _EVENT_FOLDER_NAMES:
         try:
             result = subprocess.run(
                 ["rclone", "lsf", "--config", conf_path,
@@ -4404,11 +4644,76 @@ def get_sync_history(db_path: str, limit: int = 20) -> List[dict]:
         conn.close()
 
 
+# ---------------------------------------------------------------------------
+# Dashboard counter "Reset Stats" — baseline-timestamp model
+# ---------------------------------------------------------------------------
+
+def get_stats_baseline(db_path: str) -> Optional[str]:
+    """Return the ISO-8601 UTC timestamp of the last counter reset, or ``None``.
+
+    Stored in the ``cloud_archive_meta`` table under the
+    ``stats_baseline_at`` key. ``get_sync_stats`` filters the cumulative
+    ``total_synced`` count and ``total_bytes`` sum by ``synced_at >
+    baseline``, so the UI can show a fresh starting point WITHOUT
+    deleting the dedup-critical ``cloud_synced_files`` rows that prevent
+    already-synced clips from being re-uploaded on the next sync pass.
+
+    Returns ``None`` when no reset has been performed (counters then
+    show full lifetime totals).
+    """
+    conn = _init_cloud_tables(db_path)
+    try:
+        row = conn.execute(
+            "SELECT value FROM cloud_archive_meta WHERE key = ?",
+            (_CLOUD_STATS_BASELINE_KEY,),
+        ).fetchone()
+        if not row or row["value"] is None:
+            return None
+        value = str(row["value"]).strip()
+        return value or None
+    finally:
+        conn.close()
+
+
+def reset_stats_baseline(db_path: str) -> Tuple[bool, str]:
+    """Record "now" as the dashboard counter baseline.
+
+    The reset is non-destructive: ``cloud_synced_files`` rows are
+    untouched, so the next sync cycle's dedup check still sees every
+    file that was previously uploaded and skips them. The UI's
+    ``total_synced`` and ``total_bytes`` counters will start counting
+    from zero again, but the cloud archive itself is unchanged.
+
+    Returns ``(True, message)`` with the persisted baseline timestamp on
+    success, or ``(False, error_message)`` on any failure.
+    """
+    baseline_at = datetime.now(timezone.utc).isoformat()
+    conn = _init_cloud_tables(db_path)
+    try:
+        conn.execute(
+            "INSERT OR REPLACE INTO cloud_archive_meta (key, value) "
+            "VALUES (?, ?)",
+            (_CLOUD_STATS_BASELINE_KEY, baseline_at),
+        )
+        conn.commit()
+        logger.info(
+            "Cloud sync stats baseline reset to %s (cloud_synced_files "
+            "rows preserved for dedup)",
+            baseline_at,
+        )
+        return True, baseline_at
+    except sqlite3.Error as exc:  # noqa: BLE001
+        logger.exception("Failed to reset cloud sync stats baseline")
+        return False, str(exc)
+    finally:
+        conn.close()
+
+
 def get_sync_stats(db_path: str) -> dict:
     """Return aggregate sync statistics for the UI dashboard.
 
     Keys: total_synced, total_pending, total_failed, total_dead_letter,
-    total_bytes.
+    total_bytes, stats_baseline_at.
 
     ``total_failed`` is the SUM of ``failed`` and ``dead_letter`` rows
     so the dashboard counter does NOT silently DECREASE when a row hits
@@ -4420,25 +4725,54 @@ def get_sync_stats(db_path: str) -> dict:
     ``total_dead_letter`` is also exposed as a subset so a future
     Failed Jobs page (Phase 4) can break the count down by terminal
     state without changing this aggregate.
+
+    ``total_synced`` and ``total_bytes`` are filtered by
+    ``stats_baseline_at`` when set: only rows whose ``synced_at`` is
+    strictly greater than the baseline are counted. ``total_pending``
+    and ``total_failed`` are NOT filtered because they reflect current
+    work / current failures, not cumulative history — resetting them
+    would lie about the current state of the queue.
     """
     conn = _init_cloud_tables(db_path)
     try:
+        # Read baseline once per call so the COUNT and SUM stay
+        # consistent against the same cutoff.
+        baseline_row = conn.execute(
+            "SELECT value FROM cloud_archive_meta WHERE key = ?",
+            (_CLOUD_STATS_BASELINE_KEY,),
+        ).fetchone()
+        baseline = baseline_row["value"] if baseline_row else None
+        baseline = (baseline or "").strip() or None
+
         counts = {}
-        for status in ("synced", "pending", "failed", "uploading",
-                       "dead_letter"):
+        for status in ("pending", "failed", "uploading", "dead_letter"):
             row = conn.execute(
                 "SELECT COUNT(*) AS cnt FROM cloud_synced_files WHERE status = ?",
                 (status,),
             ).fetchone()
             counts[status] = row["cnt"] if row else 0
 
-        # Sum bytes from individual synced files (more accurate than session
-        # totals which are lost when sessions are interrupted by restart).
-        row = conn.execute(
-            "SELECT COALESCE(SUM(file_size), 0) AS total "
-            "FROM cloud_synced_files WHERE status = 'synced'"
-        ).fetchone()
-        total_bytes = row["total"] if row else 0
+        # Synced count + bytes honor the baseline. ``synced_at`` is
+        # written by ``_mark_upload_success`` as ISO-8601 UTC, so
+        # lexicographic comparison is correct. Rows with NULL
+        # ``synced_at`` (legacy / pre-fix data) are conservatively
+        # included so the post-reset counter never under-counts work
+        # the user actually saw complete.
+        if baseline:
+            synced_row = conn.execute(
+                "SELECT COUNT(*) AS cnt, COALESCE(SUM(file_size), 0) AS total "
+                "FROM cloud_synced_files "
+                "WHERE status = 'synced' "
+                "  AND (synced_at IS NULL OR synced_at > ?)",
+                (baseline,),
+            ).fetchone()
+        else:
+            synced_row = conn.execute(
+                "SELECT COUNT(*) AS cnt, COALESCE(SUM(file_size), 0) AS total "
+                "FROM cloud_synced_files WHERE status = 'synced'"
+            ).fetchone()
+        counts["synced"] = synced_row["cnt"] if synced_row else 0
+        total_bytes = synced_row["total"] if synced_row else 0
 
         # Use the higher of DB pending count vs in-memory discovery count.
         # The DB may not have entries for all events on disk (events only get
@@ -4456,6 +4790,7 @@ def get_sync_stats(db_path: str) -> dict:
             "total_failed": counts["failed"] + counts["dead_letter"],
             "total_dead_letter": counts["dead_letter"],
             "total_bytes": total_bytes,
+            "stats_baseline_at": baseline,
         }
     finally:
         conn.close()

--- a/scripts/web/templates/cloud_archive.html
+++ b/scripts/web/templates/cloud_archive.html
@@ -105,25 +105,35 @@
     {% if sync_stats %}
     <div style="display: flex; gap: var(--space-4); flex-wrap: wrap; margin-bottom: var(--space-4);">
         <div style="flex: 1; min-width: 120px; padding: var(--space-3); background: var(--bg-info); border-radius: var(--radius-md); text-align: center;">
-            <div style="font-size: var(--text-2xl); font-weight: 600; color: var(--text-primary);">{{ sync_stats.total_synced|default(0) }}</div>
+            <div id="statSyncedCount" style="font-size: var(--text-2xl); font-weight: 600; color: var(--text-primary);">{{ sync_stats.total_synced|default(0) }}</div>
             <div style="font-size: var(--text-sm); color: var(--text-secondary);">Events Synced</div>
         </div>
         <div style="flex: 1; min-width: 120px; padding: var(--space-3); background: var(--bg-info); border-radius: var(--radius-md); text-align: center;">
-            <div style="font-size: var(--text-2xl); font-weight: 600; color: var(--text-primary);">{{ sync_stats.total_pending|default(0) }}</div>
+            <div id="statPendingCount" style="font-size: var(--text-2xl); font-weight: 600; color: var(--text-primary);">{{ sync_stats.total_pending|default(0) }}</div>
             <div style="font-size: var(--text-sm); color: var(--text-secondary);">Events Pending</div>
         </div>
         <div style="flex: 1; min-width: 120px; padding: var(--space-3); background: var(--bg-info); border-radius: var(--radius-md); text-align: center;">
-            <div style="font-size: var(--text-2xl); font-weight: 600; color: var(--text-primary);">{{ sync_stats.total_failed|default(0) }}</div>
+            <div id="statFailedCount" style="font-size: var(--text-2xl); font-weight: 600; color: var(--text-primary);">{{ sync_stats.total_failed|default(0) }}</div>
             <div style="font-size: var(--text-sm); color: var(--text-secondary);">Failed</div>
         </div>
         <div style="flex: 1; min-width: 120px; padding: var(--space-3); background: var(--bg-info); border-radius: var(--radius-md); text-align: center;">
-            <div style="font-size: var(--text-2xl); font-weight: 600; color: var(--text-primary);">
+            <div id="statTotalBytes" style="font-size: var(--text-2xl); font-weight: 600; color: var(--text-primary);">
                 {% if sync_stats.total_bytes %}{{ sync_stats.total_bytes|filesizeformat }}{% else %}0 B{% endif %}
             </div>
             <div style="font-size: var(--text-sm); color: var(--text-secondary);">Transferred</div>
         </div>
     </div>
-    <p style="font-size: var(--text-xs); color: var(--text-muted); margin: -8px 0 var(--space-4); text-align: center;">Each event contains multiple camera files (up to 6 angles per clip)</p>
+    <div style="display: flex; align-items: center; justify-content: space-between; gap: var(--space-3); flex-wrap: wrap; margin: -8px 0 var(--space-4);">
+        <p style="font-size: var(--text-xs); color: var(--text-muted); margin: 0;">
+            Each event contains multiple camera files (up to 6 angles per clip).
+            <span id="statBaselineHint">{% if sync_stats.stats_baseline_at %}Synced/Transferred counts since {{ sync_stats.stats_baseline_at[:10] }}.{% endif %}</span>
+        </p>
+        <button type="button" id="resetStatsBtn" onclick="resetSyncStats()"
+                title="Reset Synced/Transferred counters. Does NOT delete the sync history that prevents re-uploads."
+                style="padding: 4px 12px; font-size: var(--text-xs); border: 1px solid var(--border); border-radius: var(--radius-md); background: var(--bg-secondary); color: var(--text-secondary); cursor: pointer;">
+            Reset counters
+        </button>
+    </div>
     {% endif %}
 
     <!-- ================================================================
@@ -428,8 +438,8 @@
                 <strong style="color: var(--text-primary);">How sync works:</strong>
                 <ul style="margin: 6px 0 0; padding-left: 18px;">
                     <li><strong>Automatic:</strong> Starts syncing whenever WiFi connects</li>
-                    <li><strong>Events only:</strong> Syncs Sentry and Saved clips (not RecentClips rolling buffer)</li>
-                    <li><strong>Oldest first:</strong> Preserves the most at-risk clips first</li>
+                    <li><strong>Events &amp; archived clips:</strong> Syncs Sentry / Saved event folders and the SD-card-resident <em>ArchivedClips</em> snapshot (RecentClips itself is skipped because Tesla rotates it hourly)</li>
+                    <li><strong>Oldest first:</strong> Within each folder, preserves the most at-risk clips first</li>
                     <li><strong>Skip existing:</strong> Files already on cloud storage are never re-uploaded</li>
                     <li><strong>Manual:</strong> Click &ldquo;Sync Now&rdquo; at any time</li>
                 </ul>
@@ -445,14 +455,21 @@
                 <div style="margin-bottom: var(--space-4);">
                     <label style="display: block; margin-bottom: var(--space-2); font-weight: 600; color: var(--text-primary);">Folders to sync:</label>
                     <div style="display: flex; flex-direction: column; gap: var(--space-2);">
-                        {% set folder_options = ['SentryClips', 'SavedClips', 'RecentClips'] %}
-                        {% for folder in folder_options %}
-                        <label style="display: flex; align-items: center; gap: var(--space-2); padding: 8px; border-radius: var(--radius-md); cursor: pointer; transition: background var(--transition-fast);"
+                        {% set folder_options = [
+                            ('SentryClips',   'Sentry-triggered events (impacts, intrusions)'),
+                            ('SavedClips',    'Manually saved clips (horn-honk / on-screen save)'),
+                            ('ArchivedClips', 'SD-card snapshot of RecentClips (RecentClips itself rotates hourly)'),
+                        ] %}
+                        {% for folder, blurb in folder_options %}
+                        <label style="display: flex; align-items: flex-start; gap: var(--space-2); padding: 8px; border-radius: var(--radius-md); cursor: pointer; transition: background var(--transition-fast);"
                                onmouseover="this.style.background='var(--bg-hover)'" onmouseout="this.style.background='transparent'">
                             <input type="checkbox" name="sync_folders" value="{{ folder }}"
                                    {% if folder in sync_folders %}checked{% endif %}
-                                   style="width: 18px; height: 18px; cursor: pointer; accent-color: var(--btn-success-bg);">
-                            <span style="color: var(--text-primary); font-size: 15px;">{{ folder }}</span>
+                                   style="width: 18px; height: 18px; cursor: pointer; accent-color: var(--btn-success-bg); margin-top: 2px;">
+                            <span style="display: flex; flex-direction: column; gap: 2px;">
+                                <span style="color: var(--text-primary); font-size: 15px; font-weight: 500;">{{ folder }}</span>
+                                <span style="color: var(--text-muted); font-size: var(--text-xs);">{{ blurb }}</span>
+                            </span>
                         </label>
                         {% endfor %}
                     </div>
@@ -854,6 +871,7 @@
                 if (!resp.ok) return;
                 var data = await resp.json();
                 updateStatusCard(data.status || {}, data.stats || {});
+                updateStatCounters(data.stats || {});
                 if (!(data.status && data.status.running)) {
                     stopPolling();
                 }
@@ -865,6 +883,82 @@
 
     function stopPolling() {
         if (pollInterval) { clearInterval(pollInterval); pollInterval = null; }
+    }
+
+    /* ===================================================================
+       Counter card updaters (kept fresh by both the polling loop while
+       sync is running AND the manual ``Reset counters`` button so the
+       user sees the change immediately).
+       =================================================================== */
+    function _formatBytesPretty(n) {
+        if (!n) return '0 B';
+        if (n < 1024) return n + ' B';
+        var units = ['KB','MB','GB','TB'];
+        var i = -1; var v = n;
+        do { v /= 1024; i++; } while (v >= 1024 && i < units.length - 1);
+        return v.toFixed(v >= 100 ? 0 : 1) + ' ' + units[i];
+    }
+
+    function updateStatCounters(stats) {
+        if (!stats) return;
+        var ids = [
+            ['statSyncedCount',  stats.total_synced  || 0],
+            ['statPendingCount', stats.total_pending || 0],
+            ['statFailedCount',  stats.total_failed  || 0],
+        ];
+        ids.forEach(function(pair) {
+            var el = document.getElementById(pair[0]);
+            if (el) el.textContent = pair[1];
+        });
+        var bytesEl = document.getElementById('statTotalBytes');
+        if (bytesEl) bytesEl.textContent = _formatBytesPretty(stats.total_bytes || 0);
+        var hintEl = document.getElementById('statBaselineHint');
+        if (hintEl) {
+            if (stats.stats_baseline_at) {
+                hintEl.textContent = 'Synced/Transferred counts since ' +
+                    String(stats.stats_baseline_at).slice(0, 10) + '.';
+            } else {
+                hintEl.textContent = '';
+            }
+        }
+    }
+
+    async function resetSyncStats() {
+        if (!confirm("Reset the Synced and Transferred counters?\n\n" +
+                     "This only clears the displayed totals. Files already " +
+                     "uploaded to the cloud will NOT be re-uploaded — the " +
+                     "sync history that prevents duplicates is preserved.")) {
+            return;
+        }
+        var btn = document.getElementById('resetStatsBtn');
+        if (btn) { btn.disabled = true; btn.textContent = 'Resetting…'; }
+        try {
+            var resp = await fetch(
+                '{{ url_for("cloud_archive.api_reset_stats") }}',
+                {method: 'POST', headers: {'X-Requested-With': 'XMLHttpRequest'}}
+            );
+            var data = await resp.json();
+            if (!resp.ok || data.success === false) {
+                throw new Error((data && data.message) || 'Reset failed');
+            }
+            /* Immediately reflect zeroes in the UI; poll will refresh
+               the live state on the next tick. */
+            updateStatCounters({
+                total_synced: 0,
+                total_pending: parseInt(
+                    (document.getElementById('statPendingCount') || {}).textContent || '0', 10
+                ),
+                total_failed: parseInt(
+                    (document.getElementById('statFailedCount') || {}).textContent || '0', 10
+                ),
+                total_bytes: 0,
+                stats_baseline_at: data.stats_baseline_at,
+            });
+        } catch (e) {
+            alert('Reset failed: ' + (e && e.message ? e.message : e));
+        } finally {
+            if (btn) { btn.disabled = false; btn.textContent = 'Reset counters'; }
+        }
     }
 
     function updateStatusCard(status, stats) {

--- a/tests/test_cloud_archive_folders_archive.py
+++ b/tests/test_cloud_archive_folders_archive.py
@@ -1,0 +1,207 @@
+"""Tests for the cloud-sync folder rework (RecentClips → ArchivedClips).
+
+The Cloud Sync settings page used to list ``RecentClips`` as a sync
+target. That was a foot-gun:
+
+* Tesla rotates ``RecentClips`` on a 1-hour ring; uploading from it is
+  racey and wasteful (the archive subsystem copies *survivors* to
+  ``ArchivedClips`` on SD before they age out).
+* ``_discover_events`` walks per-event subdirectories — ``RecentClips``
+  is flat files, so the checkbox silently did nothing.
+* ``ArchivedClips`` was already being scanned, but the UI offered no
+  way to turn it on or off, and the configured ``priority_order`` was
+  read at boot and then thrown away (never used downstream).
+
+This rework:
+
+* swaps ``RecentClips`` → ``ArchivedClips`` everywhere in the UI / config
+  defaults / live normalization
+* honors the checkbox for ``ArchivedClips`` (no more always-on
+  silent-upload)
+* wires ``priority_order`` into the discovery sort so the configured
+  folder ordering becomes the primary sort axis
+
+These tests pin the public contract.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+SCRIPTS_WEB = Path(__file__).resolve().parent.parent / "scripts" / "web"
+if str(SCRIPTS_WEB) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_WEB))
+
+from services import cloud_archive_service as cas  # noqa: E402
+import config as web_config  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Normalization helpers
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeFolderList:
+    """Service-internal normalizer (used by every YAML read path)."""
+
+    def test_recentclips_rewritten_to_archivedclips(self):
+        assert cas._normalize_folder_list(["RecentClips"]) == ["ArchivedClips"]
+
+    def test_recentclips_in_middle_rewritten(self):
+        assert cas._normalize_folder_list(
+            ["SentryClips", "RecentClips", "SavedClips"]
+        ) == ["SentryClips", "ArchivedClips", "SavedClips"]
+
+    def test_unknown_folder_dropped(self):
+        assert cas._normalize_folder_list(["SentryClips", "WeirdFolder"]) == [
+            "SentryClips"
+        ]
+
+    def test_dedup_preserves_order(self):
+        assert cas._normalize_folder_list(
+            ["SavedClips", "SentryClips", "SavedClips"]
+        ) == ["SavedClips", "SentryClips"]
+
+    def test_empty_list_returns_empty(self):
+        """Normalizer is pure — fallback to default is the reader's job."""
+        assert cas._normalize_folder_list([]) == []
+
+    def test_none_returns_empty(self):
+        """None / non-list inputs collapse to empty so the reader can
+        notice "user has not configured a list" and fall back."""
+        assert cas._normalize_folder_list(None) == []
+
+    def test_archivedclips_passthrough(self):
+        assert cas._normalize_folder_list(
+            ["SentryClips", "SavedClips", "ArchivedClips"]
+        ) == ["SentryClips", "SavedClips", "ArchivedClips"]
+
+
+class TestConfigNormalizeCloudFolderList:
+    """Config wrapper normalizer (used at boot + by blueprint)."""
+
+    def test_recentclips_rewritten(self):
+        assert web_config._normalize_cloud_folder_list(
+            ["RecentClips"], ["SentryClips", "SavedClips", "ArchivedClips"]
+        ) == ["ArchivedClips"]
+
+    def test_legacy_full_list_rewritten(self):
+        result = web_config._normalize_cloud_folder_list(
+            ["SentryClips", "SavedClips", "RecentClips"],
+            ["SentryClips", "SavedClips", "ArchivedClips"],
+        )
+        assert "RecentClips" not in result
+        assert "ArchivedClips" in result
+        assert result.index("SentryClips") < result.index("SavedClips")
+
+    def test_default_when_empty(self):
+        result = web_config._normalize_cloud_folder_list(
+            [], ["SentryClips", "SavedClips", "ArchivedClips"]
+        )
+        assert result == ["SentryClips", "SavedClips", "ArchivedClips"]
+
+    def test_default_includes_archivedclips(self):
+        """Module-level default must NOT contain RecentClips."""
+        assert "RecentClips" not in web_config.CLOUD_ARCHIVE_SYNC_FOLDERS
+        assert "ArchivedClips" in web_config.CLOUD_ARCHIVE_SYNC_FOLDERS
+        assert "RecentClips" not in web_config.CLOUD_ARCHIVE_PRIORITY_ORDER
+        assert "ArchivedClips" in web_config.CLOUD_ARCHIVE_PRIORITY_ORDER
+
+
+# ---------------------------------------------------------------------------
+# Folder priority sort
+# ---------------------------------------------------------------------------
+
+
+class TestFolderPriorityIndex:
+    def test_in_order(self):
+        order = ["SentryClips", "SavedClips", "ArchivedClips"]
+        assert cas._folder_priority_index("SentryClips", order) == 0
+        assert cas._folder_priority_index("SavedClips", order) == 1
+        assert cas._folder_priority_index("ArchivedClips", order) == 2
+
+    def test_unknown_sorts_after_known(self):
+        order = ["SentryClips", "SavedClips"]
+        # Unknown gets len(order) → sorts AFTER configured folders.
+        assert cas._folder_priority_index("ArchivedClips", order) == 2
+        assert cas._folder_priority_index("Whatever", order) == 2
+
+    def test_empty_order(self):
+        assert cas._folder_priority_index("SentryClips", []) == 0
+
+
+class TestFolderOfEventRel:
+    def test_sentryclips_prefix(self):
+        assert cas._folder_of_event_rel("SentryClips/2026-01-01_12-00-00") == "SentryClips"
+
+    def test_savedclips_prefix(self):
+        assert cas._folder_of_event_rel("SavedClips/foo/bar") == "SavedClips"
+
+    def test_archivedclips_prefix(self):
+        assert cas._folder_of_event_rel("ArchivedClips/clip.mp4") == "ArchivedClips"
+
+    def test_no_separator_returns_empty(self):
+        """Defensive: a malformed path with no leading folder component
+        returns ``""`` so the priority sort puts it at the end."""
+        assert cas._folder_of_event_rel("SentryClips") == ""
+
+    def test_empty_string_returns_empty(self):
+        assert cas._folder_of_event_rel("") == ""
+
+    def test_leading_slash_returns_empty_folder(self):
+        # A path that starts with "/" has an empty leading component.
+        assert cas._folder_of_event_rel("/SentryClips/foo") == ""
+
+    def test_priority_multiplier_dominates_content_score(self):
+        """Folder axis must outrank the per-event content score."""
+        # Max content score is ~299 (200 event-folder bonus + 99 age cap).
+        # _FOLDER_PRIORITY_MULTIPLIER must be strictly greater.
+        assert cas._FOLDER_PRIORITY_MULTIPLIER > 299
+
+
+# ---------------------------------------------------------------------------
+# YAML readers honoring live config
+# ---------------------------------------------------------------------------
+
+
+class TestLiveYamlReaders:
+    def test_sync_folders_reader_returns_list(self):
+        result = cas._read_sync_folders_setting()
+        assert isinstance(result, list)
+        # Whatever it returns must be normalized.
+        assert "RecentClips" not in result
+        for entry in result:
+            assert entry in cas._VALID_SYNC_FOLDERS
+
+    def test_priority_order_reader_returns_list(self):
+        result = cas._read_priority_order_setting()
+        assert isinstance(result, list)
+        assert "RecentClips" not in result
+
+
+# ---------------------------------------------------------------------------
+# Reconcile contract — must scan EVERY historical folder regardless of
+# current user selection (otherwise unchecking SentryClips would trigger
+# re-upload when it's checked again).
+# ---------------------------------------------------------------------------
+
+
+class TestReconcileFolderContract:
+    def test_event_folder_names_is_tesla_canonical(self):
+        """Tesla firmware fixes the event-folder names — they cannot
+        be user-configured because Tesla writes to them directly."""
+        assert cas._EVENT_FOLDER_NAMES == ("SentryClips", "SavedClips")
+
+    def test_known_cloud_roots_includes_all_historical(self):
+        """Reconciliation scans every folder Tesla / TeslaUSB has ever
+        written to so unchecking a folder can't lose dedup info."""
+        roots = set(cas._KNOWN_CLOUD_ROOTS)
+        for required in ("SentryClips", "SavedClips", "RecentClips", "ArchivedClips"):
+            assert required in roots, (
+                f"{required!r} missing from _KNOWN_CLOUD_ROOTS — re-checking "
+                f"the folder after un-checking would re-upload everything"
+            )

--- a/tests/test_cloud_archive_reset_stats_route.py
+++ b/tests/test_cloud_archive_reset_stats_route.py
@@ -1,0 +1,110 @@
+"""Tests for blueprints/cloud_archive POST /api/reset_stats.
+
+The route invokes :func:`cloud_archive_service.reset_stats_baseline`
+and must:
+
+* return ``{"success": True, "stats_baseline_at": "..."}`` on success
+* return HTTP 500 + ``{"success": False, "message": ...}`` on failure
+* invalidate the 10-second ``api_status._cache`` so the user sees the
+  reset reflected on the very next poll (not 10 s later)
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture
+def app(monkeypatch):
+    from flask import Flask
+
+    from blueprints.cloud_archive import cloud_archive_bp
+
+    flask_app = Flask(__name__)
+    flask_app.secret_key = "test-only"
+    flask_app.register_blueprint(cloud_archive_bp)
+    flask_app.config["TESTING"] = True
+    return flask_app
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+class TestApiResetStats:
+    def test_success_returns_baseline(self, client, monkeypatch):
+        # Stub out the underlying service helper.
+        from services import cloud_archive_service as cas
+
+        captured = {}
+
+        def fake_reset(db_path):
+            captured["db_path"] = db_path
+            return True, "2026-05-15T00:00:00+00:00"
+
+        monkeypatch.setattr(cas, "reset_stats_baseline", fake_reset)
+
+        resp = client.post("/cloud/api/reset_stats")
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["success"] is True
+        assert body["stats_baseline_at"] == "2026-05-15T00:00:00+00:00"
+        assert captured["db_path"]  # called with the configured DB path
+
+    def test_failure_returns_500_with_message(self, client, monkeypatch):
+        from services import cloud_archive_service as cas
+
+        monkeypatch.setattr(
+            cas,
+            "reset_stats_baseline",
+            lambda db: (False, "disk I/O error"),
+        )
+
+        resp = client.post("/cloud/api/reset_stats")
+        assert resp.status_code == 500
+        body = resp.get_json()
+        assert body["success"] is False
+        assert "disk I/O error" in body["message"]
+
+    def test_unexpected_exception_returns_500(self, client, monkeypatch):
+        from services import cloud_archive_service as cas
+
+        def raises(db_path):
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(cas, "reset_stats_baseline", raises)
+
+        resp = client.post("/cloud/api/reset_stats")
+        assert resp.status_code == 500
+        body = resp.get_json()
+        assert body["success"] is False
+        assert "boom" in body["message"]
+
+    def test_get_method_not_allowed(self, client):
+        """Reset is a mutating action — must require POST."""
+        resp = client.get("/cloud/api/reset_stats")
+        assert resp.status_code == 405
+
+    def test_cache_invalidated_after_reset(self, client, monkeypatch):
+        """The 10-second api_status cache must be cleared so the user
+        sees the reset reflected on the next poll."""
+        from services import cloud_archive_service as cas
+        from blueprints import cloud_archive as bp
+
+        # Pre-seed the cache.
+        bp.api_status._cache = {"data": {"total_synced": 99}, "ts": 9999}
+        assert hasattr(bp.api_status, "_cache")
+
+        monkeypatch.setattr(
+            cas,
+            "reset_stats_baseline",
+            lambda db: (True, "2026-05-15T00:00:00+00:00"),
+        )
+
+        resp = client.post("/cloud/api/reset_stats")
+        assert resp.status_code == 200
+        # Cache attribute must be gone (next poll re-fetches).
+        assert not hasattr(bp.api_status, "_cache")

--- a/tests/test_cloud_archive_v4_migration.py
+++ b/tests/test_cloud_archive_v4_migration.py
@@ -810,20 +810,24 @@ class TestInitCloudDbV4:
         conn = cas._init_cloud_tables(cloud_db_v3_with_les)
         conn.close()
 
-        assert _module_version(cloud_db_v3_with_les, 'cloud_archive') == 4
+        # Migration cascades to current target schema; the v3→v4
+        # contract (LES table dropped, version no longer < 4) is the
+        # invariant we care about — track ``_CLOUD_SCHEMA_VERSION``
+        # so future schema bumps don't break this assertion.
+        assert _module_version(cloud_db_v3_with_les, 'cloud_archive') == cas._CLOUD_SCHEMA_VERSION
         assert not _table_exists(cloud_db_v3_with_les, 'live_event_queue')
 
     def test_idempotent_on_v4(self, cloud_db_v3_with_les):
-        # First call lifts to v4.
+        # First call lifts to the current schema target.
         conn = cas._init_cloud_tables(cloud_db_v3_with_les)
         conn.close()
-        assert _module_version(cloud_db_v3_with_les, 'cloud_archive') == 4
+        assert _module_version(cloud_db_v3_with_les, 'cloud_archive') == cas._CLOUD_SCHEMA_VERSION
 
         # Second call must be a no-op (the ``if current < ...`` guard
         # short-circuits the migration block entirely).
         conn = cas._init_cloud_tables(cloud_db_v3_with_les)
         conn.close()
-        assert _module_version(cloud_db_v3_with_les, 'cloud_archive') == 4
+        assert _module_version(cloud_db_v3_with_les, 'cloud_archive') == cas._CLOUD_SCHEMA_VERSION
         assert not _table_exists(cloud_db_v3_with_les, 'live_event_queue')
 
     def test_failure_holds_version_at_3_for_retry(

--- a/tests/test_cloud_stats_baseline.py
+++ b/tests/test_cloud_stats_baseline.py
@@ -1,0 +1,281 @@
+"""Tests for the cloud-sync stats baseline (counter reset).
+
+The Cloud Sync page now exposes a *Reset counters* button that zeros the
+*Synced* and *Transferred* dashboard totals **without** wiping the
+``cloud_synced_files`` rows that prevent already-uploaded clips from
+being re-uploaded. Implementation is a single timestamp in
+``cloud_archive_meta`` that ``get_sync_stats`` uses to filter the COUNT
+and SUM. These tests pin the contract:
+
+* baseline starts unset → counters show full lifetime totals
+* :func:`reset_stats_baseline` persists ``stats_baseline_at``
+* rows whose ``synced_at`` is ≤ the baseline are excluded from
+  ``total_synced`` and ``total_bytes``
+* NULL ``synced_at`` rows are *included* (defensive: never under-count
+  work the user actually saw complete)
+* ``total_pending`` / ``total_failed`` (current state metrics) are NOT
+  filtered — a reset must never lie about the current queue depth
+* schema is at the current target version after init
+* baseline survives across connections (real persistence, not session
+  state)
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_WEB = Path(__file__).resolve().parent.parent / "scripts" / "web"
+if str(SCRIPTS_WEB) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_WEB))
+
+from services import cloud_archive_service as cas  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def cloud_db(tmp_path: Path) -> str:
+    """Fresh cloud_sync.db at the current schema target."""
+    db = tmp_path / "cloud_sync.db"
+    conn = cas._init_cloud_tables(str(db))
+    conn.close()
+    return str(db)
+
+
+def _insert_synced(db: str, path: str, file_size: int, synced_at: str) -> None:
+    """Insert a row directly so tests don't depend on the upload pipeline."""
+    conn = sqlite3.connect(db)
+    try:
+        conn.execute(
+            "INSERT INTO cloud_synced_files "
+            "(file_path, file_size, status, synced_at) "
+            "VALUES (?, ?, 'synced', ?)",
+            (path, file_size, synced_at),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _insert_pending(db: str, path: str) -> None:
+    conn = sqlite3.connect(db)
+    try:
+        conn.execute(
+            "INSERT INTO cloud_synced_files "
+            "(file_path, file_size, status) "
+            "VALUES (?, ?, 'pending')",
+            (path, 0),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _insert_failed(db: str, path: str) -> None:
+    conn = sqlite3.connect(db)
+    try:
+        conn.execute(
+            "INSERT INTO cloud_synced_files "
+            "(file_path, file_size, status) "
+            "VALUES (?, ?, 'failed')",
+            (path, 0),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _module_version(db: str) -> int:
+    conn = sqlite3.connect(db)
+    try:
+        row = conn.execute(
+            "SELECT version FROM module_versions WHERE module='cloud_archive'"
+        ).fetchone()
+    finally:
+        conn.close()
+    return int(row[0]) if row else 0
+
+
+# ---------------------------------------------------------------------------
+# get_stats_baseline / reset_stats_baseline
+# ---------------------------------------------------------------------------
+
+
+class TestStatsBaselineHelpers:
+    def test_initial_baseline_is_none(self, cloud_db):
+        assert cas.get_stats_baseline(cloud_db) is None
+
+    def test_reset_persists_timestamp(self, cloud_db):
+        ok, ts = cas.reset_stats_baseline(cloud_db)
+        assert ok is True
+        assert ts  # ISO-8601 string
+        # Returned value matches what's now stored.
+        assert cas.get_stats_baseline(cloud_db) == ts
+
+    def test_reset_returns_iso8601_utc(self, cloud_db):
+        ok, ts = cas.reset_stats_baseline(cloud_db)
+        assert ok is True
+        # ISO-8601 with offset (+00:00) — lexicographic comparison safe.
+        assert "T" in ts
+        assert ts.endswith("+00:00") or ts.endswith("Z")
+
+    def test_repeated_reset_overwrites(self, cloud_db):
+        ok1, ts1 = cas.reset_stats_baseline(cloud_db)
+        time.sleep(0.01)
+        ok2, ts2 = cas.reset_stats_baseline(cloud_db)
+        assert ok1 and ok2
+        assert ts2 > ts1
+        assert cas.get_stats_baseline(cloud_db) == ts2
+
+    def test_baseline_survives_reopen(self, cloud_db):
+        ok, ts = cas.reset_stats_baseline(cloud_db)
+        assert ok
+        # Open a fresh connection (simulates a new request).
+        assert cas.get_stats_baseline(cloud_db) == ts
+
+
+# ---------------------------------------------------------------------------
+# get_sync_stats filtering
+# ---------------------------------------------------------------------------
+
+
+class TestGetSyncStatsBaselineFilter:
+    def test_no_baseline_counts_everything(self, cloud_db):
+        _insert_synced(cloud_db, "SentryClips/a.mp4", 1000, "2026-01-01T00:00:00+00:00")
+        _insert_synced(cloud_db, "SentryClips/b.mp4", 2000, "2026-06-01T00:00:00+00:00")
+        stats = cas.get_sync_stats(cloud_db)
+        assert stats["total_synced"] == 2
+        assert stats["total_bytes"] == 3000
+        assert stats["stats_baseline_at"] is None
+
+    def test_baseline_excludes_older_rows(self, cloud_db):
+        _insert_synced(cloud_db, "SentryClips/old1.mp4", 100, "2026-01-01T00:00:00+00:00")
+        _insert_synced(cloud_db, "SentryClips/old2.mp4", 200, "2026-02-01T00:00:00+00:00")
+        # Reset baseline to 2026-03-01.
+        baseline = "2026-03-01T00:00:00+00:00"
+        conn = sqlite3.connect(cloud_db)
+        conn.execute(
+            "INSERT OR REPLACE INTO cloud_archive_meta (key, value) VALUES (?, ?)",
+            (cas._CLOUD_STATS_BASELINE_KEY, baseline),
+        )
+        conn.commit()
+        conn.close()
+        _insert_synced(cloud_db, "SentryClips/new1.mp4", 500, "2026-04-01T00:00:00+00:00")
+        _insert_synced(cloud_db, "SentryClips/new2.mp4", 1000, "2026-05-01T00:00:00+00:00")
+
+        stats = cas.get_sync_stats(cloud_db)
+        # Only the post-baseline rows count.
+        assert stats["total_synced"] == 2
+        assert stats["total_bytes"] == 1500
+        assert stats["stats_baseline_at"] == baseline
+
+    def test_baseline_includes_null_synced_at(self, cloud_db):
+        """Legacy rows with NULL synced_at must NOT silently disappear."""
+        conn = sqlite3.connect(cloud_db)
+        # Synthesize a legacy row (no synced_at column value).
+        conn.execute(
+            "INSERT INTO cloud_synced_files "
+            "(file_path, file_size, status, synced_at) "
+            "VALUES (?, ?, 'synced', NULL)",
+            ("SentryClips/legacy.mp4", 999),
+        )
+        conn.execute(
+            "INSERT OR REPLACE INTO cloud_archive_meta (key, value) VALUES (?, ?)",
+            (cas._CLOUD_STATS_BASELINE_KEY, "2026-12-31T23:59:59+00:00"),
+        )
+        conn.commit()
+        conn.close()
+
+        stats = cas.get_sync_stats(cloud_db)
+        # Defensive inclusion of NULL rows so the counter never under-counts.
+        assert stats["total_synced"] == 1
+        assert stats["total_bytes"] == 999
+
+    def test_pending_not_filtered_by_baseline(self, cloud_db):
+        """Pending count is current state — must NOT be zeroed by a reset."""
+        _insert_pending(cloud_db, "SentryClips/p1.mp4")
+        _insert_pending(cloud_db, "SentryClips/p2.mp4")
+        ok, _ = cas.reset_stats_baseline(cloud_db)
+        assert ok
+        stats = cas.get_sync_stats(cloud_db)
+        assert stats["total_pending"] >= 2
+
+    def test_failed_not_filtered_by_baseline(self, cloud_db):
+        _insert_failed(cloud_db, "SentryClips/f1.mp4")
+        _insert_failed(cloud_db, "SentryClips/f2.mp4")
+        ok, _ = cas.reset_stats_baseline(cloud_db)
+        assert ok
+        stats = cas.get_sync_stats(cloud_db)
+        assert stats["total_failed"] == 2
+
+    def test_after_reset_old_synced_rows_drop_out(self, cloud_db):
+        _insert_synced(cloud_db, "SentryClips/a.mp4", 100, "2026-01-01T00:00:00+00:00")
+        before = cas.get_sync_stats(cloud_db)
+        assert before["total_synced"] == 1
+        assert before["total_bytes"] == 100
+
+        ok, _ = cas.reset_stats_baseline(cloud_db)
+        assert ok
+        after = cas.get_sync_stats(cloud_db)
+        # The old row's synced_at is before the just-set baseline.
+        assert after["total_synced"] == 0
+        assert after["total_bytes"] == 0
+        assert after["stats_baseline_at"] is not None
+
+    def test_dedup_rows_preserved_after_reset(self, cloud_db):
+        """Reset MUST NOT delete cloud_synced_files rows (would re-upload)."""
+        _insert_synced(cloud_db, "SentryClips/keep.mp4", 100, "2026-01-01T00:00:00+00:00")
+        ok, _ = cas.reset_stats_baseline(cloud_db)
+        assert ok
+        conn = sqlite3.connect(cloud_db)
+        try:
+            row = conn.execute(
+                "SELECT COUNT(*) AS n FROM cloud_synced_files WHERE status='synced'"
+            ).fetchone()
+        finally:
+            conn.close()
+        assert row[0] == 1, "Dedup rows must survive a counter reset"
+
+
+# ---------------------------------------------------------------------------
+# Schema
+# ---------------------------------------------------------------------------
+
+
+class TestStatsBaselineSchema:
+    def test_meta_table_exists(self, cloud_db):
+        conn = sqlite3.connect(cloud_db)
+        try:
+            row = conn.execute(
+                "SELECT name FROM sqlite_master "
+                "WHERE type='table' AND name='cloud_archive_meta'"
+            ).fetchone()
+        finally:
+            conn.close()
+        assert row is not None
+
+    def test_synced_at_index_exists(self, cloud_db):
+        """``idx_cloud_synced_synced_at`` keeps baseline-filter COUNT fast."""
+        conn = sqlite3.connect(cloud_db)
+        try:
+            row = conn.execute(
+                "SELECT name FROM sqlite_master "
+                "WHERE type='index' AND name='idx_cloud_synced_synced_at'"
+            ).fetchone()
+        finally:
+            conn.close()
+        assert row is not None
+
+    def test_schema_version_bumped(self, cloud_db):
+        version = _module_version(cloud_db)
+        assert version == cas._CLOUD_SCHEMA_VERSION
+        assert cas._CLOUD_SCHEMA_VERSION >= 5


### PR DESCRIPTION
## Summary

User-requested improvements on the Cloud Sync page:

1. **Reset counters button** — a non-destructive way to zero the *Events Synced* and *Transferred* cumulative totals at the top of the page **without** losing the dedup history that prevents already-uploaded clips from being re-uploaded.
2. **Folder rework** — replace `RecentClips` (rotates hourly, was always a no-op in the existing discovery code) with `ArchivedClips` (the SD-card-resident snapshot that actually gets synced today), make `ArchivedClips` a normal user toggle, and finally wire up the previously-unused `priority_order` setting.

## What changed

### Reset Stats (baseline-timestamp model)

- New `cloud_archive_meta` key/value table (schema **v5**) stores a `stats_baseline_at` ISO-8601 UTC timestamp.
- `get_sync_stats` filters `total_synced` count and `total_bytes` sum by `synced_at > baseline OR synced_at IS NULL`. NULL inclusion is defensive — legacy rows must never silently under-count.
- `total_pending` and `total_failed` are **NOT** filtered (current-state metrics — resetting them would lie about the queue depth).
- `cloud_synced_files` rows are preserved, so the next sync pass's dedup check still skips every previously-uploaded clip.
- New helpers: `get_stats_baseline`, `reset_stats_baseline`.
- New route `POST /cloud/api/reset_stats` invalidates the 10 s `api_status._cache` so the UI sees the reset immediately.
- New **Reset counters** button on the page with a clear confirm dialog ("only clears displayed totals; files already uploaded will NOT be re-uploaded").

### Folder rework (RecentClips → ArchivedClips)

- UI checklist now offers `SentryClips` / `SavedClips` / `ArchivedClips`, each with a one-line description so users understand what they're toggling.
- `ArchivedClips` is now a real toggle — it used to be unconditionally appended with no UI control (silent-upload foot-gun closed).
- Live YAML readers (`_read_sync_folders_setting`, `_read_priority_order_setting`) silently rewrite legacy `RecentClips` → `ArchivedClips` so existing Pi installs don't need a manual config edit. Boot-time normalizer in `config.py` does the same for module-level constants.
- `save_settings()` also normalizes the form-posted list so a stale browser cache can't persist `RecentClips`.
- `priority_order` is now wired into the discovery sort: `composite_score = folder_index * 1000 + content_score`. `_FOLDER_PRIORITY_MULTIPLIER = 1000` is strictly larger than the max content score (~299) so the folder axis dominates. Folders not in the configured order sort to the end.

### Reconciliation invariants

- New constants `_EVENT_FOLDER_NAMES = ("SentryClips", "SavedClips")` (Tesla-firmware canonical) and reused `_KNOWN_CLOUD_ROOTS` (broader historical set). Reconciliation scans every historical root regardless of the user's current toggle so unchecking a folder can't make re-checking it later re-upload everything.

## Tests

- `tests/test_cloud_stats_baseline.py` (NEW, 14 tests) — baseline get/set, filter behavior, NULL safety, dedup-row preservation, schema v5.
- `tests/test_cloud_archive_folders_archive.py` (NEW, 23 tests) — normalizer rewrites, folder priority sort, YAML readers, reconcile invariants.
- `tests/test_cloud_archive_reset_stats_route.py` (NEW, 5 tests) — success / failure / 405 / cache invalidation.
- `tests/test_cloud_archive_v4_migration.py` — bumped the v3→v4 assertions to track `cas._CLOUD_SCHEMA_VERSION` (the migration cascades to the current schema target now that we've added v5).

Full suite: **2083 pass / 5 skip** (was 2038, +45 new tests, **0 regressions**).

## Deploy notes

- `config.yaml` template default updated to use `ArchivedClips` in both `sync_folders` and `priority_order`. The Pi's user-saved `config.yaml` is **not** edited on deploy — live normalization in the code reads invisibly rewrites legacy `RecentClips` → `ArchivedClips`, and the next "Save Settings" click writes back the canonical form.
- No schema migration script needed — v4→v5 uses idempotent `CREATE TABLE IF NOT EXISTS` + `CREATE INDEX IF NOT EXISTS`.
- Deploy with: `ssh pi@cybertruckusb.local "cd ~/TeslaUSB && sudo git pull && sudo systemctl restart gadget_web.service"`.
